### PR TITLE
Complete Summary Issue Links

### DIFF
--- a/lib/format-complete-summary.py
+++ b/lib/format-complete-summary.py
@@ -9,6 +9,7 @@ Output (JSON to stdout):
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -76,6 +77,11 @@ def format_complete_summary(state):
         lines.append("  " + "─" * 28)
         if issues:
             lines.append(f"  Issues filed: {len(issues)}")
+            for issue in issues:
+                url = issue.get("url", "")
+                match = re.search(r"/issues/(\d+)$", url)
+                ref = f"#{match.group(1)}" if match else url
+                lines.append(f"    [{issue['label']}] {ref}: {issue['title']}")
         if notes:
             lines.append(f"  Notes captured: {len(notes)}")
         lines.append("")

--- a/tests/test_format_complete_summary.py
+++ b/tests/test_format_complete_summary.py
@@ -87,6 +87,50 @@ def test_summary_with_issues():
     result = mod.format_complete_summary(state)
 
     assert "Issues filed: 2" in result["summary"]
+    assert "[Rule] #1: Test rule" in result["summary"]
+    assert "[Tech Debt] #2: Refactor X" in result["summary"]
+
+
+def test_summary_with_single_issue():
+    """Summary lists a single issue with label, number, and title."""
+    mod = _import_module()
+    state = _all_complete_state()
+    state["issues_filed"] = [
+        {
+            "label": "Flow",
+            "title": "Fix routing logic",
+            "url": "https://github.com/test/test/issues/42",
+            "phase": "flow-learn",
+            "phase_name": "Learn",
+            "timestamp": "2026-01-01T00:00:00-08:00",
+        },
+    ]
+
+    result = mod.format_complete_summary(state)
+
+    assert "Issues filed: 1" in result["summary"]
+    assert "[Flow] #42: Fix routing logic" in result["summary"]
+
+
+def test_summary_with_issues_url_without_number():
+    """Issues with non-standard URLs fall back to full URL."""
+    mod = _import_module()
+    state = _all_complete_state()
+    state["issues_filed"] = [
+        {
+            "label": "Rule",
+            "title": "Some rule",
+            "url": "https://example.com/custom-path",
+            "phase": "flow-learn",
+            "phase_name": "Learn",
+            "timestamp": "2026-01-01T00:00:00-08:00",
+        },
+    ]
+
+    result = mod.format_complete_summary(state)
+
+    assert "Issues filed: 1" in result["summary"]
+    assert "[Rule] https://example.com/custom-path: Some rule" in result["summary"]
 
 
 def test_summary_with_notes():


### PR DESCRIPTION
## What

List individual issues with links in the Complete phase summary #313.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/complete-summary-issue-links-plan.md` |
| DAG | `.flow-states/complete-summary-issue-links-dag.md` |
| Log | `.flow-states/complete-summary-issue-links.log` |
| State | `.flow-states/complete-summary-issue-links.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/34ee9d5d-8345-4d5f-a3ff-ff5d756906a6.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: List individual issues with links in Complete phase summary

## Context

Issue #313: The `format-complete-summary.py` script renders filed issues as only a count
("Issues filed: 2"). The `issues_filed` array in the state file contains `label`, `title`,
`url`, `phase`, and `phase_name` for each issue. This data should be rendered as individual
lines below the count, matching the format: `    [Rule] #487: Add rule — title here`.

## Exploration

- `lib/format-complete-summary.py` (line 77-78): Currently appends only
  `f"  Issues filed: {len(issues)}"`. No `import re` exists.
- `lib/format-issues-summary.py` (line 47-48): Reference pattern for extracting issue
  numbers: `re.search(r"/issues/(\d+)$", url)`.
- `tests/test_format_complete_summary.py`: `test_summary_with_issues` (line 64) only
  asserts `"Issues filed: 2"` is present. Needs updating to also verify individual lines.
- `tests/conftest.py`: `make_state()` includes `issues_filed: []` — no new fixtures needed.

## Risks

- Changing existing test assertions could mask regressions if not careful — verify both
  count and individual lines.
- URL patterns without `/issues/N` suffix (edge case) — fallback to full URL, matching
  the existing pattern in `format-issues-summary.py`.

## Approach

Add `import re` to `format-complete-summary.py`. After the count line, iterate through
each issue and append a formatted line with label, issue number (extracted from URL),
and title. Follow the exact same extraction pattern used in `format-issues-summary.py`.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write tests for individual issue listing | test | — |
| 2. Implement individual issue listing in format-complete-summary.py | implement | 1 |

## Tasks

### Task 1 — Write tests for individual issue listing

**Files:** `tests/test_format_complete_summary.py`

Update `test_summary_with_issues` to also assert individual issue lines appear in the
summary. Add a new test `test_summary_with_issues_shows_individual_lines` that verifies:
- Each issue appears with `[Label] #N: Title` format
- Issue number is extracted from URL
- Multiple issues each get their own line
- The count line is preserved above the individual listings

Add a test `test_summary_with_issues_url_without_number` for the edge case where the
URL does not match the `/issues/(\d+)$` pattern — should fall back to full URL.

### Task 2 — Implement individual issue listing

**Files:** `lib/format-complete-summary.py`

- Add `import re` to imports
- After `lines.append(f"  Issues filed: {len(issues)}")` (line 78), add a loop:
  - For each issue in `issues`, extract issue number from `url` via
    `re.search(r"/issues/(\d+)$", url)`
  - Append `f"    [{label}] #{number}: {title}"` (4-space indent for sub-items)
  - If URL doesn't match, use the full URL instead of `#N`
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# Pre-Decomposed Analysis: List individual issues with links in the Complete phase summary

## Problem

The `format-complete-summary.py` script (line 86-87) renders filed issues as a count only:

```
  Artifacts
  ────────────────────────────
  Issues filed: 1
```

The `issues_filed` array in the state file contains `label`, `title`, `url`, `phase`, and `phase_name` for each issue, but this data is discarded. The user must check GitHub separately to see what was filed.

## Acceptance Criteria

- [ ] `format-complete-summary.py` lists each issue under the count line with label, issue number, title, and URL
- [ ] Format matches: `    [Rule] #487: Add rule — verify global vs repo .claude/rules/ before editing`
- [ ] Issue number extracted from URL using the same `re.search(r"/issues/(\d+)$", url)` pattern already used in `format-issues-summary.py`
- [ ] `import re` added to the script imports
- [ ] Output renders correctly when 0, 1, or multiple issues are filed
- [ ] Existing count line (`Issues filed: N`) is preserved — individual listings appear below it

## Files to Investigate

- `lib/format-complete-summary.py` — the script to modify (lines 86-87 in the Artifacts section)
- `lib/format-issues-summary.py` — reference for the `#N` extraction pattern (line 47-48)

## Out of Scope

- Changing the `format-issues-summary.py` script or its PR body rendering
- Changing the `flow-complete` skill markdown
- Adding test infrastructure to the plugin
- Changing the `issues_filed` data schema in the state file

## Context

The Complete phase summary is the final output the user sees after a FLOW feature finishes. When issues are filed during Learn or Code Review, the user wants to see exactly what was filed without leaving the terminal. The data is already in the state file — it just needs to be rendered.
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 2m |
| Code | 7m |
| Code Review | 6m |
| Learn | <1m |
| Complete | <1m |
| **Total** | **17m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/complete-summary-issue-links.json</summary>

```json
{
  "schema_version": 1,
  "branch": "complete-summary-issue-links",
  "repo": "benkruger/flow",
  "pr_number": 316,
  "pr_url": "https://github.com/benkruger/flow/pull/316",
  "started_at": "2026-03-20T15:17:34-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/complete-summary-issue-links-plan.md",
    "dag": ".flow-states/complete-summary-issue-links-dag.md",
    "log": ".flow-states/complete-summary-issue-links.log",
    "state": ".flow-states/complete-summary-issue-links.json"
  },
  "session_id": "34ee9d5d-8345-4d5f-a3ff-ff5d756906a6",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/34ee9d5d-8345-4d5f-a3ff-ff5d756906a6.jsonl",
  "notes": [],
  "prompt": "List individual issues with links in the Complete phase summary #313",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-20T15:17:34-07:00",
      "completed_at": "2026-03-20T15:18:06-07:00",
      "session_started_at": null,
      "cumulative_seconds": 32,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-20T15:18:58-07:00",
      "completed_at": "2026-03-20T15:21:02-07:00",
      "session_started_at": null,
      "cumulative_seconds": 124,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-20T15:22:07-07:00",
      "completed_at": "2026-03-20T15:29:10-07:00",
      "session_started_at": null,
      "cumulative_seconds": 423,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-20T15:29:50-07:00",
      "completed_at": "2026-03-20T15:35:55-07:00",
      "session_started_at": null,
      "cumulative_seconds": 365,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-20T15:36:35-07:00",
      "completed_at": "2026-03-20T15:37:30-07:00",
      "session_started_at": null,
      "cumulative_seconds": 55,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-20T15:38:47-07:00",
      "completed_at": "2026-03-20T15:39:44-07:00",
      "session_started_at": null,
      "cumulative_seconds": 57,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-20T15:18:58-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-20T15:22:07-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-20T15:29:50-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-20T15:36:35-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-20T15:38:47-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "never"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "code_task": 2,
  "_continue_context": "",
  "_continue_pending": "",
  "diff_stats": {
    "files_changed": 2,
    "insertions": 50,
    "deletions": 0,
    "captured_at": "2026-03-20T15:29:10-07:00"
  },
  "code_review_step": 3,
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "Extract shared short_issue_ref helper from duplicated URL-to-issue-number pattern",
      "url": "https://github.com/benkruger/flow/issues/319",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-03-20T15:32:00-07:00"
    }
  ],
  "learn_step": 3,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/complete-summary-issue-links.log</summary>

```text
2026-03-20T14:59:27-07:00 [Phase 1] Step 2a — Lock acquired (exit 0)
2026-03-20T14:59:44-07:00 [Phase 1] Step 2b — git pull (exit 0)
2026-03-20T15:01:07-07:00 [Phase 1] Step 2c — CI baseline green (exit 0)
2026-03-20T15:02:22-07:00 [Phase 1] Step 2d — Dependencies updated, docs/index.html modified (exit 0)
2026-03-20T15:14:58-07:00 [Phase 1] Step 2a — Lock acquired (exit 0)
2026-03-20T15:15:19-07:00 [Phase 1] Step 2b — git pull (exit 0)
2026-03-20T15:16:43-07:00 [Phase 1] Step 2c — CI baseline green (exit 0)
2026-03-20T15:17:10-07:00 [Phase 1] Step 2g — Lock released (exit 0)
2026-03-20T15:17:26-07:00 [Phase 1] git worktree add .worktrees/complete-summary-issue-links (exit 0)
2026-03-20T15:17:34-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-20T15:17:34-07:00 [Phase 1] create .flow-states/complete-summary-issue-links.json (exit 0)
2026-03-20T15:17:34-07:00 [Phase 1] freeze .flow-states/complete-summary-issue-links-phases.json (exit 0)
2026-03-20T15:19:11-07:00 [Phase 2] Step 1 — Fetched issue #313 (exit 0)
2026-03-20T15:19:33-07:00 [Phase 2] Step 2 — Pre-decomposed issue detected, DAG saved (exit 0)
2026-03-20T15:20:35-07:00 [Phase 2] Step 4 — Plan written and stored (exit 0)
2026-03-20T15:25:00-07:00 [Phase 3] Task 1 — Tests written and passing (exit 0)
2026-03-20T15:25:07-07:00 [Phase 3] Task 2 — Implementation complete (exit 0)
2026-03-20T15:28:56-07:00 [Phase 3] Final CI sweep — green, 100% coverage (exit 0)
2026-03-20T15:32:31-07:00 [Phase 4] Step 1 — Simplify complete, no in-scope changes, 1 Tech Debt issue filed (exit 0)
2026-03-20T15:34:11-07:00 [Phase 4] Step 2 — Review complete, 0 findings (exit 0)
2026-03-20T15:34:57-07:00 [Phase 4] Step 3 — Security review complete, 0 findings (exit 0)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | Extract shared short_issue_ref helper from duplicated URL-to-issue-number pattern | Code Review | #319 |

<!-- end:Issues Filed -->