### PR TITLE
Resumed Path In Plan Extract

### DIFF
--- a/src/plan_extract.rs
+++ b/src/plan_extract.rs
@@ -317,9 +317,13 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty());
 
-    // Resume: plan already exists → enter phase, complete immediately, return "resumed"
+    // Resume: plan already exists → read file first, then enter/complete phase
     if let Some(plan_rel) = plan_path {
         let plan_abs = root.join(plan_rel);
+
+        // Read plan file FIRST — fail early before any state mutations
+        let plan_content = std::fs::read_to_string(&plan_abs)
+            .map_err(|e| format!("Could not read plan file: {}", e))?;
 
         // Enter the phase (idempotent if already in_progress)
         mutate_state(&state_path, |state| {
@@ -332,9 +336,6 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
 
         // Complete the phase
         let complete_result = complete_plan_phase(&state_path, &root, &branch)?;
-
-        let plan_content = std::fs::read_to_string(&plan_abs)
-            .map_err(|e| format!("Could not read plan file: {}", e))?;
 
         let formatted_time = complete_result
             .get("formatted_time")

--- a/src/plan_extract.rs
+++ b/src/plan_extract.rs
@@ -325,7 +325,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         let plan_content = std::fs::read_to_string(&plan_abs)
             .map_err(|e| format!("Could not read plan file: {}", e))?;
 
-        // Enter the phase (idempotent if already in_progress)
+        // Enter the phase (safe to call if already in_progress — updates timestamps and visit_count)
         mutate_state(&state_path, |state| {
             if !(state.is_object() || state.is_null()) {
                 return;

--- a/tests/plan_extract.rs
+++ b/tests/plan_extract.rs
@@ -465,6 +465,43 @@ mod integration {
         );
     }
 
+    #[test]
+    fn test_resumed_missing_plan_file_does_not_corrupt_state() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_git_repo(dir.path(), "test-feature");
+
+        let plan_rel = ".flow-states/test-feature-plan.md";
+
+        // State with files.plan set but NO plan file on disk
+        let state = make_plan_state("build a feature", |s| {
+            s["files"]["plan"] = serde_json::json!(plan_rel);
+        });
+        setup_state(dir.path(), "test-feature", &state);
+
+        // Deliberately do NOT create the plan file
+
+        let (code, json) = run_plan_extract(dir.path(), &["--branch", "test-feature"]);
+        assert_eq!(code, 1, "Should exit 1 when plan file is missing");
+        assert!(
+            json["message"]
+                .as_str()
+                .unwrap_or("")
+                .contains("Could not read plan file"),
+            "Expected 'Could not read plan file' error, got: {}",
+            json
+        );
+
+        // Critical: state file must NOT be corrupted with "complete"
+        let updated_state: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap(),
+        )
+        .unwrap();
+        assert_ne!(
+            updated_state["phases"]["flow-plan"]["status"], "complete",
+            "flow-plan must NOT be marked complete when plan file is missing"
+        );
+    }
+
     // --- gh-dependent tests ---
 
     #[test]

--- a/tests/plan_extract.rs
+++ b/tests/plan_extract.rs
@@ -482,6 +482,10 @@ mod integration {
 
         let (code, json) = run_plan_extract(dir.path(), &["--branch", "test-feature"]);
         assert_eq!(code, 1, "Should exit 1 when plan file is missing");
+        assert_eq!(
+            json["status"], "error",
+            "error path should set status=error"
+        );
         assert!(
             json["message"]
                 .as_str()


### PR DESCRIPTION
## What

workon issue #948.

Closes #948

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/resumed-path-in-plan-extract-plan.md` |
| DAG | `.flow-states/resumed-path-in-plan-extract-dag.md` |
| Log | `.flow-states/resumed-path-in-plan-extract.log` |
| State | `.flow-states/resumed-path-in-plan-extract.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/b7adb575-7618-4089-899c-ccc07f661527.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
## Context

Issue #948: The resumed path in `src/plan_extract.rs` (lines 320-358) calls
`phase_enter` and `complete_plan_phase` BEFORE reading the plan file from disk.
If the plan file referenced in `files.plan` is missing or unreadable,
`std::fs::read_to_string` returns `Err` and the binary exits 1 — but the state
file already has `flow-plan.status = "complete"`. This corrupts the state and
creates a stuck retry loop.

## Exploration

**The bug location**: `src/plan_extract.rs:320-358` — the `if let Some(plan_rel) = plan_path`
block (the "resumed" path).

Current operation order:
1. Line 322: `plan_abs = root.join(plan_rel)`
2. Lines 325-331: `mutate_state` → `phase_enter(state, "flow-plan", None)` — writes state
3. Line 334: `complete_plan_phase` — writes state
4. Lines 336-337: `read_to_string(&plan_abs)` — **can fail** (file missing/unreadable)

The `phase_enter` call is idempotent (no-op if already in_progress) and is needed
for proper bookkeeping when the phase was pending. The `complete_plan_phase` call
marks the phase done. Both mutate the state file on disk via `mutate_state`.

**Existing test coverage**: `tests/plan_extract.rs` has `test_resumed_plan_exists`
(integration test, line 421) covering the happy path. No test covers the error
path where the plan file is missing.

**Test infrastructure**: The integration module has `setup_git_repo`, `setup_state`,
`make_plan_state`, and `run_plan_extract` helpers ready to use.

## Risks

- **Low risk**: The fix is a pure reorder of one statement. No logic changes, no
  new code paths, no changes to error semantics. The `read_to_string` call and its
  `map_err` are identical — they just execute earlier.
- **phase_enter idempotency**: After the fix, if `read_to_string` fails, `phase_enter`
  never runs. On retry, the phase is still pending/in_progress — `phase_enter` handles
  both states correctly on the next attempt.

## Approach

Move the `read_to_string` call before both state mutations (`phase_enter` and
`complete_plan_phase`). If the file read fails, return early without touching state.
Add an integration test that exercises the error path and verifies state is not
corrupted.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write error-path integration test | test | — |
| 2. Reorder resumed path in plan_extract.rs | implement | 1 |

## Tasks

### Task 1: Write error-path integration test

**File**: `tests/plan_extract.rs`

Add `test_resumed_missing_plan_file_does_not_corrupt_state` to the `integration`
module, near `test_resumed_plan_exists`.

Setup:
- Create a git repo and state file with `files.plan = ".flow-states/test-feature-plan.md"`
- Do NOT create the plan file on disk

Assertions:
- Exit code is 1 (infrastructure error from `read_to_string`)
- Error output contains "Could not read plan file"
- Re-read the state file: `phases.flow-plan.status` must NOT be "complete"

**TDD note**: This test should FAIL against the current code (the bug causes state
corruption before the file read error). It will PASS after Task 2.

### Task 2: Reorder resumed path operations

**File**: `src/plan_extract.rs`

In the resumed path block (lines 320-358), move the `read_to_string` call
(currently at line 336-337) to immediately after `plan_abs` is computed
(after line 322). The `phase_enter` and `complete_plan_phase` calls remain
in their current relative order but now execute after the file read succeeds.

Before:
```
plan_abs = root.join(plan_rel)
phase_enter(...)          ← state mutation
complete_plan_phase(...)  ← state mutation
read_to_string(plan_abs)  ← can fail, state already corrupted
```

After:
```
plan_abs = root.join(plan_rel)
read_to_string(plan_abs)  ← fail early, state untouched
phase_enter(...)          ← state mutation (only if read succeeded)
complete_plan_phase(...)  ← state mutation (only if read succeeded)
```

**TDD note**: After this change, Task 1's test should pass — the state file
remains uncorrupted when the plan file is missing.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Fix state corruption in plan-extract resumed path

```
╔══════════════════════════════════════════════╗
║           DAG IMPACT PREVIEW                 ║
╚══════════════════════════════════════════════╝
Goal: Fix state corruption in plan-extract resumed path

Verdict: ⚠️ MARGINAL

Without DAG (vanilla Claude):
  ✗ Might fix the reorder without verifying the error path behavior
  ✗ Could miss the test that needs updating for the new error semantics
  ✗ Might not consider whether phase_enter should be preserved for idempotent re-entry

With DAG Simulator:
  ✓ Separates "understand the mutation" from "design the fix" from "plan the tests"
  ✓ Ensures error path test explicitly validates state is NOT corrupted

Estimated structure:
  Nodes: ~4  |  Depth: ~3  |  Parallel sets: ~1

  [1] Analyze Bug ──► [2] Design Fix  ──► [4] Synthesis
                  └──► [3] Test Plan  ──►
```

<dag goal="Fix state corruption in plan-extract resumed path: reorder file read before state mutations" mode="full">
  <plan>
    <node id="1" name="Analyze Resumed Path" type="research" depends="[]" parallel_with="[]">
      <objective>Map the exact sequence of operations in the resumed path and identify all state mutations that occur before the fallible file read</objective>
    </node>
    <node id="2" name="Design Fix" type="analysis" depends="[1]" parallel_with="3">
      <objective>Design the reordering: move read_to_string before phase_enter/complete_plan_phase, determine if phase_enter is still needed after the read</objective>
    </node>
    <node id="3" name="Test Coverage Plan" type="analysis" depends="[1]" parallel_with="2">
      <objective>Identify what tests exist, what's missing (error path with missing file), and plan the new test</objective>
    </node>
    <node id="4" name="Synthesis" type="synthesis" depends="[2,3]">
      <objective>Merge fix design and test plan into implementation tasks with dependency ordering</objective>
    </node>
  </plan>
</dag>

---

▶ NODE 1: Analyze Resumed Path (depends on: none)

The resumed path (lines 321-358 of `src/plan_extract.rs`) executes in this order:

1. **Line 321-322**: Check `files.plan` exists in state → extract `plan_rel`, compute `plan_abs`
2. **Lines 325-331**: `mutate_state` → `phase_enter(state, "flow-plan", None)` — sets `flow-plan.status = "in_progress"`, writes `started_at`, `session_started_at`, `visit_count`, clears auto-continue flags
3. **Line 334**: `complete_plan_phase` → `phase_complete(state, "flow-plan", ...)` — sets `flow-plan.status = "complete"`, writes `completed_at`, `cumulative_seconds`, computes `continue_action`
4. **Lines 336-337**: `std::fs::read_to_string(&plan_abs)` — **THIS CAN FAIL** if the plan file was deleted, moved, or is unreadable
5. **Lines 339-358**: Extract `formatted_time`, `continue_action`, return `Ok(json!({...}))`

**The corruption sequence:**
- Steps 2 and 3 mutate the state file on disk (via `mutate_state`).
- Step 4 can fail with `Err(String)` → `run_impl` returns `Err` → `run()` calls `json_error` and `process::exit(1)`.
- The state file now has `flow-plan.status = "complete"` but the operation failed.
- On retry, `files.plan` is still set → the resumed path triggers again → same failure → stuck loop.

Quality: 9/10 — complete trace of the mutation-before-read ordering bug

Key finding: Two state mutations (phase_enter + phase_complete) execute irrevocably before the only fallible operation in the resumed path.

---

▶ PARALLEL BRANCH A — NODE 2: Design Fix (depends on: 1)

**The fix**: Move `read_to_string` before both state mutations. Read the file first; if it fails, return early without touching state.

```rust
// Resume: plan already exists → read file first, then enter/complete phase
if let Some(plan_rel) = plan_path {
    let plan_abs = root.join(plan_rel);

    // Read plan file FIRST — fail early before any state mutations
    let plan_content = std::fs::read_to_string(&plan_abs)
        .map_err(|e| format!("Could not read plan file: {}", e))?;

    // Enter the phase (idempotent if already in_progress)
    mutate_state(&state_path, |state| {
        if !(state.is_object() || state.is_null()) {
            return;
        }
        phase_enter(state, "flow-plan", None);
    })
    .map_err(|e| format!("Failed to enter phase: {}", e))?;

    // Complete the phase
    let complete_result = complete_plan_phase(&state_path, &root, &branch)?;
    // ... rest unchanged
```

**Key consideration**: `phase_enter` is still needed. It's idempotent — if the phase is already in_progress, it's a no-op. On a true resume (state shows pending/in_progress), it transitions to in_progress before the complete call marks it done. The enter→complete sequence is correct; it just needs to happen AFTER the file read proves the plan file is accessible.

**No changes to error semantics**: The `map_err` still converts to `Err(String)`, which `run()` wraps in `json_error` and exits with code 1. The only difference: state is untouched on this error path.

Quality: 9/10 — minimal change, preserves all existing behavior except the bug

Key finding: The fix is a pure reorder — move one line (the read_to_string call) up by ~10 lines. No logic changes needed.

---

▶ PARALLEL BRANCH B — NODE 3: Test Coverage Plan (depends on: 1)

**Existing test**: `test_resumed_plan_exists` (line 421) covers the happy path — state has `files.plan` set, plan file exists on disk, verifies `path: "resumed"` and `status: "complete"`.

**Missing test**: No test for the error path — when `files.plan` is set but the referenced file doesn't exist. This is the exact bug scenario.

**New test needed**: `test_resumed_missing_plan_file_does_not_corrupt_state`
- Set up: state file with `files.plan = ".flow-states/test-feature-plan.md"`, but DON'T create the plan file on disk
- Execute: run `plan-extract --branch test-feature`
- Assert:
  - Exit code is 1 (infrastructure error)
  - Error message contains "Could not read plan file"
  - **Critical**: Re-read the state file and verify `phases.flow-plan.status` is still NOT "complete" — it should remain at whatever it was before (pending or in_progress)

**Test location**: Same file `tests/plan_extract.rs`, in the `integration` module, near `test_resumed_plan_exists`.

Quality: 8/10 — straightforward error-path test covering the exact bug

Key finding: One test addition covers the bug scenario; the existing happy-path test (`test_resumed_plan_exists`) validates the fix doesn't break normal operation.

---

▶ MERGE: Fix Design + Test Plan

Both branches align: the fix is a single reorder in `src/plan_extract.rs`, and the test validates the error path that was previously corrupting state. No contradictions.

---

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
**Fix**: Reorder the resumed path in `src/plan_extract.rs` (lines 321-358)
to read the plan file BEFORE calling `phase_enter` and `complete_plan_phase`.
One line moves up; no logic changes.

**Test**: Add `test_resumed_missing_plan_file_does_not_corrupt_state` to
`tests/plan_extract.rs` — sets up state with a plan file reference but
no actual file, asserts exit code 1 and that the state file is not
corrupted with "complete" status.

**Files**:
- `src/plan_extract.rs` — reorder resumed path (lines 321-358)
- `tests/plan_extract.rs` — add error-path integration test

**Task ordering** (TDD):
1. Write the test first (it should FAIL against current code — state gets corrupted)
2. Apply the fix (test should PASS)

Confidence: 95%  |  Nodes: 4  |  Parallel branches: 1

vs. Vanilla Claude (what linear reasoning would have missed):
  • Test-first ordering — linear might fix then test, missing the TDD requirement
  • Explicit verification that phase_enter still belongs in the sequence (it's idempotent, needed for state bookkeeping)
  • State corruption assertion — testing exit code alone wouldn't catch the bug; must verify state file content post-failure
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 3m |
| Plan | <1m |
| **Total** | **3m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/resumed-path-in-plan-extract.json</summary>

```json
{
  "schema_version": 1,
  "branch": "resumed-path-in-plan-extract",
  "repo": "benkruger/flow",
  "pr_number": 975,
  "pr_url": "https://github.com/benkruger/flow/pull/975",
  "started_at": "2026-04-09T23:24:04-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/resumed-path-in-plan-extract-plan.md",
    "dag": ".flow-states/resumed-path-in-plan-extract-dag.md",
    "log": ".flow-states/resumed-path-in-plan-extract.log",
    "state": ".flow-states/resumed-path-in-plan-extract.json"
  },
  "session_tty": "/dev/ttys004",
  "session_id": "b7adb575-7618-4089-899c-ccc07f661527",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/b7adb575-7618-4089-899c-ccc07f661527.jsonl",
  "notes": [],
  "prompt": "workon issue #948",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-09T23:24:04-07:00",
      "completed_at": "2026-04-09T23:27:21-07:00",
      "session_started_at": null,
      "cumulative_seconds": 197,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-09T23:27:33-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-09T23:27:33-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-09T23:27:33-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "_continue_context": "",
  "_continue_pending": "null",
  "_stop_instructed": true,
  "code_tasks_total": 2
}
```

</details>

## Session Log

<details>
<summary>.flow-states/resumed-path-in-plan-extract.log</summary>

```text
2026-04-09T23:24:04-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-09T23:24:04-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-09T23:24:04-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-09T23:24:04-07:00 [Phase 1] create .flow-states/resumed-path-in-plan-extract.json (exit 0)
2026-04-09T23:24:04-07:00 [Phase 1] freeze .flow-states/resumed-path-in-plan-extract-phases.json (exit 0)
2026-04-09T23:24:04-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-09T23:24:06-07:00 [Phase 1] start-init — label-issues (labeled: [948], failed: [])
2026-04-09T23:24:13-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-09T23:24:13-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-09T23:24:14-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-09T23:26:58-07:00 [Phase 1] start-gate — post-deps CI ("ok")
2026-04-09T23:27:07-07:00 [Phase 1] start-workspace — worktree .worktrees/resumed-path-in-plan-extract (ok)
2026-04-09T23:27:11-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-09T23:27:11-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-09T23:27:11-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-09T23:27:21-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-09T23:27:21-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-09T23:29:40-07:00 [stop-continue] first stop, conditional continue: pending=decompose
```

</details>