### PR TITLE
Complete Phase Leaves .flow-states/ Timing Artifacts Behind. #122

### DIFF
--- a/lib/cleanup.py
+++ b/lib/cleanup.py
@@ -130,6 +130,28 @@ def cleanup(project_root, branch, worktree, pr_number=None):
     else:
         steps["ci_sentinel"] = "skipped"
 
+    # Delete timings file
+    timings_file = root / ".flow-states" / f"{branch}-timings.md"
+    if timings_file.exists():
+        try:
+            timings_file.unlink()
+            steps["timings_file"] = "deleted"
+        except Exception as e:
+            steps["timings_file"] = f"failed: {e}"
+    else:
+        steps["timings_file"] = "skipped"
+
+    # Delete issues file
+    issues_file = root / ".flow-states" / f"{branch}-issues.md"
+    if issues_file.exists():
+        try:
+            issues_file.unlink()
+            steps["issues_file"] = "deleted"
+        except Exception as e:
+            steps["issues_file"] = f"failed: {e}"
+    else:
+        steps["issues_file"] = "skipped"
+
     return steps
 
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -141,8 +141,42 @@ def test_cleanup_skips_missing_ci_sentinel(git_repo):
     assert data["steps"]["ci_sentinel"] == "skipped"
 
 
+def test_cleanup_deletes_timings_file(git_repo):
+    wt_rel = _setup_feature(git_repo)
+    timings = git_repo / ".flow-states" / "test-feature-timings.md"
+    timings.write_text("| Phase | Duration |\n")
+    result = _run(git_repo, "test-feature", wt_rel)
+    data = json.loads(result.stdout)
+    assert data["steps"]["timings_file"] == "deleted"
+    assert not timings.exists()
+
+
+def test_cleanup_skips_missing_timings_file(git_repo):
+    wt_rel = _setup_feature(git_repo)
+    result = _run(git_repo, "test-feature", wt_rel)
+    data = json.loads(result.stdout)
+    assert data["steps"]["timings_file"] == "skipped"
+
+
+def test_cleanup_deletes_issues_file(git_repo):
+    wt_rel = _setup_feature(git_repo)
+    issues = git_repo / ".flow-states" / "test-feature-issues.md"
+    issues.write_text("| Label | Title |\n")
+    result = _run(git_repo, "test-feature", wt_rel)
+    data = json.loads(result.stdout)
+    assert data["steps"]["issues_file"] == "deleted"
+    assert not issues.exists()
+
+
+def test_cleanup_skips_missing_issues_file(git_repo):
+    wt_rel = _setup_feature(git_repo)
+    result = _run(git_repo, "test-feature", wt_rel)
+    data = json.loads(result.stdout)
+    assert data["steps"]["issues_file"] == "skipped"
+
+
 def test_cleanup_full_happy_path(git_repo):
-    """Single invocation asserts all 7 step results, return code, status,
+    """Single invocation asserts all 9 step results, return code, status,
     and all 3 filesystem effects (worktree, state file, log file)."""
     wt_rel = _setup_feature(git_repo)
     result = _run(git_repo, "test-feature", wt_rel)
@@ -159,6 +193,8 @@ def test_cleanup_full_happy_path(git_repo):
     assert data["steps"]["state_file"] == "deleted"
     assert data["steps"]["log_file"] == "deleted"
     assert data["steps"]["ci_sentinel"] == "skipped"
+    assert data["steps"]["timings_file"] == "skipped"
+    assert data["steps"]["issues_file"] == "skipped"
 
     # All 3 filesystem effects
     assert not (git_repo / wt_rel).exists()
@@ -343,6 +379,50 @@ def test_ci_sentinel_unlink_failure(git_repo, monkeypatch):
     monkeypatch.setattr(PosixPath, "unlink", _fail_third_unlink)
     steps = _mod.cleanup(git_repo, "test-feature", wt_rel)
     assert steps["ci_sentinel"].startswith("failed:")
+
+
+def test_timings_file_unlink_failure(git_repo, monkeypatch):
+    wt_rel = _setup_feature(git_repo)
+    timings = git_repo / ".flow-states" / "test-feature-timings.md"
+    timings.write_text("| Phase | Duration |\n")
+    original_unlink = timings.unlink.__func__
+
+    call_count = 0
+
+    # state_file=1, log_file=2, timings=3 (frozen_phases + ci_sentinel skipped)
+    def _fail_third_unlink(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 3:
+            raise PermissionError("no permission")
+        return original_unlink(self, *args, **kwargs)
+
+    from pathlib import PosixPath
+    monkeypatch.setattr(PosixPath, "unlink", _fail_third_unlink)
+    steps = _mod.cleanup(git_repo, "test-feature", wt_rel)
+    assert steps["timings_file"].startswith("failed:")
+
+
+def test_issues_file_unlink_failure(git_repo, monkeypatch):
+    wt_rel = _setup_feature(git_repo)
+    issues = git_repo / ".flow-states" / "test-feature-issues.md"
+    issues.write_text("| Label | Title |\n")
+    original_unlink = issues.unlink.__func__
+
+    call_count = 0
+
+    # state_file=1, log_file=2, issues=3 (frozen_phases + ci_sentinel + timings skipped)
+    def _fail_third_unlink(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 3:
+            raise PermissionError("no permission")
+        return original_unlink(self, *args, **kwargs)
+
+    from pathlib import PosixPath
+    monkeypatch.setattr(PosixPath, "unlink", _fail_third_unlink)
+    steps = _mod.cleanup(git_repo, "test-feature", wt_rel)
+    assert steps["issues_file"].startswith("failed:")
 
 
 # --- tmp/ directory cleanup ---


### PR DESCRIPTION
## What

Complete Phase Leaves .flow-states/ Timing Artifacts Behind. #122.

## Artifacts

- **Plan file**: `/Users/ben/.claude/plans/tranquil-wondering-thacker.md`

- **Session log**: `/Users/ben/.claude/projects/-Users-ben-code-flow/c1d30e8a-d427-440b-8952-06b9033000f7.jsonl`

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | <1m |
| Code | 3m |
| Code Review | 2m |
| Learn | 1m |
| Complete | <1m |
| **Total** | **8m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/complete-phase-leaves-flow.json</summary>

```json
{
  "feature": "Complete Phase Leaves .flow-states/ Timing Artifacts Behind. #122",
  "branch": "complete-phase-leaves-flow",
  "worktree": ".worktrees/complete-phase-leaves-flow",
  "pr_number": 126,
  "pr_url": "https://github.com/benkruger/flow/pull/126",
  "started_at": "2026-03-12T13:35:23-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "plan_file": "/Users/ben/.claude/plans/tranquil-wondering-thacker.md",
  "session_id": "c1d30e8a-d427-440b-8952-06b9033000f7",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/c1d30e8a-d427-440b-8952-06b9033000f7.jsonl",
  "notes": [],
  "prompt": "Complete phase leaves .flow-states/ timing artifacts behind. #122",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-12T13:35:23-07:00",
      "completed_at": "2026-03-12T13:35:51-07:00",
      "session_started_at": null,
      "cumulative_seconds": 28,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-12T13:36:43-07:00",
      "completed_at": "2026-03-12T13:39:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-12T13:39:24-07:00",
      "completed_at": "2026-03-12T13:43:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 236,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-12T13:43:45-07:00",
      "completed_at": "2026-03-12T13:46:38-07:00",
      "session_started_at": null,
      "cumulative_seconds": 173,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-12T13:47:06-07:00",
      "completed_at": "2026-03-12T13:48:45-07:00",
      "session_started_at": null,
      "cumulative_seconds": 99,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "code_task": 1,
  "_continue_pending": "",
  "code_review_step": 4,
  "learn_step": 5
}
```

</details>

## Session Log

<details>
<summary>.flow-states/complete-phase-leaves-flow.log</summary>

```text
2026-03-12T13:35:19-07:00 [Phase 1] git pull origin main (exit 0)
2026-03-12T13:35:19-07:00 [Phase 1] git worktree add .worktrees/complete-phase-leaves-flow (exit 0)
2026-03-12T13:35:23-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-12T13:35:23-07:00 [Phase 1] create .flow-states/complete-phase-leaves-flow.json (exit 0)
2026-03-12T13:35:23-07:00 [Phase 1] freeze .flow-states/complete-phase-leaves-flow-phases.json (exit 0)

```

</details>