### PR TITLE
Port Cleanup To Rust

### DIFF
--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -1,0 +1,702 @@
+//! Port of lib/cleanup.py — cleanup orchestrator for FLOW features.
+//!
+//! Shared by /flow:flow-complete (Phase 6) and /flow:flow-abort. Performs best-effort
+//! cleanup steps, continuing on failure.
+//!
+//! Usage:
+//!   bin/flow cleanup <project_root> --branch <name> --worktree <path> [--pr <number>] [--pull]
+//!
+//! Output (JSON to stdout):
+//!   {"status": "ok", "steps": {"worktree": "removed", "state_file": "deleted", ...}}
+//!
+//! Each step reports one of: "removed"/"deleted"/"closed", "skipped", or "failed: <reason>".
+
+use std::path::Path;
+use std::process::Command;
+
+use clap::Parser;
+use indexmap::IndexMap;
+use serde_json::json;
+
+use crate::output::json_error;
+
+#[derive(Parser, Debug)]
+#[command(name = "cleanup", about = "FLOW cleanup orchestrator")]
+pub struct Args {
+    /// Path to project root
+    pub project_root: String,
+    /// Branch name
+    #[arg(long)]
+    pub branch: String,
+    /// Worktree path (relative)
+    #[arg(long)]
+    pub worktree: String,
+    /// PR number to close
+    #[arg(long)]
+    pub pr: Option<u32>,
+    /// Run git pull origin main after cleanup
+    #[arg(long)]
+    pub pull: bool,
+}
+
+/// Run a command, returning (success, output).
+pub fn run_cmd(args: &[&str], cwd: &Path) -> (bool, String) {
+    match Command::new(args[0])
+        .args(&args[1..])
+        .current_dir(cwd)
+        .output()
+    {
+        Ok(output) => {
+            if output.status.success() {
+                (true, String::from_utf8_lossy(&output.stdout).trim().to_string())
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                (false, if stderr.is_empty() { stdout } else { stderr })
+            }
+        }
+        Err(e) => (false, e.to_string()),
+    }
+}
+
+/// Delete a file, returning "deleted", "skipped", or "failed: <reason>".
+fn delete_file(path: &Path) -> String {
+    if path.exists() {
+        match std::fs::remove_file(path) {
+            Ok(_) => "deleted".to_string(),
+            Err(e) => format!("failed: {}", e),
+        }
+    } else {
+        "skipped".to_string()
+    }
+}
+
+/// Perform cleanup steps. Returns an ordered map of step results.
+pub fn cleanup(
+    project_root: &Path,
+    branch: &str,
+    worktree: &str,
+    pr_number: Option<u32>,
+    pull: bool,
+) -> IndexMap<String, String> {
+    let mut steps = IndexMap::new();
+
+    // Close PR (abort only)
+    if let Some(pr) = pr_number {
+        let (ok, output) = run_cmd(
+            &["gh", "pr", "close", &pr.to_string()],
+            project_root,
+        );
+        steps.insert(
+            "pr_close".to_string(),
+            if ok { "closed".to_string() } else { format!("failed: {}", output) },
+        );
+    } else {
+        steps.insert("pr_close".to_string(), "skipped".to_string());
+    }
+
+    // Remove worktree tmp/ (FLOW repo only — before worktree removal)
+    let is_flow_repo = project_root.join("flow-phases.json").exists();
+    let wt_tmp = project_root.join(worktree).join("tmp");
+    if is_flow_repo && wt_tmp.is_dir() {
+        match std::fs::remove_dir_all(&wt_tmp) {
+            Ok(_) => {
+                steps.insert("worktree_tmp".to_string(), "removed".to_string());
+            }
+            Err(e) => {
+                steps.insert("worktree_tmp".to_string(), format!("failed: {}", e));
+            }
+        }
+    } else {
+        steps.insert("worktree_tmp".to_string(), "skipped".to_string());
+    }
+
+    // Remove worktree
+    let wt_path = project_root.join(worktree);
+    if wt_path.exists() {
+        let wt_str = wt_path.to_string_lossy().to_string();
+        let (ok, output) = run_cmd(
+            &["git", "worktree", "remove", &wt_str, "--force"],
+            project_root,
+        );
+        steps.insert(
+            "worktree".to_string(),
+            if ok { "removed".to_string() } else { format!("failed: {}", output) },
+        );
+    } else {
+        steps.insert("worktree".to_string(), "skipped".to_string());
+    }
+
+    // Delete remote branch
+    let (ok, output) = run_cmd(
+        &["git", "push", "origin", "--delete", branch],
+        project_root,
+    );
+    steps.insert(
+        "remote_branch".to_string(),
+        if ok { "deleted".to_string() } else { format!("failed: {}", output) },
+    );
+
+    // Delete local branch
+    let (ok, output) = run_cmd(
+        &["git", "branch", "-D", branch],
+        project_root,
+    );
+    steps.insert(
+        "local_branch".to_string(),
+        if ok { "deleted".to_string() } else { format!("failed: {}", output) },
+    );
+
+    // Delete state files
+    let state_dir = project_root.join(".flow-states");
+    steps.insert(
+        "state_file".to_string(),
+        delete_file(&state_dir.join(format!("{}.json", branch))),
+    );
+    steps.insert(
+        "plan_file".to_string(),
+        delete_file(&state_dir.join(format!("{}-plan.md", branch))),
+    );
+    steps.insert(
+        "dag_file".to_string(),
+        delete_file(&state_dir.join(format!("{}-dag.md", branch))),
+    );
+    steps.insert(
+        "log_file".to_string(),
+        delete_file(&state_dir.join(format!("{}.log", branch))),
+    );
+    steps.insert(
+        "frozen_phases".to_string(),
+        delete_file(&state_dir.join(format!("{}-phases.json", branch))),
+    );
+    steps.insert(
+        "ci_sentinel".to_string(),
+        delete_file(&state_dir.join(format!("{}-ci-passed", branch))),
+    );
+    steps.insert(
+        "timings_file".to_string(),
+        delete_file(&state_dir.join(format!("{}-timings.md", branch))),
+    );
+    steps.insert(
+        "closed_issues_file".to_string(),
+        delete_file(&state_dir.join(format!("{}-closed-issues.json", branch))),
+    );
+    steps.insert(
+        "issues_file".to_string(),
+        delete_file(&state_dir.join(format!("{}-issues.md", branch))),
+    );
+
+    // Pull latest main (after worktree removal — ordering matters)
+    if pull {
+        let (ok, output) = run_cmd(
+            &["git", "pull", "origin", "main"],
+            project_root,
+        );
+        steps.insert(
+            "git_pull".to_string(),
+            if ok { "pulled".to_string() } else { format!("failed: {}", output) },
+        );
+    }
+
+    steps
+}
+
+/// CLI entry point for the cleanup subcommand.
+pub fn run(args: Args) {
+    let root = Path::new(&args.project_root);
+    if !root.is_dir() {
+        json_error(
+            &format!("Project root not found: {}", args.project_root),
+            &[],
+        );
+        std::process::exit(1);
+    }
+
+    let steps = cleanup(root, &args.branch, &args.worktree, args.pr, args.pull);
+    println!("{}", json!({"status": "ok", "steps": steps}));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process::Command as StdCommand;
+
+    /// Initialize a bare git repo with an initial commit.
+    fn init_git_repo(root: &Path) {
+        StdCommand::new("git")
+            .args(["init"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+        StdCommand::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+        StdCommand::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+        StdCommand::new("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+    }
+
+    /// Create a worktree and state files for testing cleanup.
+    fn setup_feature(root: &Path, branch: &str) -> String {
+        let wt_rel = format!(".worktrees/{}", branch);
+        StdCommand::new("git")
+            .args(["worktree", "add", &wt_rel, "-b", branch])
+            .current_dir(root)
+            .output()
+            .unwrap();
+
+        let state_dir = root.join(".flow-states");
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join(format!("{}.json", branch)),
+            json!({"branch": branch}).to_string(),
+        )
+        .unwrap();
+        fs::write(state_dir.join(format!("{}.log", branch)), "test log\n").unwrap();
+
+        wt_rel
+    }
+
+    fn git_repo() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        init_git_repo(&root);
+        (dir, root)
+    }
+
+    // --- run_cmd tests ---
+
+    #[test]
+    fn run_cmd_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let (ok, output) = run_cmd(&["echo", "hello"], dir.path());
+        assert!(ok);
+        assert_eq!(output, "hello");
+    }
+
+    #[test]
+    fn run_cmd_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let (ok, _output) = run_cmd(&["git", "status"], dir.path());
+        // No git repo, so git status will fail or succeed depending on parent
+        // Just verify it returns without panic
+        let _ = ok;
+    }
+
+    #[test]
+    fn run_cmd_handles_missing_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let (ok, output) = run_cmd(&["nonexistent-command-xyz"], dir.path());
+        assert!(!ok);
+        assert!(!output.is_empty());
+    }
+
+    // --- cleanup removes worktree ---
+
+    #[test]
+    fn cleanup_removes_worktree() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["worktree"], "removed");
+        assert!(!root.join(&wt_rel).exists());
+    }
+
+    // --- cleanup deletes state file ---
+
+    #[test]
+    fn cleanup_deletes_state_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["state_file"], "deleted");
+        assert!(!root.join(".flow-states/test-feature.json").exists());
+    }
+
+    // --- cleanup deletes log file ---
+
+    #[test]
+    fn cleanup_deletes_log_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["log_file"], "deleted");
+        assert!(!root.join(".flow-states/test-feature.log").exists());
+    }
+
+    // --- cleanup deletes plan file ---
+
+    #[test]
+    fn cleanup_deletes_plan_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let plan = root.join(".flow-states/test-feature-plan.md");
+        fs::write(&plan, "# Plan\n").unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["plan_file"], "deleted");
+        assert!(!plan.exists());
+    }
+
+    #[test]
+    fn cleanup_skips_missing_plan_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["plan_file"], "skipped");
+    }
+
+    // --- cleanup deletes DAG file ---
+
+    #[test]
+    fn cleanup_deletes_dag_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let dag = root.join(".flow-states/test-feature-dag.md");
+        fs::write(&dag, "# DAG\n").unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["dag_file"], "deleted");
+        assert!(!dag.exists());
+    }
+
+    #[test]
+    fn cleanup_skips_missing_dag_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["dag_file"], "skipped");
+    }
+
+    // --- cleanup deletes frozen phases file ---
+
+    #[test]
+    fn cleanup_deletes_frozen_phases_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let frozen = root.join(".flow-states/test-feature-phases.json");
+        fs::write(&frozen, r#"{"phases": {}, "order": []}"#).unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["frozen_phases"], "deleted");
+        assert!(!frozen.exists());
+    }
+
+    #[test]
+    fn cleanup_skips_missing_frozen_phases() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["frozen_phases"], "skipped");
+    }
+
+    // --- cleanup deletes CI sentinel ---
+
+    #[test]
+    fn cleanup_deletes_ci_sentinel() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let sentinel = root.join(".flow-states/test-feature-ci-passed");
+        fs::write(&sentinel, "snapshot\n").unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["ci_sentinel"], "deleted");
+        assert!(!sentinel.exists());
+    }
+
+    #[test]
+    fn cleanup_skips_missing_ci_sentinel() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["ci_sentinel"], "skipped");
+    }
+
+    // --- cleanup deletes timings file ---
+
+    #[test]
+    fn cleanup_deletes_timings_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let timings = root.join(".flow-states/test-feature-timings.md");
+        fs::write(&timings, "| Phase | Duration |\n").unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["timings_file"], "deleted");
+        assert!(!timings.exists());
+    }
+
+    #[test]
+    fn cleanup_skips_missing_timings_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["timings_file"], "skipped");
+    }
+
+    // --- cleanup deletes closed issues file ---
+
+    #[test]
+    fn cleanup_deletes_closed_issues_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let closed = root.join(".flow-states/test-feature-closed-issues.json");
+        fs::write(&closed, r#"[{"number": 42, "url": "https://github.com/t/t/issues/42"}]"#).unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["closed_issues_file"], "deleted");
+        assert!(!closed.exists());
+    }
+
+    #[test]
+    fn cleanup_skips_missing_closed_issues_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["closed_issues_file"], "skipped");
+    }
+
+    // --- cleanup deletes issues file ---
+
+    #[test]
+    fn cleanup_deletes_issues_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let issues = root.join(".flow-states/test-feature-issues.md");
+        fs::write(&issues, "| Label | Title |\n").unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["issues_file"], "deleted");
+        assert!(!issues.exists());
+    }
+
+    #[test]
+    fn cleanup_skips_missing_issues_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["issues_file"], "skipped");
+    }
+
+    // --- PR close ---
+
+    #[test]
+    fn cleanup_skips_pr_by_default() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["pr_close"], "skipped");
+    }
+
+    #[test]
+    fn cleanup_pr_close_fails_gracefully() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, Some(999), false);
+        // No GitHub remote configured, so gh pr close will fail
+        assert!(steps["pr_close"].starts_with("failed:"));
+    }
+
+    // --- Full happy path ---
+
+    #[test]
+    fn cleanup_full_happy_path() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+
+        // All step results
+        assert_eq!(steps["pr_close"], "skipped");
+        assert_eq!(steps["worktree_tmp"], "skipped");
+        assert_eq!(steps["worktree"], "removed");
+        assert!(steps["remote_branch"].starts_with("failed:")); // no remote
+        assert_eq!(steps["local_branch"], "deleted");
+        assert_eq!(steps["state_file"], "deleted");
+        assert_eq!(steps["plan_file"], "skipped");
+        assert_eq!(steps["dag_file"], "skipped");
+        assert_eq!(steps["log_file"], "deleted");
+        assert_eq!(steps["frozen_phases"], "skipped");
+        assert_eq!(steps["ci_sentinel"], "skipped");
+        assert_eq!(steps["timings_file"], "skipped");
+        assert_eq!(steps["closed_issues_file"], "skipped");
+        assert_eq!(steps["issues_file"], "skipped");
+
+        // Filesystem effects
+        assert!(!root.join(&wt_rel).exists());
+        assert!(!root.join(".flow-states/test-feature.json").exists());
+        assert!(!root.join(".flow-states/test-feature.log").exists());
+    }
+
+    // --- Key order matches Python ---
+
+    #[test]
+    fn cleanup_key_order_matches_python() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+
+        let keys: Vec<&String> = steps.keys().collect();
+        let expected = vec![
+            "pr_close",
+            "worktree_tmp",
+            "worktree",
+            "remote_branch",
+            "local_branch",
+            "state_file",
+            "plan_file",
+            "dag_file",
+            "log_file",
+            "frozen_phases",
+            "ci_sentinel",
+            "timings_file",
+            "closed_issues_file",
+            "issues_file",
+        ];
+        assert_eq!(keys, expected);
+    }
+
+    #[test]
+    fn cleanup_key_order_with_pull() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, true);
+
+        let keys: Vec<&String> = steps.keys().collect();
+        assert_eq!(keys.last().unwrap().as_str(), "git_pull");
+        assert_eq!(keys.len(), 15); // 14 standard + git_pull
+    }
+
+    // --- Missing resources ---
+
+    #[test]
+    fn cleanup_skips_missing_worktree() {
+        let (_dir, root) = git_repo();
+        setup_feature(&root, "test-feature");
+        // Remove worktree before cleanup
+        StdCommand::new("git")
+            .args(["worktree", "remove", ".worktrees/test-feature", "--force"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        let steps = cleanup(&root, "test-feature", ".worktrees/test-feature", None, false);
+        assert_eq!(steps["worktree"], "skipped");
+    }
+
+    #[test]
+    fn cleanup_skips_missing_state_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        fs::remove_file(root.join(".flow-states/test-feature.json")).unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["state_file"], "skipped");
+    }
+
+    #[test]
+    fn cleanup_skips_missing_log_file() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        fs::remove_file(root.join(".flow-states/test-feature.log")).unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["log_file"], "skipped");
+    }
+
+    // --- Branch deletion ---
+
+    #[test]
+    fn cleanup_always_deletes_local_branch() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        // Remove worktree first so branch can be deleted
+        StdCommand::new("git")
+            .args(["worktree", "remove", &wt_rel, "--force"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["local_branch"], "deleted");
+    }
+
+    #[test]
+    fn cleanup_always_attempts_remote_branch() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        // No remote configured, so push --delete will fail
+        assert!(steps["remote_branch"].starts_with("failed:"));
+    }
+
+    // --- tmp/ directory cleanup ---
+
+    #[test]
+    fn cleanup_removes_worktree_tmp_in_flow_repo() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        // Mark as FLOW repo
+        fs::write(root.join("flow-phases.json"), "{}").unwrap();
+        // Create tmp/ inside the worktree
+        let wt_tmp = root.join(&wt_rel).join("tmp");
+        fs::create_dir_all(&wt_tmp).unwrap();
+        fs::write(wt_tmp.join("release-notes-v1.0.md"), "notes").unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["worktree_tmp"], "removed");
+    }
+
+    #[test]
+    fn cleanup_skips_tmp_without_flow_phases() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        // No flow-phases.json — not a FLOW repo
+        let wt_tmp = root.join(&wt_rel).join("tmp");
+        fs::create_dir_all(&wt_tmp).unwrap();
+        fs::write(wt_tmp.join("some-file.txt"), "data").unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["worktree_tmp"], "skipped");
+    }
+
+    #[test]
+    fn cleanup_skips_missing_worktree_tmp() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        fs::write(root.join("flow-phases.json"), "{}").unwrap();
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert_eq!(steps["worktree_tmp"], "skipped");
+    }
+
+    // --- --pull flag tests ---
+
+    #[test]
+    fn no_pull_flag_no_git_pull_step() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        assert!(!steps.contains_key("git_pull"));
+    }
+
+    #[test]
+    fn pull_flag_present_adds_step() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, true);
+        assert!(steps.contains_key("git_pull"));
+        // No remote configured, so pull will fail
+        assert!(steps["git_pull"].starts_with("failed:"));
+    }
+
+    // --- JSON output format ---
+
+    #[test]
+    fn cleanup_json_output_format() {
+        let (_dir, root) = git_repo();
+        let wt_rel = setup_feature(&root, "test-feature");
+        let steps = cleanup(&root, "test-feature", &wt_rel, None, false);
+        let output = json!({"status": "ok", "steps": steps});
+        let parsed: serde_json::Value = serde_json::from_str(&output.to_string()).unwrap();
+        assert_eq!(parsed["status"], "ok");
+        assert!(parsed["steps"].is_object());
+        assert_eq!(parsed["steps"]["pr_close"], "skipped");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod add_issue;
 pub mod add_notification;
 pub mod append_note;
 pub mod check_phase;
+pub mod cleanup;
 pub mod commands;
 pub mod error;
 pub mod format_status;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use flow_rs::add_issue;
 use flow_rs::add_notification;
 use flow_rs::append_note;
 use flow_rs::check_phase::check_phase;
+use flow_rs::cleanup;
 use flow_rs::commands;
 use flow_rs::format_status;
 use flow_rs::git::{project_root, resolve_branch};
@@ -157,6 +158,10 @@ enum Commands {
     #[command(name = "start-setup")]
     StartSetup(start_setup::Args),
 
+    /// FLOW cleanup orchestrator (best-effort multi-step cleanup)
+    #[command(name = "cleanup")]
+    Cleanup(cleanup::Args),
+
     /// Format the FLOW status panel for display.
     #[command(name = "format-status")]
     FormatStatus {
@@ -270,6 +275,9 @@ fn main() {
         }
         Some(Commands::StartSetup(args)) => {
             start_setup::run(args);
+        }
+        Some(Commands::Cleanup(args)) => {
+            cleanup::run(args);
         }
         Some(Commands::FormatStatus { branch }) => {
             run_format_status(branch.as_deref());


### PR DESCRIPTION
## What

work on issue #780.

Closes #780

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/port-cleanup-to-rust-plan.md` |
| DAG | `.flow-states/port-cleanup-to-rust-dag.md` |
| Log | `.flow-states/port-cleanup-to-rust.log` |
| State | `.flow-states/port-cleanup-to-rust.json` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Plan: Port cleanup to Rust

## Context

Issue #780: Port `lib/cleanup.py` (228 lines) to Rust. The cleanup module is a best-effort multi-step orchestrator used by `flow-complete` (Phase 6) and `flow-abort`. It removes worktrees, deletes branches, removes state files, and optionally closes PRs. It is standalone — no `flow_utils` imports.

Two consumers call `bin/flow cleanup` from SKILL.md bash blocks:
- `skills/flow-complete/SKILL.md` (Step 7): `bin/flow cleanup <root> --branch <b> --worktree <wt> --pull`
- `skills/flow-abort/SKILL.md` (Steps 3–8): `bin/flow cleanup <root> --branch <b> --worktree <wt> --pr <n>`

## Exploration

**Python source** (`lib/cleanup.py`):
- `_run_cmd(args, cwd)` → `(bool, str)` — simple subprocess runner, no timeout
- `cleanup(project_root, branch, worktree, pr_number=None, pull=False)` → dict of step results
- `main()` — argparse CLI: `project_root --branch --worktree [--pr] [--pull]`
- 14 cleanup steps with ordered key names in the result dict
- Output: `{"status": "ok", "steps": {...}}` or `{"status": "error", "message": "..."}`
- No Python callers import this module — it's called only via subprocess through `bin/flow`

**Python tests** (`tests/test_cleanup.py`, 657 lines):
- Subprocess tests via `_run` helper (calls `python3 cleanup.py`)
- In-process tests importing `_mod` via `importlib`
- Uses `git_repo` fixture, `make_state`/`write_state` from conftest
- Covers: happy path, missing resources, abort mode, unlink failures, tmp/ cleanup, --pull flag

**Existing Rust patterns**:
- `run_cmd` in `start_setup.rs` handles subprocess with timeout support — cleanup's `_run_cmd` is simpler (no timeout)
- `IndexMap` used for ordered JSON output (key order parity with Python)
- `serde_json` has `preserve_order` feature enabled in `Cargo.toml`
- Subcommands registered in `main.rs` via clap `Commands` enum
- Module registered in `lib.rs`
- `output::json_error` for error JSON output

**Dispatcher**: `bin/flow` tries Rust binary first, falls back to Python on exit 127. Once Rust handles `cleanup`, Python fallback is never reached. After verification, Python files are deleted.

## Risks

1. **Key order parity** — Python dict preserves insertion order. Must use `IndexMap` for the steps result to match JSON key order exactly.
2. **`shutil.rmtree` equivalent** — Rust's `std::fs::remove_dir_all` is the equivalent. Need to handle permission errors gracefully like Python's try/except.
3. **`flow-phases.json` detection** — The FLOW repo detection (`is_flow_repo = (root / "flow-phases.json").exists()`) must be preserved exactly for the worktree tmp/ cleanup step.
4. **Test parity** — Rust tests need to cover the same scenarios. In-process tests (monkeypatch-based unlink failures) will need different approaches in Rust — filesystem permission tests may need to be adapted.

## Approach

Port cleanup.py to a new `src/cleanup.rs` module. Register the `cleanup` subcommand in `main.rs`. Write Rust tests that cover the same scenarios as `test_cleanup.py`. Delete Python files after verification.

The `_run_cmd` for cleanup is simpler than `start_setup::run_cmd` (no timeout), but we can reuse `start_setup::run_cmd` with `timeout: None` to avoid code duplication. However, the return type differs — cleanup returns `(bool, String)` while start_setup returns `Result<(String, String), SetupError>`. We'll write a thin wrapper or a local helper that matches the Python semantics.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write Rust cleanup tests | test | — |
| 2. Implement cleanup module | implement | 1 |
| 3. Register subcommand in main.rs | implement | 2 |
| 4. Verify parity via bin/ci | verify | 3 |
| 5. Delete Python files | cleanup | 4 |
| 6. Add tombstone test | test | 5 |
| 7. Final bin/ci verification | verify | 6 |

## Tasks

### Task 1 — Write Rust cleanup tests

Write unit tests in `src/cleanup.rs` `#[cfg(test)] mod tests` covering:
- `run_cmd_success` and `run_cmd_failure` — basic subprocess behavior
- `cleanup_removes_worktree` — worktree removal via git
- `cleanup_deletes_state_file`, `cleanup_deletes_log_file`, `cleanup_deletes_plan_file`, etc. — each file type
- `cleanup_skips_missing_*` — skip behavior for nonexistent files
- `cleanup_full_happy_path` — all 14 steps in one invocation
- `cleanup_pr_close_skipped` — no --pr flag
- `cleanup_flow_repo_tmp_removal` — tmp/ cleanup when flow-phases.json exists
- `cleanup_skips_tmp_without_flow_phases` — tmp/ skipped in non-FLOW repos
- `cleanup_pull_flag` — git_pull step added when pull=true
- Key order verification — assert JSON key order matches Python output exactly

Tests use `tempfile::tempdir()` and `std::process::Command` for git setup (same pattern as `utils.rs` tests). For in-process tests, call `cleanup()` directly.

**Files**: `src/cleanup.rs` (test section)
**TDD**: Tests written first, will fail until Task 2 implements the functions.

### Task 2 — Implement cleanup module

Create `src/cleanup.rs` with:

- `run_cmd(args: &[&str], cwd: &Path) -> (bool, String)` — subprocess runner matching Python's `_run_cmd` semantics. Returns `(true, stdout)` on success, `(false, stderr_or_stdout)` on failure, `(false, error_message)` on spawn failure.
- `cleanup(project_root: &Path, branch: &str, worktree: &str, pr_number: Option<u32>, pull: bool) -> IndexMap<String, String>` — orchestrator matching Python's `cleanup()`. Steps in Python's insertion order:
  1. `pr_close` — `gh pr close <n>` or "skipped"
  2. `worktree_tmp` — `remove_dir_all` on worktree/tmp if FLOW repo
  3. `worktree` — `git worktree remove --force`
  4. `remote_branch` — `git push origin --delete`
  5. `local_branch` — `git branch -D`
  6. `state_file` — `.flow-states/<branch>.json`
  7. `plan_file` — `.flow-states/<branch>-plan.md`
  8. `dag_file` — `.flow-states/<branch>-dag.md`
  9. `log_file` — `.flow-states/<branch>.log`
  10. `frozen_phases` — `.flow-states/<branch>-phases.json`
  11. `ci_sentinel` — `.flow-states/<branch>-ci-passed`
  12. `timings_file` — `.flow-states/<branch>-timings.md`
  13. `closed_issues_file` — `.flow-states/<branch>-closed-issues.json`
  14. `issues_file` — `.flow-states/<branch>-issues.md`
  15. `git_pull` (conditional on `pull`) — `git pull origin main`

Each step inserts into `IndexMap` with value "removed"/"deleted"/"closed", "skipped", or "failed: <reason>".

Register module in `src/lib.rs`: `pub mod cleanup;`

**Files**: `src/cleanup.rs`, `src/lib.rs`

### Task 3 — Register subcommand in main.rs

Add `Cleanup` variant to `Commands` enum with clap args matching Python's argparse:
- `project_root: String` (positional)
- `--branch` (required)
- `--worktree` (required)
- `--pr` (optional u32)
- `--pull` (flag)

Add match arm in `main()` that calls `cleanup::run(args)`.

The `run` function:
- Validates project_root exists
- Calls `cleanup()`
- Prints `{"status": "ok", "steps": {...}}`
- On invalid root: prints `{"status": "error", "message": "..."}` and exits 1

**Files**: `src/main.rs`

### Task 4 — Verify parity via bin/ci

Run `bin/ci` to ensure all tests pass. The Rust binary now handles `cleanup`, so the hybrid dispatcher routes to Rust. Python tests still run cleanup.py directly via subprocess — they should still pass since the Python file is still present.

### Task 5 ��� Delete Python files

Delete `lib/cleanup.py` and `tests/test_cleanup.py`. The Rust implementation is now the sole handler.

**Files**: `lib/cleanup.py` (delete), `tests/test_cleanup.py` (delete)

### Task 6 — Add tombstone test

Add a tombstone test in `tests/test_structural.py` asserting that `lib/cleanup.py` does not exist:

```python
def test_cleanup_py_removed():
    """Tombstone: ported to Rust in PR #836. Must not return."""
    assert not (LIB_DIR / "cleanup.py").exists(), "lib/cleanup.py was ported to Rust — do not re-add"
```

**Files**: `tests/test_structural.py`

### Task 7 — Final bin/ci verification

Run `bin/ci` to confirm everything passes with Python files removed and tombstone test in place.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: Port cleanup to Rust

## Problem

cleanup (228 lines) orchestrates best-effort cleanup: remove worktree, delete branches, remove state files, optionally close PR.

## Acceptance Criteria

- `flow cleanup` subcommand: best-effort multi-step cleanup with per-step success/failure reporting
- Rust tests covering test_cleanup.py (657 lines)
- Delete corresponding Python files
- bin/ci passes

## Files to Investigate

- `lib/cleanup.py` (228 lines) — standalone (no flow_utils imports)
- `tests/test_cleanup.py` (657 lines)

## Out of Scope

- Complete phase commands

## Context

Standalone script with no flow_utils imports.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 4m |
| Plan | 2m |
| **Total** | **6m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/port-cleanup-to-rust.json</summary>

```json
{
  "schema_version": 1,
  "branch": "port-cleanup-to-rust",
  "repo": "benkruger/flow",
  "pr_number": 836,
  "pr_url": "https://github.com/benkruger/flow/pull/836",
  "started_at": "2026-04-03T23:59:11-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/port-cleanup-to-rust-plan.md",
    "dag": ".flow-states/port-cleanup-to-rust-dag.md",
    "log": ".flow-states/port-cleanup-to-rust.log",
    "state": ".flow-states/port-cleanup-to-rust.json"
  },
  "session_tty": "/dev/ttys007",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #780",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-03T23:59:11-07:00",
      "completed_at": "2026-04-04T00:10:04-07:00",
      "session_started_at": null,
      "cumulative_seconds": 269,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-04T00:11:01-07:00",
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 122,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-04T00:11:01-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "start_step": 11,
  "start_steps_total": 11,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 7
}
```

</details>

## Session Log

<details>
<summary>.flow-states/port-cleanup-to-rust.log</summary>

```text
2026-04-03T23:59:11-07:00 [Phase 1] create .flow-states/port-cleanup-to-rust.json (exit 0)
2026-04-03T23:59:11-07:00 [Phase 1] freeze .flow-states/port-cleanup-to-rust-phases.json (exit 0)
2026-04-03T23:59:24-07:00 [Phase 1] Step 3 — init-state (exit 0)
2026-04-03T23:59:43-07:00 [Phase 1] Step 4 — label-issues (exit 0)
2026-04-04T00:02:19-07:00 [Phase 1] Step 5 — pull main (exit 0)
2026-04-04T00:02:32-07:00 [Phase 1] Step 6 — ci baseline (exit 0)
2026-04-04T00:05:45-07:00 [Phase 1] Step 7 — update-deps (exit 0)
2026-04-04T00:06:20-07:00 [Phase 1] Step 8 — ci post-deps (exit 0, flaky)
2026-04-04T00:09:17-07:00 [Phase 1] Step 9 — commit (nothing to commit)
2026-04-04T00:09:30-07:00 [Phase 1] git worktree add .worktrees/port-cleanup-to-rust (exit 0)
2026-04-04T00:09:38-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-04-04T00:09:39-07:00 [Phase 1] backfill .flow-states/port-cleanup-to-rust.json (exit 0)
2026-04-04T00:11:44-07:00 [Phase 2] Step 1 — fetch issue #780 (exit 0)
2026-04-04T00:11:46-07:00 [Phase 2] Step 2 — pre-decomposed skip (exit 0)
```

</details>