### PR TITLE
Tui Open Pr Changes Url

### DIFF
--- a/lib/tui.py
+++ b/lib/tui.py
@@ -393,7 +393,7 @@ class TuiApp:
         pr_url = flow.get("pr_url")
         if pr_url:
             subprocess.Popen(
-                ["open", str(pr_url)],
+                ["open", f"{pr_url.rstrip('/')}/files"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -613,6 +613,7 @@ def test_open_pr():
         args = mock_popen.call_args[0][0]
         assert args[0] == "open"
         assert "github.com" in args[1]
+        assert args[1].endswith("/files")
 
 
 def test_open_pr_no_url():


### PR DESCRIPTION
## What

work on issue #453.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/tui-open-pr-changes-url-plan.md` |
| DAG | `.flow-states/tui-open-pr-changes-url-dag.md` |
| Log | `.flow-states/tui-open-pr-changes-url.log` |
| State | `.flow-states/tui-open-pr-changes-url.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/adf6d9ef-8d3b-47b6-9d47-013a51a566e3.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: TUI Open PR on Changes URL

## Context

Issue #453: When pressing 'p' in the TUI, the browser opens the PR's main
page (`/pull/N`). The changes/files view (`/pull/N/files`) is more useful
for reviewing active flows — it shows the diff immediately without an
extra click.

## Exploration

- `lib/tui.py:388-399` — `_open_pr()` reads `flow.get("pr_url")` and
  passes it directly to `subprocess.Popen(["open", ...])`. No URL
  transformation occurs.
- `tests/test_tui.py:606-615` — `test_open_pr()` asserts `"github.com"
  in args[1]` but does not check for the `/files` suffix.
- `lib/tui_data.py:39` — `flow_summary()` passes `pr_url` through from
  the state file unchanged. Per the issue's out-of-scope section, this
  should not be modified.
- `tests/conftest.py:144` — `make_state()` sets `pr_url` to
  `"https://github.com/test/test/pull/1"`.

## Risks

- **Trailing slash edge case** — if `pr_url` already ends with `/`,
  appending `/files` would produce `//files`. Mitigated by using
  `rstrip("/")` before appending.
- **None case** — already handled by the existing `if pr_url:` guard.

## Approach

Append `/files` to the `pr_url` in `_open_pr()` before passing it to
`subprocess.Popen`. Use `rstrip("/")` for safety. Update the existing
test to assert the `/files` suffix.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Update test assertion | test | — |
| 2. Append `/files` in `_open_pr()` | implement | 1 |

## Tasks

### Task 1 — Update test assertion for `/files` suffix

**Files:** `tests/test_tui.py`

Update `test_open_pr()` to assert that the URL passed to
`subprocess.Popen` ends with `/files`. The assertion should check
`args[1].endswith("/files")`.

**TDD:** Test should fail before Task 2 (current code opens the base URL).

### Task 2 — Append `/files` to PR URL in `_open_pr()`

**Files:** `lib/tui.py`

In `_open_pr()`, change the URL construction from `str(pr_url)` to
`f"{pr_url.rstrip('/')}/files"`. This appends `/files` after stripping
any trailing slash for safety.

**TDD:** `test_open_pr` should now pass with the `/files` suffix.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: TUI: Open PR on Changes URL When Pressing 'p'

## Problem

In the TUI (`lib/tui.py`), pressing 'p' opens the PR's main page (`https://github.com/org/repo/pull/N`). When reviewing active flows, the changes/files view is more useful — it shows the diff immediately without an extra click. The `_open_pr()` method at line 396 passes the raw `pr_url` from state to `subprocess.Popen(["open", ...])` with no transformation.

## Acceptance Criteria

- [ ] Pressing 'p' in the TUI opens `https://github.com/.../pull/N/files` instead of `https://github.com/.../pull/N`
- [ ] `test_open_pr` asserts the opened URL ends with `/files`
- [ ] `bin/ci` passes with no new warnings

## Files to Investigate

- `lib/tui.py` — `_open_pr()` method (line 388–399): append `/files` to `pr_url` before passing to `open`
- `tests/test_tui.py` — `test_open_pr()` (line 606–615): update assertion to validate `/files` suffix

## Out of Scope

- Do not change how `pr_url` is stored in state files or `tui_data.py` — the base URL is correct as-is
- Do not add a second key binding for opening the base PR URL
- Do not modify any other `pr_url` consumers (display, logging, orchestration)

## Context

The TUI is a curses-based interface for viewing and managing active flows (`flow tui`). The 'p' key is one of several actions available from the list view. GitHub's `/files` view shows the full diff — the natural landing page when checking on a flow's progress.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 1m |
| Code | 6m |
| Code Review | 7m |
| Learn | <1m |
| Complete | 3m |
| **Total** | **19m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/tui-open-pr-changes-url.json</summary>

```json
{
  "schema_version": 1,
  "branch": "tui-open-pr-changes-url",
  "repo": "benkruger/flow",
  "pr_number": 454,
  "pr_url": "https://github.com/benkruger/flow/pull/454",
  "started_at": "2026-03-22T19:15:51-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/tui-open-pr-changes-url-plan.md",
    "dag": ".flow-states/tui-open-pr-changes-url-dag.md",
    "log": ".flow-states/tui-open-pr-changes-url.log",
    "state": ".flow-states/tui-open-pr-changes-url.json"
  },
  "session_id": "adf6d9ef-8d3b-47b6-9d47-013a51a566e3",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/adf6d9ef-8d3b-47b6-9d47-013a51a566e3.jsonl",
  "notes": [],
  "prompt": "work on issue #453",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-22T19:15:51-07:00",
      "completed_at": "2026-03-22T19:16:16-07:00",
      "session_started_at": null,
      "cumulative_seconds": 25,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-22T19:16:52-07:00",
      "completed_at": "2026-03-22T19:18:40-07:00",
      "session_started_at": null,
      "cumulative_seconds": 108,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-22T19:20:05-07:00",
      "completed_at": "2026-03-22T19:26:11-07:00",
      "session_started_at": null,
      "cumulative_seconds": 366,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-22T19:26:47-07:00",
      "completed_at": "2026-03-22T19:34:15-07:00",
      "session_started_at": null,
      "cumulative_seconds": 448,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-22T19:35:06-07:00",
      "completed_at": "2026-03-22T19:35:45-07:00",
      "session_started_at": null,
      "cumulative_seconds": 39,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-22T19:36:23-07:00",
      "completed_at": "2026-03-22T19:39:26-07:00",
      "session_started_at": null,
      "cumulative_seconds": 183,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-22T19:16:52-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-22T19:20:05-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-22T19:26:47-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-22T19:35:06-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-22T19:36:23-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "always"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "code_task": 2,
  "_continue_context": "",
  "_continue_pending": "",
  "diff_stats": {
    "files_changed": 2,
    "insertions": 2,
    "deletions": 1,
    "captured_at": "2026-03-22T19:26:11-07:00"
  },
  "code_review_step": 4,
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "TUI: Inconsistent trailing-slash handling in pr_url consumers",
      "url": "https://github.com/benkruger/flow/issues/455",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-03-22T19:28:58-07:00"
    }
  ],
  "learn_step": 3,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/tui-open-pr-changes-url.log</summary>

```text
2026-03-22T19:14:53-07:00 [Phase 1] Step 2b — git pull origin main (exit 0)
2026-03-22T19:15:34-07:00 [Phase 1] Step 2c — bin/flow ci --branch main (exit 0)
2026-03-22T19:15:44-07:00 [Phase 1] git worktree add .worktrees/tui-open-pr-changes-url (exit 0)
2026-03-22T19:15:51-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-22T19:15:51-07:00 [Phase 1] create .flow-states/tui-open-pr-changes-url.json (exit 0)
2026-03-22T19:15:51-07:00 [Phase 1] freeze .flow-states/tui-open-pr-changes-url-phases.json (exit 0)
2026-03-22T19:22:01-07:00 [stop-continue] set_tab_title error: [Errno 6] Device not configured: '/dev/tty'
2026-03-22T19:26:00-07:00 [stop-continue] blocking: pending=commit
2026-03-22T19:26:00-07:00 [stop-continue] set_tab_title error: [Errno 6] Device not configured: '/dev/tty'
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | TUI: Inconsistent trailing-slash handling in pr_url consumers | Code Review | #455 |

<!-- end:Issues Filed -->