### PR TITLE
Interactive Tui

### DIFF
--- a/skills/flow-code-review/SKILL.md
+++ b/skills/flow-code-review/SKILL.md
@@ -262,12 +262,6 @@ Record step completion:
 exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set code_review_step=1
 ```
 
-Clear the continuation flag before self-invoking:
-
-```bash
-exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=
-```
-
 To continue to Step 2, invoke `flow:flow-code-review --continue-step` using
 the Skill tool as your final action. If commit=auto was resolved, pass
 `--auto` as well. Do not output anything else after this invocation.


### PR DESCRIPTION
## What

work on issue #287.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/interactive-tui-plan.md` |
| DAG | `.flow-states/interactive-tui-dag.md` |
| Log | `.flow-states/interactive-tui.log` |
| State | `.flow-states/interactive-tui.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/bf06203e-824e-4fa2-851b-ebb94bdf1175.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Plan: Remove redundant double-clear of _continue_pending in Code Review Step 1

## Context

Issue #287: In `skills/flow-code-review/SKILL.md` Step 1, `_continue_pending` is cleared twice with only a `code_review_step=1` set-timestamp between them. The first clear (after commit completes, line 255-257) makes the second clear (before self-invoking, line 265-269) a no-op. Steps 2, 3, and 4 have justified second clears because they have summary banners and mode resolution logic between their two clears.

## Exploration

- **Step 1 (lines 253-273)**: First clear at 255, `code_review_step=1` at 261, redundant second clear at 265-269, self-invoke at 271-273.
- **Step 2 (lines 386-427)**: First clear at 389, Review summary banner at 392-411, `code_review_step=2` at 416, second clear at 421. Justified — summary banner intervenes.
- **Step 3 (lines 487-547)**: First clear at 487, Security summary banner at 505-523, `code_review_step=3` at 528, second clear at 533. Justified — summary banner + mode resolution intervene.
- **Step 4 (lines 610-661)**: First clear at 612, Plugin summary banner at 623-645, `code_review_step=4` at 650, second clear at 655. Justified — summary banner intervenes.
- **Contract tests**: `test_code_review_sets_continue_pending_before_child_skills` only checks that `_continue_pending` is SET before child skills. No test counts or validates clears.

## Risks

- Low risk. The removed block is provably a no-op — nothing between the two clears sets `_continue_pending`.
- No contract test depends on the count of clears.
- The docs page `docs/skills/flow-code-review.md` describes behavior but not internal implementation details like clear counts, so no docs update needed.

## Approach

Remove lines 265-269 (prose + bash block) from `skills/flow-code-review/SKILL.md`. This is the second `_continue_pending=` clear in Step 1. Leave Steps 2-4 untouched.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Verify no contract test breaks | test | — |
| 2. Remove redundant clear from SKILL.md | implement | 1 |

## Tasks

### Task 1 — Verify no contract test breaks

Run `bin/ci` before making changes to confirm the baseline is green. This validates that no existing test will break from the removal.

- **Files**: none modified
- **TDD notes**: Confirm `bin/ci` passes clean before editing

### Task 2 — Remove redundant clear from SKILL.md

Remove lines 265-269 from `skills/flow-code-review/SKILL.md`:
- Line 265: `Clear the continuation flag before self-invoking:`
- Line 266: (blank)
- Line 267: `` ```bash ``
- Line 268: `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=`
- Line 269: `` ``` ``

The blank line after line 269 (line 270) should also be removed to avoid a double-blank before the "To continue to Step 2" instruction.

- **Files**: `skills/flow-code-review/SKILL.md`
- **TDD notes**: `bin/ci` must pass after edit. Contract tests auto-cover this skill via glob discovery. Verify `test_code_review_sets_continue_pending_before_child_skills` still passes (it checks SET, not clears).
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Remove redundant double-clear of _continue_pending in Code Review Step 1

## DAG Plan

```xml
<dag goal="Remove redundant double-clear of _continue_pending in Code Review Step 1" mode="full">
  <plan>
    <node id="1" name="Read Step 1 Structure" type="research" depends="[]" parallel_with="[2]">
      <objective>Read the Code Review SKILL.md Step 1 to find the exact two _continue_pending= clears and what sits between them</objective>
    </node>
    <node id="2" name="Read Steps 2-4 Pattern" type="research" depends="[]" parallel_with="[1]">
      <objective>Read Steps 2-4 to confirm the double-clear pattern is justified there (safety net after intervening work)</objective>
    </node>
    <node id="3" name="Contract Test Check" type="validation" depends="[1]" parallel_with="[]">
      <objective>Check test_skill_contracts.py for any assertion that counts or validates _continue_pending clears in Step 1</objective>
    </node>
    <node id="4" name="Synthesis" type="synthesis" depends="[1,2,3]" parallel_with="[]">
      <objective>Determine exactly which bash block to remove, confirm no test or downstream dependency breaks</objective>
    </node>
  </plan>
</dag>
```

## Node Execution

### Node 1: Read Step 1 Structure

Found the exact pattern in Step 1 (lines 255-269):

- **Line 255-257** — First clear (after commit completes): `set _continue_pending=`
- **Line 261-263** — Set code_review_step (does NOT touch _continue_pending): `set code_review_step=1`
- **Line 265-269** — Second clear (before self-invoking): `set _continue_pending=`

The second clear is redundant — nothing between the two clears sets `_continue_pending`.

Quality: 9/10

### Node 2: Read Steps 2-4 Pattern

- **Step 2**: Review summary banner sits between the two clears — justified
- **Step 3**: Security summary banner + mode resolution logic between clears — justified
- **Step 4**: Code Review Plugin summary banner between clears — justified

Quality: 9/10

### Node 3: Contract Test Check

Contract tests (`test_code_review_sets_continue_pending_before_child_skills`) only assert that `_continue_pending` is SET before child skill invocations. No test counts or validates clears. Removing the redundant clear is safe.

Quality: 9/10

## Synthesis

The fix is surgical: remove lines 265-269 of skills/flow-code-review/SKILL.md (the second `set _continue_pending=` clear in Step 1) and the prose line that introduces it. Steps 2-4 retain their second clears.

Confidence: 95% | Nodes: 4 | Parallel branches: 2
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 3m |
| Code | 4m |
| Code Review | 3m |
| Learn | 3m |
| Complete | 1m |
| **Total** | **17m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/interactive-tui.json</summary>

```json
{
  "schema_version": 1,
  "branch": "interactive-tui",
  "repo": "benkruger/flow",
  "pr_number": 290,
  "pr_url": "https://github.com/benkruger/flow/pull/290",
  "started_at": "2026-03-19T20:25:21-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/interactive-tui-plan.md",
    "dag": ".flow-states/interactive-tui-dag.md",
    "log": ".flow-states/interactive-tui.log",
    "state": ".flow-states/interactive-tui.json"
  },
  "session_id": "bf06203e-824e-4fa2-851b-ebb94bdf1175",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/bf06203e-824e-4fa2-851b-ebb94bdf1175.jsonl",
  "notes": [],
  "prompt": "work on issue #287",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-19T20:25:21-07:00",
      "completed_at": "2026-03-19T20:25:38-07:00",
      "session_started_at": null,
      "cumulative_seconds": 17,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-19T20:26:16-07:00",
      "completed_at": "2026-03-19T20:29:21-07:00",
      "session_started_at": null,
      "cumulative_seconds": 185,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-19T20:29:52-07:00",
      "completed_at": "2026-03-19T20:34:46-07:00",
      "session_started_at": null,
      "cumulative_seconds": 294,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-19T20:35:19-07:00",
      "completed_at": "2026-03-19T20:39:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 226,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-19T20:39:39-07:00",
      "completed_at": "2026-03-19T20:43:04-07:00",
      "session_started_at": null,
      "cumulative_seconds": 205,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-19T20:44:18-07:00",
      "completed_at": "2026-03-19T20:46:10-07:00",
      "session_started_at": null,
      "cumulative_seconds": 112,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-19T20:26:16-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-19T20:29:52-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-19T20:35:19-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-19T20:39:39-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-19T20:44:18-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "never"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "_continue_context": "",
  "_continue_pending": "",
  "code_task": 2,
  "diff_stats": {
    "files_changed": 1,
    "insertions": 0,
    "deletions": 6,
    "captured_at": "2026-03-19T20:34:46-07:00"
  },
  "code_review_step": 3,
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "Post-commit _continue_pending clears in Code Review are redundant with stop-continue hook",
      "url": "https://github.com/benkruger/flow/issues/292",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-03-19T20:36:47-07:00"
    },
    {
      "label": "Flow",
      "title": "flow-create-issue should detect exploratory questions and facilitate design discussion before decomposing",
      "url": "https://github.com/benkruger/flow/issues/293",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-03-19T20:40:58-07:00"
    }
  ],
  "learn_step": 5,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/interactive-tui.log</summary>

```text
2026-03-19T20:25:05-07:00 [Phase 1] Step 2 — git pull + ci + dependencies (exit 0)
2026-03-19T20:25:14-07:00 [Phase 1] git worktree add .worktrees/interactive-tui (exit 0)
2026-03-19T20:25:21-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-19T20:25:21-07:00 [Phase 1] create .flow-states/interactive-tui.json (exit 0)
2026-03-19T20:25:21-07:00 [Phase 1] freeze .flow-states/interactive-tui-phases.json (exit 0)
2026-03-19T20:25:38-07:00 [Phase 1] Step 3-4 — start-setup + label-issues (exit 0)
2026-03-19T20:29:22-07:00 [Phase 2] Plan complete — DAG + plan written (exit 0)
2026-03-19T20:30:54-07:00 [Phase 3] Task 1 — baseline CI green (exit 0)
2026-03-19T20:33:35-07:00 [Phase 3] Task 2 — remove redundant clear, committed (exit 0)
2026-03-19T20:34:47-07:00 [Phase 3] All tasks complete, CI green (exit 0)
2026-03-19T20:36:55-07:00 [Phase 4] Step 1 — Simplify: no changes, 1 tech debt issue filed (exit 0)
2026-03-19T20:38:05-07:00 [Phase 4] Step 2 — Review: no findings (exit 0)
2026-03-19T20:38:49-07:00 [Phase 4] Step 3 — Security: no findings (exit 0)
2026-03-19T20:39:06-07:00 [Phase 4] Done — Code Review complete (exit 0)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | Post-commit _continue_pending clears in Code Review are redundant with stop-continue hook | Code Review | #292 |
| Flow | flow-create-issue should detect exploratory questions and facilitate design discussion before decomposing | Learn | #293 |

<!-- end:Issues Filed -->