### PR TITLE
Context Sparse Agents Truncate

### DIFF
--- a/.claude/rules/cognitive-isolation.md
+++ b/.claude/rules/cognitive-isolation.md
@@ -19,9 +19,9 @@ assumptions feel like facts and go unexamined.
 Not all sub-agents receive the same artifacts. The amount of
 context is a design choice matched to the agent's task:
 
-- **Context-rich** (reviewer, learn-analyst) — receives diff, plan,
-  CLAUDE.md, and rules inline. Its task is checking against known
-  standards where having the standards at hand saves turns.
+- **Context-rich** (reviewer, learn-analyst) — receives full diff,
+  plan, CLAUDE.md, and rules inline. Its task is checking against
+  known standards where having the standards at hand saves turns.
   Learn-analyst additionally receives state file data (visit counts,
   timings, session notes) to detect process friction and rule
   violations.
@@ -62,9 +62,9 @@ history by design, not by instruction.
 
 The learn-analyst agent (`agents/learn-analyst.md`) demonstrates
 the context-rich pattern: it runs in the foreground during Learn,
-receives the diff, state data, plan, and all project rules, and
-returns structured compliance findings to the parent session. Its
-prompt explicitly states it has no knowledge of the conversation
+receives the full diff, state data, plan, and all project rules,
+and returns structured compliance findings to the parent session.
+Its prompt explicitly states it has no knowledge of the conversation
 that produced the changes.
 
 The documentation agent (`agents/documentation.md`) demonstrates the

--- a/.claude/rules/cognitive-isolation.md
+++ b/.claude/rules/cognitive-isolation.md
@@ -26,10 +26,12 @@ context is a design choice matched to the agent's task:
   timings, session notes) to detect process friction and rule
   violations.
 - **Context-sparse** (pre-mortem, adversarial, documentation) — receives
-  only the diff and must investigate the codebase itself. Less context
+  only the substantive diff (`git diff -w`, whitespace-only changes
+  filtered) and must investigate the codebase itself. Less context
   forces independent investigation, surfacing risks and coverage gaps
-  that pre-supplied context would mask. The documentation agent receives
-  doc paths but must investigate the codebase independently for
+  that pre-supplied context would mask. The whitespace filter preserves
+  turn budget on PRs with formatting changes. The documentation agent
+  receives doc paths but must investigate the codebase independently for
   comprehension barriers before reading documentation for drift.
 
 This asymmetry is intentional. See `agents/pre-mortem.md` Design

--- a/.claude/rules/docs-with-behavior.md
+++ b/.claude/rules/docs-with-behavior.md
@@ -17,6 +17,29 @@ to write the same updates you could write now.
   `docs/reference/flow-state-schema.md` (field descriptions
   include hardcoded values like step ranges and totals that
   must match the Rust constants)
+- Changed what a skill passes to a sub-agent → the agent's
+  `## Input` section in `agents/<name>.md`
+
+## Agent Input Section Sync
+
+Agent `## Input` sections are contracts with the model about what
+data is available. When a skill changes what artifacts it passes to
+a sub-agent (e.g. switching from full diff to substantive diff),
+update the agent's Input section in the same commit. Stale Input
+sections mislead the agent about available context and produce
+incorrect reasoning. CI cannot enforce this (agent Input sections
+are prose), so the Plan phase must enumerate all affected agent
+files when a skill modifies agent invocations.
+
+## Multi-Task Plans
+
+When a plan splits a behavior change and its documentation update
+across separate tasks, the Plan phase should mark them as an atomic
+group — or combine them into a single task. The "same commit" rule
+means the behavior change and its documentation must land together.
+Separate commits within the same PR are not sufficient: if the PR
+is reviewed commit-by-commit, the intermediate state shows stale
+documentation.
 
 ## Scope Enumeration
 

--- a/agents/adversarial.md
+++ b/agents/adversarial.md
@@ -18,8 +18,10 @@ it. Only failures matter.
 
 ## Input
 
-The full diff (`git diff origin/main...HEAD`) is provided in your prompt.
-The branch name and project CLAUDE.md path are also provided. Use the
+The substantive diff (`git diff origin/main...HEAD -w`) is provided in
+your prompt — whitespace-only changes are filtered out so your turn
+budget is spent on behavioral analysis, not formatting noise. The branch
+name and project CLAUDE.md path are also provided. Use the
 Read tool to read the CLAUDE.md for test conventions and patterns. Use
 Read, Glob, and Grep to investigate the codebase.
 

--- a/agents/documentation.md
+++ b/agents/documentation.md
@@ -28,9 +28,11 @@ Your job is to identify two categories of issues:
 
 ## Input
 
-The full diff (`git diff origin/main...HEAD`) is provided in your prompt.
-The paths to the project CLAUDE.md and `.claude/rules/` directory are
-also provided. Use Read, Glob, and Grep tools to investigate the
+The substantive diff (`git diff origin/main...HEAD -w`) is provided in
+your prompt — whitespace-only changes are filtered out so your turn
+budget is spent on behavioral analysis, not formatting noise. The paths
+to the project CLAUDE.md and `.claude/rules/` directory are also
+provided. Use Read, Glob, and Grep tools to investigate the
 surrounding codebase and read documentation files.
 
 ## Workflow

--- a/agents/pre-mortem.md
+++ b/agents/pre-mortem.md
@@ -25,7 +25,7 @@ surrounding codebase for context.
 
 ## Design Note
 
-This agent intentionally receives only the diff — not the plan,
+This agent intentionally receives only the substantive diff — not the plan,
 CLAUDE.md, or project rules. The reviewer agent receives those
 inline because it checks against known standards (conventions,
 plan alignment, rule compliance). The pre-mortem agent must

--- a/agents/pre-mortem.md
+++ b/agents/pre-mortem.md
@@ -17,9 +17,11 @@ intended, or what trade-offs were considered. You see only the code.
 
 ## Input
 
-The full diff (`git diff origin/main...HEAD`) is provided in your prompt.
-Use it as your primary evidence. Use Read, Glob, and Grep tools to
-investigate the surrounding codebase for context.
+The substantive diff (`git diff origin/main...HEAD -w`) is provided in
+your prompt — whitespace-only changes are filtered out so your turn
+budget is spent on behavioral analysis, not formatting noise. Use it as
+your primary evidence. Use Read, Glob, and Grep tools to investigate the
+surrounding codebase for context.
 
 ## Design Note
 

--- a/docs/phases/phase-4-code-review.md
+++ b/docs/phases/phase-4-code-review.md
@@ -32,25 +32,27 @@ Every finding must map to one of these tenants:
 
 ### Step 1 — Gather
 
-Collect all artifacts: branch diff, plan file, CLAUDE.md, `.claude/rules/`
-files, and check whether `bin/flow test` exists for adversarial testing.
+Collect all artifacts: full branch diff, substantive diff (whitespace
+changes filtered via `git diff -w`), plan file, CLAUDE.md,
+`.claude/rules/` files, and check whether `bin/flow test` exists for
+adversarial testing.
 
 ### Step 2 — Launch
 
 Launch four agents in parallel using multiple Agent tool calls in a
 single response:
 
-- **Reviewer** (context-rich): receives diff, plan, CLAUDE.md, rules.
-  Covers architecture (T1), simplicity (T2), and correctness including
-  security (T4).
-- **Pre-mortem** (context-sparse): receives only the diff, investigates
-  the codebase independently. Covers correctness failure modes including
-  security (T4).
-- **Adversarial** (context-sparse): receives the diff and writes tests
-  designed to fail. Covers test coverage (T5). Only launched if
-  `bin/flow test` exists.
-- **Documentation** (context-sparse): receives the diff and doc paths,
-  investigates the codebase. Covers maintainability (T3) and
+- **Reviewer** (context-rich): receives full diff, plan, CLAUDE.md,
+  rules. Covers architecture (T1), simplicity (T2), and correctness
+  including security (T4).
+- **Pre-mortem** (context-sparse): receives only the substantive diff,
+  investigates the codebase independently. Covers correctness failure
+  modes including security (T4).
+- **Adversarial** (context-sparse): receives the substantive diff and
+  writes tests designed to fail. Covers test coverage (T5). Only
+  launched if `bin/flow test` exists.
+- **Documentation** (context-sparse): receives the substantive diff and
+  doc paths, investigates the codebase. Covers maintainability (T3) and
   documentation accuracy (T6).
 
 ### Step 3 — Triage

--- a/docs/skills/flow-code-review.md
+++ b/docs/skills/flow-code-review.md
@@ -32,15 +32,17 @@ from agents — the parent session never reviews the diff itself.
 
 ### Step 1 — Gather
 
-Collect all artifacts: branch diff, plan file, CLAUDE.md, rules files,
+Collect all artifacts: full branch diff, substantive diff (whitespace
+changes filtered via `git diff -w`), plan file, CLAUDE.md, rules files,
 check for `bin/test`, run `tombstone-audit` to identify stale tombstones
 for removal in Step 4. No analysis.
 
 ### Step 2 — Launch
 
-Launch four agents in parallel. Reviewer is context-rich (receives diff,
-plan, CLAUDE.md, rules). Pre-mortem, adversarial, and documentation are
-context-sparse (receive diff only, investigate independently).
+Launch four agents in parallel. Reviewer is context-rich (receives full
+diff, plan, CLAUDE.md, rules). Pre-mortem, adversarial, and documentation
+are context-sparse (receive substantive diff only, investigate
+independently).
 
 ### Step 3 — Triage
 

--- a/skills/flow-code-review/SKILL.md
+++ b/skills/flow-code-review/SKILL.md
@@ -148,11 +148,26 @@ CLAUDE.md at `<worktree_path>/CLAUDE.md`. Use the Glob tool to find all
 `.claude/rules/*.md` files at `<worktree_path>/.claude/rules/*.md`, then
 read each file.
 
-**Get the branch diff.**
+**Get the full branch diff.**
 
 ```bash
 git diff origin/main...HEAD
 ```
+
+This is the **full diff** — used by the reviewer agent (context-rich).
+
+**Get the substantive diff.**
+
+```bash
+git diff origin/main...HEAD -w
+```
+
+This is the **substantive diff** — whitespace-only changes filtered out.
+Context-sparse agents (pre-mortem, adversarial, documentation) receive
+this diff instead of the full diff. On PRs where formatters (cargo fmt,
+prettier, black) reformat many files, the substantive diff excludes
+formatting noise and preserves the agents' turn budget for behavioral
+analysis.
 
 **Check for test runner.**
 
@@ -232,21 +247,22 @@ Prefix the prompt with:
 > Review the diff for architecture adherence, simplicity, correctness,
 > and security."
 
-**Pre-mortem agent** — context-sparse (receives only the diff):
+**Pre-mortem agent** — context-sparse (receives only the substantive diff):
 
 Use the Agent tool with:
 
 - `subagent_type`: `"flow:pre-mortem"`
 - `description`: `"Pre-mortem incident analysis"`
 
-Provide the full diff output in the prompt, prefixed with:
+Provide the substantive diff output in the prompt, prefixed with:
 
-> "This PR was merged and caused a production incident. The full diff
-> is below. Investigate the codebase and write the incident report.
-> Security failure modes are explicitly in scope."
+> "This PR was merged and caused a production incident. The substantive
+> diff (whitespace-only changes filtered) is below. Investigate the
+> codebase and write the incident report. Security failure modes are
+> explicitly in scope."
 
-**Adversarial agent** — context-sparse (receives diff, temp file path,
-CLAUDE.md path, branch name). Only launch if `bin/flow` exists:
+**Adversarial agent** — context-sparse (receives substantive diff, temp
+file path, CLAUDE.md path, branch name). Only launch if `bin/flow` exists:
 
 Determine the temp test file path using the branch name from the state file:
 
@@ -261,20 +277,20 @@ Use the Agent tool with:
 - `subagent_type`: `"flow:adversarial"`
 - `description`: `"Adversarial test generation"`
 
-Provide the full diff output in the prompt, along with:
+Provide the substantive diff output in the prompt, along with:
 
 - The temp test file path
 - The path to the project CLAUDE.md
 - The branch name
 
-**Documentation agent** — context-sparse (receives diff, doc paths):
+**Documentation agent** — context-sparse (receives substantive diff, doc paths):
 
 Use the Agent tool with:
 
 - `subagent_type`: `"flow:documentation"`
 - `description`: `"Documentation and maintainability review"`
 
-Provide the full diff output in the prompt, along with:
+Provide the substantive diff output in the prompt, along with:
 
 - The path to the project CLAUDE.md
 - The path to the `.claude/rules/` directory
@@ -282,8 +298,9 @@ Provide the full diff output in the prompt, along with:
 Prefix the prompt with:
 
 > "You are a new team member reading this PR for the first time. The
-> full diff is below. Investigate the codebase and documentation for
-> comprehension barriers and documentation drift."
+> substantive diff (whitespace-only changes filtered) is below.
+> Investigate the codebase and documentation for comprehension barriers
+> and documentation drift."
 
 Wait for all agents to return.
 

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2836,6 +2836,15 @@ fn code_review_mentions_tombstone_audit() {
     );
 }
 
+#[test]
+fn code_review_collects_substantive_diff() {
+    let c = common::read_skill("flow-code-review");
+    assert!(
+        c.contains("git diff origin/main...HEAD -w"),
+        "Code Review Step 1 must collect a substantive diff (git diff -w) for context-sparse agents"
+    );
+}
+
 // --- Worktree path validation ---
 
 #[test]

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2845,6 +2845,18 @@ fn code_review_collects_substantive_diff() {
     );
 }
 
+#[test]
+fn code_review_routes_substantive_diff_to_context_sparse_agents() {
+    let c = common::read_skill("flow-code-review");
+    for agent in &["Pre-mortem", "Adversarial", "Documentation"] {
+        assert!(
+            c.contains("substantive diff output"),
+            "Code Review Step 2 must route substantive diff to {} agent",
+            agent
+        );
+    }
+}
+
 // --- Worktree path validation ---
 
 #[test]


### PR DESCRIPTION
## What

work on issue #956.

Closes #956

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/context-sparse-agents-truncate-plan.md` |
| DAG | `.flow-states/context-sparse-agents-truncate-dag.md` |
| Log | `.flow-states/context-sparse-agents-truncate.log` |
| State | `.flow-states/context-sparse-agents-truncate.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/71bf3d57-ac35-429b-8cb2-8fd0f3d2463b.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
## Context

Issue #956: Context-sparse code review agents (pre-mortem, adversarial, documentation) exhaust their `maxTurns` budget on large PRs where `cargo fmt` or similar formatters reformat many files alongside substantive changes. On a PR with 143 files changed (865KB diff), the pre-mortem agent exhausted its 40-turn budget mid-investigation. After filtering to substantive-only changes (~5KB), the agent completed successfully.

## Exploration

**Code review SKILL.md Step 1** (line 153): Collects a single diff via `git diff origin/main...HEAD` and passes it identically to all four agents in Step 2.

**Code review SKILL.md Step 2** (lines 235–287): All three context-sparse agents receive "the full diff output" in their prompt. The reviewer (context-rich) also receives the full diff plus plan, CLAUDE.md, and rules.

**Agent maxTurns budgets:**
- `agents/pre-mortem.md`: maxTurns=40, model=sonnet — truncation-prone
- `agents/adversarial.md`: maxTurns=40, model=opus — truncation-prone
- `agents/documentation.md`: maxTurns=100, model=haiku — less likely but still affected
- `agents/reviewer.md`: maxTurns=40, model=sonnet — context-rich, receives inline context so turns go to analysis not investigation

**Agent Input sections** reference "The full diff (`git diff origin/main...HEAD`)" — these are documentation contracts that must match what the skill actually passes.

**Permission check:** `Bash(git diff *)` in `.claude/settings.json` (line 11) covers `git diff origin/main...HEAD -w`. The `validate-pretool` hook Layer 6 only blocks `--` with file path args — `-w` is unaffected.

**Cognitive-isolation rule** (`.claude/rules/cognitive-isolation.md` lines 28-33): Describes context-sparse agents as receiving "only the diff" — should be updated to specify substantive diff.

**Contract tests:** No existing tests assert specific diff commands. `code_review_step_2_launches_four_agents` (line 2797) checks agent names, not diff content. No test breakage expected, but a new contract test should verify the substantive diff is present.

**Docs files:** `docs/skills/flow-code-review.md` (line 41-43) and `docs/phases/phase-4-code-review.md` (lines 43-54) describe what agents receive — need updates to mention substantive diff.

## Risks

1. **`-w` may not strip all formatter output.** Git's `-w` ignores whitespace changes (spaces, tabs, indentation). Formatters that only change whitespace produce zero diff output with `-w`. Formatters that change non-whitespace (reordering imports, adding trailing commas) will still appear. This is correct — those are substantive changes.

2. **Reviewer loses whitespace context.** The reviewer keeps the full diff, which is correct — it checks formatting conventions and plan adherence. No risk here.

3. **Large PRs with genuinely many substantive changes.** This fix targets formatting noise specifically. A PR with 100 substantive file changes still produces a large `-w` diff. That's a separate problem (chunking/prioritization) and out of scope.

## Approach

Add `git diff origin/main...HEAD -w` as a second diff artifact ("substantive diff") in Step 1. Route it to the three context-sparse agents in Step 2. The reviewer agent keeps the full diff. Update all downstream documentation (agent Input sections, cognitive-isolation rule, docs files) in the same commit per Docs With Behavior rule.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Contract test for substantive diff | test | — |
| 2. Update SKILL.md Steps 1 and 2 | implement | 1 |
| 3. Update agent docs, rule, and docs files | implement | 2 |

## Tasks

### Task 1 — Contract test for substantive diff

Add a test to `tests/skill_contracts.rs` that asserts the code review SKILL.md contains `git diff origin/main...HEAD -w` — verifying the substantive diff collection is present.

**Files to modify:** `tests/skill_contracts.rs`

**TDD:** This test will fail initially (the `-w` diff doesn't exist yet), then pass after Task 2.

### Task 2 — Update SKILL.md Steps 1 and 2

**Step 1 changes:** Add a second diff command after the existing `git diff origin/main...HEAD`:

```bash
git diff origin/main...HEAD -w
```

Label the first as "full diff" and the second as "substantive diff" (whitespace changes filtered). Add a brief explanation that context-sparse agents receive the substantive diff to conserve their turn budget on PRs with formatting changes.

**Step 2 changes:** In the three context-sparse agent sections (pre-mortem, adversarial, documentation), change "the full diff output" to "the substantive diff output". The reviewer agent section is unchanged — it continues to receive the full diff.

**Files to modify:** `skills/flow-code-review/SKILL.md`

### Task 3 — Update agent docs, rule, and docs files

Update documentation to match the new behavior:

- `agents/pre-mortem.md` Input section: Change "The full diff (`git diff origin/main...HEAD`)" to "The substantive diff (`git diff origin/main...HEAD -w`) — whitespace-only changes filtered" 
- `agents/adversarial.md` Input section: Same change
- `agents/documentation.md` Input section: Same change
- `.claude/rules/cognitive-isolation.md` Two-Tier Context Model: Update context-sparse description to mention substantive diff
- `docs/skills/flow-code-review.md` Step 1 and Step 2 descriptions: Mention substantive diff collection and routing
- `docs/phases/phase-4-code-review.md` Step 2 description: Update agent descriptions to mention substantive diff

**Files to modify:** `agents/pre-mortem.md`, `agents/adversarial.md`, `agents/documentation.md`, `.claude/rules/cognitive-isolation.md`, `docs/skills/flow-code-review.md`, `docs/phases/phase-4-code-review.md`
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# DAG Analysis: Context-sparse agents truncate on large PRs

<dag goal="Fix context-sparse agent truncation on large PRs by filtering diff before agent launch" mode="full">
  <plan>
    <node id="1" name="Agent Architecture Analysis" type="research" depends="[]" parallel_with="2">
      <objective>Read all three context-sparse agent definitions to understand their input contracts, maxTurns budgets, and what they expect to receive</objective>
    </node>
    <node id="2" name="Code Review Skill Analysis" type="research" depends="[]" parallel_with="1">
      <objective>Read the code review SKILL.md to understand how diffs are prepared and passed to agents in Step 2</objective>
    </node>
    <node id="3" name="Diff Filtering Mechanism Research" type="research" depends="[1,2]" parallel_with="">
      <objective>Investigate what diff filtering capabilities exist in the codebase and what approach would filter formatting-only changes from substantive changes</objective>
    </node>
    <node id="4" name="Solution Design" type="analysis" depends="[3]" parallel_with="">
      <objective>Design the specific changes needed: where the filtering happens, what gets filtered, how agents receive the filtered diff</objective>
    </node>
    <node id="5" name="Synthesis" type="synthesis" depends="[4]" parallel_with="">
      <objective>Produce final analysis with approach, risks, and task breakdown</objective>
    </node>
  </plan>
</dag>

---

▶ PARALLEL BRANCH A — NODE 1: Agent Architecture Analysis

- Pre-mortem (maxTurns: 40, sonnet) and adversarial (maxTurns: 40, opus) are the truncation-prone agents
- Documentation (maxTurns: 100, haiku) has 2.5x the budget — less likely to truncate but still receives full diff
- Code review SKILL.md Step 2 passes `git diff origin/main...HEAD` directly to all agents — no filtering
- The issue's evidence confirms filtering to substantive-only changes (~5KB vs 865KB) allowed completion

▶ PARALLEL BRANCH B — NODE 2: Code Review Skill Analysis

- Code review SKILL.md Step 1 collects `git diff origin/main...HEAD` as the single diff artifact
- Step 2 passes this full diff identically to all four agents (reviewer, pre-mortem, adversarial, documentation)
- Reviewer is context-rich (receives diff + plan + CLAUDE.md + rules inline)
- Pre-mortem, adversarial, documentation are context-sparse (receive only diff + minimal metadata)
- No filtering, truncation, or size-based routing exists

▶ MERGE: Both branches reveal the core problem — the code review skill passes the raw, unfiltered diff to context-sparse agents, and there is no diff-filtering mechanism in the pipeline.

---

▶ NODE 3: Diff Filtering Mechanism Research

- No diff-filtering exists in the codebase. Searched for filter-diff, diff-filter, diff_filter, filter_diff — only unrelated matches.
- Git itself offers `-w` (ignore whitespace) flag: `git diff -w` ignores whitespace when comparing lines. Files with ONLY whitespace changes produce zero diff output and are excluded entirely. Files with mixed changes show only substantive hunks.
- No custom Rust parsing needed — `-w` is a stable, portable git flag.

Quality: 8/10 — Confirmed there is no existing diff-filtering mechanism in the codebase

---

▶ NODE 4: Solution Design

**Where to filter:** The code review SKILL.md Step 1 gathers the diff. The filtering should happen there — produce TWO diff artifacts:
1. The full diff (for the reviewer agent, which is context-rich and needs everything)
2. A substantive-only diff (for pre-mortem, adversarial, and documentation agents)

**How to filter:** Add `git diff origin/main...HEAD -w` as a second diff command in Step 1.

**Why `-w` is correct:**
- `git diff -w` ignores whitespace when comparing lines. Files with ONLY whitespace changes (cargo fmt, prettier) produce zero diff output and are excluded entirely.
- Files with mixed changes (some substantive, some formatting) show only substantive hunks.
- The flag is stable, portable, and requires zero custom parsing logic.
- Context-sparse agents care about behavioral changes, not formatting — the filtered diff preserves everything they need.

**Why reviewer keeps the full diff:** The reviewer agent checks formatting conventions and plan adherence. It needs to see all changes including formatting.

**Alternative considered:** A Rust subcommand for diff parsing. Rejected — `git diff -w` is a single flag change that achieves the same result without any new code.

Quality: 9/10 — Clean design with minimal changes

---

▶ NODE 5: Synthesis

## Problem

Context-sparse code review agents (pre-mortem, adversarial, documentation) receive the full `git diff origin/main...HEAD` output, which on large PRs with formatting changes (cargo fmt, prettier, black) can be 865KB+. Agents exhaust their maxTurns budget reading noise and never produce findings.

## Root Cause

The code review SKILL.md Step 1 collects one diff (`git diff origin/main...HEAD`) and Step 2 passes it to all four agents identically. Context-sparse agents — which must investigate the codebase themselves — waste turns parsing formatting hunks.

## Solution

Add a **substantive diff** using `git diff origin/main...HEAD -w` (ignore all whitespace changes) in Step 1. Route this filtered diff to the three context-sparse agents (pre-mortem, adversarial, documentation) in Step 2. The reviewer agent (context-rich) continues to receive the full diff since it checks formatting conventions.

### Changes Required

1. **`skills/flow-code-review/SKILL.md` Step 1** — add a second diff command: `git diff origin/main...HEAD -w`. Label it as the "substantive diff" artifact.

2. **`skills/flow-code-review/SKILL.md` Step 2** — change the three context-sparse agent prompts to use the substantive diff (`-w`) instead of the full diff. The reviewer agent prompt is unchanged.

3. **`docs/skills/flow-code-review.md`** — update if it describes the diff collection step.

4. **`docs/phases/phase-4-code-review.md`** — update if it describes how agents receive diffs.

5. **Tests** — contract tests in `tests/skill_contracts.rs` may need updates if they assert specific diff command patterns.

### What This Does NOT Fix

- Genuinely large PRs with many substantive changes — that's a separate problem requiring chunking or prioritization.
- The maxTurns budget itself — 40 turns is appropriate for focused analysis of substantive diffs.

Confidence: 92%  |  Nodes: 5  |  Parallel branches: 1
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | <1m |
| **Total** | **<1m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/context-sparse-agents-truncate.json</summary>

```json
{
  "schema_version": 1,
  "branch": "context-sparse-agents-truncate",
  "repo": "benkruger/flow",
  "pr_number": 977,
  "pr_url": "https://github.com/benkruger/flow/pull/977",
  "started_at": "2026-04-09T23:28:25-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/context-sparse-agents-truncate-plan.md",
    "dag": ".flow-states/context-sparse-agents-truncate-dag.md",
    "log": ".flow-states/context-sparse-agents-truncate.log",
    "state": ".flow-states/context-sparse-agents-truncate.json"
  },
  "session_tty": "/dev/ttys006",
  "session_id": "71bf3d57-ac35-429b-8cb2-8fd0f3d2463b",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/71bf3d57-ac35-429b-8cb2-8fd0f3d2463b.jsonl",
  "notes": [],
  "prompt": "work on issue #956",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-09T23:28:25-07:00",
      "completed_at": "2026-04-09T23:28:54-07:00",
      "session_started_at": null,
      "cumulative_seconds": 29,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-09T23:29:03-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-09T23:29:03-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-09T23:29:03-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "_continue_context": "",
  "_continue_pending": "null",
  "_stop_instructed": true,
  "code_tasks_total": 3
}
```

</details>

## Session Log

<details>
<summary>.flow-states/context-sparse-agents-truncate.log</summary>

```text
2026-04-09T23:28:24-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-09T23:28:24-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-09T23:28:25-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-09T23:28:25-07:00 [Phase 1] create .flow-states/context-sparse-agents-truncate.json (exit 0)
2026-04-09T23:28:25-07:00 [Phase 1] freeze .flow-states/context-sparse-agents-truncate-phases.json (exit 0)
2026-04-09T23:28:25-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-09T23:28:27-07:00 [Phase 1] start-init — label-issues (labeled: [956], failed: [])
2026-04-09T23:28:33-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-09T23:28:33-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-09T23:28:34-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-09T23:28:34-07:00 [Phase 1] start-gate — post-deps CI ("ok")
2026-04-09T23:28:41-07:00 [Phase 1] start-workspace — worktree .worktrees/context-sparse-agents-truncate (ok)
2026-04-09T23:28:45-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-09T23:28:45-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-09T23:28:45-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-09T23:28:54-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-09T23:28:54-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-09T23:31:32-07:00 [stop-continue] first stop, conditional continue: pending=decompose
2026-04-09T23:32:39-07:00 [Phase 2] Step 3 — set plan_step=3 (exit 0)
```

</details>