### PR TITLE
Flow Doc Sync Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Available at any point in the workflow:
 | `/flow-abort` | Abandon feature — close PR, delete remote branch, remove worktree, delete state |
 | `/flow-reset` | Remove all FLOW artifacts — close PRs, delete worktrees/branches/state files |
 | `/flow-config` | Display current configuration — version, framework, per-skill autonomy |
+| `/flow-doc-sync` | Full codebase documentation accuracy review — reports drift between code and docs |
 | `/flow-issues` | Fetch open issues, categorize, prioritize, and display a dashboard. Supports readiness filters |
 | `/flow-create-issue` | Explore a design question or decompose a concrete problem, iterate until work-ready, then file it |
 | `/flow-decompose-project` | Decompose a large project into linked GitHub issues with sub-issue relationships, blocked-by dependencies, and milestones |

--- a/docs/skills/flow-doc-sync.md
+++ b/docs/skills/flow-doc-sync.md
@@ -1,0 +1,46 @@
+---
+title: /flow-doc-sync
+nav_order: 14
+parent: Skills
+---
+
+# /flow-doc-sync
+
+**Phase:** Any
+
+**Usage:**
+
+```text
+/flow-doc-sync
+```
+
+Full codebase documentation accuracy review. Compares behavioral sources (skills, lib scripts, config files) against all documentation surfaces (README, docs pages, CLAUDE.md, rules) and produces a severity-tagged drift report. Read-only — reports drift but does not fix anything.
+
+---
+
+## What It Does
+
+1. Discovers project structure by reading CLAUDE.md and using Glob to find all documentation surfaces (README.md, docs/\*\*/\*.md, docs/\*\*/\*.html, .claude/rules/\*.md)
+2. Reads all behavioral sources identified from CLAUDE.md and all documentation surfaces
+3. Cross-references each doc surface against behavioral sources, tagging findings by severity
+4. Produces an inline drift report with a summary line and per-file findings
+
+---
+
+## Severity Tags
+
+| Tag | Meaning |
+|-----|---------|
+| `[STALE]` | Doc describes behavior that has changed — feature exists but works differently |
+| `[MISSING]` | Behavior exists in code but is not documented in any surface |
+| `[OUTDATED]` | Doc references something that no longer exists — removed file, renamed command |
+
+Each finding includes doc-says/code-does pairs with source file references.
+
+---
+
+## Gates
+
+- Read-only — never fixes, edits, or commits anything
+- No state file mutations — stateless utility skill
+- Display-only — no AskUserQuestion prompts

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -40,6 +40,7 @@ These skills are available at any point in the workflow, regardless of phase.
 | [`/flow-abort`](flow-abort.md) | Abandon the current feature — close PR, delete branch, remove worktree |
 | [`/flow-reset`](flow-reset.md) | Remove all FLOW artifacts — close PRs, delete worktrees/branches/state files |
 | [`/flow-config`](flow-config.md) | Display current configuration — version, framework, per-skill autonomy |
+| [`/flow-doc-sync`](flow-doc-sync.md) | Full codebase documentation accuracy review — reports drift between code and docs |
 | [`/flow-issues`](flow-issues.md) | Fetch open issues, categorize, prioritize, and display a dashboard with recommended work order. Supports readiness filters (`--ready`, `--blocked`, `--decomposed`, `--quick-start`) |
 | [`/flow-create-issue`](flow-create-issue.md) | Capture a brainstormed solution as a pre-planned issue with an Implementation Plan for fast-tracking through Plan |
 | [`/flow-decompose-project`](flow-decompose-project.md) | Decompose a large project into linked GitHub issues with sub-issue relationships, blocked-by dependencies, and milestones |

--- a/skills/flow-doc-sync/SKILL.md
+++ b/skills/flow-doc-sync/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: flow-doc-sync
+description: "Full codebase documentation accuracy review — reports drift between code behavior and documentation."
+---
+
+# FLOW Doc Sync
+
+Full codebase documentation accuracy review. Compares behavioral sources
+(skills, lib scripts, config files) against all documentation surfaces
+(README, docs pages, inline references) and produces a severity-tagged
+drift report. Read-only — reports drift but does not fix anything.
+
+## Usage
+
+```text
+/flow:flow-doc-sync
+```
+
+## Announce
+
+At the very start, output the following banner in your response (not via Bash) inside a fenced code block:
+
+````markdown
+```text
+──────────────────────────────────────────────────
+  FLOW v1.0.1 — flow:flow-doc-sync — STARTING
+──────────────────────────────────────────────────
+```
+````
+
+## Steps
+
+### Step 1 — Discover project structure
+
+Read `CLAUDE.md` at the project root using the Read tool. Identify:
+
+- **Key files** — the files listed as important to the project
+- **Architecture sections** — how the project is structured
+- **Conventions** — rules and patterns the project follows
+
+Use the Glob tool to find all documentation surfaces:
+
+- `README.md`
+- `docs/**/*.md`
+- `docs/**/*.html`
+- `CLAUDE.md` (also a documentation surface — it describes the project)
+- `.claude/rules/*.md`
+
+Record the full list of documentation surface paths for Step 2.
+
+### Step 2 — Read sources
+
+Read all behavioral sources identified from CLAUDE.md — skill files,
+lib scripts, config files, hook definitions, phase definitions. These
+are the source of truth for what the project actually does.
+
+Read all documentation surfaces found in Step 1. For each surface,
+note what it claims about project behavior, commands, file paths,
+architecture, and conventions.
+
+Use the Read tool for each file. For large files, read the sections
+that make behavioral claims (skip license headers, boilerplate, etc.).
+
+### Step 3 — Cross-reference
+
+Compare each documentation surface against the behavioral sources.
+For every behavioral claim in a doc surface, verify it against the
+actual source. Tag each finding:
+
+- **`[STALE]`** — the doc describes behavior that has changed. The
+  feature still exists but works differently than documented.
+  Include: what the doc says, what the code actually does, and the
+  source file with line reference.
+
+- **`[MISSING]`** — behavior exists in the code but is not documented
+  in any surface. A feature, command, config option, or convention
+  that users or maintainers should know about but cannot discover
+  from documentation alone.
+
+- **`[OUTDATED]`** — the doc references something that no longer
+  exists: a removed file, renamed command, deleted config option,
+  or deprecated pattern. The reference itself is the problem.
+  Include: what the doc references and evidence it no longer exists.
+
+Skip cosmetic differences (formatting, word choice) that do not
+affect accuracy. Focus on factual claims: commands, file paths,
+behavior descriptions, config options, step counts, and
+architectural statements.
+
+### Step 4 — Report
+
+Produce the drift report inline in the response.
+
+**Summary line.** Start with a one-line summary:
+
+> **Doc Sync: N findings (X stale, Y missing, Z outdated)**
+
+If no findings, output:
+
+> **Doc Sync: No drift detected — documentation is in sync with code.**
+
+**Findings.** List each finding grouped by documentation surface file.
+For each file with findings, show the file path as a heading, then
+each finding:
+
+```text
+## <doc_surface_path>
+
+**[STALE]** <description>
+- Doc says: <what the doc claims>
+- Code does: <what the code actually does>
+- Source: <behavioral_source_path>:<line>
+
+**[OUTDATED]** <description>
+- Doc references: <what it references>
+- Status: <removed in commit/PR, renamed to X, etc.>
+```
+
+**Missing features.** List `[MISSING]` findings separately at the end
+under a "## Undocumented" heading, since they are not tied to a
+specific doc surface.
+
+After the report, output the following banner in your response (not via Bash) inside a fenced code block:
+
+````markdown
+```text
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ✓ FLOW v1.0.1 — flow:flow-doc-sync — COMPLETE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+````
+
+## Hard Rules
+
+- Read-only — never fix, edit, or commit anything
+- No state file mutations — this is a stateless utility skill
+- No AskUserQuestion — produce the report and finish
+- No sub-agents — all comparison is inline
+- Never use Bash to print banners — output them as text in your response
+- Never use Bash for file reads — use Glob, Read, and Grep tools
+- Focus on factual accuracy, not style or formatting preferences

--- a/tests/test_skill_contracts.py
+++ b/tests/test_skill_contracts.py
@@ -983,6 +983,7 @@ def test_utility_skill_banners_include_version():
         "flow-status",
         "flow-issues",
         "flow-create-issue",
+        "flow-doc-sync",
         "flow-orchestrate",
     ]
 


### PR DESCRIPTION
## What

work on issue #689.

Closes #689

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/flow-doc-sync-skill-plan.md` |
| DAG | `.flow-states/flow-doc-sync-skill-dag.md` |
| Log | `.flow-states/flow-doc-sync-skill.log` |
| State | `.flow-states/flow-doc-sync-skill.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: Add standalone /flow-doc-sync skill

## Context

`test_docs_sync.py` checks that doc files exist but not that their content is accurate. PR #672 changed the TUI Enter key behavior but CI didn't catch the stale docs. The Learn phase's documentation drift filing (being removed in #687) was the only mechanism, and it was per-PR rather than full-codebase. This skill replaces it with a comprehensive on-demand audit.

## Exploration

Existing standalone skills (`flow-issues`, `flow-config`, `flow-status`) provide the pattern: frontmatter with name/description, no phase gate, auto-discovered by `_utility_skills()` in `test_skill_contracts.py`. New skills require:

- `docs/skills/flow-doc-sync.md` — enforced by `test_every_skill_has_a_docs_page`
- `/flow-doc-sync` in `docs/skills/index.md` — enforced by `test_index_mentions_every_skill_command`
- `/flow-doc-sync` in `README.md` utility commands table — enforced by `test_readme_mentions_all_utility_commands`
- `docs/index.html` — NOT required by tests (only phases and `REQUIRED_FEATURES` checked)

The skill has 4 steps: Discover project structure (read CLAUDE.md, Glob for doc surfaces), Read all sources (behavioral + documentation), Cross-reference for accuracy, Produce report.

`test_utility_skill_banners_include_version` has a hard-coded `utility_with_banners` list — the new skill needs to be added there since it will have STARTING/COMPLETE banners.

## Risks

- Discovery must be generic enough for Rails/Python/iOS projects — CLAUDE.md-driven approach handles this since every FLOW-primed project has CLAUDE.md describing its structure
- Large projects may have many doc surfaces — the report should be concise with severity tags so the user can triage quickly
- pymarkdown linting on the SKILL.md — must follow flat sequential `### Step N` headings, no numbered lists with code blocks, blank lines after fenced code blocks

## Approach

A 4-step read-only skill with CLAUDE.md-driven discovery and severity-tagged output. No sub-agents, no state file, no phase coupling. The report uses `[STALE]`/`[MISSING]`/`[OUTDATED]` tags with doc-says/code-does pairs and source file references. A one-line summary at the top seeds `/flow-create-issue` with enough context to file a pre-planned fix issue.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add flow-doc-sync to `utility_with_banners` in test_skill_contracts.py | test | — |
| 2. Create skills/flow-doc-sync/SKILL.md | implement | 1 |
| 3. Add docs/skills/flow-doc-sync.md | implement | 2 |
| 4. Add flow-doc-sync to docs/skills/index.md | implement | 3 |
| 5. Add flow-doc-sync to README.md utility commands table | implement | 4 |
| 6. Run bin/ci | test | 5 |

## Tasks

**Task 1 — Add flow-doc-sync to `utility_with_banners` in test_skill_contracts.py.** Add `"flow-doc-sync"` to the `utility_with_banners` list in `test_utility_skill_banners_include_version`. This ensures the STARTING/COMPLETE banners in the new skill include the version string. The glob-based `_utility_skills()` discovery handles all other utility skill contract tests automatically.

Files: `tests/test_skill_contracts.py`

**Task 2 — Create skills/flow-doc-sync/SKILL.md.** The skill with frontmatter (name: flow-doc-sync, description) and 4 steps:

- Step 1: Discover project structure by reading CLAUDE.md and using Glob for doc surfaces (README.md, docs/\*\*/\*.md, docs/\*\*/\*.html). Read CLAUDE.md to understand key files, architecture, and conventions.
- Step 2: Read all behavioral sources (skill files, lib scripts, config files identified from CLAUDE.md) and documentation surfaces found in Step 1.
- Step 3: Cross-reference each doc surface against behavioral sources, tagging findings as `[STALE]` (doc describes old behavior), `[MISSING]` (behavior exists but undocumented), or `[OUTDATED]` (doc references removed/renamed entities).
- Step 4: Produce the drift report with a summary line (count of findings by severity), severity-tagged findings with doc-says/code-does pairs and source file references. Print COMPLETE banner.

Include Announce section with STARTING banner (version-tagged: `FLOW v1.0.1 — flow:flow-doc-sync — STARTING`). Include Hard Rules section (read-only, no fixes, no commits, no state file mutations, no AskUserQuestion). Use Read/Glob/Grep tools only — no Bash commands needed.

Files: `skills/flow-doc-sync/SKILL.md`

**Task 3 — Add docs/skills/flow-doc-sync.md.** Documentation page describing the skill's purpose, usage, and report format. Follow the pattern from `docs/skills/flow-issues.md`: frontmatter with title/nav_order/parent, Usage section, What It Does section, Gates section.

Files: `docs/skills/flow-doc-sync.md`

**Task 4 — Add flow-doc-sync to docs/skills/index.md.** Add a row to the Utility Skills table: `| [/flow-doc-sync](flow-doc-sync.md) | Full codebase documentation accuracy review — reports drift between code and docs |`

Files: `docs/skills/index.md`

**Task 5 — Add flow-doc-sync to README.md utility commands table.** Add a row: `| /flow-doc-sync | Full codebase documentation accuracy review — reports drift between code and docs |`

Files: `README.md`

**Task 6 — Run bin/ci.** Verify all changes pass CI including structural sync tests, contract tests, pymarkdown linting, and ruff formatting.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: Add standalone /flow-doc-sync skill for full codebase documentation accuracy review

## Problem

Documentation content drifts out of sync with code behavior between releases. `test_docs_sync.py` enforces structural sync (file existence) but not content accuracy. When a skill or feature behavior changes, CI doesn't catch that the docs still describe the old behavior. The only current mechanism — Learn filing "Documentation Drift" issues — is being removed (issue #687) because it wastes flow cycles on trivial fixes that don't matter until release time.

There is no way to audit the full codebase for documentation accuracy on demand.

## Acceptance Criteria

- A standalone skill `/flow:flow-doc-sync` exists and can be invoked manually
- The skill performs a full codebase review comparing behavioral sources against all documentation surfaces
- It produces a severity-tagged drift report (`[STALE]`, `[MISSING]`, `[OUTDATED]`)
- The report is actionable enough to feed into `/flow:flow-create-issue` for a fix cycle
- The skill is read-only — it reports drift but does not fix anything
- The skill works in any FLOW-primed target project, not just the FLOW repo
- Discovery is CLAUDE.md-driven and Glob-based — no hardcoded project-specific paths

## Scope Boundaries

- Read-only — no fixes, no commits, no state file mutations
- No sub-agents — inline comparison is simpler and the parallelism benefit doesn't justify agent architecture overhead
- No coupling to `/flow-release` — standalone invocation only
- No phase gate — this is a utility skill like `/flow-config` or `/flow-issues`

## Implementation Plan

### Context

`test_docs_sync.py` checks that doc files exist but not that their content is accurate. PR #672 changed the TUI Enter key behavior but CI didn't catch the stale docs. The Learn phase's documentation drift filing (being removed in #687) was the only mechanism, and it was per-PR rather than full-codebase. This skill replaces it with a comprehensive on-demand audit.

### Exploration

Existing standalone skills (`flow-issues`, `flow-config`, `flow-status`) provide the pattern: frontmatter with name/description, no phase gate, auto-discovered by `_utility_skills()` in `test_skill_contracts.py`. New skills require `docs/skills/<name>.md`, `docs/skills/index.md` entry, and `README.md` mention — enforced by `test_docs_sync.py`.

The skill has 4 steps: Discover project structure (read CLAUDE.md, Glob for doc surfaces), Read all sources (behavioral + documentation), Cross-reference for accuracy, Produce report.

### Risks

- Discovery must be generic enough for Rails/Python/iOS projects — CLAUDE.md-driven approach handles this since every FLOW-primed project has CLAUDE.md describing its structure
- Large projects may have many doc surfaces — the report should be concise with severity tags so the user can triage quickly

### Approach

A 4-step read-only skill with CLAUDE.md-driven discovery and severity-tagged output. No sub-agents, no state file, no phase coupling. The report uses `[STALE]`/`[MISSING]`/`[OUTDATED]` tags with doc-says/code-does pairs and source file references. A one-line summary at the top seeds `/flow-create-issue` with enough context to file a pre-planned fix issue.

### Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write contract test for flow-doc-sync | test | — |
| 2. Create skills/flow-doc-sync/SKILL.md | implement | 1 |
| 3. Add docs/skills/flow-doc-sync.md | implement | 2 |
| 4. Add flow-doc-sync to docs/skills/index.md | implement | 3 |
| 5. Add flow-doc-sync to README.md utility commands table | implement | 4 |
| 6. Add flow-doc-sync mention to docs/index.html if required by test_docs_sync.py | implement | 5 |
| 7. Run bin/ci | test | 6 |

### Tasks

**Task 1 — Write contract test for flow-doc-sync.** Add a test in `test_skill_contracts.py` asserting the skill exists, has correct frontmatter, and contains the expected step structure (Discover, Read, Compare, Report). The existing `_utility_skills()` glob-based discovery will auto-cover it for utility skill contract tests.

**Task 2 — Create skills/flow-doc-sync/SKILL.md.** The skill with 4 steps: Step 1 discovers the project structure by reading CLAUDE.md and Globbing for doc surfaces (README.md, docs/**/*.md, docs/**/*.html). Step 2 reads all behavioral sources and documentation surfaces. Step 3 cross-references each doc surface against behavioral sources, tagging findings as `[STALE]`, `[MISSING]`, or `[OUTDATED]`. Step 4 produces the drift report with a summary line, severity-tagged findings with doc-says/code-does pairs, and source references.

**Task 3 — Add docs/skills/flow-doc-sync.md.** Documentation page describing the skill's purpose, usage, and report format.

**Task 4 — Add flow-doc-sync to docs/skills/index.md.** Add a row to the skills index with name and description.

**Task 5 — Add flow-doc-sync to README.md utility commands table.** Add `/flow-doc-sync` to the Utility Commands table with description "Full codebase documentation accuracy review — reports drift between code and docs".

**Task 6 — Add flow-doc-sync mention to docs/index.html.** Add if required by `test_docs_sync.py` REQUIRED_FEATURES check. Read the test to determine if a keyword match is needed.

**Task 7 — Run bin/ci.** Verify all changes pass CI including structural sync, contract tests, and coverage.

## Files to Investigate

- `skills/flow-issues/SKILL.md` — reference pattern for standalone read-only skills
- `skills/flow-config/SKILL.md` — reference pattern for simple utility skills
- `tests/test_skill_contracts.py` — auto-discovery mechanism and existing utility skill tests
- `tests/test_docs_sync.py` — structural sync requirements for new skills
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 3m |
| Code | 10m |
| Code Review | 8m |
| Learn | 6m |
| Complete | 3m |
| **Total** | **32m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/flow-doc-sync-skill.json</summary>

```json
{
  "schema_version": 1,
  "branch": "flow-doc-sync-skill",
  "repo": "benkruger/flow",
  "pr_number": 691,
  "pr_url": "https://github.com/benkruger/flow/pull/691",
  "started_at": "2026-03-30T05:19:34-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/flow-doc-sync-skill-plan.md",
    "dag": ".flow-states/flow-doc-sync-skill-dag.md",
    "log": ".flow-states/flow-doc-sync-skill.log",
    "state": ".flow-states/flow-doc-sync-skill.json"
  },
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #689",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-30T05:19:34-07:00",
      "completed_at": "2026-03-30T05:21:58-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-30T05:22:40-07:00",
      "completed_at": "2026-03-30T05:26:27-07:00",
      "session_started_at": null,
      "cumulative_seconds": 227,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-30T05:27:19-07:00",
      "completed_at": "2026-03-30T05:37:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 624,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-30T05:38:35-07:00",
      "completed_at": "2026-03-30T05:47:11-07:00",
      "session_started_at": null,
      "cumulative_seconds": 516,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-30T05:48:00-07:00",
      "completed_at": "2026-03-30T05:54:21-07:00",
      "session_started_at": null,
      "cumulative_seconds": 381,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-30T05:55:13-07:00",
      "completed_at": "2026-03-30T05:58:25-07:00",
      "session_started_at": null,
      "cumulative_seconds": 192,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-30T05:22:40-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-30T05:27:19-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-30T05:38:35-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-30T05:48:00-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-30T05:55:13-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "always"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "start_steps_total": 11,
  "start_step": 11,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 6,
  "code_task_name": "Run bin/ci",
  "code_task": 6,
  "_continue_context": "Self-invoke flow:flow-code --continue-step --auto.",
  "_continue_pending": "commit",
  "diff_stats": {
    "files_changed": 5,
    "insertions": 190,
    "deletions": 0,
    "captured_at": "2026-03-30T05:37:43-07:00"
  },
  "code_review_step": 4,
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 12,
  "complete_step": 7,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/flow-doc-sync-skill.log</summary>

```text
2026-03-30T05:19:23-07:00 [Phase 1] Step 1 — Acquired start lock (exit 0)
2026-03-30T05:19:24-07:00 [Phase 1] Step 2 — Prime check passed, upgrade check current (exit 0)
2026-03-30T05:19:34-07:00 [Phase 1] create .flow-states/flow-doc-sync-skill.json (exit 0)
2026-03-30T05:19:34-07:00 [Phase 1] freeze .flow-states/flow-doc-sync-skill-phases.json (exit 0)
2026-03-30T05:20:04-07:00 [Phase 1] Step 4 — Labeled issue #689 as Flow In-Progress (exit 0)
2026-03-30T05:20:22-07:00 [Phase 1] Step 5 — Pull latest main, already up to date (exit 0)
2026-03-30T05:20:34-07:00 [Phase 1] Step 6 — CI baseline gate skipped, no changes since last pass (exit 0)
2026-03-30T05:21:10-07:00 [Phase 1] Step 7 — Dependencies unchanged (exit 0)
2026-03-30T05:21:27-07:00 [Phase 1] Step 10 — Released start lock (exit 0)
2026-03-30T05:21:40-07:00 [Phase 1] git worktree add .worktrees/flow-doc-sync-skill (exit 0)
2026-03-30T05:21:48-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-30T05:21:48-07:00 [Phase 1] backfill .flow-states/flow-doc-sync-skill.json (exit 0)
2026-03-30T05:22:47-07:00 [Phase 2] Phase entry — Plan entered (exit 0)
2026-03-30T05:23:27-07:00 [Phase 2] Step 1 — Fetched issue #689 with Decomposed label (exit 0)
2026-03-30T05:23:28-07:00 [Phase 2] Step 2 — Pre-decomposed issue, wrote DAG file (exit 0)
2026-03-30T05:26:01-07:00 [Phase 2] Step 3 — Explored codebase, validated issue claims, wrote plan (exit 0)
2026-03-30T05:26:35-07:00 [Phase 2] Step 4 — Stored plan, rendered PR body, completed phase (exit 0)
2026-03-30T05:27:26-07:00 [Phase 3] Phase entry — Code entered (exit 0)
2026-03-30T05:33:40-07:00 [Phase 3] Tasks 1-5 — Atomic group complete, CI green (exit 0)
2026-03-30T05:37:33-07:00 [Phase 3] Final CI sweep — 2205 passed, 100% coverage (exit 0)
2026-03-30T05:38:47-07:00 [Phase 4] Phase entry — Code Review entered (exit 0)
2026-03-30T05:39:35-07:00 [Phase 4] Step 1 — Simplify: no findings, no changes (exit 0)
2026-03-30T05:40:20-07:00 [Phase 4] Step 2 — Review: zero findings across 5 passes (exit 0)
2026-03-30T05:41:13-07:00 [Phase 4] Step 3 — Security: zero findings (exit 0)
2026-03-30T05:46:40-07:00 [Phase 4] Step 4 — Agent Reviews: 0 real findings from 3 agents (exit 0)
2026-03-30T05:47:19-07:00 [Phase 4] Done — Code Review complete, 0 fixes across 4 steps (exit 0)
```

</details>