### PR TITLE
Sort Tui Flow List By Phase

### DIFF
--- a/src/tui_data.rs
+++ b/src/tui_data.rs
@@ -506,7 +506,10 @@ pub fn flow_summary(state: &Value, now: Option<DateTime<FixedOffset>>) -> FlowSu
             .get("pr_url")
             .and_then(|u| u.as_str())
             .map(|s| s.to_string()),
-        phase_number: numbers_map.get(current_phase).copied().unwrap_or(0),
+        phase_number: numbers_map
+            .get(current_phase)
+            .copied()
+            .unwrap_or(usize::MAX),
         phase_name: names_map
             .get(current_phase)
             .cloned()
@@ -2371,6 +2374,40 @@ mod tests {
         // Phase 3 (Code) last
         assert_eq!(flows[3].branch, "alpha-feature");
         assert_eq!(flows[3].phase_number, 3);
+    }
+
+    #[test]
+    fn test_load_all_flows_unknown_phase_sorts_last() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        std::fs::create_dir(&state_dir).unwrap();
+
+        // Flow with recognized phase (Start, phase 1)
+        let mut start_state = make_state("flow-start", &[("flow-start", "in_progress")]);
+        start_state["branch"] = json!("known-feature");
+        std::fs::write(
+            state_dir.join("known-feature.json"),
+            serde_json::to_string(&start_state).unwrap(),
+        )
+        .unwrap();
+
+        // Flow with unrecognized phase
+        let mut unknown_state = make_state("flow-nonexistent", &[]);
+        unknown_state["branch"] = json!("unknown-feature");
+        std::fs::write(
+            state_dir.join("unknown-feature.json"),
+            serde_json::to_string(&unknown_state).unwrap(),
+        )
+        .unwrap();
+
+        let flows = load_all_flows(dir.path());
+
+        assert_eq!(flows.len(), 2);
+        // Known phase sorts first; unknown phase sorts last
+        assert_eq!(flows[0].branch, "known-feature");
+        assert_eq!(flows[0].phase_number, 1);
+        assert_eq!(flows[1].branch, "unknown-feature");
+        assert_eq!(flows[1].phase_number, usize::MAX);
     }
 
     #[test]


### PR DESCRIPTION
## What

Sort TUI flow list by phase progression instead of alphabetically #958.

Closes #958

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/sort-tui-flow-list-by-phase-plan.md` |
| DAG | `.flow-states/sort-tui-flow-list-by-phase-dag.md` |
| Log | `.flow-states/sort-tui-flow-list-by-phase.log` |
| State | `.flow-states/sort-tui-flow-list-by-phase.json` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
## Context

The user wants the TUI Active Flows list to sort by phase progression (Start→Complete) instead of alphabetically by feature name. This makes the dashboard reflect workflow priority — earlier phases need attention first.

## Exploration

- `src/tui_data.rs:583` — Rust `load_all_flows()` sorts by `a.feature.cmp(&b.feature)`
- `lib/tui_data.py:288` — Python `load_all_flows()` sorts by `key=lambda f: f["feature"]`
- `FlowSummary` in both implementations already includes `phase_number` (1-6 mapped from `PHASE_NUMBER`), computed from `current_phase` in the state file
- Phase numbers are stable: 1=Start, 2=Plan, 3=Code, 4=Code Review, 5=Learn, 6=Complete
- The Python `FlowSummary` dict uses `"phase_number"` key; the Rust struct uses `phase_number: usize` field

## Risks

- **Minimal risk** — the change is a sort key swap on an existing field. No new data, no new structs, no new dependencies.
- **Parity risk** — Rust and Python must produce identical ordering. Both use the same `phase_number` source, so as long as the sort key is the same tuple `(phase_number, feature)`, parity is guaranteed.

## Approach

Change both sort calls to sort by `(phase_number, feature)` — phase number ascending as the primary key, feature name alphabetical as the tiebreaker. This is a one-line change in each implementation.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add Rust sort test | test | — |
| 2. Add Python sort test | test | — |
| 3. Update Rust sort | implement | 1 |
| 4. Update Python sort | implement | 2 |

## Tasks

### Task 1: Add Rust test for phase-based sort order

Add a test in the Rust TUI data test module that creates multiple flow state files with different phases, calls `load_all_flows()`, and asserts the returned vector is ordered by phase number then feature name.

- **Files:** Rust test file for `tui_data` (likely `tests/tui_data.rs` or inline `#[cfg(test)]` module in `src/tui_data.rs`)
- **TDD:** Test creates 3+ state files with phases out of order (e.g., Code, Start, Plan) and verifies the result sorts Start < Plan < Code. Include two flows in the same phase to verify the feature-name tiebreaker.

### Task 2: Add Python test for phase-based sort order

Add a test in `tests/test_tui_data.py` that creates multiple state files with different phases, calls `load_all_flows()`, and asserts the returned list is ordered by phase number then feature name.

- **Files:** `tests/test_tui_data.py`
- **TDD:** Same structure as Task 1 — multiple phases, verify ordering, verify tiebreaker within same phase.

### Task 3: Update Rust sort in load_all_flows

Change `src/tui_data.rs:583` from:

```rust
flows.sort_by(|a, b| a.feature.cmp(&b.feature));
```

to:

```rust
flows.sort_by(|a, b| a.phase_number.cmp(&b.phase_number).then_with(|| a.feature.cmp(&b.feature)));
```

- **Files:** `src/tui_data.rs`

### Task 4: Update Python sort in load_all_flows

Change `lib/tui_data.py:288` from:

```python
flows.sort(key=lambda f: f["feature"])
```

to:

```python
flows.sort(key=lambda f: (f["phase_number"], f["feature"]))
```

- **Files:** `lib/tui_data.py`
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# Pre-Decomposed Analysis: Sort TUI flow list by phase progression instead of alphabetically

## Problem

The TUI flow list (`flow tui`, Active Flows tab) sorts flows alphabetically by feature name. When multiple flows are active simultaneously, there is no visual indication of lifecycle progression — a flow in the Complete phase appears before one in the Start phase if its feature name sorts earlier alphabetically.

Users managing concurrent flows need to see which flows are earliest in the lifecycle (need attention first) vs. which are furthest along. Phase-based sorting surfaces this naturally: Start flows appear at the top, Complete flows at the bottom.

**Current sort logic:**

- Rust (`src/tui_data.rs:583`): `flows.sort_by(|a, b| a.feature.cmp(&b.feature))`
- Python (`lib/tui_data.py:288`): `flows.sort(key=lambda f: f["feature"])`

Both `FlowSummary` structs already carry `phase_number` (1-6), so no new data plumbing is needed.

## Acceptance Criteria

- Flows in the TUI list view are sorted by phase number ascending (1=Start first, 6=Complete last)
- Within the same phase, flows are sorted alphabetically by feature name (tiebreaker)
- Both Rust and Python implementations produce identical sort order
- Existing TUI tests pass; new tests verify phase-based ordering

## Implementation Plan

### Context

The user wants the TUI Active Flows list to sort by phase progression (Start→Complete) instead of alphabetically by feature name. This makes the dashboard reflect workflow priority — earlier phases need attention first.

### Exploration

- `src/tui_data.rs:583` — Rust `load_all_flows()` sorts by `a.feature.cmp(&b.feature)`
- `lib/tui_data.py:288` — Python `load_all_flows()` sorts by `key=lambda f: f["feature"]`
- `FlowSummary` in both implementations already includes `phase_number` (1-6 mapped from `PHASE_NUMBER`), computed from `current_phase` in the state file
- Phase numbers are stable: 1=Start, 2=Plan, 3=Code, 4=Code Review, 5=Learn, 6=Complete
- The Python `FlowSummary` dict uses `"phase_number"` key; the Rust struct uses `phase_number: usize` field

### Risks

- **Minimal risk** — the change is a sort key swap on an existing field. No new data, no new structs, no new dependencies.
- **Parity risk** — Rust and Python must produce identical ordering. Both use the same `phase_number` source, so as long as the sort key is the same tuple `(phase_number, feature)`, parity is guaranteed.

### Approach

Change both sort calls to sort by `(phase_number, feature)` — phase number ascending as the primary key, feature name alphabetical as the tiebreaker. This is a one-line change in each implementation.

### Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add Rust sort test | test | — |
| 2. Add Python sort test | test | — |
| 3. Update Rust sort | implement | 1 |
| 4. Update Python sort | implement | 2 |

### Tasks

#### Task 1: Add Rust test for phase-based sort order

Add a test in the Rust TUI data test module that creates multiple flow state files with different phases, calls `load_all_flows()`, and asserts the returned vector is ordered by phase number then feature name.

- **Files:** Rust test file for `tui_data` (likely `tests/tui_data.rs` or inline `#[cfg(test)]` module in `src/tui_data.rs`)
- **TDD:** Test creates 3+ state files with phases out of order (e.g., Code, Start, Plan) and verifies the result sorts Start < Plan < Code. Include two flows in the same phase to verify the feature-name tiebreaker.

#### Task 2: Add Python test for phase-based sort order

Add a test in `tests/test_tui_data.py` that creates multiple state files with different phases, calls `load_all_flows()`, and asserts the returned list is ordered by phase number then feature name.

- **Files:** `tests/test_tui_data.py`
- **TDD:** Same structure as Task 1 — multiple phases, verify ordering, verify tiebreaker within same phase.

#### Task 3: Update Rust sort in load_all_flows

Change `src/tui_data.rs:583` from:

```rust
flows.sort_by(|a, b| a.feature.cmp(&b.feature));
```

to:

```rust
flows.sort_by(|a, b| a.phase_number.cmp(&b.phase_number).then_with(|| a.feature.cmp(&b.feature)));
```

- **Files:** `src/tui_data.rs`

#### Task 4: Update Python sort in load_all_flows

Change `lib/tui_data.py:288` from:

```python
flows.sort(key=lambda f: f["feature"])
```

to:

```python
flows.sort(key=lambda f: (f["phase_number"], f["feature"]))
```

- **Files:** `lib/tui_data.py`

## Files to Investigate

- `src/tui_data.rs` — Rust `load_all_flows()` contains the sort at line 583
- `lib/tui_data.py` — Python `load_all_flows()` contains the sort at line 288
- `tests/tui_data.rs` or equivalent — Rust tests for TUI data layer
- `tests/test_tui_data.py` — Python tests for TUI data layer

## Out of Scope

- Changing the detail panel phase timeline order (already correct — uses PHASE_ORDER)
- Adding user-configurable sort options
- Changing orchestration tab sort order

## Context

The TUI is the primary dashboard for managing concurrent FLOW features. Phase-based sorting aligns the visual order with the natural workflow progression, making it easier to identify which flows need attention next.
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 4m |
| Plan | <1m |
| **Total** | **4m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/sort-tui-flow-list-by-phase.json</summary>

```json
{
  "schema_version": 1,
  "branch": "sort-tui-flow-list-by-phase",
  "repo": "benkruger/flow",
  "pr_number": 960,
  "pr_url": "https://github.com/benkruger/flow/pull/960",
  "started_at": "2026-04-08T01:04:36-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/sort-tui-flow-list-by-phase-plan.md",
    "dag": ".flow-states/sort-tui-flow-list-by-phase-dag.md",
    "log": ".flow-states/sort-tui-flow-list-by-phase.log",
    "state": ".flow-states/sort-tui-flow-list-by-phase.json"
  },
  "session_tty": "/dev/ttys001",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "Sort TUI flow list by phase progression instead of alphabetically #958",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-08T01:04:36-07:00",
      "completed_at": "2026-04-08T01:09:35-07:00",
      "session_started_at": null,
      "cumulative_seconds": 299,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-08T01:09:46-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-08T01:09:46-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-08T01:09:46-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 3,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 4
}
```

</details>

## Session Log

<details>
<summary>.flow-states/sort-tui-flow-list-by-phase.log</summary>

```text
2026-04-08T01:04:36-07:00 [Phase 1] create .flow-states/sort-tui-flow-list-by-phase.json (exit 0)
2026-04-08T01:04:36-07:00 [Phase 1] freeze .flow-states/sort-tui-flow-list-by-phase-phases.json (exit 0)
2026-04-08T01:04:39-07:00 [Phase 1] start-init — label-issues (labeled: [958], failed: [])
2026-04-08T01:04:54-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-08T01:06:28-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-08T01:06:31-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-08T01:09:08-07:00 [Phase 1] start-gate — post-deps CI ("ok")
2026-04-08T01:09:17-07:00 [Phase 1] start-workspace — worktree .worktrees/sort-tui-flow-list-by-phase (ok)
2026-04-08T01:09:26-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-08T01:09:26-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-08T01:09:26-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-08T01:09:35-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-08T01:09:35-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-08T01:09:47-07:00 [Phase 2] plan-extract — gate check passed (exit 0)
2026-04-08T01:09:47-07:00 [Phase 2] plan-extract — issue #958 fetched, decomposed label detected (exit 0)
2026-04-08T01:09:47-07:00 [Phase 2] plan-extract — DAG file written: .flow-states/sort-tui-flow-list-by-phase-dag.md (exit 0)
2026-04-08T01:09:47-07:00 [Phase 2] plan-extract — plan extracted, 4 tasks, written: .flow-states/sort-tui-flow-list-by-phase-plan.md (exit 0)
```

</details>