### PR TITLE
Fix Bin Flow Permission

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,6 @@
       "Bash(gh repo clone *)",
       "Bash(gh label *)",
       "Bash(bin/*)",
-      "Bash(*bin/flow *)",
       "Bash(claude plugin marketplace add *)",
       "Bash(claude plugin marketplace update *)",
       "Bash(claude plugin uninstall *)",

--- a/lib/prime-setup.py
+++ b/lib/prime-setup.py
@@ -68,7 +68,6 @@ UNIVERSAL_ALLOW = [
     "Bash(gh label *)",
     "Bash(bin/*)",
     "Bash(rm .flow-*)",
-    "Bash(*bin/flow *)",
     "Bash(claude plugin list)",
     "Bash(claude plugin marketplace add *)",
     "Bash(claude plugin install *)",
@@ -101,6 +100,20 @@ EXCLUDE_ENTRIES = [
     "bin/dependencies",
     ".claude/scheduled_tasks.lock",
 ]
+
+
+def _dynamic_plugin_patterns(plugin_root):
+    """Generate dynamic permission patterns for the plugin's bin/flow.
+
+    Produces 4 patterns covering exec/no-exec prefix and single/double
+    slash separator (CLAUDE_PLUGIN_ROOT may have a trailing slash).
+    """
+    root = plugin_root.rstrip("/")
+    patterns = []
+    for prefix in ("exec ", ""):
+        for sep in ("/", "//"):
+            patterns.append(f"Bash({prefix}{root}{sep}bin/flow *)")
+    return patterns
 
 
 def _load_framework_permissions(framework):
@@ -205,7 +218,7 @@ def _is_subsumed(candidate, existing_set):
     return False
 
 
-def merge_settings(project_root, framework):
+def merge_settings(project_root, framework, plugin_root=None):
     """Merge FLOW permissions into .claude/settings.json. Returns merged dict."""
     settings_dir = project_root / ".claude"
     settings_path = settings_dir / "settings.json"
@@ -234,6 +247,13 @@ def merge_settings(project_root, framework):
         if entry not in existing_allow and not _is_subsumed(entry, existing_allow):
             settings["permissions"]["allow"].append(entry)
             existing_allow.add(entry)
+
+    # Merge dynamic plugin patterns (installation-specific)
+    if plugin_root is not None:
+        for entry in _dynamic_plugin_patterns(plugin_root):
+            if entry not in existing_allow and not _is_subsumed(entry, existing_allow):
+                settings["permissions"]["allow"].append(entry)
+                existing_allow.add(entry)
 
     existing_deny = set(settings["permissions"]["deny"])
     for entry in FLOW_DENY:
@@ -552,7 +572,7 @@ def main():
         version = plugin_data["version"]
         config_hash = compute_config_hash(framework)
         setup_hash = compute_setup_hash()
-        merge_settings(project_root, framework)
+        merge_settings(project_root, framework, plugin_root=plugin_root)
         write_version_marker(project_root, version, framework,
                              skills=skills, config_hash=config_hash,
                              setup_hash=setup_hash,

--- a/skills/flow-prime/SKILL.md
+++ b/skills/flow-prime/SKILL.md
@@ -295,7 +295,6 @@ All permissions (universal + all framework sets) for reference:
       "Bash(gh pr list *)",
       "Bash(bin/*)",
       "Bash(rm .flow-*)",
-      "Bash(*bin/flow *)",
       "Bash(gh pr view *)",
       "Bash(bin/rails test *)",
       "Bash(rails *)",

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -6,11 +6,19 @@ skills). Prohibition tests enforce that bash blocks never contain patterns
 that break permission matching or shell behavior.
 """
 
+import importlib.util
 import json
 import re
 
 from conftest import LIB_DIR, REPO_ROOT, SKILLS_DIR
 from flow_utils import permission_to_regex as _permission_to_regex_impl
+
+# Import prime-setup.py for dynamic pattern generation
+_ps_spec = importlib.util.spec_from_file_location(
+    "prime_setup", LIB_DIR / "prime-setup.py"
+)
+_ps_mod = importlib.util.module_from_spec(_ps_spec)
+_ps_spec.loader.exec_module(_ps_mod)
 
 MAINTAINER_SKILLS_DIR = REPO_ROOT / ".claude" / "skills"
 SETTINGS_JSON = REPO_ROOT / ".claude" / "settings.json"
@@ -168,8 +176,14 @@ PLACEHOLDER_SUBS = {
 def _substitute_placeholders(line):
     """Replace angle-bracket placeholders with concrete test values.
 
+    Also expands ${CLAUDE_PLUGIN_ROOT} to the repo root path so that
+    commands like 'exec ${CLAUDE_PLUGIN_ROOT}/bin/flow ...' become
+    concrete paths for permission matching.
+
     Returns the substituted line, or None if unrecognized placeholders remain.
     """
+    # Expand shell variable used in plugin skill bash blocks
+    line = line.replace("${CLAUDE_PLUGIN_ROOT}", str(REPO_ROOT))
     for placeholder, value in PLACEHOLDER_SUBS.items():
         line = line.replace(placeholder, value)
     # If any angle-bracket placeholders remain, skip (safety net)
@@ -524,7 +538,11 @@ def test_all_bash_commands_have_permission_coverage():
     """Every ```bash``` block in all SKILL.md and docs/*.md files must match
     at least one permission from prime/SKILL.md or be in the auto-allowed set."""
     permissions = _extract_prime_permissions()
-    regexes = [_permission_to_regex(p) for p in permissions]
+    # Add dynamic patterns for the test plugin root (simulates runtime behavior
+    # where merge_settings generates patterns from the actual plugin path)
+    dynamic = _ps_mod._dynamic_plugin_patterns(str(REPO_ROOT))
+    all_permissions = permissions + dynamic
+    regexes = [_permission_to_regex(p) for p in all_permissions]
     regexes = [r for r in regexes if r is not None]
 
     errors = []
@@ -849,12 +867,6 @@ def test_permission_to_regex_known_conversions():
     r = _permission_to_regex("Bash(git -C *)")
     assert r is not None
     assert r.match("git -C .worktrees/my-branch status")
-
-    # Leading glob
-    r = _permission_to_regex("Bash(*bin/flow *)")
-    assert r is not None
-    assert r.match("/usr/local/bin/flow run")
-    assert r.match("bin/flow run")
 
     # rm with glob suffix
     r = _permission_to_regex("Bash(rm .flow-*)")

--- a/tests/test_prime_setup.py
+++ b/tests/test_prime_setup.py
@@ -824,6 +824,51 @@ def test_cli_derives_permissions_from_project(git_repo, monkeypatch, capsys):
     assert "Bash(killall TestApp)" in settings["permissions"]["allow"]
 
 
+# --- Dynamic plugin patterns (in-process) ---
+
+
+def test_merge_settings_with_plugin_root_adds_dynamic_patterns(tmp_path):
+    """When plugin_root is provided, dynamic patterns are added to allow list."""
+    _mod.merge_settings(tmp_path, "rails", plugin_root="/some/plugin/path")
+    settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    allow = settings["permissions"]["allow"]
+    assert "Bash(exec /some/plugin/path/bin/flow *)" in allow
+    assert "Bash(exec /some/plugin/path//bin/flow *)" in allow
+    assert "Bash(/some/plugin/path/bin/flow *)" in allow
+    assert "Bash(/some/plugin/path//bin/flow *)" in allow
+
+
+def test_merge_settings_plugin_root_trailing_slash(tmp_path):
+    """Trailing slash on plugin_root is normalized — same 4 patterns."""
+    _mod.merge_settings(tmp_path, "rails", plugin_root="/some/plugin/path/")
+    settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    allow = settings["permissions"]["allow"]
+    assert "Bash(exec /some/plugin/path/bin/flow *)" in allow
+    assert "Bash(exec /some/plugin/path//bin/flow *)" in allow
+    assert "Bash(/some/plugin/path/bin/flow *)" in allow
+    assert "Bash(/some/plugin/path//bin/flow *)" in allow
+
+
+def test_merge_settings_no_plugin_root_no_dynamic_patterns(tmp_path):
+    """Without plugin_root, no dynamic patterns are added."""
+    _mod.merge_settings(tmp_path, "rails")
+    settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    allow = settings["permissions"]["allow"]
+    assert not any("/some/" in entry for entry in allow)
+    # No exec-prefixed plugin paths should appear
+    assert not any(entry.startswith("Bash(exec /") for entry in allow)
+
+
+def test_merge_settings_idempotent_with_plugin_root(tmp_path):
+    """Calling merge_settings twice with same plugin_root doesn't duplicate."""
+    _mod.merge_settings(tmp_path, "rails", plugin_root="/some/plugin/path")
+    _mod.merge_settings(tmp_path, "rails", plugin_root="/some/plugin/path")
+    settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    allow = settings["permissions"]["allow"]
+    assert allow.count("Bash(exec /some/plugin/path/bin/flow *)") == 1
+    assert allow.count("Bash(exec /some/plugin/path//bin/flow *)") == 1
+
+
 def test_pre_commit_hook_allows_commit_without_flow_state(git_repo):
     """No active FLOW feature — direct commits should succeed."""
     _mod.install_pre_commit_hook(git_repo)


### PR DESCRIPTION
## What

work on issue #500.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/fix-bin-flow-permission-plan.md` |
| DAG | `.flow-states/fix-bin-flow-permission-dag.md` |
| Log | `.flow-states/fix-bin-flow-permission.log` |
| State | `.flow-states/fix-bin-flow-permission.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/fed91c68-7359-42c3-84b3-d2c9162e3b1f.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: Fix broken Bash(*bin/flow *) permission pattern

## Context

Issue #500: Every `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow <subcommand>` command in every
FLOW skill triggers a Claude Code permission prompt in target projects. The permission
pattern `Bash(*bin/flow *)` was written when skills used bare `bin/flow`. After skills
were changed to use `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow`, the pattern was never updated.
Claude Code's glob matching does not match `*` across path separators, so the expanded
path (e.g. `/Users/ben/.claude/plugins/marketplaces/flow-marketplace//bin/flow`) never
matches.

## Exploration

### Affected files

1. **`lib/prime-setup.py`** — `UNIVERSAL_ALLOW` list (line 71) contains the broken
   `Bash(*bin/flow *)`. `merge_settings(project_root, framework)` writes permissions
   to `.claude/settings.json` but has no `plugin_root` parameter. `main()` already
   parses `--plugin-root` (line 526) and passes it to `write_version_marker()` but NOT
   to `merge_settings()`. `_canonical_config()` uses `_allow_list()` which returns only
   static lists — dynamic patterns stay out of the config hash automatically.

2. **`skills/flow-prime/SKILL.md`** — reference JSON block at line 298 has
   `Bash(*bin/flow *)`. Must stay in sync with `UNIVERSAL_ALLOW` per
   `test_prime_setup_lists_match_skill_md_reference`.

3. **`.claude/settings.json`** — line 14 has `Bash(*bin/flow *)`. This is the FLOW
   repo's own settings (maintainer skills). Local `bin/flow` is already covered by
   `Bash(bin/*)` so removing this is safe.

4. **`tests/test_permissions.py`** — `_substitute_placeholders()` only handles
   `<angle-bracket>` placeholders. `${CLAUDE_PLUGIN_ROOT}` passes through untouched.
   The unrecognized placeholder check (`re.search(r"<[a-z_/-]+>")`) doesn't catch
   `${...}` patterns. The command `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow generate-id`
   matches `.*bin/flow .*` (from `permission_to_regex`) because regex `.*` crosses
   slashes — masking the runtime bug. `test_permission_to_regex_known_conversions`
   (line 854) pins `Bash(*bin/flow *)` and must be removed.

5. **`tests/test_prime_setup.py`** — count-based tests (`test_merge_settings_empty_project_rails`,
   etc.) compute expected counts from `_mod.UNIVERSAL_ALLOW` dynamically, so they
   adjust automatically when the list shrinks.

### Patterns discovered

- 169 occurrences of `${CLAUDE_PLUGIN_ROOT}` across 16 skill files — all need dynamic
  permission patterns
- `merge_settings()` is called from `main()` (line 555) and 30+ test call sites — adding
  an optional parameter is backwards-compatible
- `_dynamic_plugin_patterns()` must generate 4 patterns per plugin_root to cover: exec/no-exec
  prefix × single-slash/double-slash separator
- Dynamic patterns must NOT enter `_canonical_config()` / `compute_config_hash()` — they
  are installation-specific. The architecture already isolates them since `_allow_list()`
  only returns `UNIVERSAL_ALLOW + framework_permissions`.

## Risks

1. **Sync test atomicity** — `test_prime_setup_lists_match_skill_md_reference` enforces
   that `UNIVERSAL_ALLOW` and flow-prime/SKILL.md reference JSON match. Removal must be
   atomic (same commit) from both files.
2. **Test permission coverage gap** — After removing `Bash(*bin/flow *)`, all 169
   `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow` commands lose permission coverage in tests
   unless dynamic patterns are added to the test's regex set AND `${CLAUDE_PLUGIN_ROOT}`
   is expanded.
3. **Pinned regex test** — `test_permission_to_regex_known_conversions` references
   `Bash(*bin/flow *)` directly. Must be removed in the same commit as the pattern
   removal.

## Approach

1. Add `_dynamic_plugin_patterns(plugin_root)` to `prime-setup.py` — generates 4
   patterns from the literal plugin path
2. Add optional `plugin_root=None` to `merge_settings()` — when provided, merges
   dynamic patterns into the allow list
3. Wire `plugin_root` through from `main()` to `merge_settings()`
4. Remove `Bash(*bin/flow *)` from all 3 locations atomically
5. Update `test_permissions.py` to expand `${CLAUDE_PLUGIN_ROOT}` and include dynamic
   patterns in the coverage check
6. Update `test_prime_setup.py` with new tests for dynamic patterns

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write test_prime_setup.py tests for dynamic patterns | test | — |
| 2. Add `_dynamic_plugin_patterns()` and update `merge_settings()` in prime-setup.py | implement | 1 |
| 3. Wire `plugin_root` through `main()` to `merge_settings()` | implement | 2 |
| 4. Remove `Bash(*bin/flow *)` from prime-setup.py and flow-prime/SKILL.md (atomic) | implement | 3 |
| 5. Remove `Bash(*bin/flow *)` from `.claude/settings.json` and pinned regex test | implement | 4 |
| 6. Update test_permissions.py: expand `${CLAUDE_PLUGIN_ROOT}` and add dynamic patterns | test+implement | 5 |

## Tasks

### Task 1: Write test_prime_setup.py tests for dynamic patterns

**Files:** `tests/test_prime_setup.py`
**Description:** Add 4 new tests in a new section after the derived permissions tests:
- `test_merge_settings_with_plugin_root_adds_dynamic_patterns` — call `merge_settings(tmp_path, "rails", plugin_root="/some/plugin/path")`, verify all 4 dynamic patterns are in the allow list
- `test_merge_settings_plugin_root_trailing_slash` — call with trailing slash `/some/plugin/path/`, verify same 4 normalized patterns
- `test_merge_settings_no_plugin_root_no_dynamic_patterns` — call without plugin_root, verify no patterns containing `/some/` appear
- `test_merge_settings_idempotent_with_plugin_root` — call twice with same plugin_root, verify no duplicate patterns

**TDD:** Tests should fail initially (merge_settings doesn't accept plugin_root yet).

### Task 2: Add `_dynamic_plugin_patterns()` and update `merge_settings()`

**Files:** `lib/prime-setup.py`
**Description:**
- Add `_dynamic_plugin_patterns(plugin_root)` function that strips trailing slashes from plugin_root and generates 4 patterns (exec/no-exec × single/double slash)
- Add optional `plugin_root=None` parameter to `merge_settings()`
- When plugin_root is provided, merge dynamic patterns into the allow list (after existing UNIVERSAL_ALLOW + framework merge, before writing)
- Use same dedup logic (existing_allow set check + `_is_subsumed`) for dynamic patterns

**TDD:** Task 1 tests should now pass.

### Task 3: Wire `plugin_root` through `main()` to `merge_settings()`

**Files:** `lib/prime-setup.py`
**Description:** Update line 555 from `merge_settings(project_root, framework)` to `merge_settings(project_root, framework, plugin_root=plugin_root)`.

**TDD:** Existing CLI tests with `plugin_root` parameter should now produce settings with dynamic patterns. No new tests needed — Task 1 tests cover the merge_settings behavior.

### Task 4: Remove `Bash(*bin/flow *)` from prime-setup.py and flow-prime/SKILL.md

**Files:** `lib/prime-setup.py`, `skills/flow-prime/SKILL.md`
**Description:** Remove `"Bash(*bin/flow *)"` from `UNIVERSAL_ALLOW` (line 71) and from the reference JSON block in flow-prime/SKILL.md (line 298). These must be in the same commit due to `test_prime_setup_lists_match_skill_md_reference`.

**TDD:** The sync test still passes (both removed). Dynamic pattern tests from Task 1 still pass (they don't depend on UNIVERSAL_ALLOW).

### Task 5: Remove from `.claude/settings.json` and pinned regex test

**Files:** `.claude/settings.json`, `tests/test_permissions.py`
**Description:**
- Remove `"Bash(*bin/flow *)"` from `.claude/settings.json` line 14
- Remove the `Bash(*bin/flow *)` test case from `test_permission_to_regex_known_conversions` (lines 854-857 — the "Leading glob" section)

**TDD:** Settings category ordering test still passes. Regex test still covers remaining patterns.

### Task 6: Update test_permissions.py for variable expansion and dynamic patterns

**Files:** `tests/test_permissions.py`
**Description:**
- In `_substitute_placeholders()`: before the angle-bracket check, replace `${CLAUDE_PLUGIN_ROOT}` with `str(REPO_ROOT)`. This expands the shell variable to a concrete path so commands like `exec /Users/ben/code/flow/bin/flow generate-id` get matched
- In `test_all_bash_commands_have_permission_coverage()`: import `_dynamic_plugin_patterns` from prime_setup, generate patterns from `str(REPO_ROOT)`, convert to regexes, add to the regex list alongside static permissions
- Add an `exec ` prefix handling note: `exec` is a shell builtin that replaces the current process — the actual command after `exec` is what Claude Code matches. Check whether existing commands starting with `exec` need the full `exec <path>` pattern or just `<path>`. If Claude Code matches the full string including `exec`, the dynamic patterns with `exec` prefix are correct.

**TDD:** All 169 `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow` commands now have permission coverage via expanded paths + dynamic patterns. `test_all_bash_commands_have_permission_coverage` passes.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Fix broken Bash(*bin/flow *) permission pattern

```xml
<dag goal="Fix broken Bash(*bin/flow *) permission pattern — dynamic plugin_root patterns" mode="full">
  <plan>
    <node id="1" name="Understand current permission system" type="research"
          depends="[]" parallel_with="[]">
      <objective>Read prime-setup.py to understand UNIVERSAL_ALLOW, merge_settings(), _allow_list(), main(), and how plugin_root is already passed in</objective>
    </node>
    <node id="2" name="Understand test infrastructure" type="research"
          depends="[]" parallel_with="1">
      <objective>Read test_permissions.py and test_prime_setup.py to understand PLACEHOLDER_SUBS, _substitute_placeholders(), and existing merge_settings tests</objective>
    </node>
    <node id="3" name="Understand reference locations" type="research"
          depends="[]" parallel_with="1,2">
      <objective>Read the three locations where Bash(*bin/flow *) appears: prime-setup.py UNIVERSAL_ALLOW, flow-prime/SKILL.md reference JSON, .claude/settings.json</objective>
    </node>
    <node id="4" name="Design dynamic pattern generation" type="analysis"
          depends="[1,3]" parallel_with="[]">
      <objective>Design how merge_settings() generates dynamic patterns from plugin_root, handling trailing slash variance and exec prefix</objective>
    </node>
    <node id="5" name="Design test updates" type="analysis"
          depends="[2,4]" parallel_with="[]">
      <objective>Design test_permissions.py variable expansion and test_prime_setup.py new test cases for dynamic patterns</objective>
    </node>
    <node id="6" name="Synthesize implementation plan" type="synthesis"
          depends="[4,5]" parallel_with="[]">
      <objective>Produce ordered task list with dependencies, TDD ordering, and risk assessment</objective>
    </node>
  </plan>
</dag>
```

▶ NODE 1: Understand current permission system

Key findings from `prime-setup.py`:
- `UNIVERSAL_ALLOW` line 71: `"Bash(*bin/flow *)"` — the broken pattern
- `merge_settings(project_root, framework)` — no `plugin_root` parameter yet
- `main()` already parses `--plugin-root` (line 526-528) but only passes it to `write_version_marker()`
- `_canonical_config()` feeds `compute_config_hash()` — dynamic patterns must NOT be in it (per out-of-scope)
- `_allow_list(framework)` returns `UNIVERSAL_ALLOW + framework_permissions` — used by both `merge_settings()` and `_canonical_config()`

Quality: 9/10 — Complete understanding of the permission pipeline and exactly where the fix goes.

Key finding: `main()` already has `plugin_root` from CLI args but never passes it to `merge_settings()`.

▶ NODE 2: Understand test infrastructure

Key findings from `test_permissions.py`:
- `PLACEHOLDER_SUBS` (line 126) handles only `<angle-bracket>` placeholders, NOT `${shell_var}` patterns
- `${CLAUDE_PLUGIN_ROOT}` passes through `_substitute_placeholders()` untouched — the unrecognized check only catches `<...>` patterns
- `test_all_bash_commands_have_permission_coverage()` (line 523) matches the literal `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow` against `.*bin/flow .*` which succeeds — masking the bug
- `test_prime_setup_lists_match_skill_md_reference()` (line 1054) enforces sync between `UNIVERSAL_ALLOW` and flow-prime/SKILL.md
- `_extract_primary_command` does NOT strip `exec`. The command `exec ${CLAUDE_PLUGIN_ROOT}/bin/flow generate-id` gets matched against `.*bin/flow .*` (from `Bash(*bin/flow *)`), and `.*` matches `exec ${CLAUDE_PLUGIN_ROOT}/` which works because regex `.*` crosses slashes. That's why the test passes but runtime fails — Claude Code uses glob matching (where `*` does NOT cross `/`).

Key findings from `test_prime_setup.py`:
- `_run_main()` helper already supports `plugin_root` parameter
- Tests verify allow list count (`test_merge_settings_empty_project_rails`) — these will need adjustment when removing from UNIVERSAL_ALLOW
- Existing idempotency tests (`test_settings_no_duplicate_entries`) cover the merge path
- `test_permission_to_regex_known_conversions` (line 854) pins `Bash(*bin/flow *)` — must be removed

Quality: 9/10 — Complete understanding of the test gap and why it masked the bug.

Key finding: `${CLAUDE_PLUGIN_ROOT}` must be expanded to a concrete path in tests, and dynamic permission patterns must be generated from that path.

▶ NODE 3: Understand reference locations

The broken pattern `Bash(*bin/flow *)` exists in 3 synced locations:
1. `lib/prime-setup.py:71` — `UNIVERSAL_ALLOW` list (runtime source of truth)
2. `skills/flow-prime/SKILL.md:298` — reference JSON block (docs)
3. `.claude/settings.json:14` — FLOW repo's own settings

The sync test (`test_prime_setup_lists_match_skill_md_reference`) requires atomic removal from both `UNIVERSAL_ALLOW` and flow-prime/SKILL.md.

`.claude/settings.json` is independent — the FLOW repo uses `Bash(bin/*)` which already covers local `bin/flow`.

Quality: 9/10

Key finding: Removals from prime-setup.py and flow-prime/SKILL.md must be atomic due to sync test.

▶ NODE 4: Design dynamic pattern generation

Design for `_dynamic_plugin_patterns()`:

```python
def _dynamic_plugin_patterns(plugin_root):
    """Generate dynamic permission patterns for the plugin's bin/flow."""
    root = plugin_root.rstrip("/")
    patterns = []
    for prefix in ("exec ", ""):
        for sep in ("/", "//"):
            patterns.append(f"Bash({prefix}{root}{sep}bin/flow *)")
    return patterns
```

This generates 4 patterns:
1. `Bash(exec <path>/bin/flow *)` — exec, single slash
2. `Bash(exec <path>//bin/flow *)` — exec, double slash (trailing-slash CLAUDE_PLUGIN_ROOT)
3. `Bash(<path>/bin/flow *)` — no exec, single slash
4. `Bash(<path>//bin/flow *)` — no exec, double slash

Dynamic patterns stay out of `_canonical_config()` automatically since `_allow_list()` only returns static lists.

Quality: 9/10

Key finding: 4 patterns from one plugin_root covers all command forms; they stay out of the config hash automatically.

▶ NODE 5: Design test updates

**test_prime_setup.py** — 4 new tests:
1. `test_merge_settings_with_plugin_root_adds_dynamic_patterns` — pass plugin_root, verify all 4 patterns present
2. `test_merge_settings_plugin_root_trailing_slash` — pass with trailing slash, verify same 4 patterns
3. `test_merge_settings_no_plugin_root_no_dynamic_patterns` — pass None, verify no dynamic patterns
4. `test_merge_settings_idempotent_with_plugin_root` — call twice, verify no duplicates

**test_permissions.py** — 3 changes:
1. In `_substitute_placeholders()`: add `${CLAUDE_PLUGIN_ROOT}` → REPO_ROOT expansion before angle-bracket check
2. In `test_all_bash_commands_have_permission_coverage()`: generate dynamic patterns from REPO_ROOT, add to regex set
3. Remove `Bash(*bin/flow *)` pinned test case from `test_permission_to_regex_known_conversions`

Quality: 9/10

Key finding: The test_permissions fix has two parts — variable expansion AND dynamic pattern generation — both needed to close the gap.

▶ NODE 6: Synthesis

### Implementation Plan

**Removals** (atomic — must happen in one commit due to `test_prime_setup_lists_match_skill_md_reference`):
1. Remove `Bash(*bin/flow *)` from `UNIVERSAL_ALLOW` in `lib/prime-setup.py:71`
2. Remove `Bash(*bin/flow *)` from reference JSON in `skills/flow-prime/SKILL.md:298`
3. Remove `Bash(*bin/flow *)` from `.claude/settings.json:14`

**Additions to prime-setup.py:**
4. Add `_dynamic_plugin_patterns(plugin_root)` function
5. Add `plugin_root=None` parameter to `merge_settings()`
6. Update `main()` to pass `plugin_root` through to `merge_settings()`

**Test updates:**
7. `test_prime_setup.py` — 4 new tests for dynamic patterns
8. `test_permissions.py` — expand `${CLAUDE_PLUGIN_ROOT}`, generate dynamic patterns, remove pinned test case

**Dependency graph:**

| Task | Type | Depends On |
|------|------|------------|
| 1. Write test_prime_setup tests for dynamic patterns | test | — |
| 2. Write test_permissions updates (variable expansion + dynamic patterns) | test | — |
| 3. Add `_dynamic_plugin_patterns()` to prime-setup.py | implement | 1 |
| 4. Add `plugin_root` to `merge_settings()` and wire in `main()` | implement | 1, 3 |
| 5. Remove `Bash(*bin/flow *)` from all 3 locations (atomic) | implement | 2, 4 |
| 6. Remove pinned regex test for `Bash(*bin/flow *)` | implement | 5 |

**Risks:**
- The `test_prime_setup_lists_match_skill_md_reference` test requires `UNIVERSAL_ALLOW` and flow-prime/SKILL.md to be in sync — removal must be atomic
- Dynamic patterns should NOT appear in `_canonical_config()` — verified: they don't
- Existing tests that assert on the count of allow entries will adjust naturally since count changes with UNIVERSAL_ALLOW
- The `test_permission_to_regex_known_conversions` pinned test case references the removed pattern

Confidence: 95%  |  Nodes: 6  |  Parallel branches: 3

vs. Vanilla Claude:
- The count-based assertions in test_prime_setup.py that will break on UNIVERSAL_ALLOW removal
- The `test_permission_to_regex_known_conversions` pinned test case that references the removed pattern
- The `_canonical_config` isolation — dynamic patterns must NOT enter the config hash
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 2m |
| Plan | 7m |
| Code | 9m |
| Code Review | 11m |
| Learn | <1m |
| Complete | 1m |
| **Total** | **32m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/fix-bin-flow-permission.json</summary>

```json
{
  "schema_version": 1,
  "branch": "fix-bin-flow-permission",
  "repo": "benkruger/flow",
  "pr_number": 501,
  "pr_url": "https://github.com/benkruger/flow/pull/501",
  "started_at": "2026-03-26T19:43:14-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/fix-bin-flow-permission-plan.md",
    "dag": ".flow-states/fix-bin-flow-permission-dag.md",
    "log": ".flow-states/fix-bin-flow-permission.log",
    "state": ".flow-states/fix-bin-flow-permission.json"
  },
  "session_id": "fed91c68-7359-42c3-84b3-d2c9162e3b1f",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/fed91c68-7359-42c3-84b3-d2c9162e3b1f.jsonl",
  "notes": [],
  "prompt": "work on issue #500",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-26T19:43:14-07:00",
      "completed_at": "2026-03-26T19:45:21-07:00",
      "session_started_at": null,
      "cumulative_seconds": 127,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-26T19:45:52-07:00",
      "completed_at": "2026-03-26T19:53:01-07:00",
      "session_started_at": null,
      "cumulative_seconds": 429,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-26T19:54:01-07:00",
      "completed_at": "2026-03-26T20:03:25-07:00",
      "session_started_at": null,
      "cumulative_seconds": 564,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-26T20:07:44-07:00",
      "completed_at": "2026-03-26T20:19:38-07:00",
      "session_started_at": null,
      "cumulative_seconds": 714,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-26T20:20:12-07:00",
      "completed_at": "2026-03-26T20:20:47-07:00",
      "session_started_at": null,
      "cumulative_seconds": 35,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-26T20:21:19-07:00",
      "completed_at": "2026-03-26T20:22:52-07:00",
      "session_started_at": null,
      "cumulative_seconds": 93,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-26T19:45:52-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-26T19:54:01-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-26T20:07:44-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-26T20:20:12-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-26T20:21:19-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "always"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "_continue_context": "",
  "_continue_pending": "",
  "code_tasks_total": 6,
  "code_task": 6,
  "diff_stats": {
    "files_changed": 5,
    "insertions": 87,
    "deletions": 12,
    "captured_at": "2026-03-26T20:03:25-07:00"
  },
  "code_review_step": 4,
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "merge_settings existing_allow set not updated in first loop",
      "url": "https://github.com/benkruger/flow/issues/502",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-03-26T20:10:34-07:00"
    }
  ],
  "learn_step": 4,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/fix-bin-flow-permission.log</summary>

```text
2026-03-26T19:43:14-07:00 [Phase 1] create .flow-states/fix-bin-flow-permission.json (exit 0)
2026-03-26T19:43:14-07:00 [Phase 1] freeze .flow-states/fix-bin-flow-permission-phases.json (exit 0)
2026-03-26T19:43:26-07:00 [Phase 1] Step 3 — Acquire start lock (exit 0)
2026-03-26T19:43:35-07:00 [Phase 1] Step 4 — Pull latest main (exit 0)
2026-03-26T19:44:32-07:00 [Phase 1] Step 5 — CI baseline gate (exit 0)
2026-03-26T19:44:46-07:00 [Phase 1] Step 6 — Update dependencies, no changes (exit 0)
2026-03-26T19:44:51-07:00 [Phase 1] Step 9 — Release start lock (exit 0)
2026-03-26T19:44:56-07:00 [Phase 1] git worktree add .worktrees/fix-bin-flow-permission (exit 0)
2026-03-26T19:45:04-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-26T19:45:04-07:00 [Phase 1] backfill .flow-states/fix-bin-flow-permission.json (exit 0)
2026-03-26T19:45:16-07:00 [Phase 1] Step 10 — Workspace setup (exit 0)
2026-03-26T19:45:19-07:00 [Phase 1] Step 11 — Label issues (exit 0)
2026-03-26T19:46:05-07:00 [Phase 2] Step 1 — Fetch issue #500 (exit 0)
2026-03-26T19:49:51-07:00 [stop-continue] blocking: pending=decompose
2026-03-26T19:52:57-07:00 [Phase 2] Step 3-4 — Plan written, PR body rendered (exit 0)
2026-03-26T20:00:24-07:00 [Phase 3] Tasks 1-6 — All tasks complete, committed a56368f (exit 0)
2026-03-26T20:10:49-07:00 [Phase 4] Step 1 — Simplify: no changes, 1 tech debt issue filed (exit 0)
2026-03-26T20:15:06-07:00 [stop-continue] blocking: pending=review
2026-03-26T20:15:16-07:00 [Phase 4] Step 2 — Review: no findings (exit 0)
2026-03-26T20:16:13-07:00 [stop-continue] blocking: pending=security-review
2026-03-26T20:16:25-07:00 [Phase 4] Step 3 — Security: no findings (exit 0)
2026-03-26T20:19:06-07:00 [stop-continue] blocking: pending=code-review:code-review
2026-03-26T20:19:16-07:00 [Phase 4] Step 4 — Code Review Plugin: no findings (exit 0)
2026-03-26T20:19:44-07:00 [Phase 4] Done — Code Review complete (exit 0)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | merge_settings existing_allow set not updated in first loop | Code Review | #502 |

<!-- end:Issues Filed -->