### PR TITLE
Freshness Use Flow Utils

### DIFF
--- a/lib/check-freshness.py
+++ b/lib/check-freshness.py
@@ -20,9 +20,12 @@ and stops at 3 retries (configurable via MAX_RETRIES).
 import json
 import subprocess
 import sys
+from pathlib import Path
 
-LOCAL_TIMEOUT = 30
-NETWORK_TIMEOUT = 60
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from flow_utils import LOCAL_TIMEOUT, NETWORK_TIMEOUT, mutate_state, parse_conflict_files
+
 MAX_RETRIES = 3
 
 
@@ -33,8 +36,6 @@ def _check_and_increment_retries(state_file, increment=False):
     When increment=True, increments and returns the new count.
     Both operations happen under the mutate_state lock to prevent races.
     """
-    from flow_utils import mutate_state
-
     count = 0
 
     def _transform(state):
@@ -128,11 +129,7 @@ def check_freshness(state_file=None):
             "message": result.stderr.strip(),
         }
 
-    conflict_files = []
-    for line in status.stdout.splitlines():
-        xy = line[:2]
-        if "U" in xy or xy in ("DD", "AA"):
-            conflict_files.append(line[3:].strip())
+    conflict_files = parse_conflict_files(status.stdout)
 
     if conflict_files:
         response = {"status": "conflict", "files": conflict_files}


### PR DESCRIPTION
## What

work on issue #483.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/freshness-use-flow-utils-plan.md` |
| DAG | `.flow-states/freshness-use-flow-utils-dag.md` |
| Log | `.flow-states/freshness-use-flow-utils.log` |
| State | `.flow-states/freshness-use-flow-utils.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/757a4cb9-163d-495d-9c51-b35c01f8c62b.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: check-freshness.py — adopt flow_utils exports

## Context

Issue #483: `lib/check-freshness.py` defines its own `LOCAL_TIMEOUT` and
`NETWORK_TIMEOUT` constants and has inline conflict parsing logic that
duplicates exports from `lib/flow_utils.py`. This happened because PR #473
landed concurrently with extraction PRs #476 and #481. The file already
imports `mutate_state` from `flow_utils` (as a lazy import), so the import
path is established. This is a single-file refactor with no behavioral change.

## Exploration

**`lib/check-freshness.py`** (173 lines):

- Lines 20-22: imports `json`, `subprocess`, `sys` — no `pathlib`
- Lines 24-25: `LOCAL_TIMEOUT = 30`, `NETWORK_TIMEOUT = 60` — duplicates
- Line 26: `MAX_RETRIES = 3` — unique, not a duplicate, stays
- Line 36: `from flow_utils import mutate_state` — lazy import inside
  `_check_and_increment_retries()`, needs to move to top-level
- Lines 131-135: inline conflict parsing — duplicate of `parse_conflict_files()`
- `LOCAL_TIMEOUT` used at line 88 (merge-base timeout) and line 122 (status timeout)
- `NETWORK_TIMEOUT` used at line 68 (fetch timeout), line 74 (error message),
  line 100 (merge timeout), line 106 (error message)

**`lib/finalize-commit.py`** (reference pattern):

- Line 23: `sys.path.insert(0, str(Path(__file__).resolve().parent))`
- Line 25: `from flow_utils import LOCAL_TIMEOUT, NETWORK_TIMEOUT, parse_conflict_files`

**`lib/flow_utils.py`**:

- Lines 24-25: `LOCAL_TIMEOUT = 30`, `NETWORK_TIMEOUT = 60` — canonical source
- Lines 274-287: `parse_conflict_files(porcelain_output)` — takes string, returns list
- `parse_conflict_files` does `.strip().split("\n")` vs inline `.splitlines()` — functionally
  equivalent for git status output

**`tests/test_check_freshness.py`** (20 tests):

- Tests assert exact timeout values (30 and 60) in subprocess calls — these match
  the flow_utils constants, so tests pass unchanged after refactoring
- Tests mock `subprocess.run` — the import source of constants doesn't affect behavior
- No test patches `LOCAL_TIMEOUT` or `NETWORK_TIMEOUT` directly

## Risks

- **Behavioral equivalence**: `parse_conflict_files()` strips the full output and
  skips empty lines; inline code uses `.splitlines()`. Both produce identical results
  for git status porcelain output. No risk.
- **Import resolution**: `check-freshness.py` runs via `bin/flow` which adds `lib/`
  to `sys.path`. Adding an explicit `sys.path.insert` at the top matches the
  `finalize-commit.py` pattern and ensures the import works regardless of invocation method.

## Approach

Single-file edit to `lib/check-freshness.py`:

1. Add `from pathlib import Path` to the imports
2. Add `sys.path.insert(0, str(Path(__file__).resolve().parent))` after imports
3. Add top-level `from flow_utils import LOCAL_TIMEOUT, NETWORK_TIMEOUT, mutate_state, parse_conflict_files`
4. Remove lines 24-25 (duplicate constants)
5. Remove the lazy `from flow_utils import mutate_state` inside `_check_and_increment_retries()`
6. Replace inline conflict parsing (lines 131-135) with `conflict_files = parse_conflict_files(status.stdout)`

No test changes needed — all 20 existing tests pass unchanged.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Run existing tests to confirm green baseline | test | — |
| 2. Edit check-freshness.py imports and remove duplicates | implement | 1 |
| 3. Run tests to confirm all 20 pass unchanged | test | 2 |

## Tasks

### Task 1 — Confirm green baseline

Run `bin/test tests/test_check_freshness.py` to verify all 20 tests pass
before any changes.

### Task 2 — Refactor check-freshness.py

Edit `lib/check-freshness.py`:

- Add `from pathlib import Path` to the import block (after `import sys`)
- Add `sys.path.insert(0, str(Path(__file__).resolve().parent))` after the
  stdlib imports
- Add `from flow_utils import LOCAL_TIMEOUT, NETWORK_TIMEOUT, mutate_state, parse_conflict_files`
  after the sys.path insert
- Remove the two duplicate constant definitions (`LOCAL_TIMEOUT = 30` and
  `NETWORK_TIMEOUT = 60`)
- Remove the lazy `from flow_utils import mutate_state` inside
  `_check_and_increment_retries()`
- Replace the 5-line inline conflict parsing block with
  `conflict_files = parse_conflict_files(status.stdout)`

Files to modify: `lib/check-freshness.py`

### Task 3 — Verify all tests pass unchanged

Run `bin/test tests/test_check_freshness.py` to confirm all 20 tests pass.
Then run `bin/ci` for full suite validation.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# Pre-Decomposed Analysis: check-freshness.py uses duplicate constants and inline conflict parsing instead of flow_utils exports

## Problem

`lib/check-freshness.py` defines its own `LOCAL_TIMEOUT` and `NETWORK_TIMEOUT` constants (lines 24-25) and has inline conflict parsing logic (lines 131-135) that duplicates `parse_conflict_files()` from `lib/flow_utils.py` (line 274).

This happened because PR #473 (Pre Merge Freshness Check) landed concurrently with the extraction PRs #476 (Extract Conflict Parser) and #481 (Adopt Local Timeout). Those PRs updated `lib/finalize-commit.py` to import from `flow_utils` but missed `check-freshness.py`.

**Duplicate constants** (`check-freshness.py` lines 24-25):
```python
LOCAL_TIMEOUT = 30
NETWORK_TIMEOUT = 60
```

These are identical to `flow_utils.py` lines 24-25.

**Duplicate conflict parsing** (`check-freshness.py` lines 131-135):
```python
conflict_files = []
for line in status.stdout.splitlines():
    xy = line[:2]
    if "U" in xy or xy in ("DD", "AA"):
        conflict_files.append(line[3:].strip())
```

This is functionally identical to `parse_conflict_files()` in `flow_utils.py` lines 274-287.

The file already imports from `flow_utils` (line 36: `from flow_utils import mutate_state`), so the import path is established. Additionally, the `mutate_state` import is a lazy import inside `_check_and_increment_retries()` — it should move to the top-level import block alongside the new imports.

`lib/finalize-commit.py` line 25 shows the correct pattern:
```python
from flow_utils import LOCAL_TIMEOUT, NETWORK_TIMEOUT, parse_conflict_files
```

## Acceptance Criteria

- [ ] `lib/check-freshness.py` imports `LOCAL_TIMEOUT`, `NETWORK_TIMEOUT`, and `parse_conflict_files` from `flow_utils`
- [ ] Lines 24-25 (inline constant definitions) are removed
- [ ] Lines 131-135 (inline conflict parsing) are replaced with `parse_conflict_files(status.stdout)`
- [ ] The lazy `from flow_utils import mutate_state` on line 36 moves to the top-level import block
- [ ] `sys.path.insert(0, ...)` is added before the import (matching `finalize-commit.py` line 23)
- [ ] All 20 existing tests in `tests/test_check_freshness.py` pass unchanged
- [ ] `bin/ci` passes
- [ ] CLAUDE.md Key Files entry for `check-freshness.py` is unchanged (already accurate)

## Files to Investigate

- `lib/check-freshness.py` — the file with duplicate code (lines 24-25, 36, 131-135)
- `lib/flow_utils.py` — source of truth for `LOCAL_TIMEOUT`, `NETWORK_TIMEOUT`, `parse_conflict_files`
- `lib/finalize-commit.py` — reference pattern for the correct imports (line 23-25)
- `tests/test_check_freshness.py` — 20 existing tests that must pass unchanged

## Out of Scope

- Do not modify `flow_utils.py` — the exports already exist and are correct
- Do not modify `tests/test_check_freshness.py` — all tests pass unchanged after refactoring
- Do not modify `finalize-commit.py` — it already uses the correct pattern
- Do not change `MAX_RETRIES` — it is unique to `check-freshness.py` and not a duplicate
- Do not refactor any other files — this is a single-file cleanup

## Context

FLOW centralizes shared constants and utilities in `lib/flow_utils.py`. PRs #476 and #481 extracted conflict parsing and timeout constants into `flow_utils` and updated all known callers. `check-freshness.py` was missed because it landed concurrently. If `LOCAL_TIMEOUT` or `parse_conflict_files` behavior ever changes in `flow_utils`, `check-freshness.py` would silently diverge. This is a maintenance hazard, not a functional bug — the current values are identical.
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 2m |
| Code | 6m |
| Code Review | 6m |
| Learn | <1m |
| Complete | <1m |
| **Total** | **17m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/freshness-use-flow-utils.json</summary>

```json
{
  "schema_version": 1,
  "branch": "freshness-use-flow-utils",
  "repo": "benkruger/flow",
  "pr_number": 484,
  "pr_url": "https://github.com/benkruger/flow/pull/484",
  "started_at": "2026-03-23T17:28:19-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/freshness-use-flow-utils-plan.md",
    "dag": ".flow-states/freshness-use-flow-utils-dag.md",
    "log": ".flow-states/freshness-use-flow-utils.log",
    "state": ".flow-states/freshness-use-flow-utils.json"
  },
  "session_id": "757a4cb9-163d-495d-9c51-b35c01f8c62b",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/757a4cb9-163d-495d-9c51-b35c01f8c62b.jsonl",
  "notes": [],
  "prompt": "work on issue #483",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-23T17:28:19-07:00",
      "completed_at": "2026-03-23T17:28:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 24,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-23T17:29:19-07:00",
      "completed_at": "2026-03-23T17:31:50-07:00",
      "session_started_at": null,
      "cumulative_seconds": 151,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-23T17:32:37-07:00",
      "completed_at": "2026-03-23T17:39:13-07:00",
      "session_started_at": null,
      "cumulative_seconds": 396,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-23T17:39:44-07:00",
      "completed_at": "2026-03-23T17:46:12-07:00",
      "session_started_at": null,
      "cumulative_seconds": 388,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-23T17:47:16-07:00",
      "completed_at": "2026-03-23T17:47:51-07:00",
      "session_started_at": null,
      "cumulative_seconds": 35,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-23T17:48:29-07:00",
      "completed_at": "2026-03-23T17:49:15-07:00",
      "session_started_at": null,
      "cumulative_seconds": 46,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-23T17:29:19-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-23T17:32:37-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-23T17:39:44-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-23T17:47:16-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-23T17:48:29-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "always"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "code_task": 3,
  "_continue_context": "",
  "_continue_pending": "",
  "diff_stats": {
    "files_changed": 1,
    "insertions": 6,
    "deletions": 9,
    "captured_at": "2026-03-23T17:39:13-07:00"
  },
  "code_review_step": 4,
  "learn_step": 4,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/freshness-use-flow-utils.log</summary>

```text
2026-03-23T17:27:44-07:00 [Phase 1] Step 2 — prepare main: pull, CI green, deps clean, lock released (exit 0)
2026-03-23T17:28:09-07:00 [Phase 1] git worktree add .worktrees/freshness-use-flow-utils (exit 0)
2026-03-23T17:28:19-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-23T17:28:19-07:00 [Phase 1] create .flow-states/freshness-use-flow-utils.json (exit 0)
2026-03-23T17:28:19-07:00 [Phase 1] freeze .flow-states/freshness-use-flow-utils-phases.json (exit 0)
2026-03-23T17:28:25-07:00 [Phase 1] Step 3 — workspace setup complete, PR #484 (exit 0)
2026-03-23T17:28:44-07:00 [Phase 1] Step 4 — labeled issue #483 as Flow In-Progress (exit 0)
2026-03-23T17:29:39-07:00 [Phase 2] Step 1 — fetched issue #483 (decomposed), phase entered (exit 0)
2026-03-23T17:31:51-07:00 [Phase 2] Step 3-4 — plan written, PR body rendered, phase complete (exit 0)
2026-03-23T17:33:00-07:00 [Phase 3] Task 1 — baseline tests green, 23 passed (exit 0)
2026-03-23T17:35:46-07:00 [stop-continue] set_tab_title error: [Errno 6] Device not configured: '/dev/tty'
2026-03-23T17:36:34-07:00 [Phase 3] Tasks 1-3 — baseline green, refactored check-freshness.py, CI green 1952 passed (exit 0)
2026-03-23T17:39:00-07:00 [stop-continue] blocking: pending=commit
2026-03-23T17:39:00-07:00 [stop-continue] set_tab_title error: [Errno 6] Device not configured: '/dev/tty'
2026-03-23T17:39:15-07:00 [Phase 3] Complete — 1 commit, CI green, 1952 passed, 100% coverage (exit 0)
2026-03-23T17:40:55-07:00 [Phase 4] Step 1 — Simplify: 3 agents, 0 findings, no changes (exit 0)
2026-03-23T17:41:56-07:00 [Phase 4] Step 2 — Review: 0 findings, no changes (exit 0)
2026-03-23T17:42:54-07:00 [Phase 4] Step 3 — Security: 0 findings, no changes (exit 0)
2026-03-23T17:45:57-07:00 [Phase 4] Step 4 — Code Review Plugin: 0 findings, no changes (exit 0)
```

</details>