### PR TITLE
Close Issues Repo Flag

### DIFF
--- a/lib/close-issues.py
+++ b/lib/close-issues.py
@@ -29,8 +29,11 @@ def close_issues(issue_numbers, repo=None):
     failed = []
     for num in issue_numbers:
         try:
+            cmd = ["gh", "issue", "close", str(num)]
+            if repo:
+                cmd.extend(["--repo", repo])
             result = subprocess.run(
-                ["gh", "issue", "close", str(num)],
+                cmd,
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -41,9 +44,9 @@ def close_issues(issue_numbers, repo=None):
                     entry["url"] = f"https://github.com/{repo}/issues/{num}"
                 closed.append(entry)
             else:
-                failed.append(num)
+                failed.append({"number": num, "error": result.stderr.strip()})
         except subprocess.TimeoutExpired:
-            failed.append(num)
+            failed.append({"number": num, "error": "timeout"})
     return {"closed": closed, "failed": failed}
 
 

--- a/tests/test_close_issues.py
+++ b/tests/test_close_issues.py
@@ -67,13 +67,13 @@ def test_closes_all_extracted_issues_with_repo():
     }
     assert mock_run.call_count == 2
     mock_run.assert_any_call(
-        ["gh", "issue", "close", "83"],
+        ["gh", "issue", "close", "83", "--repo", "test/test"],
         capture_output=True,
         text=True,
         timeout=30,
     )
     mock_run.assert_any_call(
-        ["gh", "issue", "close", "89"],
+        ["gh", "issue", "close", "89", "--repo", "test/test"],
         capture_output=True,
         text=True,
         timeout=30,
@@ -81,7 +81,7 @@ def test_closes_all_extracted_issues_with_repo():
 
 
 def test_closes_issues_without_repo():
-    """When repo is None, closed items have number but no url."""
+    """When repo is None, closed items have number but no url, and no --repo flag."""
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
@@ -95,6 +95,9 @@ def test_closes_issues_without_repo():
         "closed": [{"number": 42}],
         "failed": [],
     }
+    # Verify --repo is NOT in the command args
+    call_args = mock_run.call_args[0][0]
+    assert "--repo" not in call_args
 
 
 def test_no_issues_no_gh_calls():
@@ -132,7 +135,7 @@ def test_partial_failure():
         "closed": [
             {"number": 83, "url": "https://github.com/test/test/issues/83"},
         ],
-        "failed": [89],
+        "failed": [{"number": 89, "error": "not found"}],
     }
 
 
@@ -141,7 +144,7 @@ def test_timeout_counts_as_failure():
     with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=30)):
         result = _mod.close_issues([42], repo="test/test")
 
-    assert result == {"closed": [], "failed": [42]}
+    assert result == {"closed": [], "failed": [{"number": 42, "error": "timeout"}]}
 
 
 # --- CLI integration ---


### PR DESCRIPTION
## What

work on issue #644.

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/close-issues-repo-flag-plan.md` |
| DAG | `.flow-states/close-issues-repo-flag-dag.md` |
| Log | `.flow-states/close-issues-repo-flag.log` |
| State | `.flow-states/close-issues-repo-flag.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/31813894-8835-4bb5-9ee6-eed12aa9f9c3.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: Fix close-issues.py — add --repo flag and surface stderr

## Context

Issue #644: `close-issues.py` runs `gh issue close N` without `--repo`, relying on `gh` to auto-detect the repo from git context. During Complete Phase Step 9, this failed silently for issue #636 — the script captures stderr via `capture_output=True` but discards it, returning only `"failed": [636]` with no explanation. The fix adds `--repo` for reliability and surfaces stderr in failed entries for diagnosability.

## Exploration

**`lib/close-issues.py`** — The `close_issues(issue_numbers, repo=None)` function already receives `repo` from `main()` (which reads `state["repo"]`), but only uses it for URL generation in closed entries (line 40-41). The `gh` command at line 33 is `["gh", "issue", "close", str(num)]` with no `--repo`. Failed entries at line 44 are bare ints (`failed.append(num)`) with no error context.

**`tests/test_close_issues.py`** — 12 tests covering: issue number extraction, close with/without repo, no issues, partial failure, timeout, CLI integration with state file. Mock assertions at lines 69-80 verify the exact `subprocess.run` args — these will need updating to include `--repo`.

**`lib/label-issues.py`** — Also lacks `--repo` (line 38), but that is out of scope for this issue. The issue body's description of it as a "reference implementation" is misleading — both scripts have the same gap.

**Consumers of `failed` output** — Only the Complete skill reads `failed`, and only for reporting. `format-complete-summary.py` only consumes the `closed` list (line 77-87). Changing `failed` entries from bare ints to dicts is safe.

## Risks

- **Issue body claim**: The issue says `label-issues.py` "may pass `--repo` successfully" — verified FALSE. Both scripts lack `--repo`. This doesn't affect the fix but the issue body's framing is misleading. The fix scope remains only `close-issues.py`.
- **Schema change**: Changing `failed` from `[int]` to `[{"number": int, "error": str}]` is a breaking schema change but has no downstream consumers beyond Claude reading and reporting the JSON.

## Approach

Two targeted changes to `close_issues()`:

1. When `repo` is provided, append `["--repo", repo]` to the `gh issue close` command args
2. Change failed entries from bare `int` to `{"number": int, "error": str}` with `result.stderr.strip()` (or `"timeout"` for timeout failures)

No signature changes, no caller changes, no skill changes needed.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Update tests for --repo and stderr | test | — |
| 2. Fix close-issues.py | implement | 1 |

## Tasks

### Task 1: Update tests for --repo flag and stderr in failed entries

**Files**: `tests/test_close_issues.py`

Update existing tests in TDD style (tests fail first, then implementation makes them pass):

- `test_closes_all_extracted_issues_with_repo` (line 50): Change mock assertions to expect `["gh", "issue", "close", "83", "--repo", "test/test"]` and `["gh", "issue", "close", "89", "--repo", "test/test"]`
- `test_closes_issues_without_repo` (line 83): Add assertion that the mock call args do NOT contain `"--repo"`
- `test_partial_failure` (line 109): Change `"failed": [89]` to `"failed": [{"number": 89, "error": "not found"}]`
- `test_timeout_counts_as_failure` (line 139): Change `"failed": [42]` to `"failed": [{"number": 42, "error": "timeout"}]`

### Task 2: Fix close-issues.py — add --repo and surface stderr

**Files**: `lib/close-issues.py`

In `close_issues()`:

- Line 32-33: Build command as `cmd = ["gh", "issue", "close", str(num)]`, then `if repo: cmd.extend(["--repo", repo])`. Pass `cmd` to `subprocess.run`.
- Line 44: Change `failed.append(num)` to `failed.append({"number": num, "error": result.stderr.strip()})`
- Line 46: Change `failed.append(num)` to `failed.append({"number": num, "error": "timeout"})`
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Fix close-issues.py — add --repo flag and surface stderr errors

```xml
<dag goal="Fix close-issues.py: add --repo flag and surface stderr errors" mode="full">
  <plan>
    <node id="1" name="Verify Issue Claims" type="validation"
          depends="[]" parallel_with="[]">
      <objective>Validate every behavioral claim in issue #644 against actual source code</objective>
    </node>
    <node id="2" name="Analyze Consumers" type="research"
          depends="[1]" parallel_with="[]">
      <objective>Identify all consumers of close_issues output to assess schema change impact</objective>
    </node>
    <node id="3" name="Design Fix" type="decision"
          depends="[1,2]" parallel_with="[]">
      <objective>Choose the exact changes to close-issues.py and tests, considering backward compatibility</objective>
    </node>
    <node id="4" name="Synthesis" type="synthesis"
          depends="[3]" parallel_with="[]">
      <objective>Produce the implementation task list with dependencies</objective>
    </node>
  </plan>
</dag>
```

---

▶ NODE 1: Verify Issue Claims (depends on: none)

Checking each claim from issue #644:

**Claim 1:** "`close-issues.py` runs `gh issue close N` without passing `--repo`"
- **Verified TRUE** — line 33: `["gh", "issue", "close", str(num)]` has no `--repo`.

**Claim 2:** "the script captures stderr via `capture_output=True` but only checks `returncode`, discarding the error message"
- **Verified TRUE** — line 34: `capture_output=True`, line 38: checks `result.returncode`, line 44: `failed.append(num)` with no `result.stderr`.

**Claim 3:** "`label-issues.py` — reference implementation that may pass `--repo` successfully"
- **MISLEADING** — `label-issues.py` line 38 also does NOT pass `--repo`: `["gh", "issue", "edit", str(num), flag, LABEL]`. The issue body implies label-issues is a model to follow for `--repo`, but it has the same gap. However, the issue's scope is only about `close-issues.py`.

**Claim 4:** "`close_issues` function signature already accepts `repo` parameter"
- **Verified TRUE** — line 23: `def close_issues(issue_numbers, repo=None)`. It uses `repo` only for URL generation (line 41), not for the `gh` command.

**Claim 5:** "`main()` reads `repo` from state file and passes it to `close_issues`"
- **Verified TRUE** — line 68: `repo = state.get("repo")`, line 70: `close_issues(issue_numbers, repo=repo)`.

Quality: 9/10 — All claims verified against source; found one misleading reference.

Key finding: The fix is purely internal to `close_issues()` — the function already receives `repo` but only uses it for URLs, not for the `gh` command.

---

▶ NODE 2: Analyze Consumers (depends on: 1)

The `failed` list is currently `[int, ...]`. Changing it to `[{"number": int, "error": str}, ...]` is a schema change. Consumers checked:

- `skills/flow-complete/SKILL.md` — calls `close-issues`, reports "which issues were closed and which failed". Reads `closed` array to write to a file; `failed` is only mentioned in prose reporting.
- `lib/format-complete-summary.py` — does NOT consume `failed` at all.
- `tests/test_close_issues.py` — directly asserts on `failed` list structure.

Quality: 9/10 — Complete consumer analysis.

Key finding: The `failed` list is consumed by the Complete skill only for reporting. `format-complete-summary.py` does not consume `failed` at all. Changing `failed` entries from bare ints to dicts with error info is safe.

---

▶ NODE 3: Design Fix (depends on: 1, 2)

Two changes needed in `close_issues()`:

**Change 1 — Add `--repo` to gh command:**
When `repo` is provided, append `["--repo", repo]` to the subprocess args. This ensures `gh` always knows which repo to target, regardless of git context.

**Change 2 — Surface stderr in failed entries:**
Change failed entries from bare `int` to `{"number": int, "error": str}` — matching the pattern where closed entries are already dicts. Include `result.stderr.strip()` as the error value. For timeout failures, use `"timeout"` as the error string.

**Test updates:**
- `test_partial_failure` — assert failed entries are dicts with `number` and `error`
- `test_timeout_counts_as_failure` — assert failed entry has `"error": "timeout"`
- `test_closes_all_extracted_issues_with_repo` — assert `--repo` in mock call args
- `test_closes_issues_without_repo` — assert `--repo` is NOT in call args

Quality: 9/10 — Minimal, focused changes with clear test requirements.

Key finding: Both changes are internal to `close_issues()` — no signature change needed, no caller changes, no skill changes.

---

▶ NODE 4: Synthesis (depends on: 3)

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

**Implementation tasks (TDD order):**

| Task | Type | Depends On |
|------|------|------------|
| 1. Update tests for --repo flag in gh command | test | — |
| 2. Update tests for stderr in failed entries | test | — |
| 3. Add --repo to gh command and surface stderr | implement | 1, 2 |

**Task 1 — Update tests for --repo flag:**
- `test_closes_all_extracted_issues_with_repo`: assert mock calls include `["gh", "issue", "close", "83", "--repo", "test/test"]`
- `test_closes_issues_without_repo`: assert mock calls do NOT include `--repo`

**Task 2 — Update tests for stderr in failed entries:**
- `test_partial_failure`: change `"failed": [89]` to `"failed": [{"number": 89, "error": "not found"}]`
- `test_timeout_counts_as_failure`: change `"failed": [42]` to `"failed": [{"number": 42, "error": "timeout"}]`

**Task 3 — Fix close-issues.py:**
- Build command as `cmd = ["gh", "issue", "close", str(num)]` then `if repo: cmd.extend(["--repo", repo])`
- Change `failed.append(num)` to `failed.append({"number": num, "error": result.stderr.strip()})`
- Change timeout handler to `failed.append({"number": num, "error": "timeout"})`

```
Confidence: 95%  |  Nodes: 4  |  Parallel branches: 0

vs. Vanilla Claude (what linear reasoning would have missed):
  • label-issues.py claim as "reference implementation" is misleading — it also lacks --repo
  • Schema change from int to dict in failed list needed consumer analysis to confirm safety
  • format-complete-summary.py doesn't consume failed at all — change is safe
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 8m |
| Plan | 6m |
| Code | 7m |
| Code Review | 10m |
| Learn | 5m |
| Complete | 2m |
| **Total** | **41m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/close-issues-repo-flag.json</summary>

```json
{
  "schema_version": 1,
  "branch": "close-issues-repo-flag",
  "repo": "benkruger/flow",
  "pr_number": 647,
  "pr_url": "https://github.com/benkruger/flow/pull/647",
  "started_at": "2026-03-28T23:16:28-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/close-issues-repo-flag-plan.md",
    "dag": ".flow-states/close-issues-repo-flag-dag.md",
    "log": ".flow-states/close-issues-repo-flag.log",
    "state": ".flow-states/close-issues-repo-flag.json"
  },
  "session_id": "31813894-8835-4bb5-9ee6-eed12aa9f9c3",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/31813894-8835-4bb5-9ee6-eed12aa9f9c3.jsonl",
  "notes": [],
  "prompt": "work on issue #644",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-28T23:16:28-07:00",
      "completed_at": "2026-03-28T23:24:32-07:00",
      "session_started_at": null,
      "cumulative_seconds": 484,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-28T23:26:16-07:00",
      "completed_at": "2026-03-28T23:32:28-07:00",
      "session_started_at": null,
      "cumulative_seconds": 372,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-28T23:33:22-07:00",
      "completed_at": "2026-03-28T23:41:09-07:00",
      "session_started_at": null,
      "cumulative_seconds": 467,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-28T23:42:10-07:00",
      "completed_at": "2026-03-28T23:52:54-07:00",
      "session_started_at": null,
      "cumulative_seconds": 644,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-28T23:54:12-07:00",
      "completed_at": "2026-03-28T23:59:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 331,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-29T00:00:34-07:00",
      "completed_at": "2026-03-29T00:03:27-07:00",
      "session_started_at": null,
      "cumulative_seconds": 173,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-28T23:26:16-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-28T23:33:22-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-28T23:42:10-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-28T23:54:12-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-29T00:00:34-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "always"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "start_steps_total": 11,
  "start_step": 11,
  "plan_steps_total": 4,
  "plan_step": 4,
  "_continue_context": "",
  "_continue_pending": "",
  "code_tasks_total": 2,
  "code_task_name": "Fix close-issues.py",
  "code_task": 2,
  "diff_stats": {
    "files_changed": 2,
    "insertions": 14,
    "deletions": 8,
    "captured_at": "2026-03-28T23:41:09-07:00"
  },
  "code_review_step": 6,
  "learn_step": 5,
  "issues_filed": [
    {
      "label": "Documentation Drift",
      "title": "close-issues.py docstring shows stale output schema after failed entry format change",
      "url": "https://github.com/benkruger/flow/issues/648",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-03-28T23:59:34-07:00"
    }
  ],
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/close-issues-repo-flag.log</summary>

```text
2026-03-28T23:16:28-07:00 [Phase 1] create .flow-states/close-issues-repo-flag.json (exit 0)
2026-03-28T23:16:28-07:00 [Phase 1] freeze .flow-states/close-issues-repo-flag-phases.json (exit 0)
2026-03-28T23:17:37-07:00 [Phase 1] Step 3 — init-state (exit 0)
2026-03-28T23:19:10-07:00 [Phase 1] Step 4 — label-issues (exit 0)
2026-03-28T23:20:39-07:00 [Phase 1] Step 5 — git pull (exit 0)
2026-03-28T23:22:33-07:00 [Phase 1] Step 6 — CI baseline (exit 0)
2026-03-28T23:23:53-07:00 [Phase 1] Step 7 — dependencies no changes (exit 0)
2026-03-28T23:24:03-07:00 [Phase 1] Step 10 — lock released (exit 0)
2026-03-28T23:24:14-07:00 [Phase 1] git worktree add .worktrees/close-issues-repo-flag (exit 0)
2026-03-28T23:24:24-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-28T23:24:24-07:00 [Phase 1] backfill .flow-states/close-issues-repo-flag.json (exit 0)
2026-03-28T23:27:16-07:00 [Phase 2] Step 1 — fetch issue #644 (exit 0)
2026-03-28T23:29:40-07:00 [stop-continue] blocking: pending=decompose
2026-03-28T23:30:29-07:00 [Phase 2] Step 2 — decompose complete, DAG saved (exit 0)
2026-03-28T23:32:06-07:00 [Phase 2] Step 3 — explore and write plan (exit 0)
2026-03-28T23:32:29-07:00 [Phase 2] Step 4 — store plan, render PR, complete phase (exit 0)
2026-03-28T23:37:27-07:00 [Phase 3] Tasks 1-2 — tests + implementation, CI green (exit 0)
2026-03-28T23:39:47-07:00 [stop-continue] blocking: pending=commit
2026-03-28T23:41:11-07:00 [Phase 3] Complete — final CI green, 2154 passed, 100% coverage (exit 0)
2026-03-28T23:42:43-07:00 [Phase 4] Step 1 — Simplify: no findings (exit 0)
2026-03-28T23:43:23-07:00 [Phase 4] Step 2 — Review: no findings (exit 0)
2026-03-28T23:43:47-07:00 [Phase 4] Step 3 — Security: no findings (exit 0)
2026-03-28T23:48:19-07:00 [Phase 4] Step 4 — Context-Isolated Review: no findings (exit 0)
2026-03-28T23:51:17-07:00 [Phase 4] Step 5 — Pre-Mortem: no findings (exit 0)
2026-03-28T23:52:48-07:00 [Phase 4] Step 6 — Adversarial: agent unavailable, skipped (exit 0)
2026-03-28T23:52:55-07:00 [Phase 4] Complete — all 6 steps done (exit 0)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Documentation Drift | close-issues.py docstring shows stale output schema after failed entry format change | Learn | #648 |

<!-- end:Issues Filed -->