### PR TITLE
Done Banner Clickable Urls

### DIFF
--- a/lib/format-complete-summary.py
+++ b/lib/format-complete-summary.py
@@ -15,7 +15,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from flow_utils import (
-    derive_feature, format_time, read_version, short_issue_ref,
+    derive_feature, format_time, read_version,
     PHASE_NAMES, PHASE_ORDER,
 )
 
@@ -81,8 +81,9 @@ def format_complete_summary(state):
             lines.append(f"  Issues filed: {len(issues)}")
             for issue in issues:
                 url = issue.get("url", "")
-                ref = short_issue_ref(url)
-                lines.append(f"    [{issue['label']}] {ref}: {issue['title']}")
+                lines.append(f"    [{issue['label']}] {issue['title']}")
+                if url:
+                    lines.append(f"    {url}")
         if notes:
             lines.append(f"  Notes captured: {len(notes)}")
         lines.append("")

--- a/tests/test_format_complete_summary.py
+++ b/tests/test_format_complete_summary.py
@@ -87,8 +87,13 @@ def test_summary_with_issues():
     result = mod.format_complete_summary(state)
 
     assert "Issues filed: 2" in result["summary"]
-    assert "[Rule] #1: Test rule" in result["summary"]
-    assert "[Tech Debt] #2: Refactor X" in result["summary"]
+    assert "[Rule] Test rule" in result["summary"]
+    assert "https://github.com/test/test/issues/1" in result["summary"]
+    assert "[Tech Debt] Refactor X" in result["summary"]
+    assert "https://github.com/test/test/issues/2" in result["summary"]
+    # Old #N: format must not appear
+    assert "#1:" not in result["summary"]
+    assert "#2:" not in result["summary"]
 
 
 def test_summary_with_single_issue():
@@ -109,7 +114,10 @@ def test_summary_with_single_issue():
     result = mod.format_complete_summary(state)
 
     assert "Issues filed: 1" in result["summary"]
-    assert "[Flow] #42: Fix routing logic" in result["summary"]
+    assert "[Flow] Fix routing logic" in result["summary"]
+    assert "https://github.com/test/test/issues/42" in result["summary"]
+    # Old #N: format must not appear
+    assert "#42:" not in result["summary"]
 
 
 def test_summary_with_issues_url_without_number():
@@ -130,7 +138,10 @@ def test_summary_with_issues_url_without_number():
     result = mod.format_complete_summary(state)
 
     assert "Issues filed: 1" in result["summary"]
-    assert "[Rule] https://example.com/custom-path: Some rule" in result["summary"]
+    assert "[Rule] Some rule" in result["summary"]
+    assert "https://example.com/custom-path" in result["summary"]
+    # Old colon-joined format must not appear
+    assert "https://example.com/custom-path: Some rule" not in result["summary"]
 
 
 def test_summary_with_notes():


### PR DESCRIPTION
## What

work on issue #368.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/done-banner-clickable-urls-plan.md` |
| DAG | `.flow-states/done-banner-clickable-urls-dag.md` |
| Log | `.flow-states/done-banner-clickable-urls.log` |
| State | `.flow-states/done-banner-clickable-urls.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/1f42b477-7516-407d-80f8-77d3382bef91.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Plan: Done Banner Clickable Issue URLs

## Context

Issue #368: The Complete phase Done banner renders filed issues with
`short_issue_ref()` which strips `https://github.com/.../issues/N` to
`#N`. In a terminal `text` code block, `#N` is not clickable. Terminal
emulators auto-detect full URLs — rendering the full URL makes issues
clickable.

## Exploration

- `lib/format-complete-summary.py` lines 82-85: the issue loop calls
  `short_issue_ref(url)` and renders `[label] #N: title` on one line.
- `short_issue_ref` is imported on line 18. Only usage in this file is
  line 84 — safe to remove from the import.
- `short_issue_ref` is still used by `lib/format-issues-summary.py`
  (PR body rendering where GitHub auto-links `#N`) — must NOT be removed
  from `flow_utils.py`.
- Tests in `test_format_complete_summary.py`:
  - `test_summary_with_issues` (line 90-91): asserts `[Rule] #1: Test rule`
    and `[Tech Debt] #2: Refactor X`
  - `test_summary_with_single_issue` (line 112): asserts
    `[Flow] #42: Fix routing logic`
  - `test_summary_with_issues_url_without_number` (line 133): asserts
    `[Rule] https://example.com/custom-path: Some rule`

## Risks

- The non-standard URL test (`test_summary_with_issues_url_without_number`)
  currently falls back to full URL as the ref. The new format puts the URL
  on its own line, so the assertion format changes but the URL still appears.
- No other consumers of `format_complete_summary()` beyond the CLI entry
  point — safe to change the output format.

## Approach

Change the issue rendering from:

```text
    [Tech Debt] #366: Extract shared write+chmod pattern...
```

To:

```text
    [Tech Debt] Extract shared write+chmod pattern...
    https://github.com/benkruger/flow/issues/366
```

Remove `short_issue_ref` from the import since no other usage in the file.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Update tests for new issue rendering format | test | — |
| 2. Modify format-complete-summary.py | implement | 1 |

## Tasks

### Task 1: Update tests for new issue rendering format

**Files:** `tests/test_format_complete_summary.py`

Update three test functions to assert the new two-line format:

- `test_summary_with_issues`: assert `[Rule] Test rule` and full URL
  `https://github.com/test/test/issues/1` on separate lines; assert
  `[Tech Debt] Refactor X` and URL `/issues/2` similarly. Assert old
  `#1:` and `#2:` patterns are absent.
- `test_summary_with_single_issue`: assert `[Flow] Fix routing logic`
  and full URL `/issues/42`. Assert old `#42:` pattern is absent.
- `test_summary_with_issues_url_without_number`: assert
  `[Rule] Some rule` on one line and
  `https://example.com/custom-path` on the next. Assert old
  `https://example.com/custom-path: Some rule` (colon-joined) pattern
  is absent.

TDD: tests will fail until Task 2 modifies the implementation.

### Task 2: Modify format-complete-summary.py

**Files:** `lib/format-complete-summary.py`

- Remove `short_issue_ref` from the import on line 18.
- Replace lines 83-85 (the issue loop body) to render:
  - `f"    [{issue['label']}] {issue['title']}"` on one line
  - `f"    {url}"` on the next line (the full URL)
- No changes to `format_time`, borders, or any other section.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# Pre-Decomposed Analysis: Complete phase Done banner clickable issue URLs

## Problem

The Complete phase Done banner (`format-complete-summary.py`) renders filed issues with `short_issue_ref()` which strips the full GitHub URL to just `#N`. In a terminal, `#366` is not clickable — users cannot navigate to the issue without manually constructing the URL.

Current rendering (line 84-85 of `lib/format-complete-summary.py`):

```python
ref = short_issue_ref(url)  # "https://github.com/.../issues/366" → "#366"
lines.append(f"    [{issue['label']}] {ref}: {issue['title']}")
```

Produces:

```text
  Issues filed: 1
    [Tech Debt] #366: Extract shared write+chmod pattern...
```

The full URL is available in `issues_filed[].url` in the state file and is passed to `format_complete_summary()`, but `short_issue_ref()` discards it.

The banner renders inside a `text` fenced code block, so markdown links don't apply. Terminal emulators (iTerm2, Terminal.app) auto-detect full URLs and make them clickable — but only if the full URL appears in the output.

## Approach

Replace the `short_issue_ref(url)` call with the raw URL on a separate line below the title. This keeps the title readable and puts the URL where terminal emulators can detect it:

```text
  Issues filed: 1
    [Tech Debt] Extract shared write+chmod pattern from install_pre_commit_hook and install_launcher
    https://github.com/benkruger/flow/issues/366
```

## Acceptance Criteria

- [ ] `format_complete_summary()` renders each issue's full URL on its own indented line below the title
- [ ] `format_complete_summary()` no longer calls `short_issue_ref()` (remove the import if no other usage in this file)
- [ ] Tests in `test_format_complete_summary.py` assert the full URL appears in the summary
- [ ] Tests assert the old `#N: title` format is no longer produced
- [ ] `short_issue_ref()` in `flow_utils.py` is NOT removed — it is still used correctly by `format-issues-summary.py` for GitHub markdown where `#N` auto-links
- [ ] `bin/ci` passes with no new warnings

## Files to Investigate

- `lib/format-complete-summary.py` — lines 82-85, the issue rendering loop that calls `short_issue_ref()`. The import on line 18 may need `short_issue_ref` removed.
- `tests/test_format_complete_summary.py` — lines 89-91 (`test_summary_with_issues`), line 112 (`test_summary_with_single_issue`), and line 133 (`test_summary_with_issues_url_without_number`) all assert the `#N: title` format and need updating.
- `lib/flow_utils.py` — `short_issue_ref()` on line 204. Do NOT modify — still used by `format-issues-summary.py`.

## Out of Scope

- Do not modify `format-issues-summary.py` — it renders for the GitHub PR body where `#N` auto-links correctly
- Do not modify `short_issue_ref()` in `flow_utils.py` — it has other consumers
- Do not change the PR URL rendering on line 65 — it already shows the full URL
- Do not change the banner structure or borders

## Context

The Done banner is the final output users see after a FLOW feature completes. It renders inside a `text` code block in the terminal. Terminal emulators auto-detect URLs starting with `https://` and make them clickable, but they cannot detect bare `#N` patterns as links. By rendering the full URL, users can click through to filed issues directly from the completion summary.
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 1m |
| Code | 3m |
| Code Review | 2m |
| Learn | <1m |
| Complete | <1m |
| **Total** | **8m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/done-banner-clickable-urls.json</summary>

```json
{
  "schema_version": 1,
  "branch": "done-banner-clickable-urls",
  "repo": "benkruger/flow",
  "pr_number": 374,
  "pr_url": "https://github.com/benkruger/flow/pull/374",
  "started_at": "2026-03-21T01:46:21-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/done-banner-clickable-urls-plan.md",
    "dag": ".flow-states/done-banner-clickable-urls-dag.md",
    "log": ".flow-states/done-banner-clickable-urls.log",
    "state": ".flow-states/done-banner-clickable-urls.json"
  },
  "session_id": "1f42b477-7516-407d-80f8-77d3382bef91",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/1f42b477-7516-407d-80f8-77d3382bef91.jsonl",
  "notes": [],
  "prompt": "work on issue #368",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-21T01:46:21-07:00",
      "completed_at": "2026-03-21T01:46:37-07:00",
      "session_started_at": null,
      "cumulative_seconds": 16,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-21T01:47:07-07:00",
      "completed_at": "2026-03-21T01:48:45-07:00",
      "session_started_at": null,
      "cumulative_seconds": 98,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-21T01:49:28-07:00",
      "completed_at": "2026-03-21T01:52:48-07:00",
      "session_started_at": null,
      "cumulative_seconds": 200,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-21T01:53:14-07:00",
      "completed_at": "2026-03-21T01:55:19-07:00",
      "session_started_at": null,
      "cumulative_seconds": 125,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-21T01:55:47-07:00",
      "completed_at": "2026-03-21T01:56:24-07:00",
      "session_started_at": null,
      "cumulative_seconds": 37,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-21T01:56:53-07:00",
      "completed_at": "2026-03-21T01:57:36-07:00",
      "session_started_at": null,
      "cumulative_seconds": 43,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-21T01:47:07-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-21T01:49:28-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-21T01:53:14-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-21T01:55:47-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-21T01:56:53-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "never"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "code_task": 2,
  "_continue_context": "",
  "_continue_pending": "",
  "diff_stats": {
    "files_changed": 2,
    "insertions": 19,
    "deletions": 7,
    "captured_at": "2026-03-21T01:52:48-07:00"
  },
  "code_review_step": 3,
  "learn_step": 3,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/done-banner-clickable-urls.log</summary>

```text
2026-03-21T01:46:04-07:00 [Phase 1] Step 2 — prepare main: pull, CI, deps (exit 0)
2026-03-21T01:46:14-07:00 [Phase 1] git worktree add .worktrees/done-banner-clickable-urls (exit 0)
2026-03-21T01:46:21-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-21T01:46:21-07:00 [Phase 1] create .flow-states/done-banner-clickable-urls.json (exit 0)
2026-03-21T01:46:21-07:00 [Phase 1] freeze .flow-states/done-banner-clickable-urls-phases.json (exit 0)
2026-03-21T01:47:35-07:00 [Phase 2] Step 1-2 — issue fetch + pre-decomposed DAG saved (exit 0)
2026-03-21T01:48:32-07:00 [Phase 2] Step 3-4 — explore + plan written (exit 0)
2026-03-21T01:51:16-07:00 [Phase 3] Tasks 1-2 — tests + implementation, CI green (exit 0)
2026-03-21T01:52:50-07:00 [Phase 3] Code complete — 2 tasks, CI green, 100% coverage (exit 0)
2026-03-21T01:53:51-07:00 [Phase 4] Step 1 — Simplify: no findings (exit 0)
2026-03-21T01:54:38-07:00 [Phase 4] Step 2 — Review: no findings (exit 0)
2026-03-21T01:55:11-07:00 [Phase 4] Step 3 — Security: no findings (exit 0)
```

</details>