### PR TITLE
Prime Setup Redundant Permissions

### DIFF
--- a/lib/prime-setup.py
+++ b/lib/prime-setup.py
@@ -14,6 +14,7 @@ Output (JSON to stdout):
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -182,16 +183,16 @@ def _is_subsumed(candidate, existing_set):
     (e.g. Bash(git *)) matches the candidate's concrete form (e.g. git add X).
     Only checks same-type entries (Bash vs Bash, not Agent vs Bash).
     """
-    import re as _re
-    match = _re.match(r"(\w+)\((.+)\)", candidate)
-    if not match:
+    cand_match = re.match(r"(\w+)\((.+)\)", candidate)
+    if not cand_match:
         return False
-    cand_type, cand_inner = match.group(1), match.group(2)
+    cand_type, cand_inner = cand_match.group(1), cand_match.group(2)
+    # Replace wildcards with literal text so regex tests structural coverage
     test_string = cand_inner.replace("*", "XXXPLACEHOLDERXXX")
     for existing in existing_set:
         if existing == candidate:
             continue
-        ex_match = _re.match(r"(\w+)\(", existing)
+        ex_match = re.match(r"(\w+)\(", existing)
         if not ex_match or ex_match.group(1) != cand_type:
             continue
         regex = permission_to_regex(existing)

--- a/tests/test_prime_setup.py
+++ b/tests/test_prime_setup.py
@@ -162,6 +162,13 @@ def test_settings_no_duplicate_entries(tmp_path):
     assert len(deny_list) == len(set(deny_list))
 
 
+def _write_settings(tmp_path, settings):
+    """Write a settings.json file with the given content."""
+    settings_dir = tmp_path / ".claude"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "settings.json").write_text(json.dumps(settings))
+
+
 # --- Pattern subsumption (in-process) ---
 
 
@@ -244,13 +251,6 @@ def test_is_subsumed_skips_exact_match():
     """Exact match is handled by set membership, not subsumption."""
     # Entry present in both candidate and existing — skip self-comparison
     assert not _mod._is_subsumed("Bash(git add *)", {"Bash(git add *)"})
-
-
-def _write_settings(tmp_path, settings):
-    """Write a settings.json file with the given content."""
-    settings_dir = tmp_path / ".claude"
-    settings_dir.mkdir(parents=True, exist_ok=True)
-    (settings_dir / "settings.json").write_text(json.dumps(settings))
 
 
 # --- Version marker (in-process) ---


### PR DESCRIPTION
## What

work on issue #386.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/prime-setup-redundant-plan.md` |
| DAG | `.flow-states/prime-setup-redundant-dag.md` |
| Log | `.flow-states/prime-setup-redundant.log` |
| State | `.flow-states/prime-setup-redundant.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/d0b0e3a8-27fb-4606-9429-d6b67bb27f81.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Plan: Prime Setup Redundant Permissions

## Context

Issue #386: `prime-setup.py` appends redundant permission entries to
`.claude/settings.json` when the target project already has broader glob
patterns that subsume the specific FLOW entries. For example, if a project
has `Bash(git *)`, prime-setup still appends `Bash(git add *)`,
`Bash(git commit *)`, etc. because the dedup logic uses exact string
matching.

This causes:
- CI failures in repos with consolidated patterns (ordering tests break)
- Settings bloat in target projects
- Manual cleanup needed after each prime run

## Exploration

### merge_settings() — lib/prime-setup.py:178-228

The merge loop at lines 196-200:

```python
existing_allow = set(settings["permissions"]["allow"])
for entry in _allow_list(framework):
    if entry not in existing_allow:
        settings["permissions"]["allow"].append(entry)
```

Uses `set.__contains__` — pure exact string matching. No pattern awareness.

### permission_to_regex() — lib/flow_utils.py:267-281

Already exists and converts `Bash(pattern)` entries to compiled regexes:
- `Bash(git *)` → `^git .*$`
- `Bash(git add *)` → `^git add .*$`
- Returns `None` for non-Bash entries (`Agent(...)`, `Read(...)`, etc.)

This is the same function used at runtime validation in
`validate-ci-bash.py`. Reusing it for subsumption ensures identical
semantics — if a command would be allowed at runtime by an existing
pattern, the specific permission is truly redundant.

### Derived permissions — lib/prime-setup.py:202-206

The derived permissions loop (iOS-specific, from glob detection) has the
same exact-match dedup issue at line 204. Must be updated too.

### Existing tests — tests/test_prime_setup.py

- `test_settings_no_duplicate_entries` (line 154): Calls merge twice,
  asserts no exact duplicates. Won't break — subsumption is a superset.
- `test_merge_settings_empty_project_*` (lines 246, 254): Assert all
  UNIVERSAL_ALLOW entries appear. Won't break — empty project has no
  broad patterns to subsume.
- `test_derived_permissions_no_duplicates` (line 687): Tests iOS derived
  perms aren't duplicated. Won't break.

### Source-of-truth sync — tests/test_permissions.py

`test_permissions.py` line 1067 checks that `UNIVERSAL_ALLOW` matches
the prime skill's JSON block. This is unaffected — we're not changing
`UNIVERSAL_ALLOW`, only the merge logic.

## Risks

1. **False subsumption across types**: `Agent(*)` must not subsume
   `Bash(git *)`. Mitigated by `permission_to_regex()` returning `None`
   for non-Bash entries, plus explicit type matching in the helper.

2. **Bidirectional subsumption**: If FLOW wants to add `Bash(git *)` and
   the project has only `Bash(git add *)`, the broad pattern must NOT be
   skipped. The check is directional: only skip the candidate if an
   existing entry subsumes it.

3. **Self-subsumption**: `Bash(git add *)` subsumes itself via regex.
   Not a problem — exact matches are already handled by `set.__contains__`
   before the subsumption check runs.

4. **Placeholder string choice**: The `*` replacement must not accidentally
   match or fail to match. Using a long distinctive string like
   `XXXPLACEHOLDERXXX` avoids collisions.

## Approach

Add a `_is_subsumed()` helper function to `lib/prime-setup.py` that reuses
`permission_to_regex()` from `flow_utils.py`. Integrate it into
`merge_settings()` with one additional condition in the merge loop.

The helper:
1. Extracts the permission type prefix (e.g., `Bash`, `Agent`, `Read`)
2. For each existing entry of the same type, converts it to a regex
3. Tests if the candidate (with `*` replaced by a placeholder) matches
4. Returns `True` if any existing entry subsumes the candidate

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write subsumption tests | test | — |
| 2. Implement `_is_subsumed()` and integrate | implement | 1 |

## Tasks

### Task 1: Write subsumption tests

**File**: `tests/test_prime_setup.py`

Add tests for the new subsumption behavior:

- `test_broad_pattern_subsumes_narrow`: Project has `Bash(git *)`, merge
  should NOT append `Bash(git add *)`, `Bash(git commit *)`, etc.
- `test_broad_gh_pattern_subsumes_narrow`: Project has `Bash(gh pr *)`,
  merge should NOT append `Bash(gh pr create *)`, etc.
- `test_narrow_does_not_subsume_broad`: Project has `Bash(git add *)`,
  merge SHOULD still append `Bash(git *)` (bidirectional correctness).
- `test_cross_type_no_subsumption`: Project has `Agent(*)`, merge should
  still append `Bash(git add *)` (type scoping).
- `test_non_wildcard_no_subsumption`: Project has `Bash(git status)`,
  merge should still append `Bash(git add *)` (no false positives).
- `test_derived_permissions_subsumed`: If project has a broad pattern
  that subsumes a derived permission, it should be skipped.

**TDD notes**: Tests call `merge_settings()` with pre-populated
`settings.json` containing broad patterns, then assert that subsumed
entries are absent and non-subsumed entries are present.

### Task 2: Implement `_is_subsumed()` and integrate into merge loop

**File**: `lib/prime-setup.py`

1. Import `permission_to_regex` from `flow_utils`
2. Add `_is_subsumed(candidate, existing_set)` helper:
   - Extract type prefix via regex `(\w+)\((.+)\)`
   - Replace `*` with `XXXPLACEHOLDERXXX` in candidate inner pattern
   - For each existing entry of same type, check if its
     `permission_to_regex()` result matches the candidate's concrete form
   - Return `True` if any match found
3. Modify merge loop (line 199): change
   `if entry not in existing_allow` to
   `if entry not in existing_allow and not _is_subsumed(entry, existing_allow)`
4. Apply same change to derived permissions loop (line 204)
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: prime-setup redundant permissions subsumption

```xml
<dag goal="Fix prime-setup.py pattern subsumption so broad globs like Bash(git *) prevent appending subsumed entries like Bash(git add *)" mode="full">
  <plan>
    <node id="1" name="Map current merge logic" type="research" depends="[]" parallel_with="2">
      <objective>Document the exact code path in merge_settings() that causes redundant appends, including UNIVERSAL_ALLOW contents and the set-based dedup</objective>
    </node>
    <node id="2" name="Define subsumption semantics" type="analysis" depends="[]" parallel_with="1">
      <objective>Define what "pattern A subsumes pattern B" means for Bash(...) permission entries, considering the existing permission_to_regex() function</objective>
    </node>
    <node id="3" name="Identify edge cases" type="analysis" depends="[1,2]" parallel_with="4">
      <objective>Enumerate edge cases: non-Bash entries, deny-list entries, entries without wildcards, Agent() entries, entries with special characters</objective>
    </node>
    <node id="4" name="Assess test impact" type="research" depends="[1]" parallel_with="3">
      <objective>Identify which existing tests will break, need updating, or serve as regression anchors for this change</objective>
    </node>
    <node id="5" name="Design subsumption check" type="decision" depends="[2,3]" parallel_with="">
      <objective>Choose the algorithm: reuse permission_to_regex() to test if existing patterns match new entries, or implement separate glob matching</objective>
    </node>
    <node id="6" name="Synthesize implementation plan" type="synthesis" depends="[4,5]" parallel_with="">
      <objective>Produce the final task list with TDD ordering, files to modify, and dependency graph</objective>
    </node>
  </plan>
</dag>
```

## Node 1: Map current merge logic

The `merge_settings()` function in `lib/prime-setup.py` (lines ~178-228):

1. Loads existing `.claude/settings.json` or creates a new one
2. Builds `existing_allow = set(settings["permissions"]["allow"])` — a set of exact strings
3. Iterates `_allow_list(framework)` which combines `UNIVERSAL_ALLOW` + framework-specific entries
4. For each entry: `if entry not in existing_allow` — pure string membership test
5. If not present, appends to the allow list

`UNIVERSAL_ALLOW` (lines 33-77) contains ~40+ specific entries including:
- `Bash(git add *)`, `Bash(git blame *)`, `Bash(git commit *)`, etc.
- `Bash(gh pr create *)`, `Bash(gh pr edit *)`, etc.
- `Bash(bin/ci)`, `Bash(bin/test *)`, etc.

When a target project already has `Bash(git *)`, the set contains that broad pattern. But `"Bash(git add *)" not in {"Bash(git *)"}` is `True`, so every specific git entry gets appended — 29+ redundant entries landing after the agents category, breaking ordering tests.

Quality: 9/10 — Complete trace of the bug path.
Key finding: The dedup is a flat `set.__contains__` with no pattern awareness.

## Node 2: Define subsumption semantics

Pattern A subsumes pattern B when every command that matches B also matches A. Using the existing `permission_to_regex()`:

- `Bash(git *)` → regex `^git .*$` → matches `git add foo`, `git commit -m bar`, etc.
- `Bash(git add *)` → regex `^git add .*$` → matches only `git add foo`

So `Bash(git *)` subsumes `Bash(git add *)` because the regex from `git *` matches the canonical form of `git add *`.

The subsumption test: extract the inner pattern from the candidate, replace `*` with a concrete placeholder string, and check if any existing entry's regex matches it. If yes, the existing entry subsumes the candidate.

Quality: 8/10 — Solid semantic definition with a concrete algorithm.
Key finding: Subsumption can be checked by converting existing patterns to regexes and testing whether they match the candidate's concrete form.

## Node 3: Identify edge cases

1. **Non-Bash entries**: `Agent(flow:ci-fixer)`, `Read(...)`, `Edit(...)` — subsumption should only apply within the same permission type.
2. **Exact match (no wildcard)**: `Bash(bin/ci)` vs `Bash(bin/ci)` — already handled by exact dedup.
3. **Deny-list entries**: Separate `deny` array. Subsumption only applies to `allow`.
4. **Bidirectional check**: If FLOW wants to add `Bash(git *)` and the project has `Bash(git add *)`, the broad pattern must NOT be skipped. Subsumption is directional: only skip the candidate if an existing entry subsumes it.
5. **Partial overlap**: `Bash(gh pr *)` and `Bash(gh issue *)` — neither subsumes the other.
6. **Same-prefix different flags**: `Bash(git -C *)` and `Bash(git *)` — `git *` subsumes `git -C *`.
7. **Special regex chars**: `Bash(bin/ci;*)` — handled by `re.escape()` in `permission_to_regex()`.

Quality: 9/10 — Comprehensive edge case enumeration.
Key finding: Subsumption must be directional (existing subsumes candidate) and type-scoped (only same type).

## Node 4: Assess test impact

- `test_settings_no_duplicate_entries` — won't break; subsumption is a superset of exact dedup
- `test_settings_merge_preserves_existing` — won't break; we only skip additions
- `test_settings_allow_list_ordered_by_category` — this test currently fails when redundant entries are appended; the fix resolves it
- New tests needed: subsumption-specific cases

Quality: 8/10 — Clear test impact assessment.
Key finding: The ordering test breaks are resolved naturally by preventing redundant appends.

## Node 5: Design subsumption check

Algorithm: Reuse `permission_to_regex()` from `flow_utils.py`.

Helper function `_is_subsumed(candidate, existing_set)`:
1. Extract permission type and inner pattern from candidate
2. Replace `*` with a concrete placeholder
3. For each existing entry of the same type, check if its regex matches the candidate's concrete form
4. Return True if any existing entry subsumes the candidate

Integration: Add `and not _is_subsumed(entry, existing_allow)` to the merge loop condition.

Quality: 9/10 — Minimal change, reuses existing infrastructure.
Key finding: One helper function + one-line integration.

## Synthesis

Implementation approach:
1. Add `_is_subsumed()` helper to `lib/prime-setup.py` reusing `permission_to_regex()` from `flow_utils.py`
2. Integrate into `merge_settings()` merge loop with one additional condition
3. Subsumption is directional (existing→candidate) and type-scoped
4. Tests: subsumption cases (broad subsumes narrow, cross-type no subsumption, bidirectional correctness)

Files to modify:
- `lib/prime-setup.py` — add `_is_subsumed()`, modify merge loop
- `tests/test_prime_setup.py` — add subsumption test cases
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 5m |
| Code | 6m |
| Code Review | 16m |
| Learn | 1m |
| Complete | 1m |
| **Total** | **31m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/prime-setup-redundant.json</summary>

```json
{
  "schema_version": 1,
  "branch": "prime-setup-redundant",
  "repo": "benkruger/flow",
  "pr_number": 389,
  "pr_url": "https://github.com/benkruger/flow/pull/389",
  "started_at": "2026-03-21T04:33:32-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/prime-setup-redundant-plan.md",
    "dag": ".flow-states/prime-setup-redundant-dag.md",
    "log": ".flow-states/prime-setup-redundant.log",
    "state": ".flow-states/prime-setup-redundant.json"
  },
  "session_id": "d0b0e3a8-27fb-4606-9429-d6b67bb27f81",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/d0b0e3a8-27fb-4606-9429-d6b67bb27f81.jsonl",
  "notes": [],
  "prompt": "work on issue #386",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-21T04:33:32-07:00",
      "completed_at": "2026-03-21T04:33:47-07:00",
      "session_started_at": null,
      "cumulative_seconds": 15,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-21T04:34:05-07:00",
      "completed_at": "2026-03-21T04:39:27-07:00",
      "session_started_at": null,
      "cumulative_seconds": 322,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-21T04:40:20-07:00",
      "completed_at": "2026-03-21T04:46:46-07:00",
      "session_started_at": null,
      "cumulative_seconds": 386,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-21T04:47:17-07:00",
      "completed_at": "2026-03-21T05:04:14-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1017,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-21T05:04:54-07:00",
      "completed_at": "2026-03-21T05:05:57-07:00",
      "session_started_at": null,
      "cumulative_seconds": 63,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-21T05:06:45-07:00",
      "completed_at": "2026-03-21T05:07:45-07:00",
      "session_started_at": null,
      "cumulative_seconds": 60,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-21T04:34:05-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-21T04:40:20-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-21T04:47:17-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-21T05:04:54-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-21T05:06:45-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "always"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "_continue_context": "",
  "_continue_pending": "",
  "code_task": 2,
  "diff_stats": {
    "files_changed": 2,
    "insertions": 120,
    "deletions": 4,
    "captured_at": "2026-03-21T04:46:46-07:00"
  },
  "code_review_step": 4,
  "learn_step": 4,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/prime-setup-redundant.log</summary>

```text
2026-03-21T04:33:25-07:00 [Phase 1] git worktree add .worktrees/prime-setup-redundant (exit 0)
2026-03-21T04:33:32-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-21T04:33:32-07:00 [Phase 1] create .flow-states/prime-setup-redundant.json (exit 0)
2026-03-21T04:33:32-07:00 [Phase 1] freeze .flow-states/prime-setup-redundant-phases.json (exit 0)
2026-03-21T04:34:14-07:00 [Phase 2] Step 1 — fetched issue #386 (exit 0)
2026-03-21T04:39:23-07:00 [Phase 2] Step 3-4 — plan written and stored (exit 0)
2026-03-21T04:42:35-07:00 [stop-continue] TAB ERROR: [Errno 6] Device not configured: '/dev/tty'
2026-03-21T04:43:52-07:00 [stop-continue] TAB ERROR: [Errno 6] Device not configured: '/dev/tty'
2026-03-21T04:44:25-07:00 [Phase 3] Tasks 1-2 — subsumption tests + implementation, CI green (exit 0)
2026-03-21T04:46:29-07:00 [stop-continue] TAB ERROR: [Errno 6] Device not configured: '/dev/tty'
2026-03-21T04:46:47-07:00 [Phase 3] Complete — all tasks done, CI green, 100% coverage (exit 0)
2026-03-21T04:52:03-07:00 [stop-continue] TAB ERROR: [Errno 6] Device not configured: '/dev/tty'
2026-03-21T04:53:48-07:00 [stop-continue] TAB ERROR: [Errno 6] Device not configured: '/dev/tty'
2026-03-21T04:55:51-07:00 [Phase 4] Step 1 — Simplify complete, committed de4e3d8 (exit 0)
2026-03-21T04:57:51-07:00 [Phase 4] Step 2 — Review complete, no findings (exit 0)
2026-03-21T04:59:12-07:00 [Phase 4] Step 3 — Security complete, no findings (exit 0)
2026-03-21T05:04:02-07:00 [Phase 4] Step 4 — Code Review Plugin complete, no findings (exit 0)
```

</details>