### PR TITLE
Tui Iterm2 Tty Tab Switching

### DIFF
--- a/lib/tui.py
+++ b/lib/tui.py
@@ -657,9 +657,11 @@ class TuiApp:
             parts = line.split("|")
             if len(parts) != 3:
                 continue
-            tty_path, win_idx, tab_idx = parts
+            tty_path, win_idx, tab_idx = [p.strip() for p in parts]
             # Strip /dev/ prefix for ps -t
             tty_name = tty_path.replace("/dev/", "")
+            if not tty_name:
+                continue
 
             try:
                 ps_result = subprocess.run(
@@ -686,7 +688,7 @@ class TuiApp:
                     continue
 
                 for lsof_line in lsof_result.stdout.split("\n"):
-                    if lsof_line.startswith("n"):
+                    if lsof_line.startswith("n") and len(lsof_line) > 1:
                         cwd = os.path.realpath(lsof_line[1:])
                         if cwd == target:
                             # Phase C: activate matched tab

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -895,6 +895,64 @@ def test_activate_iterm_tab_activation_timeout(tmp_path):
         assert app._activate_iterm_tab(str(worktree_dir)) is True
 
 
+def test_activate_iterm_tab_empty_lsof_n_line(tmp_path):
+    """Skips bare 'n' lsof lines to avoid false-positive CWD match on empty path."""
+    worktree_dir = tmp_path / ".worktrees" / "test-feature"
+    worktree_dir.mkdir(parents=True)
+    state = make_state()
+    app = _make_app(root=tmp_path, flows=[_flow_from_state(state)])
+
+    tty_output = "/dev/ttys001|1|1\n"
+    lsof_with_bare_n = subprocess.CompletedProcess(args=[], returncode=0, stdout="p123\nfcwd\nn\n", stderr="")
+    calls = [
+        _osascript_result(tty_output),
+        _ps_result([1234]),
+        lsof_with_bare_n,
+    ]
+    with patch("tui.subprocess.run", side_effect=calls):
+        assert app._activate_iterm_tab(str(worktree_dir)) is False
+
+
+def test_activate_iterm_tab_empty_tty_name(tmp_path):
+    """Skips session when tty path strips to empty string."""
+    worktree_dir = tmp_path / ".worktrees" / "test-feature"
+    worktree_dir.mkdir(parents=True)
+    state = make_state()
+    app = _make_app(root=tmp_path, flows=[_flow_from_state(state)])
+
+    # /dev/ strips to empty, second tty matches
+    tty_output = "/dev/|1|1\n/dev/ttys002|1|2\n"
+    calls = [
+        _osascript_result(tty_output),
+        _ps_result([5678]),
+        _lsof_result(str(worktree_dir)),
+        _osascript_result("true"),
+    ]
+    with patch("tui.subprocess.run", side_effect=calls):
+        assert app._activate_iterm_tab(str(worktree_dir)) is True
+
+
+def test_activate_iterm_tab_whitespace_indices(tmp_path):
+    """Strips whitespace from window/tab indices before AppleScript interpolation."""
+    worktree_dir = tmp_path / ".worktrees" / "test-feature"
+    worktree_dir.mkdir(parents=True)
+    state = make_state()
+    app = _make_app(root=tmp_path, flows=[_flow_from_state(state)])
+
+    tty_output = "/dev/ttys001| 2 | 3 \n"
+    calls = [
+        _osascript_result(tty_output),
+        _ps_result([5678]),
+        _lsof_result(str(worktree_dir)),
+        _osascript_result("true"),
+    ]
+    with patch("tui.subprocess.run", side_effect=calls) as mock_run:
+        assert app._activate_iterm_tab(str(worktree_dir)) is True
+        activate_script = mock_run.call_args_list[3][0][0][2]
+        assert "item 2 of windows" in activate_script
+        assert "item 3 of tabs" in activate_script
+
+
 # --- _open_worktree ---
 
 
@@ -934,8 +992,8 @@ def test_open_worktree_no_terminal_fallback():
     import inspect
 
     source = inspect.getsource(tui.TuiApp._open_worktree)
-    assert "open" not in source or "open -a" not in source
-    assert "Terminal" not in source
+    assert "Popen" not in source, "subprocess.Popen fallback removed in PR #713"
+    assert "Terminal" not in source, "Terminal.app codepath removed in PR #713"
 
 
 # --- _open_pr ---


### PR DESCRIPTION
## What

work on issue #710.

Closes #710

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/tui-iterm2-tty-tab-switching-plan.md` |
| DAG | `.flow-states/tui-iterm2-tty-tab-switching-dag.md` |
| Log | `.flow-states/tui-iterm2-tty-tab-switching.log` |
| State | `.flow-states/tui-iterm2-tty-tab-switching.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

The TUI is the primary monitoring interface for active flows. Pressing Enter to jump to a flow's terminal session is a core navigation action. The current shell-integration-dependent matching fails when Claude Code is the foreground process, causing new tabs to open instead of switching to existing ones.

## Exploration

- `lib/tui.py:613-646` — `_activate_iterm_tab` uses AppleScript `variable named "path"` which requires iTerm2 shell integration. Shell integration updates `path` via `PROMPT_COMMAND`/`precmd` hooks, which don't fire when Claude Code is the foreground process.
- `lib/tui.py:648-667` — `_open_worktree` has a fallback to `open -a iTerm/Terminal` when activation fails, and a Terminal.app codepath that is dead code.
- `tests/test_tui.py:663-839` — existing test suite covers activation success/failure, fallback behavior, and Terminal.app codepath. Four tests validate fallback behavior that will be removed.
- iTerm2 AppleScript session objects expose a `tty` property (kernel-level, always set, no shell integration needed).
- macOS `lsof -a -d cwd -Fn -p <pid>` reliably returns a process's working directory. `ps -o pid= -t <tty>` returns PIDs attached to a tty. Both verified working on macOS.

## Risks

- **Multiple PIDs per tty** — a shell, Claude Code, and subprocesses all share one tty. Mitigated by checking all PIDs; any match is sufficient.
- **lsof permission errors** — some PIDs may be inaccessible. Mitigated by skipping failed lookups and trying the next PID.
- **Symlinks in paths** — worktree path and lsof CWD may differ due to symlinks. Mitigated by `os.path.realpath()` on both paths before comparing.
- **Tty naming format** — AppleScript returns `/dev/ttys000`; `ps -t` needs `ttys000`. Must strip `/dev/` prefix.

## Approach

Replace the single-AppleScript shell-integration approach with a three-phase tty-based CWD matching strategy:

1. **Collect tty-to-tab mapping** — AppleScript iterates all iTerm2 windows/tabs, outputting each session's `tty` property with its window and tab indices. Output format: `tty|window_index|tab_index`, one line per session.
2. **Match CWD via lsof** — For each tty, get attached PIDs via `ps -o pid= -t <tty>`. For each PID, query CWD via `lsof -a -d cwd -Fn -p <pid>`. Compare (after `realpath`) against target worktree path.
3. **Activate matched tab** — A second targeted AppleScript call selects the matched window and tab by index.

Remove the `open -a` fallback and Terminal.app codepath from `_open_worktree`. If no tab matches, do nothing.

All new commands (`ps`, `lsof`, `osascript`) run within the TUI Python process via `subprocess.run()` — no new Bash tool permission patterns are needed.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write tests for tty-based CWD matching | test | — |
| 2. Rewrite `_activate_iterm_tab` | implement | 1 |
| 3. Simplify `_open_worktree` | implement | 2 |
| 4. Verify all tests pass | validation | 2, 3 |

## Tasks

### Task 1: Write tests for tty-based CWD matching

Write 8 new tests for `_activate_iterm_tab` in `tests/test_tui.py`:

- `test_activate_iterm_tab_tty_cwd_match` — mock AppleScript returning ttys, mock `ps` returning PIDs, mock `lsof` returning matching CWD. Returns True.
- `test_activate_iterm_tab_no_match` — all lsof CWDs differ from target. Returns False.
- `test_activate_iterm_tab_lsof_permission_error` — some PIDs fail lsof, but a later one matches. Returns True (tests skip-on-error resilience).
- `test_activate_iterm_tab_osascript_timeout` — AppleScript times out. Returns False.
- `test_activate_iterm_tab_osascript_error` — AppleScript exits non-zero. Returns False.
- `test_activate_iterm_tab_no_sessions` — AppleScript returns empty. Returns False.
- `test_activate_iterm_tab_activates_correct_tab` — verifies the second AppleScript call targets the correct window/tab index.
- `test_activate_iterm_tab_symlink_resolution` — worktree path contains symlink, CWD returns resolved path. Still matches.

Write 2 tombstone tests:

- `test_open_worktree_no_terminal_fallback` — assert `open -a` not in `_open_worktree` source.
- `test_activate_iterm_tab_no_shell_integration` — assert `variable named "path"` not in `_activate_iterm_tab` source.

Remove 4 fallback tests: `test_open_worktree` (Terminal default), `test_open_worktree_iterm_fallback`, `test_open_worktree_terminal_no_activation`, `test_open_worktree_iterm`.

Update `test_activate_iterm_tab_script_contains_path` for new tty-based mechanism.

TDD: all new tests fail initially (red phase).

### Task 2: Rewrite `_activate_iterm_tab`

Modify `lib/tui.py`. Replace the shell-integration-based AppleScript with three-phase approach:

- Phase A: AppleScript collects tty/window-index/tab-index for every iTerm2 session
- Phase B: For each tty, run `ps` to get PIDs, then `lsof` per PID to get CWD. Compare via `os.path.realpath()`.
- Phase C: On match, run a second AppleScript to `select` the correct window and tab by index

Handle edge cases: multiple PIDs per tty (any match is sufficient), lsof permission errors (skip silently), symlink resolution, tty name format stripping. Keep 5-second timeout on AppleScript calls.

TDD: new tests from Task 1 pass (green phase).

### Task 3: Simplify `_open_worktree`

Modify `lib/tui.py`. Remove `open -a` fallback entirely. Remove Terminal.app codepath. Remove `TERM_PROGRAM` check. Method becomes: guard on empty flows, get worktree path, guard on directory existence, call `_activate_iterm_tab`.

Update remaining tests: `test_open_worktree_iterm_activates_existing_tab` (simplified signature), `test_open_worktree_no_dir` and `test_open_worktree_no_flows` (still valid, no Popen assertions).

TDD: tombstone tests pass, updated tests pass.

### Task 4: Verify all tests pass

Run `bin/ci` to confirm full suite is green.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: TUI Enter key: reliable iTerm2 tab switching via tty-based CWD matching

## Problem

The TUI's Enter key handler (`_open_worktree` in `lib/tui.py:648-667`) attempts to switch to an existing iTerm2 tab whose working directory matches the selected flow's worktree path. The matching mechanism (`_activate_iterm_tab`, lines 613-646) uses iTerm2's `variable named "path"` — a session property that depends on shell integration's `PROMPT_COMMAND`/`precmd` hooks to stay current.

When Claude Code is the foreground process in a tab, the shell prompt is never displayed, so the `path` variable is stale or unset. This causes `_activate_iterm_tab` to return `False`, and `_open_worktree` falls back to `open -a iTerm <worktree_path>`, which opens a **new** tab instead of switching to the existing one.

The fallback is wrong by design: if a flow appears in the TUI, its worktree tab exists. The matching must be deterministic, not best-effort with a fallback.

Additionally, the Terminal.app codepath is dead code — this feature is iTerm2-only.

## Acceptance Criteria

- Pressing Enter on a flow in the TUI switches to the existing iTerm2 tab running in that worktree — 100% of the time when the tab exists
- No new iTerm2 tabs are ever opened by the Enter key action
- The `open -a` fallback and Terminal.app codepath are removed
- Matching works regardless of whether iTerm2 shell integration is installed
- Matching works when Claude Code (or any long-running process) is the foreground process in the target tab

## Implementation Plan

### Context

The TUI is the primary monitoring interface for active flows. Pressing Enter to jump to a flow's terminal session is a core navigation action. The current shell-integration-dependent matching fails when Claude Code is the foreground process, causing new tabs to open instead of switching to existing ones.

### Exploration

- `lib/tui.py:613-646` — `_activate_iterm_tab` uses AppleScript `variable named "path"` which requires iTerm2 shell integration. Shell integration updates `path` via `PROMPT_COMMAND`/`precmd` hooks, which don't fire when Claude Code is the foreground process.
- `lib/tui.py:648-667` — `_open_worktree` has a fallback to `open -a iTerm/Terminal` when activation fails, and a Terminal.app codepath that is dead code.
- `tests/test_tui.py:663-839` — existing test suite covers activation success/failure, fallback behavior, and Terminal.app codepath. Four tests validate fallback behavior that will be removed.
- iTerm2 AppleScript session objects expose a `tty` property (kernel-level, always set, no shell integration needed).
- macOS `lsof -a -d cwd -Fn -p <pid>` reliably returns a process's working directory. `ps -o pid= -t <tty>` returns PIDs attached to a tty. Both verified working on macOS.

### Risks

- **Multiple PIDs per tty** — a shell, Claude Code, and subprocesses all share one tty. Mitigated by checking all PIDs; any match is sufficient.
- **lsof permission errors** — some PIDs may be inaccessible. Mitigated by skipping failed lookups and trying the next PID.
- **Symlinks in paths** — worktree path and lsof CWD may differ due to symlinks. Mitigated by `os.path.realpath()` on both paths before comparing.
- **Tty naming format** — AppleScript returns `/dev/ttys000`; `ps -t` needs `ttys000`. Must strip `/dev/` prefix.

### Approach

Replace the single-AppleScript shell-integration approach with a three-phase tty-based CWD matching strategy:

1. **Collect tty-to-tab mapping** — AppleScript iterates all iTerm2 windows/tabs, outputting each session's `tty` property with its window and tab indices. Output format: `tty|window_index|tab_index`, one line per session.
2. **Match CWD via lsof** — For each tty, get attached PIDs via `ps -o pid= -t <tty>`. For each PID, query CWD via `lsof -a -d cwd -Fn -p <pid>`. Compare (after `realpath`) against target worktree path.
3. **Activate matched tab** — A second targeted AppleScript call selects the matched window and tab by index.

Remove the `open -a` fallback and Terminal.app codepath from `_open_worktree`. If no tab matches, do nothing.

All new commands (`ps`, `lsof`, `osascript`) run within the TUI Python process via `subprocess.run()` — no new Bash tool permission patterns are needed.

### Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write tests for tty-based CWD matching | test | — |
| 2. Rewrite `_activate_iterm_tab` | implement | 1 |
| 3. Simplify `_open_worktree` | implement | 2 |
| 4. Verify all tests pass | validation | 2, 3 |

### Tasks

#### Task 1: Write tests for tty-based CWD matching

Write 8 new tests for `_activate_iterm_tab` in `tests/test_tui.py`:
- `test_activate_iterm_tab_tty_cwd_match` — mock AppleScript returning ttys, mock `ps` returning PIDs, mock `lsof` returning matching CWD. Returns True.
- `test_activate_iterm_tab_no_match` — all lsof CWDs differ from target. Returns False.
- `test_activate_iterm_tab_lsof_permission_error` — some PIDs fail lsof, but a later one matches. Returns True (tests skip-on-error resilience).
- `test_activate_iterm_tab_osascript_timeout` — AppleScript times out. Returns False.
- `test_activate_iterm_tab_osascript_error` — AppleScript exits non-zero. Returns False.
- `test_activate_iterm_tab_no_sessions` — AppleScript returns empty. Returns False.
- `test_activate_iterm_tab_activates_correct_tab` — verifies the second AppleScript call targets the correct window/tab index.
- `test_activate_iterm_tab_symlink_resolution` — worktree path contains symlink, CWD returns resolved path. Still matches.

Write 2 tombstone tests:
- `test_open_worktree_no_terminal_fallback` — assert `open -a` not in `_open_worktree` source.
- `test_activate_iterm_tab_no_shell_integration` — assert `variable named "path"` not in `_activate_iterm_tab` source.

Remove 4 fallback tests: `test_open_worktree` (Terminal default), `test_open_worktree_iterm_fallback`, `test_open_worktree_terminal_no_activation`, `test_open_worktree_iterm`.

Update `test_activate_iterm_tab_script_contains_path` for new tty-based mechanism.

TDD: all new tests fail initially (red phase).

#### Task 2: Rewrite `_activate_iterm_tab`

Modify `lib/tui.py`. Replace the shell-integration-based AppleScript with three-phase approach:
- Phase A: AppleScript collects tty/window-index/tab-index for every iTerm2 session
- Phase B: For each tty, run `ps` to get PIDs, then `lsof` per PID to get CWD. Compare via `os.path.realpath()`.
- Phase C: On match, run a second AppleScript to `select` the correct window and tab by index

Handle edge cases: multiple PIDs per tty (any match is sufficient), lsof permission errors (skip silently), symlink resolution, tty name format stripping. Keep 5-second timeout on AppleScript calls.

TDD: new tests from Task 1 pass (green phase).

#### Task 3: Simplify `_open_worktree`

Modify `lib/tui.py`. Remove `open -a` fallback entirely. Remove Terminal.app codepath. Remove `TERM_PROGRAM` check. Method becomes: guard on empty flows, get worktree path, guard on directory existence, call `_activate_iterm_tab`.

Update remaining tests: `test_open_worktree_iterm_activates_existing_tab` (simplified signature), `test_open_worktree_no_dir` and `test_open_worktree_no_flows` (still valid, no Popen assertions).

TDD: tombstone tests pass, updated tests pass.

#### Task 4: Verify all tests pass

Run `bin/ci` to confirm full suite is green.

## Files to Investigate

- `lib/tui.py` — `_activate_iterm_tab` (lines 613-646) and `_open_worktree` (lines 648-667): current matching logic and fallback
- `tests/test_tui.py` — existing tests for activation and fallback (lines 663-839): tests need updating to match new behavior
- `lib/flow_utils.py` — `write_tab_sequences` (lines 478-508): existing iTerm2 escape sequence infrastructure

## Out of Scope

- Terminal.app support — iTerm2 only
- Setting custom tab titles/colors as part of this change (existing `write_tab_sequences` is separate)
- Changes to the start phase or session-start hook

## Context

The TUI is the primary monitoring interface for active flows. Pressing Enter to jump to a flow's terminal session is a core navigation action. When it opens a new tab instead of switching to the existing one, it defeats the purpose — the user wants to monitor an active session, not start a new one.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 1m |
| Plan | 3m |
| Code | 17m |
| Code Review | 11m |
| Learn | 2m |
| Complete | 2m |
| **Total** | **37m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/tui-iterm2-tty-tab-switching.json</summary>

```json
{
  "schema_version": 1,
  "branch": "tui-iterm2-tty-tab-switching",
  "repo": "benkruger/flow",
  "pr_number": 713,
  "pr_url": "https://github.com/benkruger/flow/pull/713",
  "started_at": "2026-03-31T02:45:52-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/tui-iterm2-tty-tab-switching-plan.md",
    "dag": ".flow-states/tui-iterm2-tty-tab-switching-dag.md",
    "log": ".flow-states/tui-iterm2-tty-tab-switching.log",
    "state": ".flow-states/tui-iterm2-tty-tab-switching.json"
  },
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #710",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-03-31T02:45:52-07:00",
      "completed_at": "2026-03-31T02:51:54-07:00",
      "session_started_at": null,
      "cumulative_seconds": 63,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-03-31T02:52:49-07:00",
      "completed_at": "2026-03-31T02:55:55-07:00",
      "session_started_at": null,
      "cumulative_seconds": 186,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-03-31T02:57:03-07:00",
      "completed_at": "2026-03-31T03:14:41-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1058,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-03-31T03:15:06-07:00",
      "completed_at": "2026-03-31T03:26:24-07:00",
      "session_started_at": null,
      "cumulative_seconds": 678,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-03-31T03:26:53-07:00",
      "completed_at": "2026-03-31T03:29:58-07:00",
      "session_started_at": null,
      "cumulative_seconds": 127,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-03-31T03:30:34-07:00",
      "completed_at": "2026-03-31T03:33:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 166,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-03-31T02:52:49-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-03-31T02:57:03-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-03-31T03:15:06-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-03-31T03:26:53-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-03-31T03:30:34-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto",
      "code_review_plugin": "always"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "start_steps_total": 11,
  "start_step": 11,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 4,
  "code_task_name": "Verify all tests pass",
  "code_task": 4,
  "_continue_context": "Set code_review_step=4, then self-invoke flow:flow-code-review --continue-step --auto.",
  "_continue_pending": "commit",
  "diff_stats": {
    "files_changed": 2,
    "insertions": 272,
    "deletions": 119,
    "captured_at": "2026-03-31T03:14:41-07:00"
  },
  "code_review_step": 4,
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 12,
  "complete_step": 7,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/tui-iterm2-tty-tab-switching.log</summary>

```text
2026-03-31T02:45:38-07:00 [Phase 1] Step 2 — prime-check ok, upgrade-check current (exit 0)
2026-03-31T02:45:52-07:00 [Phase 1] create .flow-states/tui-iterm2-tty-tab-switching.json (exit 0)
2026-03-31T02:45:52-07:00 [Phase 1] freeze .flow-states/tui-iterm2-tty-tab-switching-phases.json (exit 0)
2026-03-31T02:46:10-07:00 [Phase 1] Step 3 — init-state ok (exit 0)
2026-03-31T02:46:27-07:00 [Phase 1] Step 4 — label-issues labeled #710 (exit 0)
2026-03-31T02:50:24-07:00 [Phase 1] Step 5 — git pull origin main (exit 0)
2026-03-31T02:50:40-07:00 [Phase 1] Step 6 — CI baseline skipped, no changes since last pass (exit 0)
2026-03-31T02:51:06-07:00 [Phase 1] Step 7 — dependencies, no changes (exit 0)
2026-03-31T02:51:18-07:00 [Phase 1] Step 10 — start-lock released (exit 0)
2026-03-31T02:51:35-07:00 [Phase 1] git worktree add .worktrees/tui-iterm2-tty-tab-switching (exit 0)
2026-03-31T02:51:42-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-03-31T02:51:42-07:00 [Phase 1] backfill .flow-states/tui-iterm2-tty-tab-switching.json (exit 0)
2026-03-31T02:53:10-07:00 [Phase 2] Step 1 — fetched issue #710, has decomposed label (exit 0)
2026-03-31T02:54:13-07:00 [Phase 2] Step 2 — pre-decomposed issue, wrote DAG file (exit 0)
2026-03-31T02:55:24-07:00 [Phase 2] Step 3 — extracted pre-planned issue, wrote plan file (exit 0)
2026-03-31T02:55:59-07:00 [Phase 2] Step 4 — stored plan, rendered PR body, phase complete (exit 0)
2026-03-31T02:59:24-07:00 [Phase 3] Task 1 — wrote 8 new tests + 2 tombstone + 3 updated, removed 4 fallback tests, TDD red confirmed (exit 0)
2026-03-31T03:12:03-07:00 [Phase 3] Tasks 1-4 — all tasks complete, committed 872f0ea (exit 0)
2026-03-31T03:15:35-07:00 [Phase 4] Step 1 — Simplify: no findings (exit 0)
2026-03-31T03:16:21-07:00 [Phase 4] Step 2 — Review: no findings (exit 0)
2026-03-31T03:16:38-07:00 [Phase 4] Step 3 — Security: no findings (exit 0)
2026-03-31T03:26:12-07:00 [Phase 4] Step 4 — Agent Reviews: 4 real findings fixed, 6 false positives (exit 0)
```

</details>