### PR TITLE
Tui Issue Number Reuse

### DIFF
--- a/lib/tui.py
+++ b/lib/tui.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from flow_utils import detect_repo, extract_issue_numbers, project_root, read_version
+from flow_utils import detect_repo, project_root, read_version
 from tui_data import (
     load_all_flows, load_orchestration, orchestration_summary,
     parse_log_entries, phase_timeline,
@@ -308,11 +308,10 @@ class TuiApp:
         if not self.flows:
             return
         flow = self.flows[self.selected]
-        prompt = flow["state"].get("prompt", "")
-        issues = extract_issue_numbers(prompt)
-        if issues:
+        issue_numbers = flow.get("issue_numbers", set())
+        if issue_numbers:
             repo = flow["state"].get("repo")
-            self._open_issue(issues[0], repo=repo)
+            self._open_issue(min(issue_numbers), repo=repo)
 
     def _open_issue(self, issue_number, repo=None):
         """Open a GitHub issue by number in the browser."""


### PR DESCRIPTION
## What

wokr on #351.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/tui-issue-number-reuse-plan.md` |
| DAG | `.flow-states/tui-issue-number-reuse-dag.md` |
| Log | `.flow-states/tui-issue-number-reuse.log` |
| State | `.flow-states/tui-issue-number-reuse.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/503bceea-cacc-47d7-9ea2-1c06d626adaf.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: TUI Issue Number Reuse

## Context

Issue #351: `TuiApp._open_flow_issue()` re-extracts issue numbers from the
raw prompt string instead of using the pre-computed `issue_numbers` set
already available in the flow summary dict. This is redundant — the list
view renderer and `_flow_matches_issue()` already use the summary field.
The fix consolidates all consumers onto the same data source.

## Exploration

### Current data flow

- `tui_data.flow_summary()` (line 47) computes
  `"issue_numbers": set(extract_issue_numbers(state.get("prompt", "")))` —
  a set of ints, stored in the flow summary dict.
- `tui.py:158` — list view renderer reads `flow.get("issue_numbers", set())`
  and displays with `sorted()`.
- `tui.py:476` — `_flow_matches_issue()` uses `in flow.get("issue_numbers", set())`.
- `tui.py:306-315` — `_open_flow_issue()` bypasses the summary and calls
  `extract_issue_numbers(prompt)` directly on `flow["state"]["prompt"]`.

### Import analysis

`extract_issue_numbers` is imported at `tui.py:16`. After removing the call
at line 312, no other usage exists in `tui.py` — the import becomes dead.
The function remains used in `tui_data.py`, `close-issues.py`, `label-issues.py`,
and `flow_utils.py`.

### Test coverage

- `test_i_key_opens_issue` (line 908) — sets prompt to `"fix issue #42"`,
  `_flow_from_state` → `flow_summary()` → `issue_numbers={42}`. Assertion:
  `_open_issue(42, repo="test/test")`. Passes after change since `min({42}) = 42`.
- `test_i_key_no_issue_in_prompt` (line 918) — empty set, `_open_issue` not called.
- `test_open_flow_issue_no_flows` (line 928) — empty flows, early return.

All existing tests pass without modification.

## Risks

- **Set vs list ordering**: Current code uses `issues[0]` (first `#N` in prompt
  order). New code uses `min(issue_numbers)` (lowest number). These differ only
  when a prompt has multiple issues and the first-mentioned has a higher number.
  Trivial edge case with no user-visible impact — both open a valid referenced issue.

## Approach

Pure refactor — replace the direct `extract_issue_numbers` call with a read from
the pre-computed flow summary dict. Remove the now-unused import. No behavior
change, no new tests needed.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Verify test baseline | test | — |
| 2. Refactor _open_flow_issue and remove unused import | implement | 1 |

## Tasks

### Task 1 — Verify test baseline

Run `bin/test tests/test_tui.py` to confirm all existing TUI tests pass before
making changes.

- Files: none (read-only)
- TDD: establishes green baseline

### Task 2 — Refactor _open_flow_issue and remove unused import

Modify `lib/tui.py`:

1. **Line 16**: Remove `extract_issue_numbers` from the `flow_utils` import line.
2. **Lines 306-315**: Rewrite `_open_flow_issue` to:
   - Read `issue_numbers` from the flow summary dict: `flow.get("issue_numbers", set())`
   - Pick the issue deterministically with `min(issue_numbers)`
   - Read repo from `flow["state"].get("repo")` (unchanged)

- Files to modify: `lib/tui.py`
- TDD: Run `bin/ci` — existing tests validate both happy path and empty path
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# DAG Analysis: TUI _open_flow_issue issue number reuse

<dag goal="Refactor TUI _open_flow_issue to use pre-computed issue_numbers from flow summary" mode="full">
  <plan>
    <node id="1" name="Map current data flow" type="research" depends="[]" parallel_with="[]">
      <objective>Read tui.py and tui_data.py to understand how issue_numbers are computed, stored in the flow summary dict, and currently consumed by both the list view renderer and _open_flow_issue</objective>
    </node>
    <node id="2" name="Trace all extract_issue_numbers consumers" type="analysis" depends="[1]" parallel_with="[]">
      <objective>Grep for all usages of extract_issue_numbers across the codebase to determine whether removing the import from tui.py is safe or whether other call sites exist in the same module</objective>
    </node>
    <node id="3" name="Validate flow summary contract" type="validation" depends="[1]" parallel_with="2">
      <objective>Confirm that flow_summary() always populates issue_numbers with the same semantics that _open_flow_issue expects (set of ints, handles empty prompt, handles no matches)</objective>
    </node>
    <node id="4" name="Audit test coverage" type="research" depends="[1]" parallel_with="[2,3]">
      <objective>Read test_tui.py to find existing tests for _open_flow_issue and the list view's issue_numbers usage, identify what new/modified tests are needed</objective>
    </node>
    <node id="5" name="Synthesize plan" type="synthesis" depends="[2,3,4]" parallel_with="[]">
      <objective>Merge findings into a concrete implementation plan: exact code changes, test changes, import cleanup, and risk assessment</objective>
    </node>
  </plan>
</dag>

## Node Executions

### NODE 1: Map current data flow

**tui_data.py:47** — `flow_summary()` computes `"issue_numbers": set(extract_issue_numbers(state.get("prompt", "")))` — a set of ints.

**tui.py:306-315** — `_open_flow_issue()` digs into `flow["state"].get("prompt", "")` and calls `extract_issue_numbers(prompt)` directly, then uses `issues[0]` to pick the first issue.

**tui.py:158** — The list view renderer already reads from `flow.get("issue_numbers", set())` and displays with `sorted()`.

**tui.py:476** — `_flow_matches_issue()` uses `issue_number in flow.get("issue_numbers", set())` for membership testing.

Quality: 9/10 — Complete picture of both the producer and consumer.
Key finding: `_open_flow_issue` digs into `flow["state"]` for the prompt and re-parses it, while the same flow dict already has `flow["issue_numbers"]` pre-computed.

### NODE 2: Trace all extract_issue_numbers consumers

Full grep shows `extract_issue_numbers` is used in: `flow_utils.py` (definition), `tui_data.py` (import + call), `close-issues.py` (import + call), `label-issues.py` (import + call), `tui.py` (import at line 16 + call at line 312).

After removing the call at line 312, the import at line 16 becomes unused and can be removed. No other usage in tui.py.

Quality: 9/10 — Full grep confirms the import is safe to remove.
Key finding: Only one call site in tui.py (line 312); removing it makes the import at line 16 dead.

### NODE 3: Validate flow summary contract

`extract_issue_numbers()` returns a list of ints (deduplicated, order-preserving). `tui_data.flow_summary()` wraps this in `set(...)`, producing a set of ints. `_open_flow_issue` uses `issues[0]` — it picks the first issue from the ordered list. The summary has a set (unordered).

The list view uses `sorted()` for display and `in` for membership testing — both work fine with a set. The `_open_flow_issue` method needs to pick one issue number from the set. Using `min(issue_numbers)` is the deterministic equivalent (lowest issue number = first in sorted order), matching the sorted display.

Quality: 9/10 — The contract difference is clear.
Key finding: Set vs ordered list semantic gap. Using `min()` gives deterministic behavior matching the sorted display.

### NODE 4: Audit test coverage

Tests at lines 908-925 exercise the happy and empty paths via `_handle_list_input` → `_open_flow_issue`. `_flow_from_state` delegates to `flow_summary()`, so tests already use the real summary dict with `issue_numbers` populated.

- `test_i_key_opens_issue` (line 908): sets `state["prompt"] = "fix issue #42"`, `_flow_from_state` → `flow_summary()` → `issue_numbers={42}`. `min({42})` = 42, assertion still passes.
- `test_i_key_no_issue_in_prompt` (line 918): empty set, `_open_issue` not called. Still passes.
- `test_open_flow_issue_no_flows` (line 928): empty flows list, early return. Still passes.

Quality: 9/10 — Complete test audit.
Key finding: Existing tests pass without modification after the refactor.

## Synthesis

### Changes Required

**lib/tui.py:**
1. Line 16 — Remove `extract_issue_numbers` from the import
2. Lines 306-315 — Rewrite `_open_flow_issue` to use `flow.get("issue_numbers", set())` instead of re-extracting from `flow["state"]`. Use `min(issue_numbers)` for deterministic pick.

**tests/test_tui.py:**
No changes needed — existing tests pass as-is.

### Risks
- Ordering difference: current `issues[0]` vs new `min()`. Only differs with multiple issues where first-mentioned has higher number. Edge case with no user-visible impact.

### Scope
- 2 locations changed in `lib/tui.py` (import + method body)
- 0 test changes required
- No new files, no doc changes
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 5m |
| Code | 5m |
| Code Review | 3m |
| Learn | <1m |
| Complete | <1m |
| **Total** | **15m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/tui-issue-number-reuse.json</summary>

```json
{
  "schema_version": 1,
  "branch": "tui-issue-number-reuse",
  "repo": "benkruger/flow",
  "pr_number": 355,
  "pr_url": "https://github.com/benkruger/flow/pull/355",
  "started_at": "2026-03-20T19:05:37-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/tui-issue-number-reuse-plan.md",
    "dag": ".flow-states/tui-issue-number-reuse-dag.md",
    "log": ".flow-states/tui-issue-number-reuse.log",
    "state": ".flow-states/tui-issue-number-reuse.json"
  },
  "session_id": "503bceea-cacc-47d7-9ea2-1c06d626adaf",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/503bceea-cacc-47d7-9ea2-1c06d626adaf.jsonl",
  "notes": [],
  "prompt": "wokr on #351",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-20T19:05:37-07:00",
      "completed_at": "2026-03-20T19:05:56-07:00",
      "session_started_at": null,
      "cumulative_seconds": 19,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-20T19:06:27-07:00",
      "completed_at": "2026-03-20T19:11:46-07:00",
      "session_started_at": null,
      "cumulative_seconds": 319,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-20T19:12:21-07:00",
      "completed_at": "2026-03-20T19:17:28-07:00",
      "session_started_at": null,
      "cumulative_seconds": 307,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-20T19:17:57-07:00",
      "completed_at": "2026-03-20T19:21:25-07:00",
      "session_started_at": null,
      "cumulative_seconds": 208,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-20T19:21:53-07:00",
      "completed_at": "2026-03-20T19:22:25-07:00",
      "session_started_at": null,
      "cumulative_seconds": 32,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-20T19:22:51-07:00",
      "completed_at": "2026-03-20T19:23:31-07:00",
      "session_started_at": null,
      "cumulative_seconds": 40,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-20T19:06:27-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-20T19:12:21-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-20T19:17:57-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-20T19:21:53-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-20T19:22:51-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "never"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "_continue_context": "",
  "_continue_pending": "",
  "code_task": 2,
  "diff_stats": {
    "files_changed": 1,
    "insertions": 4,
    "deletions": 5,
    "captured_at": "2026-03-20T19:17:28-07:00"
  },
  "code_review_step": 3,
  "learn_step": 3,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/tui-issue-number-reuse.log</summary>

```text
2026-03-20T19:05:17-07:00 [Phase 1] Step 2 — prepare main: pull, CI green, deps unchanged, lock released (exit 0)
2026-03-20T19:05:29-07:00 [Phase 1] git worktree add .worktrees/tui-issue-number-reuse (exit 0)
2026-03-20T19:05:37-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-20T19:05:37-07:00 [Phase 1] create .flow-states/tui-issue-number-reuse.json (exit 0)
2026-03-20T19:05:37-07:00 [Phase 1] freeze .flow-states/tui-issue-number-reuse-phases.json (exit 0)
2026-03-20T19:07:18-07:00 [Phase 2] Step 1 — fetch issue #351 (exit 0)
2026-03-20T19:10:16-07:00 [Phase 2] Step 2 — DAG decomposition saved (exit 0)
2026-03-20T19:11:39-07:00 [Phase 2] Step 3-4 — plan written and stored (exit 0)
2026-03-20T19:12:47-07:00 [Phase 3] Task 1 — verify test baseline (exit 0, 102 passed)
2026-03-20T19:14:45-07:00 [Phase 3] Task 2 — refactor _open_flow_issue, remove unused import, CI green (exit 0)
2026-03-20T19:17:29-07:00 [Phase 3] All tasks complete — CI green, 100% coverage (exit 0)
2026-03-20T19:19:08-07:00 [Phase 4] Step 1 — Simplify: no changes needed (exit 0)
2026-03-20T19:20:09-07:00 [Phase 4] Step 2 — Review: no findings (exit 0)
2026-03-20T19:21:01-07:00 [Phase 4] Step 3 — Security: no findings (exit 0)
2026-03-20T19:21:27-07:00 [Phase 4] Done — Code Review complete, 0 findings across all steps (exit 0)
```

</details>