### PR TITLE
Redundant Continue Clears

### DIFF
--- a/skills/flow-code/SKILL.md
+++ b/skills/flow-code/SKILL.md
@@ -326,12 +326,6 @@ The commit message subject should reference the task:
 Add <what was built> — Task <n> of <total>
 ```
 
-After the commit completes, clear the continuation flag:
-
-```bash
-exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=
-```
-
 To continue to the next task, invoke `flow:flow-code --continue-step`
 using the Skill tool as your final action. If commit=auto was resolved,
 pass `--auto` as well. Do not output anything else after this

--- a/skills/flow-complete/SKILL.md
+++ b/skills/flow-complete/SKILL.md
@@ -199,12 +199,7 @@ exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=commit
 Commit the resolution via `/flow:flow-commit` — the commit skill handles
 staging, diff review, and push.
 
-After the commit completes, clear the continuation flag and record the
-resume step:
-
-```bash
-exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=
-```
+After the commit completes, record the resume step:
 
 ```bash
 exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set complete_step=4
@@ -253,12 +248,7 @@ exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=commit
 
 Commit the fixes via `/flow:flow-commit`.
 
-After the commit completes, clear the continuation flag and record the
-resume step:
-
-```bash
-exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=
-```
+After the commit completes, record the resume step:
 
 ```bash
 exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set complete_step=4

--- a/skills/flow-learn/SKILL.md
+++ b/skills/flow-learn/SKILL.md
@@ -319,12 +319,7 @@ exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=commit
 If commit=auto, use `/flow:flow-commit --auto`. Otherwise, use
 `/flow:flow-commit`.
 
-After the commit completes, clear the continuation flag and record step
-completion:
-
-```bash
-exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=
-```
+After the commit completes, record step completion:
 
 ```bash
 exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set learn_step=4


### PR DESCRIPTION
## What

Redundant _continue_pending clears in flow-code, flow-complete, and flow-learn skills #296.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/redundant-continue-clears-plan.md` |
| DAG | `.flow-states/redundant-continue-clears-dag.md` |
| Log | `.flow-states/redundant-continue-clears.log` |
| State | `.flow-states/redundant-continue-clears.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/00e41ac0-5566-4637-a619-2a3c97722e60.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Plan: Remove redundant _continue_pending clears

## Context

Issue #296: The stop-continue hook (`lib/stop-continue.py`) atomically clears
both `_continue_pending` and `_continue_context` when it fires after any child
skill returns (lines 88-90 of `check_continue()`). Three phase skills contain
explicit clears after commit that are no-ops because the hook already cleared
the fields. PR #294 removed the same pattern from `flow-code-review` — this
completes the cleanup across the remaining skills.

## Exploration

### Affected files and exact blocks

1. **`skills/flow-code/SKILL.md` line 329-333** — prose "After the commit
   completes, clear the continuation flag:" + bash block setting
   `_continue_pending=`. Standalone clear — no co-located instructions.

2. **`skills/flow-complete/SKILL.md` lines 202-207** — prose "After the commit
   completes, clear the continuation flag and record the resume step:" + bash
   block setting `_continue_pending=`. Co-located with `complete_step=4` set
   on lines 209-211 which must be preserved.

3. **`skills/flow-complete/SKILL.md` lines 256-261** — identical pattern to #2.
   Prose "After the commit completes, clear the continuation flag and record
   the resume step:" + bash block. Co-located with `complete_step=4` set on
   lines 263-265 which must be preserved.

4. **`skills/flow-learn/SKILL.md` lines 322-327** — prose "After the commit
   completes, clear the continuation flag and record step completion:" + bash
   block. Co-located with `learn_step=4` set on lines 329-331 which must be
   preserved.

### Reference pattern (flow-code-review after PR #294)

After PR #294, `flow-code-review` has no post-commit clear blocks. It goes
from the commit invocation directly to "Record step completion:" with the
step counter set. This is the target state for all three remaining skills.

### Contract test safety

- `test_code_skill_sets_continue_pending_before_commit` — asserts
  `_continue_pending=commit` (SET) appears before `/flow:flow-commit`. Safe.
- `test_complete_sets_continue_pending_before_commit` — counts
  `_continue_pending=commit` (SET) occurrences, asserts >= 2. Safe.
- `test_learn_sets_continue_pending_before_child_skills` — asserts
  `_continue_pending=commit` (SET) appears before `/flow:flow-commit`. Safe.
- No test asserts the presence of `_continue_pending=` (the clear). All
  removals are safe.

## Risks

- **Prose rewording in co-located blocks**: flow-complete and flow-learn have
  prose that mentions both "clear the continuation flag" AND "record the
  resume step". Must reword to only mention the preserved instruction.
- **Markdown lint**: Removing a bash block between two other bash blocks could
  create adjacent fenced code blocks without separating prose. Must ensure
  MD031 compliance (blank lines around fenced code blocks).
- **Low risk overall**: Pure Markdown removal, no executable code changes, no
  test changes needed.

## Approach

Remove each redundant clear block (prose + bash) and reword co-located prose
to reflect only the remaining instruction. Follow the flow-code-review
reference pattern. No test changes needed — contract tests only check SET
operations.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Remove flow-code clear block | implement | — |
| 2. Remove flow-complete clear blocks (2) | implement | — |
| 3. Remove flow-learn clear block | implement | — |
| 4. Run CI | validate | 1, 2, 3 |

No test tasks needed — these are pure Markdown changes and existing contract
tests validate the SET operations remain. The removals don't add new behavior.

## Tasks

### Task 1 — Remove flow-code clear block

**Files**: `skills/flow-code/SKILL.md`

Remove lines 329-333:

```
After the commit completes, clear the continuation flag:

\```bash
exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=
\```
```

The next line ("To continue to the next task...") follows directly after the
commit message example block.

### Task 2 — Remove flow-complete clear blocks (2 instances)

**Files**: `skills/flow-complete/SKILL.md`

**Instance 1 (lines 202-207)**: Remove the clear prose and bash block. Reword
the introduction from "After the commit completes, clear the continuation flag
and record the resume step:" to "After the commit completes, record the resume
step:". Keep the `complete_step=4` bash block.

**Instance 2 (lines 256-261)**: Same pattern. Remove the clear prose and bash
block. Reword similarly. Keep the `complete_step=4` bash block.

### Task 3 — Remove flow-learn clear block

**Files**: `skills/flow-learn/SKILL.md`

Remove the clear prose and bash block (lines 322-327). Reword from "After the
commit completes, clear the continuation flag and record step completion:" to
"After the commit completes, record step completion:". Keep the `learn_step=4`
bash block.

### Task 4 — Run CI

Run `bin/flow ci` to verify all contract tests pass and no markdown lint
violations were introduced.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Remove redundant _continue_pending clears

```
╔══════════════════════════════════════════════╗
║           DAG IMPACT PREVIEW                 ║
╚══════════════════════════════════════════════╝
Goal: Remove 4 redundant _continue_pending clear blocks from 3 phase skills

Verdict: ⚠️ MARGINAL

Without DAG (vanilla Claude):
  ✗ Might remove clears without verifying the hook actually covers each case
  ✗ Could miss that some clears serve a different purpose than post-hook cleanup
  ✗ Might not check for contract tests that assert the presence of these blocks

With DAG Simulator:
  ✓ Verify hook behavior before touching skills
  ✓ Parallel analysis of all 3 skills catches asymmetries
  ✓ Validation node catches test/contract dependencies

Estimated structure:
  Nodes: ~5  |  Depth: ~3  |  Parallel sets: ~1

  [1] Hook verification ──► [2] flow-code    ──► [5] Synthesis
                         ├──► [3] flow-complete ──►
                         └──► [4] flow-learn    ──►
```

```xml
<dag goal="Remove redundant _continue_pending clears from flow-code, flow-complete, flow-learn" mode="full">
  <plan>
    <node id="1" name="Hook Behavior Verification" type="research"
          depends="[]" parallel_with="[]">
      <objective>Confirm that stop-continue.py atomically clears both _continue_pending and _continue_context after every child skill return, making downstream clears no-ops</objective>
    </node>
    <node id="2" name="Analyze flow-code clear" type="analysis"
          depends="[1]" parallel_with="[3,4]">
      <objective>Locate the 1 redundant clear block in flow-code/SKILL.md, confirm it is post-commit and purely redundant</objective>
    </node>
    <node id="3" name="Analyze flow-complete clears" type="analysis"
          depends="[1]" parallel_with="[2,4]">
      <objective>Locate the 2 redundant clear blocks in flow-complete/SKILL.md, confirm both are post-commit and purely redundant</objective>
    </node>
    <node id="4" name="Analyze flow-learn clear" type="analysis"
          depends="[1]" parallel_with="[2,3]">
      <objective>Locate the 1 redundant clear block in flow-learn/SKILL.md, confirm it is post-commit and purely redundant</objective>
    </node>
    <node id="5" name="Synthesis and Risk Check" type="synthesis"
          depends="[2,3,4]">
      <objective>Merge findings, check for contract test impacts, produce removal plan</objective>
    </node>
  </plan>
</dag>
```

## Node Executions

### NODE 1: Hook Behavior Verification

`lib/stop-continue.py` lines 88-90 in `check_continue()`: when `_continue_pending` is non-empty, both `_continue_pending` and `_continue_context` are cleared atomically before the parent skill resumes. Any explicit clears after a child skill returns are no-ops.

Quality: 9/10 — Direct code evidence confirms the issue description.
Key finding: The hook clears both fields before the parent skill gets control back.

### NODE 2: Analyze flow-code clear (PARALLEL BRANCH A)

`skills/flow-code/SKILL.md` line 332: `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=`
Preceded by prose at line 329: "After the commit completes, clear the continuation flag:"
This is a post-commit clear — the SET happens at line 318 before `/flow:flow-commit`, and the clear at line 332 is after commit returns. Purely redundant.

Quality: 9/10 — Single instance, clearly redundant.

### NODE 3: Analyze flow-complete clears (PARALLEL BRANCH B)

`skills/flow-complete/SKILL.md`:
- Line 206: `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=` (SET at line 196, clear after commit in Step 3)
- Line 260: `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=` (SET at line 251, clear after commit in Step 4)

Both preceded by prose: "After the commit completes, clear the continuation flag and record the resume step:"
Co-located with `set-timestamp --set complete_step=4` commands that must be preserved.

Quality: 9/10 — Two instances, both clearly redundant, but prose needs careful rewording.

### NODE 4: Analyze flow-learn clear (PARALLEL BRANCH C)

`skills/flow-learn/SKILL.md` line 326: `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set _continue_pending=`
SET at line 316 before `/flow:flow-commit`. Clear after commit returns.
Preceded by prose: "After the commit completes, clear the continuation flag and record step completion:"
Co-located with `set-timestamp --set learn_step=4` that must be preserved.

Quality: 9/10 — Single instance, clearly redundant, prose needs rewording.

### MERGE: Parallel branches 2/3/4

All three skills follow the same pattern: SET before commit, redundant CLEAR after commit returns. Contract tests only assert SET operations (`_continue_pending=commit` before `/flow:flow-commit`). Clear lines are not tested. Removing them is safe. Reference: `flow-code-review` (PR #294) already has this fix applied — only SET operations remain, no clears.

## Synthesis

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
4 redundant `_continue_pending` clear blocks across 3 skills:

| Skill | Line | Pattern |
|-------|------|---------|
| flow-code | 332 | Post-commit clear (1 bash block + prose) |
| flow-complete | 206 | Post-commit clear #1 (1 bash block + prose) |
| flow-complete | 260 | Post-commit clear #2 (1 bash block + prose) |
| flow-learn | 326 | Post-commit clear (1 bash block + prose) |

Each clear block = 1 prose line ("After the commit completes, clear...") +
1 bash block (`set-timestamp --set _continue_pending=`). The prose needs
rewording to remove the "clear the continuation flag" instruction while
preserving any co-located instructions (e.g., "record the resume step"
in flow-complete and flow-learn).

Risks: None. Contract tests only check SET operations.
Reference: flow-code-review (PR #294) already has this fix applied.

Confidence: 95%  |  Nodes: 5  |  Parallel branches: 1

vs. Vanilla Claude (what linear reasoning would have missed):
  • Contract test check would have been skipped — could miss count assertions
  • The co-located prose ("clear the flag AND record the step") needs careful
    rewording, not just line deletion — a linear pass might delete too much
  • Reference pattern from flow-code-review confirms the target state
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 4m |
| Code | 6m |
| Code Review | 6m |
| Learn | 1m |
| Complete | 1m |
| **Total** | **21m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/redundant-continue-clears.json</summary>

```json
{
  "schema_version": 1,
  "branch": "redundant-continue-clears",
  "repo": "benkruger/flow",
  "pr_number": 298,
  "pr_url": "https://github.com/benkruger/flow/pull/298",
  "started_at": "2026-03-20T01:50:09-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/redundant-continue-clears-plan.md",
    "dag": ".flow-states/redundant-continue-clears-dag.md",
    "log": ".flow-states/redundant-continue-clears.log",
    "state": ".flow-states/redundant-continue-clears.json"
  },
  "session_id": "00e41ac0-5566-4637-a619-2a3c97722e60",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/00e41ac0-5566-4637-a619-2a3c97722e60.jsonl",
  "notes": [],
  "prompt": "Redundant _continue_pending clears in flow-code, flow-complete, and flow-learn skills #296",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-20T01:50:09-07:00",
      "completed_at": "2026-03-20T01:50:29-07:00",
      "session_started_at": null,
      "cumulative_seconds": 20,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-20T01:50:58-07:00",
      "completed_at": "2026-03-20T01:55:16-07:00",
      "session_started_at": null,
      "cumulative_seconds": 258,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-20T01:55:46-07:00",
      "completed_at": "2026-03-20T02:02:25-07:00",
      "session_started_at": null,
      "cumulative_seconds": 399,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-20T02:03:22-07:00",
      "completed_at": "2026-03-20T02:09:50-07:00",
      "session_started_at": null,
      "cumulative_seconds": 388,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-20T02:10:28-07:00",
      "completed_at": "2026-03-20T02:12:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 97,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-20T02:12:53-07:00",
      "completed_at": "2026-03-20T02:14:31-07:00",
      "session_started_at": null,
      "cumulative_seconds": 98,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-20T01:50:58-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-20T01:55:46-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-20T02:03:22-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-20T02:10:28-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-20T02:12:53-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "never"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "_continue_context": "",
  "_continue_pending": "",
  "code_task": 4,
  "diff_stats": {
    "files_changed": 3,
    "insertions": 3,
    "deletions": 24,
    "captured_at": "2026-03-20T02:02:25-07:00"
  },
  "code_review_step": 3,
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "Remaining redundant _continue_pending clears in flow-code-review and flow-plan",
      "url": "https://github.com/benkruger/flow/issues/301",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-03-20T02:06:41-07:00"
    }
  ],
  "learn_step": 5,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/redundant-continue-clears.log</summary>

```text
2026-03-20T01:50:01-07:00 [Phase 1] git worktree add .worktrees/redundant-continue-clears (exit 0)
2026-03-20T01:50:09-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-20T01:50:09-07:00 [Phase 1] create .flow-states/redundant-continue-clears.json (exit 0)
2026-03-20T01:50:09-07:00 [Phase 1] freeze .flow-states/redundant-continue-clears-phases.json (exit 0)
2026-03-20T01:51:10-07:00 [Phase 2] Step 1 — Fetched issue #296 (exit 0)
2026-03-20T01:55:09-07:00 [Phase 2] Step 3-4 — Plan written, PR body rendered (exit 0)
2026-03-20T01:58:58-07:00 [Phase 3] Tasks 1-4 — All edits + CI green (exit 0)
2026-03-20T02:02:26-07:00 [Phase 3] Done — All tasks complete, CI green (exit 0)
2026-03-20T02:06:57-07:00 [Phase 4] Step 1 — Simplify complete, 1 tech debt issue filed (exit 0)
2026-03-20T02:08:24-07:00 [Phase 4] Step 2 — Review complete, no findings (exit 0)
2026-03-20T02:09:04-07:00 [Phase 4] Step 3 — Security complete, no findings (exit 0)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | Remaining redundant _continue_pending clears in flow-code-review and flow-plan | Code Review | #301 |

<!-- end:Issues Filed -->