### PR TITLE
Tui Trailing Slash Pr Url

### DIFF
--- a/lib/tui.py
+++ b/lib/tui.py
@@ -486,7 +486,7 @@ class TuiApp:
             elapsed_str = f"  {item['elapsed']}" if item["elapsed"] else ""
             pr_str = ""
             if item["pr_url"]:
-                pr_str = f"  PR {item['pr_url'].rsplit('/', 1)[-1]}"
+                pr_str = f"  PR {item['pr_url'].rstrip('/').rsplit('/', 1)[-1]}"
             line = f"{marker}{item['icon']} #{item['issue_number']}  {item['title']:<30s}{elapsed_str}{pr_str}"
             self._safe_addstr(row, 2, line, attr)
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1679,6 +1679,23 @@ def test_orch_view_item_with_pr_url():
     assert "PR 58" in text
 
 
+def test_orch_view_item_with_pr_url_trailing_slash():
+    """PR number extraction handles trailing slash in pr_url."""
+    items = [
+        _make_orch_item(42, "Done", icon="\u2713", status="completed",
+                        elapsed="1h 24m",
+                        pr_url="https://github.com/test/test/pull/58/"),
+    ]
+    orch = _make_orch_data(items=items, completed_count=1)
+    stdscr = _make_stdscr(rows=30, cols=80)
+    app = _make_app(stdscr, flows=[], orch_data=orch)
+    app.active_tab = 1
+    app._draw_orchestration_view()
+    calls = [str(c) for c in stdscr.addstr.call_args_list]
+    text = " ".join(calls)
+    assert "PR 58" in text
+
+
 def test_refresh_data_clamps_orch_selected(state_dir):
     """refresh_data clamps orch_selected when items shrink."""
     app = _make_app(root=state_dir.parent)


### PR DESCRIPTION
## What

work on issue #455.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/tui-trailing-slash-pr-url-plan.md` |
| DAG | `.flow-states/tui-trailing-slash-pr-url-dag.md` |
| Log | `.flow-states/tui-trailing-slash-pr-url.log` |
| State | `.flow-states/tui-trailing-slash-pr-url.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/432f9350-0b8f-4580-b8a8-fba9dd8b480b.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: Fix inconsistent trailing-slash handling in pr_url consumers

## Context

Issue #455 reports that `_draw_orchestration_view()` in `lib/tui.py` extracts
a PR number from a URL using `rsplit('/', 1)[-1]` without first stripping
trailing slashes. If `pr_url` contained a trailing slash, the expression would
return an empty string instead of the PR number. The `_open_pr()` method
already uses `rstrip('/')` defensively at line 396. The fix brings line 489
into consistency.

## Exploration

**All `pr_url` consumers in `lib/tui.py`:**

| Line | Method | Pattern | Status |
|------|--------|---------|--------|
| 396 | `_open_pr()` | `pr_url.rstrip('/') + "/files"` | Defensive |
| 489 | `_draw_orchestration_view()` | `pr_url.rsplit('/', 1)[-1]` | Vulnerable |
| 500 | `_draw_orchestration_view()` | `f"PR: {selected_item['pr_url']}"` | Passthrough (display only) |

**Data layer (`lib/tui_data.py`):** Lines 39 and 229 are passthrough reads from
state — no URL parsing. Not affected.

**Existing test coverage:** `test_orch_view_item_with_pr_url` (line 1665) tests
PR number extraction with a clean URL. No trailing-slash test exists.

## Risks

- Minimal risk. The fix adds one `.rstrip('/')` call before existing parsing logic.
- Line 500 is left unchanged — it displays the full URL, so a trailing slash is
  cosmetic, not functional.

## Approach

Add `.rstrip('/')` before `.rsplit('/', 1)[-1]` at line 489. Write a test that
passes a `pr_url` with a trailing slash and asserts the PR number is still
correctly extracted.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write trailing-slash test | test | — |
| 2. Fix line 489 | implement | 1 |

## Tasks

### Task 1 — Write trailing-slash test

- **File:** `tests/test_tui.py`
- **Description:** Add `test_orch_view_item_with_pr_url_trailing_slash` that creates
  an orch item with `pr_url="https://github.com/test/test/pull/58/"` (note trailing
  slash), draws the orchestration view, and asserts `"PR 58"` appears in the output.
- **TDD:** This test should fail before the fix (it will find `"PR "` instead of
  `"PR 58"` because `rsplit` returns empty string).

### Task 2 — Fix pr_url parsing at line 489

- **File:** `lib/tui.py`
- **Description:** Change line 489 from
  `item['pr_url'].rsplit('/', 1)[-1]` to
  `item['pr_url'].rstrip('/').rsplit('/', 1)[-1]`
- **TDD:** The test from Task 1 should now pass.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Fix inconsistent trailing-slash handling in pr_url consumers

```
╔══════════════════════════════════════════════╗
║           DAG IMPACT PREVIEW                 ║
╚══════════════════════════════════════════════╝
```

**Goal:** Fix inconsistent trailing-slash handling in all pr_url consumers in lib/tui.py

**Verdict:** ⚠️ MARGINAL

This is a focused consistency fix in a single file. Let me run a compact DAG to ensure we catch all consumers — not just the two mentioned in the issue.

```xml
<dag goal="Fix inconsistent trailing-slash handling in all pr_url consumers in lib/tui.py" mode="full">
  <plan>
    <node id="1" name="Audit all pr_url consumers" type="research" depends="[]" parallel_with="[]">
      <objective>Find every place in lib/tui.py that reads, parses, or passes pr_url — not just the two mentioned in the issue</objective>
    </node>
    <node id="2" name="Categorize handling patterns" type="analysis" depends="[1]" parallel_with="[]">
      <objective>For each consumer, classify: already defensive (has rstrip), vulnerable (no rstrip), or passthrough (doesn't parse, just displays/passes)</objective>
    </node>
    <node id="3" name="Design fix and test strategy" type="synthesis" depends="[2]" parallel_with="[]">
      <objective>Determine the minimal fix for consistency and identify what tests need to cover</objective>
    </node>
  </plan>
</dag>
```

Validation: No cycles, all deps exist, terminal synthesis node present. Proceeding.

---

**NODE 1: Audit all pr_url consumers**

Grep results for `pr_url` in `lib/tui.py`:

| Line | Code |
|------|------|
| 393 | `pr_url = flow.get("pr_url")` |
| 394 | `if pr_url:` |
| 396 | `["open", f"{pr_url.rstrip('/')}/files"]` |
| 488 | `if item["pr_url"]:` |
| 489 | `pr_str = f"  PR {item['pr_url'].rsplit('/', 1)[-1]}"` |
| 499 | `elif selected_item["status"] == "completed" and selected_item["pr_url"]:` |
| 500 | `self._safe_addstr(detail_row, 4, f"PR: {selected_item['pr_url']}")` |

Grep results for `pr_url` in `lib/tui_data.py`:

| Line | Code |
|------|------|
| 39 | `"pr_url": state.get("pr_url")` |
| 229 | `"pr_url": item.get("pr_url")` |

Those are passthrough reads from state — no URL parsing.

Quality: 9/10 — Complete audit of all `pr_url` usage in tui.py and tui_data.py.

Key finding: There are 4 `pr_url` references in `tui.py` across 3 methods, and 2 passthrough references in `tui_data.py`.

---

**NODE 2: Categorize handling patterns**

| Location | Line | Method | Pattern | Status |
|----------|------|--------|---------|--------|
| `tui.py:396` | 396 | `_open_pr()` | `pr_url.rstrip('/') + "/files"` | **Defensive** — strips trailing slash before appending |
| `tui.py:489` | 489 | `_draw_orchestration_view()` | `pr_url.rsplit('/', 1)[-1]` (extracts PR number) | **Vulnerable** — no `rstrip('/')`, trailing slash → empty string |
| `tui.py:500` | 500 | `_draw_orchestration_view()` | `f"PR: {selected_item['pr_url']}"` (display only) | **Passthrough** — displays raw URL, trailing slash is cosmetic only |
| `tui_data.py:39` | 39 | `flow_summary()` | `state.get("pr_url")` | **Passthrough** — raw read from state |
| `tui_data.py:229` | 229 | orchestration item | `item.get("pr_url")` | **Passthrough** — raw read from state |

Quality: 9/10 — Clear classification of each consumer.

Key finding: Only line 489 is actually vulnerable. Line 500 is display-only (a trailing slash in a displayed URL is harmless). Line 396 is already defended.

---

**NODE 3: Design fix and test strategy**

The fix is minimal: add `.rstrip('/')` before `.rsplit('/', 1)[-1]` at line 489.

For tests, `test_tui.py` already covers `_draw_orchestration_view()`. The fix needs a test that verifies PR number extraction works correctly when `pr_url` has a trailing slash.

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

**Fix scope:** One line change in `lib/tui.py` line 489.

**Current code (vulnerable):**
  `item['pr_url'].rsplit('/', 1)[-1]`

**Fixed code:**
  `item['pr_url'].rstrip('/').rsplit('/', 1)[-1]`

**Why only line 489:** Line 396 is already defended. Line 500 is a
display-only passthrough (trailing slash in a displayed URL is cosmetic,
not functional). The data layer (`tui_data.py`) never parses URLs — it
only passes them through from state.

**Test strategy:** Add a test case to `test_tui.py` that verifies
`_draw_orchestration_view()` renders the correct PR number when
`pr_url` contains a trailing slash.

Confidence: 95%  |  Nodes: 3  |  Parallel branches: 0

vs. Vanilla Claude (what linear reasoning would have missed):
  - The full audit ensures no other pr_url consumers exist beyond the 4 identified
  - Classifying line 500 as "passthrough" prevents unnecessary changes to display-only code
  - Checking tui_data.py confirms the fix is isolated to the presentation layer
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 4m |
| Code | 9m |
| Code Review | 9m |
| Learn | <1m |
| Complete | 1m |
| **Total** | **25m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/tui-trailing-slash-pr-url.json</summary>

```json
{
  "schema_version": 1,
  "branch": "tui-trailing-slash-pr-url",
  "repo": "benkruger/flow",
  "pr_number": 462,
  "pr_url": "https://github.com/benkruger/flow/pull/462",
  "started_at": "2026-03-23T02:39:17-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/tui-trailing-slash-pr-url-plan.md",
    "dag": ".flow-states/tui-trailing-slash-pr-url-dag.md",
    "log": ".flow-states/tui-trailing-slash-pr-url.log",
    "state": ".flow-states/tui-trailing-slash-pr-url.json"
  },
  "session_id": "432f9350-0b8f-4580-b8a8-fba9dd8b480b",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/432f9350-0b8f-4580-b8a8-fba9dd8b480b.jsonl",
  "notes": [],
  "prompt": "work on issue #455",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-23T02:39:17-07:00",
      "completed_at": "2026-03-23T02:39:46-07:00",
      "session_started_at": null,
      "cumulative_seconds": 29,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-23T02:40:42-07:00",
      "completed_at": "2026-03-23T02:45:10-07:00",
      "session_started_at": null,
      "cumulative_seconds": 268,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-23T02:45:52-07:00",
      "completed_at": "2026-03-23T02:55:19-07:00",
      "session_started_at": null,
      "cumulative_seconds": 567,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-23T02:56:16-07:00",
      "completed_at": "2026-03-23T03:05:24-07:00",
      "session_started_at": null,
      "cumulative_seconds": 548,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-23T03:06:05-07:00",
      "completed_at": "2026-03-23T03:06:52-07:00",
      "session_started_at": null,
      "cumulative_seconds": 47,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-23T03:07:33-07:00",
      "completed_at": "2026-03-23T03:08:49-07:00",
      "session_started_at": null,
      "cumulative_seconds": 76,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-23T02:40:42-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-23T02:45:52-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-23T02:56:16-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-23T03:06:05-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-23T03:07:33-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "always"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "_continue_context": "",
  "_continue_pending": "",
  "code_task": 2,
  "diff_stats": {
    "files_changed": 2,
    "insertions": 18,
    "deletions": 1,
    "captured_at": "2026-03-23T02:55:19-07:00"
  },
  "code_review_step": 4,
  "learn_step": 4,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/tui-trailing-slash-pr-url.log</summary>

```text
2026-03-23T02:38:17-07:00 [Phase 1] Step 2 — pull main, CI baseline (exit 0)
2026-03-23T02:38:54-07:00 [Phase 1] Step 2 — deps check, lock released (exit 0)
2026-03-23T02:39:03-07:00 [Phase 1] git worktree add .worktrees/tui-trailing-slash-pr-url (exit 0)
2026-03-23T02:39:17-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-23T02:39:18-07:00 [Phase 1] create .flow-states/tui-trailing-slash-pr-url.json (exit 0)
2026-03-23T02:39:18-07:00 [Phase 1] freeze .flow-states/tui-trailing-slash-pr-url-phases.json (exit 0)
2026-03-23T02:39:25-07:00 [Phase 1] Step 3 — workspace setup complete (exit 0)
2026-03-23T02:39:40-07:00 [Phase 1] Step 4 — labeled issue #455 (exit 0)
2026-03-23T02:41:02-07:00 [Phase 2] Step 1 — fetched issue #455 (exit 0)
2026-03-23T02:42:59-07:00 [Phase 2] Step 2 — DAG decompose complete, saved to dag file (exit 0)
2026-03-23T02:44:44-07:00 [Phase 2] Step 3-4 — plan written and stored (exit 0)
2026-03-23T02:48:56-07:00 [stop-continue] set_tab_title error: [Errno 6] Device not configured: '/dev/tty'
2026-03-23T02:49:14-07:00 [Phase 3] Task 1-2 — test + fix, CI green (exit 0)
2026-03-23T02:54:27-07:00 [stop-continue] set_tab_title error: [Errno 6] Device not configured: '/dev/tty'
2026-03-23T02:55:23-07:00 [Phase 3] All tasks complete, CI green, 100% coverage (exit 0)
2026-03-23T02:57:53-07:00 [Phase 4] Step 1 — Simplify: no findings, no changes (exit 0)
2026-03-23T02:59:26-07:00 [Phase 4] Step 2 — Review: no findings (exit 0)
2026-03-23T03:01:41-07:00 [Phase 4] Step 3 — Security: no findings (exit 0)
2026-03-23T03:04:46-07:00 [Phase 4] Step 4 — Code Review Plugin: no findings (exit 0)
2026-03-23T03:05:28-07:00 [Phase 4] Done — Code Review complete, all 4 steps clean (exit 0)
```

</details>