### PR TITLE
Replace Prose Bintest Check With

### DIFF
--- a/skills/flow-code-review/SKILL.md
+++ b/skills/flow-code-review/SKILL.md
@@ -546,10 +546,15 @@ CLAUDE.md. Use the Glob tool to find all `.claude/rules/*.md` files,
 then use the Read tool to read each one. Collect all content — you will
 pass it inline to the reviewer agent.
 
-Check if `bin/test` exists in the current working directory. Use the
-Glob tool to check for `bin/test` (no path parameter — Glob defaults
-to the current working directory, which is the worktree). Note the
-result — it determines whether the adversarial agent is launched.
+### Check for test runner
+
+```bash
+test -f bin/test
+```
+
+If the command succeeds (exit 0), `bin/test` exists — the adversarial
+agent should be launched. If it fails (exit non-zero), skip the
+adversarial agent.
 
 ### Launch agents in parallel
 

--- a/tests/test_skill_contracts.py
+++ b/tests/test_skill_contracts.py
@@ -2032,6 +2032,15 @@ def test_code_review_has_self_invocation_check():
     assert "--continue-step" in si_match.group(1), "Self-Invocation Check must reference --continue-step flag"
 
 
+def test_code_review_has_bash_bintest_check():
+    """Code Review Step 4 must check bin/test existence via bash block, not prose."""
+    content = _read_skill("flow-code-review")
+    assert "```bash\ntest -f bin/test\n```" in content, (
+        "flow-code-review must contain 'test -f bin/test' inside a fenced bash block "
+        "(prose Glob checks are intermittently skipped by the model)"
+    )
+
+
 def test_start_step_2_acquires_lock():
     """Locked section (Steps 1–10) must acquire start lock before CI work."""
     content = _read_skill("flow-start")


### PR DESCRIPTION
## What

work on issue #844.

Closes #844

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/replace-prose-bintest-check-with-plan.md` |
| DAG | `.flow-states/replace-prose-bintest-check-with-dag.md` |
| Log | `.flow-states/replace-prose-bintest-check-with.log` |
| State | `.flow-states/replace-prose-bintest-check-with.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

The adversarial agent is one of three parallel sub-agents in Code Review Step 4. Its launch is conditional on `bin/test` existing in the project — not all target projects have a test runner. The current check is a prose Glob instruction that the model intermittently skips, silently disabling adversarial testing.

## Exploration

- `skills/flow-code-review/SKILL.md:549-552` — current prose Glob instruction inside "Gather context"
- `skills/flow-code-review/SKILL.md:599-600` — conditional launch instruction referencing the check result
- `skills/flow-code-review/SKILL.md:623-631` — cleanup conditional after agents return
- `tests/test_skill_contracts.py` — no existing contract test for the bash block (none found)
- `.claude/settings.json:14` — `Bash(*bin/*)` allow pattern (covers `test -f bin/test`)
- `.claude/settings.json:67` — `Bash(ls *)` deny pattern (does not match `test -f bin/test`)
- `lib/validate-pretool.py:40` — `FILE_READ_COMMANDS` set does not include `test` — safe

## Risks

- The bash command must not match any deny-list pattern or hook block. `test -f bin/test` is safe: `test` is not in `FILE_READ_COMMANDS`, not in the deny list, and the full command matches `Bash(*bin/*)`.
- The sub-heading insertion must not break step numbering or any existing contract tests.
- The change from Glob to bash means a different tool is used — but the purpose (existence check) and the conditional logic downstream remain identical.

## Approach

Replace the 4-line prose Glob instruction (lines 549-552) with a new `### Check for test runner` sub-heading containing a `test -f bin/test` bash block. Add a contract test asserting the bash block exists in the skill. No permission changes needed.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add contract test for bash block | test | — |
| 2. Replace prose Glob with bash block | implement | 1 |
| 3. Run bin/ci | validate | 2 |

## Tasks

### Task 1: Add contract test for bash block

Add a test in `tests/test_skill_contracts.py` that asserts the code review skill contains `test -f bin/test` inside a fenced bash block. This is a regression guard — if anyone reverts to prose, CI fails.

- File: `tests/test_skill_contracts.py`
- TDD: Test should fail before Task 2 (the bash block doesn't exist yet)

### Task 2: Replace prose Glob with bash block

In `skills/flow-code-review/SKILL.md`, replace lines 549-552 (the prose Glob instruction inside "Gather context") with a new `### Check for test runner` sub-heading and `test -f bin/test` bash block. Place it between "Gather context" and "Launch agents in parallel." Add parsing instructions: if the command succeeds (exit 0), `bin/test` exists and the adversarial agent should be launched; if it fails (exit non-zero), skip the adversarial agent.

- File: `skills/flow-code-review/SKILL.md`
- TDD: Task 1's contract test should pass after this change

### Task 3: Run bin/ci

Run `bin/ci` to confirm all contract tests pass, permission tests pass, and no existing tests break.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: Replace prose bin/test check with bash block in code review Step 4

## Problem

During Code Review (Phase 4, Step 4 — Agent Reviews), the adversarial agent is sometimes skipped because the model concludes `bin/test` does not exist in the worktree — even though the file is present. The `bin/test` existence check at `skills/flow-code-review/SKILL.md:549-552` is a prose instruction inside the "Gather context" sub-section. The model intermittently skips or misinterprets this check, producing a false negative that silently disables adversarial test generation.

Evidence from a live code review session (Port Issue Linking Commands To Rust, 2026-04-04): the model reported "bin/test does not exist in the worktree — no adversarial agent will be launched" despite `bin/test` being confirmed present via `git ls-tree` and Glob. The model's summary showed "Searched for 2 patterns" when at least 3 were needed.

A prior fix (PR #717, 2026-03-31) corrected the path resolution (changed "project root" to "current working directory") but left the check as inline prose. The path fix was correct but insufficient — the failure mode shifted from "wrong path" to "check skipped entirely."

## Acceptance Criteria

- The `bin/test` existence check uses a bash block (structurally enforced), not a prose Glob instruction
- The check has its own sub-heading in Step 4, structurally distinct from the context-gathering prose
- When `bin/test` exists, the adversarial agent is always launched (no silent skip)
- `bin/ci` passes after the change

## Implementation Plan

### Context

The adversarial agent is one of three parallel sub-agents in Code Review Step 4. Its launch is conditional on `bin/test` existing in the project — not all target projects have a test runner. The current check is a prose Glob instruction that the model intermittently skips, silently disabling adversarial testing.

### Exploration

- `skills/flow-code-review/SKILL.md:549-552` — current prose Glob instruction inside "Gather context"
- `skills/flow-code-review/SKILL.md:599-600` — conditional launch instruction referencing the check result
- `skills/flow-code-review/SKILL.md:623-631` — cleanup conditional after agents return
- `tests/test_skill_contracts.py:3146-3172` — existing contract test `test_skills_no_repo_tracked_files_at_project_root` (must not break)
- `.claude/settings.json:14` — `Bash(*bin/*)` allow pattern (covers `test -f bin/test`)
- `.claude/settings.json:67` — `Bash(ls *)` deny pattern (rules out `ls bin/test`)
- `lib/validate-pretool.py:40` — `FILE_READ_COMMANDS` set (does not include `test`)

### Risks

- The bash command must not match any deny-list pattern or hook block. `test -f bin/test` is safe: `test` is not in `FILE_READ_COMMANDS`, not in the deny list, and the full command matches `Bash(*bin/*)`.
- The sub-heading insertion must not break step numbering or the existing contract test `test_code_review_step4_references_adversarial`.
- The change from Glob to bash means a different tool is used — but the purpose (existence check) and the conditional logic downstream remain identical.

### Approach

Replace the 4-line prose Glob instruction (lines 549-552) with a new `### Check for test runner` sub-heading containing a `test -f bin/test` bash block. Add a contract test asserting the bash block exists in the skill. No permission changes needed.

### Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add contract test for bash block | test | — |
| 2. Replace prose Glob with bash block | implement | 1 |
| 3. Run bin/ci | validate | 2 |

### Tasks

#### Task 1: Add contract test for bash block

Add a test in `tests/test_skill_contracts.py` that asserts the code review skill contains `test -f bin/test` inside a bash block. This is a regression guard — if anyone reverts to prose, CI fails.

- File: `tests/test_skill_contracts.py`
- TDD: Test should fail before Task 2 (the bash block doesn't exist yet)

#### Task 2: Replace prose Glob with bash block

In `skills/flow-code-review/SKILL.md`, replace lines 549-552 (the prose Glob instruction inside "Gather context") with a new `### Check for test runner` sub-heading and `test -f bin/test` bash block. Place it between "Gather context" and "Launch agents in parallel." Add parsing instructions: if the command succeeds, `bin/test` exists and the adversarial agent should be launched; if it fails, skip the adversarial agent.

- File: `skills/flow-code-review/SKILL.md`
- TDD: Task 1's contract test should pass after this change

#### Task 3: Run bin/ci

Run `bin/ci` to confirm all contract tests pass, permission tests pass, and no existing tests break.

## Files to Investigate

- `skills/flow-code-review/SKILL.md` — lines 549-552 (the prose check) and lines 599-600 (the conditional launch instruction)

## Out of Scope

- Changes to the adversarial agent itself (`agents/adversarial.md`)
- Adding hook-based enforcement (a bash block is sufficient for now)
- Fixing the specific session where this occurred

## Context

The adversarial agent is one of three parallel sub-agents in Code Review. When it is silently skipped, the code review completes without adversarial test generation — producing a false sense of thoroughness. The user only discovered the skip by reading the session output carefully.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 3m |
| Plan | 3m |
| Code | 16m |
| Code Review | 15m |
| Learn | 5m |
| Complete | 2m |
| **Total** | **46m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/replace-prose-bintest-check-with.json</summary>

```json
{
  "schema_version": 1,
  "branch": "replace-prose-bintest-check-with",
  "repo": "benkruger/flow",
  "pr_number": 845,
  "pr_url": "https://github.com/benkruger/flow/pull/845",
  "started_at": "2026-04-04T01:59:00-07:00",
  "current_phase": "flow-complete",
  "framework": "python",
  "files": {
    "plan": ".flow-states/replace-prose-bintest-check-with-plan.md",
    "dag": ".flow-states/replace-prose-bintest-check-with-dag.md",
    "log": ".flow-states/replace-prose-bintest-check-with.log",
    "state": ".flow-states/replace-prose-bintest-check-with.json"
  },
  "session_tty": "/dev/ttys005",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #844",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-04T01:59:00-07:00",
      "completed_at": "2026-04-04T02:02:13-07:00",
      "session_started_at": null,
      "cumulative_seconds": 193,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-04T02:02:54-07:00",
      "completed_at": "2026-04-04T02:06:51-07:00",
      "session_started_at": null,
      "cumulative_seconds": 237,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-04T02:07:47-07:00",
      "completed_at": "2026-04-04T02:24:02-07:00",
      "session_started_at": null,
      "cumulative_seconds": 975,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-04T02:25:17-07:00",
      "completed_at": "2026-04-04T02:40:25-07:00",
      "session_started_at": null,
      "cumulative_seconds": 908,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-04T02:41:13-07:00",
      "completed_at": "2026-04-04T02:46:53-07:00",
      "session_started_at": null,
      "cumulative_seconds": 340,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-04T02:47:43-07:00",
      "completed_at": "2026-04-04T02:49:56-07:00",
      "session_started_at": null,
      "cumulative_seconds": 133,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-04T02:02:54-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-04T02:07:47-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-04T02:25:17-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-04T02:41:13-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-04T02:47:43-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "start_step": 11,
  "start_steps_total": 11,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 3,
  "code_task_name": "Run bin/ci",
  "code_task": 3,
  "_continue_context": "Self-invoke flow:flow-code --continue-step --auto.",
  "_continue_pending": "commit",
  "code_review_step": 4,
  "diff_stats": {
    "files_changed": 2,
    "insertions": 18,
    "deletions": 4,
    "captured_at": "2026-04-04T02:24:02-07:00"
  },
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 7,
  "complete_step": 6,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/replace-prose-bintest-check-with.log</summary>

```text
2026-04-04T01:59:00-07:00 [Phase 1] create .flow-states/replace-prose-bintest-check-with.json (exit 0)
2026-04-04T01:59:00-07:00 [Phase 1] freeze .flow-states/replace-prose-bintest-check-with-phases.json (exit 0)
2026-04-04T01:59:08-07:00 [Phase 1] Step 3 — Create early state file (exit 0)
2026-04-04T01:59:24-07:00 [Phase 1] Step 4 — Label referenced issues (exit 0)
2026-04-04T01:59:37-07:00 [Phase 1] Step 5 — Pull latest main (exit 0)
2026-04-04T02:01:08-07:00 [Phase 1] Step 6 — CI baseline gate (exit 0)
2026-04-04T02:01:23-07:00 [Phase 1] Step 7 — Update dependencies (exit 0, no changes)
2026-04-04T02:01:30-07:00 [Phase 1] Step 10 — Release start lock (exit 0)
2026-04-04T02:01:45-07:00 [Phase 1] git worktree add .worktrees/replace-prose-bintest-check-with (exit 0)
2026-04-04T02:01:54-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-04-04T02:01:54-07:00 [Phase 1] backfill .flow-states/replace-prose-bintest-check-with.json (exit 0)
2026-04-04T02:03:19-07:00 [Phase 2] Step 1 — Feature description and issue context (exit 0)
2026-04-04T02:03:58-07:00 [Phase 2] Step 2 — DAG decomposition (pre-decomposed issue, skipped decompose)
2026-04-04T02:06:17-07:00 [Phase 2] Step 3 — Explore and write plan (exit 0)
2026-04-04T02:06:53-07:00 [Phase 2] Step 4 — Store plan file and complete phase (exit 0)
2026-04-04T02:15:58-07:00 [Phase 3] Tasks 1-2 — Add contract test and replace prose Glob with bash block (CI green)
2026-04-04T02:23:45-07:00 [Phase 3] Task 3 — Run bin/ci (exit 0, all green)
2026-04-04T02:26:05-07:00 [Phase 4] Step 1 — Simplify (no findings, no changes)
2026-04-04T02:28:00-07:00 [Phase 4] Step 2 — Review (no findings, no changes)
2026-04-04T02:28:47-07:00 [Phase 4] Step 3 — Security (no findings)
2026-04-04T02:39:55-07:00 [Phase 4] Step 4 — Agent Reviews (0 findings from 3 agents)
2026-04-04T02:40:39-07:00 [Phase 4] Done — Code Review complete (15m)
```

</details>