### PR TITLE
Block General Purpose Sub Agents

### DIFF
--- a/.claude/rules/skill-authoring.md
+++ b/.claude/rules/skill-authoring.md
@@ -78,8 +78,9 @@ Never use `general-purpose` sub-agents in skills — they ignore
 tool restriction rules in their prompts. Use custom plugin
 sub-agents with the global `PreToolUse` hook for system-level
 enforcement. The hook (`bin/flow hook validate-pretool`) is
-registered in `hooks/hooks.json` and blocks compound commands and
-file-read commands with exit code 2, feeding helpful error
+registered in `hooks/hooks.json` and blocks compound commands,
+file-read commands, and `general-purpose` Agent calls during
+active FLOW phases with exit code 2, feeding helpful error
 messages back to the sub-agent so it adapts.
 
 Never use `bypassPermissions` mode on sub-agents. Permission deny

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Phase auto-advance uses two layers. Layer 1: the phase completion command (`phas
 
 ### Permission Invariant
 
-Every bash block in every skill must run without triggering a permission prompt. `tests/permissions.rs` enforces at test time (placeholder substitution, allow/deny matching); `bin/flow hook validate-pretool` enforces at runtime via global PreToolUse hook (compound commands, redirection, file-read commands blocked; whitelist enforced when a flow is active). See `.claude/rules/permissions.md` for the pattern-adding protocol.
+Every bash block in every skill must run without triggering a permission prompt. `tests/permissions.rs` enforces at test time (placeholder substitution, allow/deny matching); `bin/flow hook validate-pretool` enforces at runtime via global PreToolUse hook (compound commands, redirection, file-read commands blocked; whitelist enforced when a flow is active; `general-purpose` sub-agents blocked during active FLOW phases). See `.claude/rules/permissions.md` for the pattern-adding protocol.
 
 ### Tombstone Lifecycle
 

--- a/src/hooks/validate_pretool.rs
+++ b/src/hooks/validate_pretool.rs
@@ -1,7 +1,11 @@
 //! PreToolUse hook validator for Bash and Agent tool calls.
 //!
-//! Reads the Claude Code hook input JSON from stdin, checks the Bash
-//! command against blocked patterns, and exits with the appropriate code.
+//! For Bash calls, checks the command against blocked patterns (compound
+//! commands, redirection, file-read commands, deny list, whitelist).
+//!
+//! For Agent calls, blocks `general-purpose` sub-agents during active
+//! FLOW phases. Custom plugin agents (`flow:*`) and specialized types
+//! (`Explore`, `Plan`) are allowed through.
 //!
 //! Exit 0 — allow (command passes through to normal permission system)
 //! Exit 2 — block (error message on stderr is fed back to the sub-agent)
@@ -194,6 +198,32 @@ pub fn should_block_background(command: &str, flow_active: bool) -> Option<Strin
     None
 }
 
+/// Validate an Agent tool call by subagent type.
+///
+/// During an active FLOW phase, blocks `general-purpose` sub-agents
+/// (explicit or default when `subagent_type` is absent). All other
+/// types — custom plugin agents (`flow:*`), specialized built-in
+/// types (`Explore`, `Plan`), etc. — are allowed through.
+///
+/// Outside a FLOW phase, all agent types are allowed.
+///
+/// Returns `(allowed, message)`. Message is empty if allowed.
+pub fn validate_agent(subagent_type: Option<&str>, flow_active: bool) -> (bool, String) {
+    if !flow_active {
+        return (true, String::new());
+    }
+    match subagent_type {
+        None | Some("general-purpose") => (
+            false,
+            "BLOCKED: general-purpose sub-agents are not allowed during FLOW phases. \
+             Use a custom plugin sub-agent (flow:ci-fixer, flow:reviewer, etc.) or \
+             a specialized agent type (Explore, Plan) instead."
+                .to_string(),
+        ),
+        Some(_) => (true, String::new()),
+    }
+}
+
 /// Check whether a command invokes bin/flow (any subcommand) or bin/ci.
 ///
 /// Matches by tokenizing on whitespace, so path prefixes and trailing
@@ -276,6 +306,13 @@ pub fn run() {
         }
     }
     if command.is_empty() {
+        // No command means this is an Agent tool call, not Bash.
+        let subagent_type = tool_input.get("subagent_type").and_then(|v| v.as_str());
+        let (allowed, message) = validate_agent(subagent_type, flow_active);
+        if !allowed {
+            eprintln!("{}", message);
+            std::process::exit(2);
+        }
         std::process::exit(0);
     }
 
@@ -938,5 +975,57 @@ mod tests {
     fn test_is_bg_truthy_object_and_array() {
         assert!(!is_bg_truthy(&json!({})));
         assert!(!is_bg_truthy(&json!([])));
+    }
+
+    // --- Agent validation ---
+
+    #[test]
+    fn test_validate_agent_blocks_general_purpose_when_flow_active() {
+        let (allowed, msg) = validate_agent(Some("general-purpose"), true);
+        assert!(!allowed);
+        assert!(msg.contains("general-purpose"));
+        assert!(msg.contains("BLOCKED"));
+    }
+
+    #[test]
+    fn test_validate_agent_blocks_absent_type_when_flow_active() {
+        let (allowed, msg) = validate_agent(None, true);
+        assert!(!allowed);
+        assert!(msg.contains("general-purpose"));
+    }
+
+    #[test]
+    fn test_validate_agent_allows_flow_namespace_when_flow_active() {
+        let (allowed, msg) = validate_agent(Some("flow:ci-fixer"), true);
+        assert!(allowed);
+        assert!(msg.is_empty());
+    }
+
+    #[test]
+    fn test_validate_agent_allows_explore_when_flow_active() {
+        let (allowed, msg) = validate_agent(Some("Explore"), true);
+        assert!(allowed);
+        assert!(msg.is_empty());
+    }
+
+    #[test]
+    fn test_validate_agent_allows_plan_when_flow_active() {
+        let (allowed, msg) = validate_agent(Some("Plan"), true);
+        assert!(allowed);
+        assert!(msg.is_empty());
+    }
+
+    #[test]
+    fn test_validate_agent_allows_general_purpose_when_no_flow() {
+        let (allowed, msg) = validate_agent(Some("general-purpose"), false);
+        assert!(allowed);
+        assert!(msg.is_empty());
+    }
+
+    #[test]
+    fn test_validate_agent_allows_absent_type_when_no_flow() {
+        let (allowed, msg) = validate_agent(None, false);
+        assert!(allowed);
+        assert!(msg.is_empty());
     }
 }

--- a/src/hooks/validate_pretool.rs
+++ b/src/hooks/validate_pretool.rs
@@ -212,16 +212,21 @@ pub fn validate_agent(subagent_type: Option<&str>, flow_active: bool) -> (bool, 
     if !flow_active {
         return (true, String::new());
     }
-    match subagent_type {
-        None | Some("general-purpose") => (
+    let normalized = subagent_type.map(|s| s.trim().to_ascii_lowercase());
+    let is_general_purpose = match normalized.as_deref() {
+        None | Some("") | Some("general-purpose") => true,
+        Some(_) => false,
+    };
+    if is_general_purpose {
+        return (
             false,
             "BLOCKED: general-purpose sub-agents are not allowed during FLOW phases. \
              Use a custom plugin sub-agent (flow:ci-fixer, flow:reviewer, etc.) or \
              a specialized agent type (Explore, Plan) instead."
                 .to_string(),
-        ),
-        Some(_) => (true, String::new()),
+        );
     }
+    (true, String::new())
 }
 
 /// Check whether a command invokes bin/flow (any subcommand) or bin/ci.
@@ -992,6 +997,7 @@ mod tests {
         let (allowed, msg) = validate_agent(None, true);
         assert!(!allowed);
         assert!(msg.contains("general-purpose"));
+        assert!(msg.contains("BLOCKED"));
     }
 
     #[test]
@@ -1027,5 +1033,26 @@ mod tests {
         let (allowed, msg) = validate_agent(None, false);
         assert!(allowed);
         assert!(msg.is_empty());
+    }
+
+    #[test]
+    fn test_validate_agent_blocks_case_variants_when_flow_active() {
+        let (allowed, _) = validate_agent(Some("General-Purpose"), true);
+        assert!(!allowed);
+        let (allowed, _) = validate_agent(Some("GENERAL-PURPOSE"), true);
+        assert!(!allowed);
+    }
+
+    #[test]
+    fn test_validate_agent_blocks_empty_string_when_flow_active() {
+        let (allowed, msg) = validate_agent(Some(""), true);
+        assert!(!allowed);
+        assert!(msg.contains("BLOCKED"));
+    }
+
+    #[test]
+    fn test_validate_agent_blocks_whitespace_padded_when_flow_active() {
+        let (allowed, _) = validate_agent(Some(" general-purpose "), true);
+        assert!(!allowed);
     }
 }

--- a/tests/adversarial_agent_block.rs
+++ b/tests/adversarial_agent_block.rs
@@ -1,0 +1,409 @@
+//! Adversarial tests for the validate_agent function in validate_pretool.rs.
+//!
+//! These tests target edge cases in the new Agent tool blocking logic
+//! that blocks general-purpose sub-agents during active FLOW phases.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+use serde_json::{json, Value};
+
+/// Build a `Command` targeting the compiled `flow-rs` test binary.
+fn flow_rs() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+}
+
+/// Initialize a git repo at `dir` on a specific `branch_name`, with
+/// `.claude/settings.json` (so `find_settings_and_root` succeeds) and
+/// `.flow-states/<branch_name>.json` with the given state.
+///
+/// The branch name in the git repo MUST match the state file name because
+/// `validate_pretool.run()` uses `detect_branch_from_cwd()` (which falls
+/// back to `git branch --show-current`) — not `current_branch()` which
+/// honors `FLOW_SIMULATE_BRANCH`.
+fn setup_flow_active_repo(dir: &Path, branch_name: &str, state: &Value) {
+    // Create git repo on the specified branch
+    let run = |args: &[&str]| {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git command failed");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    run(&["init", "--initial-branch", branch_name]);
+    run(&["config", "user.email", "test@test.com"]);
+    run(&["config", "user.name", "Test"]);
+    run(&["config", "commit.gpgsign", "false"]);
+    run(&["commit", "--allow-empty", "-m", "init"]);
+
+    // Create .claude/settings.json so find_settings_and_root succeeds
+    let claude_dir = dir.join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("settings.json"),
+        r#"{"permissions":{"allow":[],"deny":[]}}"#,
+    )
+    .unwrap();
+
+    // Create state file matching the branch name
+    let state_dir = dir.join(".flow-states");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join(format!("{}.json", branch_name)),
+        serde_json::to_string_pretty(state).unwrap(),
+    )
+    .unwrap();
+}
+
+/// Spawn `flow-rs hook validate-pretool`, pipe `stdin_data` to the child,
+/// and return the captured `Output`.
+///
+/// Does NOT set FLOW_SIMULATE_BRANCH because detect_branch_from_cwd()
+/// does not consult it. Instead, the fixture repo must be on the correct
+/// branch (via setup_flow_active_repo).
+fn run_validate_pretool(dir: &Path, stdin_data: &[u8]) -> Output {
+    let mut cmd = flow_rs();
+    cmd.arg("hook")
+        .arg("validate-pretool")
+        .env_remove("FLOW_SIMULATE_BRANCH")
+        .current_dir(dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().unwrap();
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        stdin.write_all(stdin_data).unwrap();
+    }
+    child.wait_with_output().unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Edge case 1: Case-insensitive bypass of "general-purpose"
+//
+// validate_agent uses exact match Some("general-purpose"). Case variants
+// like "General-Purpose" fall through to Some(_) and are allowed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_agent_block_case_insensitive_general_purpose() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "test-feature";
+    let state = json!({
+        "branch": branch,
+        "current_phase": "flow-code"
+    });
+    setup_flow_active_repo(dir.path(), branch, &state);
+
+    let hook_input = json!({
+        "tool_input": {
+            "subagent_type": "General-Purpose"
+        }
+    });
+    let stdin = serde_json::to_vec(&hook_input).unwrap();
+    let output = run_validate_pretool(dir.path(), &stdin);
+
+    assert_eq!(
+        output.status.code().unwrap(),
+        2,
+        "General-Purpose (capitalized) should be blocked during FLOW phases, \
+         but the exact-match implementation allows it through"
+    );
+}
+
+#[test]
+fn test_agent_block_uppercase_general_purpose() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "test-feature";
+    let state = json!({
+        "branch": branch,
+        "current_phase": "flow-code"
+    });
+    setup_flow_active_repo(dir.path(), branch, &state);
+
+    let hook_input = json!({
+        "tool_input": {
+            "subagent_type": "GENERAL-PURPOSE"
+        }
+    });
+    let stdin = serde_json::to_vec(&hook_input).unwrap();
+    let output = run_validate_pretool(dir.path(), &stdin);
+
+    assert_eq!(
+        output.status.code().unwrap(),
+        2,
+        "GENERAL-PURPOSE (uppercase) should be blocked during FLOW phases, \
+         but the exact-match implementation allows it through"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Edge case 2: Empty string subagent_type bypasses the block
+//
+// Some("") matches Some(_) and is allowed through, even though an empty
+// string is semantically equivalent to an absent/default type.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_agent_block_empty_string_subagent_type() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "test-feature";
+    let state = json!({
+        "branch": branch,
+        "current_phase": "flow-code"
+    });
+    setup_flow_active_repo(dir.path(), branch, &state);
+
+    let hook_input = json!({
+        "tool_input": {
+            "subagent_type": ""
+        }
+    });
+    let stdin = serde_json::to_vec(&hook_input).unwrap();
+    let output = run_validate_pretool(dir.path(), &stdin);
+
+    assert_eq!(
+        output.status.code().unwrap(),
+        2,
+        "Empty-string subagent_type should be blocked (treated as absent/default), \
+         but the current implementation allows it through via the Some(_) catch-all"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Edge case 3: Whitespace-padded "general-purpose" bypasses the block
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_agent_block_whitespace_padded_general_purpose() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "test-feature";
+    let state = json!({
+        "branch": branch,
+        "current_phase": "flow-code"
+    });
+    setup_flow_active_repo(dir.path(), branch, &state);
+
+    let hook_input = json!({
+        "tool_input": {
+            "subagent_type": " general-purpose "
+        }
+    });
+    let stdin = serde_json::to_vec(&hook_input).unwrap();
+    let output = run_validate_pretool(dir.path(), &stdin);
+
+    assert_eq!(
+        output.status.code().unwrap(),
+        2,
+        "Whitespace-padded 'general-purpose' should be blocked, \
+         but exact matching allows it through"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Edge case 4: Integration test - Agent call blocked during active flow
+//
+// Verifies the full run() path: stdin JSON -> tool_input extraction ->
+// empty command detection -> validate_agent -> exit code 2.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_agent_integration_blocked_general_purpose_during_flow() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "test-feature";
+    let state = json!({
+        "branch": branch,
+        "current_phase": "flow-code"
+    });
+    setup_flow_active_repo(dir.path(), branch, &state);
+
+    let hook_input = json!({
+        "tool_input": {
+            "subagent_type": "general-purpose",
+            "prompt": "Do something"
+        }
+    });
+    let stdin = serde_json::to_vec(&hook_input).unwrap();
+    let output = run_validate_pretool(dir.path(), &stdin);
+
+    assert_eq!(
+        output.status.code().unwrap(),
+        2,
+        "general-purpose agent must be blocked during active FLOW phase"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("BLOCKED"),
+        "stderr must contain BLOCKED message, got: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("general-purpose"),
+        "stderr must name the blocked agent type, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_agent_integration_allowed_flow_agent_during_flow() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "test-feature";
+    let state = json!({
+        "branch": branch,
+        "current_phase": "flow-code"
+    });
+    setup_flow_active_repo(dir.path(), branch, &state);
+
+    let hook_input = json!({
+        "tool_input": {
+            "subagent_type": "flow:ci-fixer",
+            "prompt": "Fix CI"
+        }
+    });
+    let stdin = serde_json::to_vec(&hook_input).unwrap();
+    let output = run_validate_pretool(dir.path(), &stdin);
+
+    assert_eq!(
+        output.status.code().unwrap(),
+        0,
+        "flow: namespace agents must be allowed through"
+    );
+}
+
+#[test]
+fn test_agent_integration_absent_type_blocked_during_flow() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "test-feature";
+    let state = json!({
+        "branch": branch,
+        "current_phase": "flow-code"
+    });
+    setup_flow_active_repo(dir.path(), branch, &state);
+
+    let hook_input = json!({
+        "tool_input": {
+            "prompt": "Do something without specifying a type"
+        }
+    });
+    let stdin = serde_json::to_vec(&hook_input).unwrap();
+    let output = run_validate_pretool(dir.path(), &stdin);
+
+    assert_eq!(
+        output.status.code().unwrap(),
+        2,
+        "Absent subagent_type (default = general-purpose) must be blocked during active FLOW phase"
+    );
+}
+
+#[test]
+fn test_agent_integration_allowed_when_no_flow() {
+    // When no flow is active (no state file), general-purpose agents
+    // should be allowed through.
+    let dir = tempfile::tempdir().unwrap();
+    let _ = Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .output();
+    // Create .claude/settings.json so find_settings_and_root succeeds
+    let claude_dir = dir.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("settings.json"),
+        r#"{"permissions":{"allow":[],"deny":[]}}"#,
+    )
+    .unwrap();
+    // No .flow-states/ directory -> flow_active is false
+
+    let hook_input = json!({
+        "tool_input": {
+            "subagent_type": "general-purpose",
+            "prompt": "Do something"
+        }
+    });
+    let stdin = serde_json::to_vec(&hook_input).unwrap();
+    let output = run_validate_pretool(dir.path(), &stdin);
+
+    assert_eq!(
+        output.status.code().unwrap(),
+        0,
+        "general-purpose agent must be allowed when no flow is active"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Edge case 5: subagent_type as non-string JSON value
+//
+// If subagent_type is a non-string JSON value (bool, int), .as_str()
+// returns None, which maps to the blocked case via the None arm.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_agent_integration_non_string_subagent_type_blocked() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "test-feature";
+    let state = json!({
+        "branch": branch,
+        "current_phase": "flow-code"
+    });
+    setup_flow_active_repo(dir.path(), branch, &state);
+
+    // subagent_type is a boolean, not a string
+    let hook_input = json!({
+        "tool_input": {
+            "subagent_type": true,
+            "prompt": "Try to bypass with non-string type"
+        }
+    });
+    let stdin = serde_json::to_vec(&hook_input).unwrap();
+    let output = run_validate_pretool(dir.path(), &stdin);
+
+    // Non-string -> as_str() returns None -> treated as absent -> blocked
+    assert_eq!(
+        output.status.code().unwrap(),
+        2,
+        "Non-string subagent_type (bool) should be treated as absent and blocked"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Edge case 6: Agent tool call with command="" (explicitly empty string)
+//
+// When tool_input has command: "", this is still treated as empty command
+// which triggers the Agent path. Verify blocking works.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_agent_integration_explicit_empty_command_triggers_agent_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "test-feature";
+    let state = json!({
+        "branch": branch,
+        "current_phase": "flow-code"
+    });
+    setup_flow_active_repo(dir.path(), branch, &state);
+
+    let hook_input = json!({
+        "tool_input": {
+            "command": "",
+            "subagent_type": "general-purpose",
+            "prompt": "Do something"
+        }
+    });
+    let stdin = serde_json::to_vec(&hook_input).unwrap();
+    let output = run_validate_pretool(dir.path(), &stdin);
+
+    assert_eq!(
+        output.status.code().unwrap(),
+        2,
+        "Explicit empty command + general-purpose must still trigger Agent blocking"
+    );
+}


### PR DESCRIPTION
## What

work on issue #952.

Closes #952

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/block-general-purpose-sub-agents-plan.md` |
| DAG | `.flow-states/block-general-purpose-sub-agents-dag.md` |
| Log | `.flow-states/block-general-purpose-sub-agents.log` |
| State | `.flow-states/block-general-purpose-sub-agents.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/f59842cd-6ddd-4ee2-bb58-24b06297a395.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
## Context

Issue #952: The `validate-pretool` PreToolUse hook handles both `Bash|Agent` tool calls (hooks.json line 17), but Agent calls pass through completely unvalidated. The `run()` function in `src/hooks/validate_pretool.rs` extracts the `command` field from `tool_input` — which is empty for Agent calls — and exits with code 0 (allow) at line 278. This means `general-purpose` sub-agents can be spawned during active FLOW phases with no enforcement.

The `.claude/rules/skill-authoring.md` rule says "Never use general-purpose sub-agents in skills" but this is instruction-level only — Claude can and does ignore it (observed in PR #942, tasks 8-9).

## Exploration

**Current code path for Agent calls** (`src/hooks/validate_pretool.rs:241-289`):
1. Line 259-262: Extracts `tool_input` from hook JSON
2. Line 264-267: Extracts `command` field → empty string for Agent calls
3. Line 270-277: Background check — `should_block_background("")` returns `None` (empty first token)
4. Line 278-280: `if command.is_empty() { std::process::exit(0); }` — **Agent calls exit here unconditionally**
5. Lines 282-288: Bash validation — never reached for Agent calls

**Hook registration** (`hooks/hooks.json:15-24`): Matcher is `Bash|Agent`, pointing to `bin/flow hook validate-pretool`. The hook already fires for Agent calls — it just doesn't validate them.

**Agent tool input schema**: For Agent calls, `tool_input` contains `prompt`, `description`, `subagent_type` (optional string), `model`, `run_in_background`, `isolation`. When `subagent_type` is omitted, Claude Code defaults to `general-purpose`.

**Existing valid agent types used in skills**:
- `flow:ci-fixer` — flow-start Step 2, flow-code CI fix
- `flow:reviewer` — flow-code-review Step 2
- `flow:pre-mortem` — flow-code-review Step 2
- `flow:adversarial` — flow-code-review Step 2
- `flow:documentation` — flow-code-review Step 2
- `flow:learn-analyst` — flow-learn Step 2
- `Explore` — flow-plan codebase exploration
- `Plan` — architecture planning

**Existing test patterns**: Unit tests for `validate()` and `should_block_background()` are inline in `src/hooks/validate_pretool.rs` (lines 291-942). They use pure function calls with no filesystem dependencies. Integration tests in `tests/hooks.rs` use `run_hook()` subprocess helper but don't cover validate-pretool.

**Module doc comment** (lines 1-7): Says "Bash and Agent tool calls" but the description only mentions Bash commands. Needs updating.

## Risks

1. **Agent tool input may not include `subagent_type` in hook JSON** — If Claude Code strips `subagent_type` from the hook input, all agent calls would have `None` and be blocked during FLOW phases. Mitigation: the `flow_active` guard limits impact; the error message tells the caller exactly what to do. Integration testing during Code phase will verify.

2. **Background blocking for Agent calls** — Currently, `should_block_background` checks the `command` field (empty for Agent), so it never blocks background Agent calls during FLOW. The background check at line 270-277 should also work for Agent calls. But this is a separate concern — the issue specifically targets `general-purpose` blocking.

## Approach

Add a `validate_agent()` function following the existing `validate()` and `should_block_background()` patterns. The validation rule is a blocklist (not allowlist): block when `subagent_type` is absent or `"general-purpose"`, allow everything else. This avoids maintaining a brittle allowlist that breaks when new specialized types are added.

Modify `run()` to call `validate_agent()` instead of early-exiting when `command` is empty. Update the module doc comment to reflect the new Agent validation.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write unit tests for `validate_agent` | test | — |
| 2. Implement `validate_agent` and integrate into `run()` | implement | 1 |
| 3. Update module doc comment | implement | 2 |

## Tasks

### Task 1 — Write unit tests for `validate_agent`

Add 7 unit tests to the inline `#[cfg(test)] mod tests` in `src/hooks/validate_pretool.rs`, following the existing pattern:

- `test_validate_agent_blocks_general_purpose_when_flow_active` — `Some("general-purpose")`, flow_active=true → blocked
- `test_validate_agent_blocks_absent_type_when_flow_active` — `None`, flow_active=true → blocked (default is general-purpose)
- `test_validate_agent_allows_flow_namespace_when_flow_active` — `Some("flow:ci-fixer")`, flow_active=true → allowed
- `test_validate_agent_allows_explore_when_flow_active` — `Some("Explore")`, flow_active=true → allowed
- `test_validate_agent_allows_plan_when_flow_active` — `Some("Plan")`, flow_active=true → allowed
- `test_validate_agent_allows_general_purpose_when_no_flow` — `Some("general-purpose")`, flow_active=false → allowed
- `test_validate_agent_allows_absent_type_when_no_flow` — `None`, flow_active=false → allowed

Tests verify both the `allowed` boolean and the `message` content (error message names "general-purpose" and suggests alternatives).

**Files**: `src/hooks/validate_pretool.rs` (add to existing `mod tests` block)

### Task 2 — Implement `validate_agent` and integrate into `run()`

Add a new public function:

```rust
pub fn validate_agent(subagent_type: Option<&str>, flow_active: bool) -> (bool, String)
```

Logic:
1. If not `flow_active` → `(true, "")`
2. If `subagent_type` is `None` or `Some("general-purpose")` → block with error message
3. Otherwise → `(true, "")`

Error message should name the problem and suggest alternatives (flow:* agents, Explore, Plan).

Replace the early exit at line 278-280 in `run()`:
```rust
if command.is_empty() {
    let subagent_type = tool_input.get("subagent_type").and_then(|v| v.as_str());
    let (allowed, message) = validate_agent(subagent_type, flow_active);
    if !allowed {
        eprintln!("{}", message);
        std::process::exit(2);
    }
    std::process::exit(0);
}
```

**Files**: `src/hooks/validate_pretool.rs`

### Task 3 — Update module doc comment

Update the module-level doc comment (lines 1-7) to mention Agent validation alongside Bash validation. The current text says "checks the Bash command against blocked patterns" — update to mention that it also blocks general-purpose Agent sub-agents during active FLOW phases.

**Files**: `src/hooks/validate_pretool.rs`
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Block general-purpose sub-agents during FLOW phases via PreToolUse hook

<dag goal="Block general-purpose sub-agents during FLOW phases via PreToolUse hook" mode="full">
  <plan>
    <node id="1" name="Analyze current hook architecture" type="research"
          depends="[]" parallel_with="2">
      <objective>Map the exact code path Agent tool calls take through validate_pretool.rs, identify the insertion point for agent-type validation</objective>
    </node>
    <node id="2" name="Determine Agent tool input schema" type="research"
          depends="[]" parallel_with="1">
      <objective>Determine the exact JSON structure Claude Code sends for Agent tool calls via PreToolUse hooks, specifically how subagent_type is represented</objective>
    </node>
    <node id="3" name="Identify allowed agent types" type="analysis"
          depends="[1,2]" parallel_with="4">
      <objective>Enumerate all valid agent types that should be allowed during FLOW phases (flow:* namespace agents, specialized types like Explore/Plan)</objective>
    </node>
    <node id="4" name="Assess test infrastructure" type="research"
          depends="[1,2]" parallel_with="3">
      <objective>Examine existing unit tests in validate_pretool.rs and integration tests in tests/hooks.rs to understand the test patterns for this hook</objective>
    </node>
    <node id="5" name="Design the validation logic" type="analysis"
          depends="[3,4]" parallel_with="[]">
      <objective>Design the specific validation function, its signature, and where it integrates into run()</objective>
    </node>
    <node id="6" name="Synthesis" type="synthesis"
          depends="[5]" parallel_with="[]">
      <objective>Produce the complete implementation plan with tasks, dependencies, risks, and approach</objective>
    </node>
  </plan>
</dag>

---

▶ PARALLEL BRANCH A — NODE 1: Analyze current hook architecture

The `run()` function in `validate_pretool.rs` (lines 241-289) processes both Bash and Agent tool calls through the same entry point. The critical code path for Agent calls:

1. **Line 259-262**: Extracts `tool_input` from hook JSON
2. **Line 264-267**: Extracts `command` field — this is Bash-specific and returns `""` for Agent calls
3. **Line 270-277**: Background check — uses `command` (empty for Agent), so `should_block_background` sees an empty first token and returns `None`
4. **Line 278-280**: **Early exit** — `if command.is_empty() { std::process::exit(0); }` — Agent calls exit here with "allow"

The insertion point is clear: between the background check (line 277) and the empty-command exit (line 278). When `command` is empty, check if this is an Agent call by looking for `subagent_type` in `tool_input`. If found and flow is active, validate the agent type.

Quality: 9/10 — Clear insertion point identified with exact line numbers.

Key finding: Agent calls currently exit unconditionally at line 278 because `command` is empty — the validation gap is a single early-return.

---

▶ PARALLEL BRANCH B — NODE 2: Determine Agent tool input schema

From Claude Code's hook documentation and the existing hook registration in `hooks/hooks.json` (matcher `Bash|Agent`), the PreToolUse hook receives the full tool input as JSON. For Agent tool calls, the `tool_input` structure includes:

- `prompt` (string) — the task description
- `description` (string) — short description
- `subagent_type` (string, optional) — e.g. `"flow:ci-fixer"`, `"flow:reviewer"`, `"general-purpose"`, `"Explore"`, `"Plan"`
- `model` (string, optional) — model override
- `run_in_background` (boolean, optional)
- `isolation` (string, optional)

When `subagent_type` is omitted, Claude Code defaults to `"general-purpose"`. The key field for validation is `subagent_type` — its presence or absence, and its value.

Quality: 8/10 — Schema derived from tool definitions and skill usage patterns.

Key finding: `subagent_type` is optional in the JSON — absence means `general-purpose` (the default).

---

▶ MERGE: Both branches confirm the implementation path — check `subagent_type` from `tool_input` when `command` is empty, using the same `flow_active` flag already computed.

---

▶ PARALLEL BRANCH A — NODE 3: Identify allowed agent types

From `agents/*.md` in the repo and skill SKILL.md files:

**Custom plugin sub-agents (flow: namespace):**
- `flow:ci-fixer` — used by flow-start (CI fix), flow-code (CI fix)
- `flow:reviewer` — used by flow-code-review Step 2
- `flow:pre-mortem` — used by flow-code-review Step 2
- `flow:adversarial` — used by flow-code-review Step 2
- `flow:documentation` — used by flow-code-review Step 2
- `flow:learn-analyst` — used by flow-learn Step 2

**Specialized built-in agents used by skills:**
- `Explore` — used by flow-plan for codebase exploration
- `Plan` — used occasionally for architecture planning

**Always blocked during FLOW phases:**
- `general-purpose` (explicit) — the problem this issue targets
- absent/null `subagent_type` — defaults to general-purpose

The validation rule: when flow is active, block if `subagent_type` is absent OR equals `"general-purpose"`. All other types (flow:*, Explore, Plan, any future specialized type) are allowed.

Quality: 9/10 — Clean rule that targets exactly the problem without over-blocking.

Key finding: Block absent or `"general-purpose"` subagent_type; allow all others (flow:*, Explore, Plan, etc.)

---

▶ PARALLEL BRANCH B — NODE 4: Assess test infrastructure

The existing test suite in `validate_pretool.rs` (lines 291-942) uses pure unit tests with `validate()` and `should_block_background()` functions. These tests don't require filesystem setup — they pass command strings and settings JSON directly.

For Agent validation, we need a new public function (following the `run_impl` testability pattern): extract the validation logic into a testable function like `validate_agent(subagent_type: Option<&str>, flow_active: bool) -> (bool, String)`.

The integration tests in `tests/hooks.rs` test the full hook binary via subprocess. These require a git repo fixture with `.flow-states/` for flow-active detection.

Quality: 9/10 — Clear test strategy: unit tests for the function, matching existing patterns.

Key finding: Follow the existing `validate()` / `should_block_background()` pattern — extract a testable `validate_agent()` function.

---

▶ NODE 5: Design the validation logic (depends on 3, 4)

**Function signature:**
```rust
pub fn validate_agent(subagent_type: Option<&str>, flow_active: bool) -> (bool, String)
```

**Logic:**
1. If not `flow_active` → allow (return `(true, "")`)
2. If `subagent_type` is `None` or `Some("general-purpose")` → block with helpful error message
3. Otherwise → allow

**Integration into `run()`:**
Replace the early exit at line 278-280:
```rust
if command.is_empty() {
    let subagent_type = tool_input.get("subagent_type").and_then(|v| v.as_str());
    let (allowed, message) = validate_agent(subagent_type, flow_active);
    if !allowed {
        eprintln!("{}", message);
        std::process::exit(2);
    }
    std::process::exit(0);
}
```

**Error message:**
```
BLOCKED: general-purpose sub-agents are not allowed during FLOW phases.
Use a custom plugin sub-agent (flow:ci-fixer, flow:reviewer, etc.) or
a specialized agent type (Explore, Plan) instead.
```

**Tests needed:**
- `test_validate_agent_blocks_general_purpose_when_flow_active`
- `test_validate_agent_blocks_absent_type_when_flow_active`
- `test_validate_agent_allows_flow_namespace_when_flow_active`
- `test_validate_agent_allows_explore_when_flow_active`
- `test_validate_agent_allows_plan_when_flow_active`
- `test_validate_agent_allows_general_purpose_when_no_flow`
- `test_validate_agent_allows_absent_type_when_no_flow`

Quality: 9/10 — Minimal, targeted change that follows existing patterns exactly.

Key finding: Single function, 7 unit tests, one integration point in `run()`.

---

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

**The implementation is surgical:** one new function (`validate_agent`), one modified code path in `run()`, and unit tests. The validation rule is: when a FLOW phase is active, block Agent tool calls where `subagent_type` is absent or `"general-purpose"`. All other types pass through. No allowlist maintenance needed.

**Files to modify:**
- `src/hooks/validate_pretool.rs` — add `validate_agent()` function, modify `run()` to call it instead of early-exiting on empty command
- `tests/hooks.rs` or inline tests — add 7 unit tests

**No files to create.** No settings.json changes. No skill modifications (the instruction in `.claude/rules/skill-authoring.md` already exists — this adds enforcement).

**Risk:** The only risk is if Claude Code's Agent tool input doesn't include `subagent_type` in the hook JSON. If the field is absent for ALL agent calls (not just general-purpose ones), the hook would block all agents. Mitigation: the `flow_active` guard means this only fires during FLOW phases, and the error message tells the caller exactly what to do.

Confidence: 92%  |  Nodes: 6  |  Parallel branches: 2

vs. Vanilla Claude:
  • The early-exit at line 278 is the root cause — without tracing the code path, a naive fix might add validation after the validate() call (which never runs for Agent calls)
  • The absent-subagent_type case — linear reasoning might only block the explicit "general-purpose" string and miss the default case
  • The distinction between allowlist (brittle) and blocklist (robust) approaches
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | <1m |
| **Total** | **<1m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/block-general-purpose-sub-agents.json</summary>

```json
{
  "schema_version": 1,
  "branch": "block-general-purpose-sub-agents",
  "repo": "benkruger/flow",
  "pr_number": 976,
  "pr_url": "https://github.com/benkruger/flow/pull/976",
  "started_at": "2026-04-09T23:27:43-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/block-general-purpose-sub-agents-plan.md",
    "dag": ".flow-states/block-general-purpose-sub-agents-dag.md",
    "log": ".flow-states/block-general-purpose-sub-agents.log",
    "state": ".flow-states/block-general-purpose-sub-agents.json"
  },
  "session_tty": "/dev/ttys005",
  "session_id": "f59842cd-6ddd-4ee2-bb58-24b06297a395",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/f59842cd-6ddd-4ee2-bb58-24b06297a395.jsonl",
  "notes": [],
  "prompt": "work on issue #952",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-09T23:27:43-07:00",
      "completed_at": "2026-04-09T23:28:14-07:00",
      "session_started_at": null,
      "cumulative_seconds": 31,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-09T23:28:24-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-09T23:28:24-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-09T23:28:24-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "_continue_context": "",
  "_continue_pending": "null",
  "_stop_instructed": true,
  "code_tasks_total": 3
}
```

</details>

## Session Log

<details>
<summary>.flow-states/block-general-purpose-sub-agents.log</summary>

```text
2026-04-09T23:27:42-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-09T23:27:42-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-09T23:27:43-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-09T23:27:43-07:00 [Phase 1] create .flow-states/block-general-purpose-sub-agents.json (exit 0)
2026-04-09T23:27:43-07:00 [Phase 1] freeze .flow-states/block-general-purpose-sub-agents-phases.json (exit 0)
2026-04-09T23:27:43-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-09T23:27:44-07:00 [Phase 1] start-init — label-issues (labeled: [952], failed: [])
2026-04-09T23:27:51-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-09T23:27:51-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-09T23:27:52-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-09T23:27:52-07:00 [Phase 1] start-gate — post-deps CI ("ok")
2026-04-09T23:28:01-07:00 [Phase 1] start-workspace — worktree .worktrees/block-general-purpose-sub-agents (ok)
2026-04-09T23:28:05-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-09T23:28:05-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-09T23:28:05-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-09T23:28:14-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-09T23:28:14-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-09T23:31:38-07:00 [stop-continue] first stop, conditional continue: pending=decompose
```

</details>