### PR TITLE
Flaky Ci Coverage Gate Fails

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
+[run]
+parallel = true
+source = lib
+
 [report]
 exclude_lines =
     if __name__ == .__main__.

--- a/tests/test_structural.py
+++ b/tests/test_structural.py
@@ -234,6 +234,21 @@ def test_n_auto_in_pytest_ini():
     assert "-n auto" in addopts, "-n auto not found in pytest.ini addopts"
 
 
+def test_coveragerc_has_parallel_run_config():
+    """`.coveragerc` must declare parallel coverage for pytest-xdist workers.
+
+    Without [run] parallel = true and source = lib, coverage.py may not
+    combine worker data files correctly, causing intermittent coverage
+    gate failures (see issue #835).
+    """
+    config = configparser.ConfigParser()
+    config.read(REPO_ROOT / ".coveragerc")
+    assert config.has_section("run"), ".coveragerc missing [run] section"
+    assert config.get("run", "parallel") == "true", ".coveragerc [run] parallel must be true"
+    source = config.get("run", "source")
+    assert "lib" in source, ".coveragerc [run] source must include lib"
+
+
 def test_claude_md_has_no_lessons_learned_section():
     """CLAUDE.md must not have a Lessons Learned section.
 


### PR DESCRIPTION
## What

work on issue #835.

Closes #835

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/flaky-ci-coverage-gate-fails-plan.md` |
| DAG | `.flow-states/flaky-ci-coverage-gate-fails-dag.md` |
| Log | `.flow-states/flaky-ci-coverage-gate-fails.log` |
| State | `.flow-states/flaky-ci-coverage-gate-fails.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/0a29c67e-58fd-4c7e-8435-a145fe22c9a6.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Plan: Fix Flaky CI Coverage Gate

## Context

Issue #835: CI baseline coverage gate intermittently reports ~31% coverage instead of 100% during `flow-start`, despite all 2116 tests passing. The coverage failure occurs after dependency updates and passes on retry. The error shows `TOTAL 4496 3104 31%` — meaning most worker coverage data was lost during the combine step.

## Exploration

### Coverage pipeline

1. `bin/ci` runs `$PYTHON -m pytest tests/`
2. `pytest.ini` addopts: `--no-header -q -n auto --dist loadscope --cov=lib --cov-report=term-missing --cov-fail-under=100`
3. `-n auto` spawns one worker per CPU core via `pytest-xdist`
4. `--cov=lib` enables `pytest-cov` to measure coverage of `lib/` directory
5. `--cov-fail-under=100` fails if total coverage drops below 100%

### Coverage configuration

- `.coveragerc` has only a `[report]` section with `exclude_lines`. No `[run]` section — no `source`, `parallel`, or `data_file` settings.
- `tests/conftest.py` has a session-scoped `_subprocess_coverage` fixture (lines 49-67) that creates a temporary coverage config with `parallel = true`, `source = lib`, and `data_file = {REPO_ROOT / '.coverage'}`, then sets `COVERAGE_PROCESS_START` in `os.environ`.

### Root cause

Under `pytest-xdist`, each worker gets its own session scope. Each worker's `_subprocess_coverage` fixture creates its own temp config file and sets `COVERAGE_PROCESS_START`. All configs point `data_file` to the same `{REPO_ROOT / '.coverage'}` with `parallel = true`.

The interaction between `pytest-cov`'s own parallel coverage handling and the `_subprocess_coverage` fixture's `COVERAGE_PROCESS_START` config creates a race condition. When worker processes finish at different times (especially after dependency updates shift import timing), some workers' `.coverage.*` data files may not be fully flushed before the combine step runs.

Adding `[run] parallel = true` and `source = lib` to `.coveragerc` gives `pytest-cov` the explicit parallel configuration it needs to handle the combine step robustly, rather than relying solely on the per-worker temp configs from the fixture.

## Risks

- Changing `.coveragerc` could affect how coverage is measured project-wide — need to verify 100% coverage still passes after the change
- The `_subprocess_coverage` fixture and `.coveragerc` settings could conflict if both specify `data_file` or `source` differently
- Since the bug is intermittent, verifying the fix requires understanding the mechanism, not just running CI once

## Approach

Add `[run]` section to `.coveragerc` with `parallel = true` and `source = lib`. This gives `coverage.py` the canonical parallel configuration at the project level rather than only via per-worker temp files. The `_subprocess_coverage` fixture's temp config remains needed for subprocess coverage routing (absolute `data_file` path), but the base `.coveragerc` now correctly declares the parallel execution model.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write test for `.coveragerc` `[run]` section | test | — |
| 2. Add `[run]` section to `.coveragerc` | implement | 1 |
| 3. Verify CI passes with new config | validate | 2 |

## Tasks

### Task 1: Write test for `.coveragerc` `[run]` section

Add a test in `tests/test_structural.py` (or appropriate test file) that asserts `.coveragerc` contains a `[run]` section with `parallel = true` and `source` including `lib`. This prevents accidental removal of the fix.

- **Files:** `tests/test_structural.py`
- **TDD:** Assert `.coveragerc` has `[run]` section, `parallel = true`, and `source` includes `lib`

### Task 2: Add `[run]` section to `.coveragerc`

Add the `[run]` configuration to `.coveragerc`:

```ini
[run]
parallel = true
source = lib
```

This tells `coverage.py` at the project level that parallel data collection is expected, ensuring the combine step waits for and merges all worker data files correctly.

- **Files:** `.coveragerc`
- **TDD:** The test from Task 1 should pass

### Task 3: Verify CI passes with new config

Run `bin/ci` to confirm the new `.coveragerc` config works with the existing test suite and coverage remains at 100%.

- **Files:** None (validation only)
- **TDD:** `bin/ci` exits 0 with 100% coverage
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# DAG Analysis: Flaky CI Coverage Gate Fails

<dag goal="Diagnose and fix flaky CI coverage gate that intermittently reports ~31% instead of 100%" mode="full">
  <plan>
    <node id="1" name="CI Script Analysis" type="research" depends="[]" parallel_with="2">
      <objective>Understand how bin/ci runs tests and measures coverage</objective>
    </node>
    <node id="2" name="Coverage Configuration" type="research" depends="[]" parallel_with="1">
      <objective>Map the coverage tool config, source paths, and fail-under threshold</objective>
    </node>
    <node id="3" name="Coverage Arithmetic" type="analysis" depends="[1,2]" parallel_with="4">
      <objective>Determine what 30.96% across 4496 statements means — which files are being measured vs missed</objective>
    </node>
    <node id="4" name="Subprocess Coverage Gaps" type="research" depends="[1,2]" parallel_with="3">
      <objective>Check whether bin/ci spawns subprocesses that execute lib scripts outside coverage measurement</objective>
    </node>
    <node id="5" name="Root Cause Synthesis" type="synthesis" depends="[3,4]">
      <objective>Identify the root cause and propose a fix</objective>
    </node>
  </plan>
</dag>

---

## NODE 1: CI Script Analysis

`bin/ci` runs `pytest tests/` with no `--cov` flag directly. Coverage is configured via `pytest.ini` addopts.

`lib/ci.py` is the `bin/flow ci` subcommand. In retry mode (`_run_with_retry`, line 92-97), `subprocess.run` uses `capture_output=True`. In non-retry mode (line 193-196), output inherits parent stdio.

## NODE 2: Coverage Configuration

- `pytest.ini`: `addopts = --no-header -q -n auto --dist loadscope --cov=lib --cov-report=term-missing --cov-fail-under=100`
- `.coveragerc`: Only has `[report]` section with `exclude_lines`. No `[run]` section — no `source`, `concurrency`, or `parallel` settings.
- Tests run in parallel via `pytest-xdist` (`-n auto`, `--dist loadscope`)
- Coverage targets `lib/` with 100% fail-under threshold

## NODE 3: Coverage Arithmetic

Error output: `TOTAL 4496 3104 31%` — 4496 statements total, 3104 missed, only 1392 covered (30.96%). All 2116 tests passed. This means coverage data collection failed to capture most execution — only a fraction of worker processes contributed coverage data.

## NODE 4: Subprocess Coverage Gaps

30 test files contain 124 total `subprocess.run`/`Popen` calls. Many tests spawn subprocesses that import and execute `lib/` modules outside pytest-cov coverage measurement. However, this is a CONSTANT issue (not intermittent), so it's not the primary cause of the flaky behavior.

The intermittent-after-deps-update pattern points to timing: when deps change, import timing shifts, and worker processes may not finish writing coverage data before the controller combines.

## NODE 5: Root Cause Synthesis

**Root Cause:** `pytest-xdist` (`-n auto`) with `pytest-cov` (`--cov=lib`) intermittently loses worker coverage data during the combine step. The `.coveragerc` has no `[run]` section configuring `source` or `parallel = true`. When worker processes finish at different times (especially after dependency updates change import timing), some workers' `.coverage.<suffix>` data files may not be fully flushed or visible to the controller's combine step, resulting in partial coverage data (31% instead of 100%).

**Fix:** Add `[run]` configuration to `.coveragerc` with `source = lib` and `parallel = true` to ensure proper parallel coverage data handling. This makes coverage.py explicitly aware of the parallel execution model and handles file combination more robustly.

Confidence: 75% | Nodes: 5 | Parallel branches: 2

vs. Vanilla Claude:
- Would have guessed at subprocess coverage gaps (constant problem) without noticing the intermittent-after-deps-update pattern points to timing
- Would have missed that `.coveragerc` lacks `[run]` parallel configuration which is the standard fix for xdist coverage flakiness
- Would have conflated the test-subprocess issue (constant undercounting) with the intermittent worker-data-loss issue (timing race)
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 8m |
| Plan | <1m |
| **Total** | **8m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/flaky-ci-coverage-gate-fails.json</summary>

```json
{
  "schema_version": 1,
  "branch": "flaky-ci-coverage-gate-fails",
  "repo": "benkruger/flow",
  "pr_number": 855,
  "pr_url": "https://github.com/benkruger/flow/pull/855",
  "started_at": "2026-04-04T03:50:55-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/flaky-ci-coverage-gate-fails-plan.md",
    "dag": ".flow-states/flaky-ci-coverage-gate-fails-dag.md",
    "log": ".flow-states/flaky-ci-coverage-gate-fails.log",
    "state": ".flow-states/flaky-ci-coverage-gate-fails.json"
  },
  "session_tty": "/dev/ttys013",
  "session_id": "0a29c67e-58fd-4c7e-8435-a145fe22c9a6",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/0a29c67e-58fd-4c7e-8435-a145fe22c9a6.jsonl",
  "notes": [],
  "prompt": "work on issue #835",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-04T03:50:55-07:00",
      "completed_at": "2026-04-04T03:58:58-07:00",
      "session_started_at": null,
      "cumulative_seconds": 483,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-04T03:59:49-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-04T03:59:49-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-04T03:59:49-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "start_step": 11,
  "start_steps_total": 11,
  "plan_steps_total": 4,
  "plan_step": 4,
  "_continue_context": "",
  "_continue_pending": "",
  "code_tasks_total": 3
}
```

</details>

## Session Log

<details>
<summary>.flow-states/flaky-ci-coverage-gate-fails.log</summary>

```text
2026-04-04T03:50:55-07:00 [Phase 1] create .flow-states/flaky-ci-coverage-gate-fails.json (exit 0)
2026-04-04T03:50:55-07:00 [Phase 1] freeze .flow-states/flaky-ci-coverage-gate-fails-phases.json (exit 0)
2026-04-04T03:51:07-07:00 [Phase 1] Step 3 — Init state (exit 0)
2026-04-04T03:51:21-07:00 [Phase 1] Step 4 — Label issues (exit 0)
2026-04-04T03:51:49-07:00 [Phase 1] Step 5 — Pull latest main (exit 0)
2026-04-04T03:57:24-07:00 [Phase 1] Step 6 — CI baseline gate (exit 0)
2026-04-04T03:58:15-07:00 [Phase 1] Step 7 — Update deps, no changes (exit 0)
2026-04-04T03:58:27-07:00 [Phase 1] Step 10 — Release lock (exit 0)
2026-04-04T03:58:37-07:00 [Phase 1] git worktree add .worktrees/flaky-ci-coverage-gate-fails (exit 0)
2026-04-04T03:58:44-07:00 [Phase 1] git commit + push + gh pr create (exit 0)
2026-04-04T03:58:44-07:00 [Phase 1] backfill .flow-states/flaky-ci-coverage-gate-fails.json (exit 0)
2026-04-04T04:11:23-07:00 [Phase 2] Step 1 — Fetch issue #835 (exit 0)
2026-04-04T04:14:59-07:00 [stop-continue] blocking: pending=decompose
2026-04-04T04:15:50-07:00 [Phase 2] Step 2 — DAG decomposition (exit 0)
```

</details>