### PR TITLE
Update Write Rule.py Docstring To Reflect All .claude/ Path Consumers

### DIFF
--- a/lib/write-rule.py
+++ b/lib/write-rule.py
@@ -4,8 +4,14 @@ Usage:
   bin/flow write-rule --path <target> --content-file <temp>
 
 Reads content from a temp file, creates parent directories if needed,
-writes to the target path, and deletes the temp file. Used by the Learn
-phase to bypass Claude Code's .claude/ permission prompts.
+writes to the target path, and deletes the temp file. Bypasses Claude
+Code's built-in .claude/ path protections, which block Edit/Write tools
+regardless of settings.json allow-list entries.
+
+Consumers:
+  - Learn phase: writes CLAUDE.md and .claude/rules/ files
+  - validate-claude-paths.py hook: redirects blocked Edit/Write calls here
+  - Any skill or hook that needs to write to .claude/ paths during a flow
 
 Output (JSON to stdout):
   Success: {"status": "ok", "path": "<target_path>"}


### PR DESCRIPTION
## What

work on issue #752.

Closes #752

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/update-write-rulepy-docstring-to-plan.md` |
| Log | `.flow-states/update-write-rulepy-docstring-to.log` |
| State | `.flow-states/update-write-rulepy-docstring-to.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: Update write-rule.py docstring

## Context

Issue #752: The docstring in `lib/write-rule.py` says "Used by the Learn phase to bypass
Claude Code's .claude/ permission prompts." This is misleading — `write-rule` is a generic
file writer used by any phase or hook that needs to write to `.claude/` paths (or any path).
The `validate-claude-paths.py` hook redirects Edit/Write operations on `.claude/` paths to
`write-rule`, so developers following that redirect see a docstring that implies it's
Learn-only.

## Exploration

**Current docstring** (lines 1–13 of `lib/write-rule.py`):
- Says "Used by the Learn phase to bypass Claude Code's .claude/ permission prompts"
- Accurate about usage/interface but misleading about scope

**Actual consumers:**
1. `skills/flow-learn/SKILL.md` — writes CLAUDE.md and `.claude/rules/` files (original consumer)
2. `lib/validate-claude-paths.py` hook — blocks Edit/Write on `.claude/` paths during active
   FLOW phases and tells the user to use `bin/flow write-rule` instead
3. Generic — the script accepts any `--path` and works for any file target

**Test file** (`tests/test_write_rule.py`): 100% coverage, no docstring-specific assertions
that would break. The test module docstring says "Tests for lib/write-rule.py — write content
to a target file path" which is already accurate.

## Risks

- Very low risk — docstring-only change, no behavioral impact
- No test assertions reference the docstring text

## Approach

Update the module docstring to describe `write-rule` as a generic file writer used by
multiple consumers (Learn phase, validate-claude-paths hook), removing the Learn-only
framing while keeping the usage and output documentation intact.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Update docstring | implement | — |

## Tasks

### Task 1: Update the module docstring in `lib/write-rule.py`

Replace the current docstring (lines 1–13) with an updated version that:
- Describes `write-rule` as a generic file writer for `.claude/` paths (and any path)
- Lists its consumers: Learn phase (CLAUDE.md, `.claude/rules/`) and
  `validate-claude-paths.py` hook (redirects Edit/Write on `.claude/` paths)
- Keeps the existing Usage and Output sections unchanged

**Files to modify:** `lib/write-rule.py` (docstring only, lines 1–13)
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 1m |
| Code | 3m |
| Code Review | 5m |
| Learn | 5h 45m |
| Complete | <1m |
| **Total** | **5h 56m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/update-write-rulepy-docstring-to.json</summary>

```json
{
  "schema_version": 1,
  "branch": "update-write-rulepy-docstring-to",
  "repo": "benkruger/flow",
  "pr_number": 754,
  "pr_url": "https://github.com/benkruger/flow/pull/754",
  "started_at": "2026-04-01T18:57:30-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/update-write-rulepy-docstring-to-plan.md",
    "dag": null,
    "log": ".flow-states/update-write-rulepy-docstring-to.log",
    "state": ".flow-states/update-write-rulepy-docstring-to.json"
  },
  "session_tty": "/dev/ttys011",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #752",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-01T18:57:30-07:00",
      "completed_at": "2026-04-01T18:57:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 13,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-01T18:58:08-07:00",
      "completed_at": "2026-04-01T18:59:50-07:00",
      "session_started_at": null,
      "cumulative_seconds": 93,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-01T19:00:30-07:00",
      "completed_at": "2026-04-01T19:04:53-07:00",
      "session_started_at": null,
      "cumulative_seconds": 180,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-01T19:05:16-07:00",
      "completed_at": "2026-04-01T19:10:18-07:00",
      "session_started_at": null,
      "cumulative_seconds": 302,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-01T19:10:43-07:00",
      "completed_at": "2026-04-02T00:56:36-07:00",
      "session_started_at": null,
      "cumulative_seconds": 20753,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-02T00:57:22-07:00",
      "completed_at": "2026-04-02T01:00:55-07:00",
      "session_started_at": null,
      "cumulative_seconds": 36,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-01T18:58:08-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-01T19:00:30-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-01T19:05:16-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-01T19:10:43-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-02T00:57:22-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 1,
  "code_task_name": "Update module docstring in write-rule.py",
  "code_task": 1,
  "_continue_context": "All tasks complete. Proceed to phase completion.",
  "_continue_pending": "commit",
  "diff_stats": {
    "files_changed": 1,
    "insertions": 8,
    "deletions": 2,
    "captured_at": "2026-04-01T19:04:53-07:00"
  },
  "code_review_step": 4,
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 12,
  "complete_step": 7,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/update-write-rulepy-docstring-to.log</summary>

```text
2026-04-01T18:57:22-07:00 [Phase 1] git worktree add .worktrees/update-write-rulepy-docstring-to (exit 0)
2026-04-01T18:57:30-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-04-01T18:57:30-07:00 [Phase 1] create .flow-states/update-write-rulepy-docstring-to.json (exit 0)
2026-04-01T18:57:30-07:00 [Phase 1] freeze .flow-states/update-write-rulepy-docstring-to-phases.json (exit 0)
2026-04-01T18:58:34-07:00 [Phase 2] Step 1 — fetch issue #752 (exit 0)
2026-04-01T18:58:36-07:00 [Phase 2] Step 2 — DAG skipped, trivial single-file change (exit 0)
2026-04-01T18:59:44-07:00 [Phase 2] Step 3 — explore and write plan (exit 0)
2026-04-01T18:59:51-07:00 [Phase 2] Step 4 — store plan and complete (exit 0)
2026-04-01T19:02:31-07:00 [Phase 3] Task 1 — update docstring, CI green (exit 0)
2026-04-01T19:04:55-07:00 [Phase 3] Complete — 1 task, CI green, 100% coverage (exit 0)
2026-04-01T19:05:32-07:00 [Phase 4] Step 1 — Simplify, no findings (exit 0)
2026-04-01T19:05:55-07:00 [Phase 4] Step 2 — Review, no findings (exit 0)
2026-04-01T19:06:07-07:00 [Phase 4] Step 3 — Security, no findings (exit 0)
2026-04-01T19:10:13-07:00 [Phase 4] Step 4 — Agent Reviews, no findings (exit 0)
```

</details>