### PR TITLE
Add Issue Noop On Main

### DIFF
--- a/lib/add-issue.py
+++ b/lib/add-issue.py
@@ -53,17 +53,14 @@ def main():
 
     if branch is None:
         if candidates:
-            print(json.dumps({
-                "status": "error",
-                "message": "Multiple active features. Pass --branch.",
-                "candidates": candidates,
-            }))
+            print(json.dumps({"status": "no_state"}))
+            sys.exit(0)
         else:
             print(json.dumps({
                 "status": "error",
                 "message": "Could not determine current branch",
             }))
-        sys.exit(1)
+            sys.exit(1)
 
     state_path = root / ".flow-states" / f"{branch}.json"
 

--- a/tests/test_add_issue.py
+++ b/tests/test_add_issue.py
@@ -218,8 +218,8 @@ def test_write_failure_returns_error(state_dir, git_repo):
     assert "Failed to add" in data["message"]
 
 
-def test_error_ambiguous_multiple_state_files(state_dir, git_repo):
-    """Multiple state files with no exact match returns ambiguity error."""
+def test_noop_ambiguous_multiple_state_files(state_dir, git_repo):
+    """Multiple state files with no exact match returns no_state (silent no-op)."""
     for name in ["feat-a", "feat-b"]:
         state = make_state(current_phase="flow-code", phase_statuses={
             "flow-start": "complete", "flow-plan": "complete",
@@ -229,8 +229,6 @@ def test_error_ambiguous_multiple_state_files(state_dir, git_repo):
 
     result = _run("Rule", "test", "https://example.com", "flow-learn", cwd=git_repo)
 
-    assert result.returncode == 1
+    assert result.returncode == 0
     data = json.loads(result.stdout)
-    assert data["status"] == "error"
-    assert "Multiple" in data["message"]
-    assert sorted(data["candidates"]) == ["feat-a", "feat-b"]
+    assert data["status"] == "no_state"


### PR DESCRIPTION
## What

#322.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/add-issue-noop-on-main-plan.md` |
| DAG | `.flow-states/add-issue-noop-on-main-dag.md` |
| Log | `.flow-states/add-issue-noop-on-main.log` |
| State | `.flow-states/add-issue-noop-on-main.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/cef2ccc9-0aa0-4f34-9594-006947c44361.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: Fix add-issue to no-op gracefully when called from main with multiple active flows

## Context

`bin/flow add-issue` exits 1 with "Multiple active features. Pass --branch." when called from main while other flows are active. This blocks `/flow:flow-create-issue` Step 4, which calls `add-issue` unconditionally and expects a silent no-op when no feature is active. With N concurrent flows being the primary use case, multiple state files are the norm.

The fix: when `resolve_branch()` returns `(None, candidates)` (ambiguous — no matching branch), treat it the same as "no state file" — return `{"status": "no_state"}` with exit code 0. The "cannot determine branch at all" case (`(None, [])`) should remain an error.

## Exploration

- `lib/add-issue.py:54-66` — the branch resolution block that needs to change. The `no_state` exit path already exists at lines 70-72 and is the correct model.
- `resolve_branch()` in `flow_utils.py:108-153` — returns `(None, candidates)` when 2+ state files exist and current branch doesn't match any. No changes needed here.
- `tests/test_add_issue.py:221-236` — `test_error_ambiguous_multiple_state_files` currently asserts `returncode == 1` and `status == "error"`. Must be updated to assert `returncode == 0` and `status == "no_state"`.
- `add-notification.py:59-72` — has the exact same bug pattern but is explicitly out of scope per #322.

## Risks

- **Swallowing real errors**: The only risk is conflating "ambiguous" with "not in a git repo". The fix preserves the `(None, [])` error case — that path only fires when `current_branch()` returns None AND no state files exist, meaning we're outside a valid project context.
- **Other callers**: `add-notification.py` has the same pattern but is out of scope. No other callers need changes.

## Approach

Minimal change to `add-issue.py`: when `resolve_branch()` returns `(None, candidates)`, output `{"status": "no_state"}` and exit 0 instead of erroring. Update the existing test to match. This is a 2-line production change and a 4-line test update.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Update test for ambiguous branch resolution | test | — |
| 2. Fix add-issue.py to no-op on ambiguous branch | implement | 1 |

## Tasks

### Task 1: Update test for ambiguous branch resolution

**Files to modify**: `tests/test_add_issue.py`

Update `test_error_ambiguous_multiple_state_files` (line 221):
- Change `assert result.returncode == 1` to `assert result.returncode == 0`
- Change `assert data["status"] == "error"` to `assert data["status"] == "no_state"`
- Remove assertions on `data["message"]` and `data["candidates"]` (no_state has no message or candidates)

**TDD**: Test will fail because the code still returns error+exit(1). Task 2 makes it pass.

### Task 2: Fix add-issue.py to no-op on ambiguous branch

**Files to modify**: `lib/add-issue.py`

Change lines 54-66: when `branch is None` and `candidates` is truthy, output `{"status": "no_state"}` and `sys.exit(0)` instead of the error. Keep the `else` branch (no candidates at all) as an error with `sys.exit(1)`.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# Pre-Decomposed Analysis: Fix add-issue to no-op gracefully when called from main with multiple active flows

## Problem

`bin/flow add-issue` fails with exit code 1 and `"Multiple active features. Pass --branch."` when called from main while other flows are active. This is the primary use case for `/flow:flow-create-issue` — filing issues from main, not from inside a FLOW feature.

The error occurs at `lib/add-issue.py` lines 54-60:

```python
branch, candidates = resolve_branch(args.branch)

if branch is None:
    if candidates:
        print(json.dumps({
            "status": "error",
            "message": "Multiple active features. Pass --branch.",
            "candidates": candidates,
        }))
    else:
        print(json.dumps({
            "status": "error",
            "message": "Could not determine current branch",
        }))
    sys.exit(1)
```

`resolve_branch()` (`lib/flow_utils.py` line 108) returns `(None, candidates)` when the current branch (e.g. `main`) has no matching state file and multiple `.flow-states/*.json` files exist. `add-issue.py` treats this as an error, but it should be a silent no-op — the script already has a `no_state` exit path at lines 70-72 for when the state file doesn't exist.

**Reproduction:**
1. Have 2+ active FLOW features (state files in `.flow-states/`)
2. Be on `main` (not in any feature's worktree)
3. Run `/flow:flow-create-issue` and file an issue
4. Step 4 calls `bin/flow add-issue` → exits 1 with error

## Acceptance Criteria

- [ ] `bin/flow add-issue` returns `{"status": "no_state"}` with exit code 0 when `resolve_branch()` returns `(None, candidates)` (ambiguous, no matching branch)
- [ ] `bin/flow add-issue` continues to return an error when `resolve_branch()` returns `(None, [])` (cannot determine current branch at all — e.g., not in a git repo)
- [ ] Existing behavior unchanged: exact branch match finds the state file, `--branch` override works, single state file auto-resolves
- [ ] `test_error_ambiguous_multiple_state_files` in `tests/test_add_issue.py` updated to assert `no_state` with exit code 0
- [ ] `bin/ci` passes with no new warnings

## Files to Investigate

- `lib/add-issue.py` — lines 52-66, the branch resolution and error handling that needs to change
- `tests/test_add_issue.py` — line 221, `test_error_ambiguous_multiple_state_files` asserts the current (wrong) error behavior
- `lib/flow_utils.py` — line 108, `resolve_branch()` for understanding what `(None, candidates)` means

## Out of Scope

- Changes to `resolve_branch()` in `flow_utils.py` — the function correctly reports ambiguity; the caller should handle it gracefully
- Changes to `flow-create-issue` skill's Step 4 bash block — the skill already documents add-issue as "(no-op if no FLOW feature is active)"; the script just needs to honor that contract
- Filtering `orchestrate.json` from `resolve_branch()` candidates — separate concern
- Changes to other callers of `resolve_branch()` (e.g., `add-notification.py`)

## Context

`/flow:flow-create-issue` is the primary way to file decomposed issues, and it runs from main — not from inside a FLOW feature. The `add-issue` call in Step 4 is intentionally unconditional with the documented expectation that it no-ops when no feature is active. With N concurrent flows being the primary use case, multiple state files are the norm, not the exception. The script must treat "ambiguous branch with no match" the same as "no state file" — both mean there's no applicable feature to record against.
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 4m |
| Code | 6m |
| Code Review | 5m |
| Learn | <1m |
| Complete | <1m |
| **Total** | **18m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/add-issue-noop-on-main.json</summary>

```json
{
  "schema_version": 1,
  "branch": "add-issue-noop-on-main",
  "repo": "benkruger/flow",
  "pr_number": 326,
  "pr_url": "https://github.com/benkruger/flow/pull/326",
  "started_at": "2026-03-20T16:02:23-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/add-issue-noop-on-main-plan.md",
    "dag": ".flow-states/add-issue-noop-on-main-dag.md",
    "log": ".flow-states/add-issue-noop-on-main.log",
    "state": ".flow-states/add-issue-noop-on-main.json"
  },
  "session_id": "cef2ccc9-0aa0-4f34-9594-006947c44361",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/cef2ccc9-0aa0-4f34-9594-006947c44361.jsonl",
  "notes": [],
  "prompt": "#322",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-20T16:02:23-07:00",
      "completed_at": "2026-03-20T16:03:02-07:00",
      "session_started_at": null,
      "cumulative_seconds": 39,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-20T16:04:07-07:00",
      "completed_at": "2026-03-20T16:08:49-07:00",
      "session_started_at": null,
      "cumulative_seconds": 282,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-20T16:09:48-07:00",
      "completed_at": "2026-03-20T16:15:49-07:00",
      "session_started_at": null,
      "cumulative_seconds": 361,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-20T16:16:35-07:00",
      "completed_at": "2026-03-20T16:21:59-07:00",
      "session_started_at": null,
      "cumulative_seconds": 324,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-20T16:22:56-07:00",
      "completed_at": "2026-03-20T16:23:48-07:00",
      "session_started_at": null,
      "cumulative_seconds": 52,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-20T16:24:35-07:00",
      "completed_at": "2026-03-20T16:25:24-07:00",
      "session_started_at": null,
      "cumulative_seconds": 49,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-20T16:04:07-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-20T16:09:48-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-20T16:16:35-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-20T16:22:56-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-20T16:24:35-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "never"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "code_task": 2,
  "_continue_context": "",
  "_continue_pending": "",
  "diff_stats": {
    "files_changed": 2,
    "insertions": 7,
    "deletions": 12,
    "captured_at": "2026-03-20T16:15:49-07:00"
  },
  "code_review_step": 3,
  "learn_step": 3,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/add-issue-noop-on-main.log</summary>

```text
2026-03-20T16:02:15-07:00 [Phase 1] git worktree add .worktrees/add-issue-noop-on-main (exit 0)
2026-03-20T16:02:23-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-20T16:02:23-07:00 [Phase 1] create .flow-states/add-issue-noop-on-main.json (exit 0)
2026-03-20T16:02:23-07:00 [Phase 1] freeze .flow-states/add-issue-noop-on-main-phases.json (exit 0)
2026-03-20T16:02:40-07:00 [Phase 1] Step 4 — label issues #322 (exit 0)
2026-03-20T16:05:11-07:00 [Phase 2] Step 2 — pre-decomposed issue skip (exit 0)
2026-03-20T16:07:50-07:00 [Phase 2] Step 4 — plan written and stored (exit 0)
2026-03-20T16:17:49-07:00 [Phase 4] Step 1 — Simplify: no findings (exit 0)
2026-03-20T16:19:29-07:00 [Phase 4] Step 2 — Review: no findings (exit 0)
2026-03-20T16:21:01-07:00 [Phase 4] Step 3 — Security: no findings (exit 0)
```

</details>