### PR TITLE
Extractimplementationplan Uses

### DIFF
--- a/src/plan_extract.rs
+++ b/src/plan_extract.rs
@@ -181,11 +181,13 @@ fn read_dag_mode(state: &Value) -> String {
 ///
 /// Returns the byte index of the heading start, or None if not found.
 /// The heading must appear at the start of a line (preceded by `\n` or at
-/// position 0) and be followed by `\n`, `\r`, or end of string.
+/// position 0) and be followed by optional trailing whitespace then `\n`,
+/// `\r`, or end of string. Trailing spaces and tabs after the heading text
+/// are tolerated (common in editor artifacts and copy-paste).
 fn find_heading(body: &str, heading: &str) -> Option<usize> {
     // Check if body starts with the heading
     if let Some(after) = body.strip_prefix(heading) {
-        if after.is_empty() || after.starts_with('\n') || after.starts_with('\r') {
+        if is_heading_terminated(after) {
             return Some(0);
         }
     }
@@ -195,16 +197,20 @@ fn find_heading(body: &str, heading: &str) -> Option<usize> {
     while let Some(pos) = body[start..].find(&search) {
         let abs_pos = start + pos + 1; // +1 to skip the \n
         let after_heading = abs_pos + heading.len();
-        if after_heading >= body.len() {
-            return Some(abs_pos);
-        }
-        let next_char = body.as_bytes()[after_heading];
-        if next_char == b'\n' || next_char == b'\r' {
+        let remainder = &body[after_heading..];
+        if is_heading_terminated(remainder) {
             return Some(abs_pos);
         }
         start = start + pos + 1;
     }
     None
+}
+
+/// Check that the text after a heading marker is a valid line termination:
+/// optional trailing whitespace (spaces/tabs) followed by `\n`, `\r`, or EOF.
+fn is_heading_terminated(after: &str) -> bool {
+    let trimmed = after.trim_start_matches([' ', '\t']);
+    trimmed.is_empty() || trimmed.starts_with('\n') || trimmed.starts_with('\r')
 }
 
 /// Extract the `## Implementation Plan` section from an issue body.

--- a/src/plan_extract.rs
+++ b/src/plan_extract.rs
@@ -177,13 +177,45 @@ fn read_dag_mode(state: &Value) -> String {
         .to_string()
 }
 
+/// Find a markdown heading as a full line match, not a substring.
+///
+/// Returns the byte index of the heading start, or None if not found.
+/// The heading must appear at the start of a line (preceded by `\n` or at
+/// position 0) and be followed by `\n`, `\r`, or end of string.
+fn find_heading(body: &str, heading: &str) -> Option<usize> {
+    // Check if body starts with the heading
+    if let Some(after) = body.strip_prefix(heading) {
+        if after.is_empty() || after.starts_with('\n') || after.starts_with('\r') {
+            return Some(0);
+        }
+    }
+    // Search for \n followed by heading
+    let search = format!("\n{}", heading);
+    let mut start = 0;
+    while let Some(pos) = body[start..].find(&search) {
+        let abs_pos = start + pos + 1; // +1 to skip the \n
+        let after_heading = abs_pos + heading.len();
+        if after_heading >= body.len() {
+            return Some(abs_pos);
+        }
+        let next_char = body.as_bytes()[after_heading];
+        if next_char == b'\n' || next_char == b'\r' {
+            return Some(abs_pos);
+        }
+        start = start + pos + 1;
+    }
+    None
+}
+
 /// Extract the `## Implementation Plan` section from an issue body.
 ///
-/// Returns the content between `## Implementation Plan` and the next `##`-level
-/// heading (or end of string). Returns None if the section is not found.
+/// Uses full-heading matching: the marker must appear at the start of a line
+/// and be followed by a newline or end of string. Returns the content between
+/// `## Implementation Plan` and the next `##`-level heading (or end of string).
+/// Returns None if the section is not found.
 pub fn extract_implementation_plan(body: &str) -> Option<String> {
     let marker = "## Implementation Plan";
-    let start_idx = body.find(marker)?;
+    let start_idx = find_heading(body, marker)?;
     let after_marker = start_idx + marker.len();
 
     // Find the next ## heading after the marker

--- a/tests/plan_extract.rs
+++ b/tests/plan_extract.rs
@@ -113,6 +113,53 @@ fn extract_plan_ends_at_first_h2() {
 }
 
 #[test]
+fn extract_plan_rejects_heading_suffix() {
+    // "## Implementation Planning" should NOT match — it's a different heading
+    let body = "## Implementation Planning\n\n### Context\n\nStuff.\n";
+    assert!(extract_implementation_plan(body).is_none());
+}
+
+#[test]
+fn extract_plan_rejects_heading_extra_words() {
+    // "## Implementation Plan Details" should NOT match
+    let body = "## Problem\n\nFoo.\n\n## Implementation Plan Details\n\n### Context\n\nStuff.\n";
+    assert!(extract_implementation_plan(body).is_none());
+}
+
+#[test]
+fn extract_plan_rejects_mid_line_heading() {
+    // "## Implementation Plan" not at line start should NOT match
+    let body = "some text ## Implementation Plan\n\n### Context\n\nStuff.\n";
+    assert!(extract_implementation_plan(body).is_none());
+}
+
+#[test]
+fn extract_plan_matches_at_start_of_body() {
+    // Body starting with the heading should match
+    let body = "## Implementation Plan\n\n### Context\n\nStuff.\n";
+    let result = extract_implementation_plan(body).unwrap();
+    assert!(result.contains("### Context"));
+}
+
+#[test]
+fn extract_plan_matches_after_other_sections() {
+    // Heading preceded by \n (after other content) should match
+    let body = "## Problem\n\nFoo.\n\n## Implementation Plan\n\n### Context\n\nContent.\n";
+    let result = extract_implementation_plan(body).unwrap();
+    assert!(result.contains("### Context"));
+    assert!(result.contains("Content."));
+}
+
+#[test]
+fn extract_plan_matches_windows_line_endings() {
+    // Heading followed by \r\n should match
+    let body =
+        "## Problem\r\n\r\nFoo.\r\n\r\n## Implementation Plan\r\n\r\n### Context\r\n\r\nStuff.\r\n";
+    let result = extract_implementation_plan(body).unwrap();
+    assert!(result.contains("### Context"));
+}
+
+#[test]
 fn promote_headings_five_hashes_unchanged() {
     // ##### should not be promoted (only ### and #### are)
     let content = "##### Five hashes\n### Three hashes\n";

--- a/tests/plan_extract.rs
+++ b/tests/plan_extract.rs
@@ -160,6 +160,31 @@ fn extract_plan_matches_windows_line_endings() {
 }
 
 #[test]
+fn extract_plan_tolerates_trailing_space() {
+    // Heading with trailing spaces should still match
+    let body = "## Problem\n\nFoo.\n\n## Implementation Plan  \n\n### Context\n\nContent.\n";
+    let result = extract_implementation_plan(body).unwrap();
+    assert!(result.contains("### Context"));
+}
+
+#[test]
+fn extract_plan_tolerates_trailing_tab() {
+    // Heading with trailing tab should still match
+    let body = "## Implementation Plan\t\n\n### Context\n\nStuff.\n";
+    let result = extract_implementation_plan(body).unwrap();
+    assert!(result.contains("### Context"));
+}
+
+#[test]
+fn extract_plan_skips_suffix_finds_exact() {
+    // First heading has suffix (rejected), second is exact (accepted)
+    let body = "## Implementation Planning\n\nIgnore.\n\n## Implementation Plan\n\nReal content.\n";
+    let result = extract_implementation_plan(body).unwrap();
+    assert!(result.contains("Real content."));
+    assert!(!result.contains("Ignore."));
+}
+
+#[test]
 fn promote_headings_five_hashes_unchanged() {
     // ##### should not be promoted (only ### and #### are)
     let content = "##### Five hashes\n### Three hashes\n";


### PR DESCRIPTION
## What

work on issue #947.

Closes #947

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/extractimplementationplan-uses-plan.md` |
| DAG | `.flow-states/extractimplementationplan-uses-dag.md` |
| Log | `.flow-states/extractimplementationplan-uses.log` |
| State | `.flow-states/extractimplementationplan-uses.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/5e919f5a-73b3-4bd8-9583-55fbff5e54f2.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

Issue #947: `extract_implementation_plan` in `src/plan_extract.rs:184-201` uses `body.find("## Implementation Plan")` which is a substring match. Any heading that starts with `## Implementation Plan` followed by additional characters (e.g., `## Implementation Planning`) will falsely match and extract the wrong section.

## Exploration

- **Bug location**: `src/plan_extract.rs:186` — `body.find(marker)` where `marker = "## Implementation Plan"`. `String::find` is a substring match, not a full-heading match.
- **Call site**: Single caller at `src/plan_extract.rs:471`.
- **End-of-section marker** (lines 191-193): Uses `find("\n## ")` which already includes line-start boundary (`\n`) and trailing space. This is sound and does not need changes.
- **Existing tests**: `tests/plan_extract.rs` has 9 unit tests and 6 integration tests. None test the false-positive substring match case.
- **No existing `find_heading` helper**: Grep confirmed no similar helper exists in the codebase.
- **Public API**: `extract_implementation_plan` is `pub` and imported in tests — new test cases can exercise it directly.

## Risks

- **Existing test regression**: The fix must not break any of the 15 existing tests. All existing tests use `## Implementation Plan` followed by `\n`, so a full-heading match will continue to match them correctly.
- **Code block edge case**: The existing `extract_plan_ends_at_first_h2` test documents an accepted limitation (line 104-106 comment). The fix must not alter the end-of-section behavior.
- **String slicing safety**: The `find_heading` helper uses byte-level checks (`body.as_bytes()[idx]`). Since `\n`, `\r` are single-byte ASCII characters, byte indexing is safe here per `.claude/rules/rust-patterns.md`.

## Approach

Add a private `find_heading(body, heading)` helper function that performs a full-heading match:
1. Check if `body` starts with the heading AND the next character is `\n`, `\r`, or end of string
2. Search for `\n` + heading occurrences, checking that each candidate also ends at a line boundary
3. Return `Some(index)` of the heading start position, or `None`

Replace `body.find(marker)` with `find_heading(body, marker)` in `extract_implementation_plan`. The rest of the function (end-of-section logic, trim, empty check) remains unchanged.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write tests for false-positive and true-positive cases | test | — |
| 2. Add `find_heading` helper and update `extract_implementation_plan` | implement | 1 |

## Tasks

### Task 1: Write tests for substring match false positives and true positives

**File**: `tests/plan_extract.rs`

Add 6 new unit tests after the existing `extract_plan_ends_at_first_h2` test (line 113):

- `extract_plan_rejects_heading_suffix` — body with `## Implementation Planning\n\n### Context\n\nStuff.\n` should return `None`
- `extract_plan_rejects_heading_extra_words` — body with `## Implementation Plan Details\n\n### Context\n\nStuff.\n` should return `None`
- `extract_plan_rejects_mid_line_heading` — body with `some text ## Implementation Plan\n\n### Context\n\nStuff.\n` should return `None`
- `extract_plan_matches_at_start_of_body` — body starting with `## Implementation Plan\n\n### Context\n\nStuff.\n` should return `Some`
- `extract_plan_matches_at_end_of_body` — body ending with `\n## Implementation Plan` (no trailing newline) should return `Some("")` → actually `None` since empty. Use `\n## Implementation Plan\n\n### Context\n\nContent.` instead
- `extract_plan_matches_windows_line_endings` — body with `## Implementation Plan\r\n\n### Context\n\nStuff.\n` should return `Some`

**TDD**: These tests will fail initially since `extract_implementation_plan` currently uses substring matching.

### Task 2: Add `find_heading` helper and update `extract_implementation_plan`

**File**: `src/plan_extract.rs`

- Add a private `fn find_heading(body: &str, heading: &str) -> Option<usize>` helper before `extract_implementation_plan`
- The helper checks line-start boundary (preceded by `\n` or at position 0) AND line-end boundary (followed by `\n`, `\r`, or end of string)
- Replace `body.find(marker)?` at line 186 with `find_heading(body, marker)?`
- Update the doc comment on `extract_implementation_plan` to mention it uses full-heading matching
- Run `bin/flow ci` to verify all existing + new tests pass
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Fix extract_implementation_plan substring match bug

```xml
<dag goal="Fix extract_implementation_plan substring match bug — replace body.find() with full-heading match" mode="full">
  <plan>
    <node id="1" name="Read Current Implementation" type="research" depends="[]" parallel_with="[]">
      <objective>Read src/plan_extract.rs to understand the exact matching logic and all callers of extract_implementation_plan</objective>
    </node>
    <node id="2" name="Analyze Match Semantics" type="analysis" depends="[1]" parallel_with="3">
      <objective>Determine what constitutes a "full heading match" for ## Implementation Plan — what characters can follow the heading text</objective>
    </node>
    <node id="3" name="Find All Heading Matches" type="research" depends="[1]" parallel_with="2">
      <objective>Search codebase for all places that match or reference "## Implementation Plan" to understand the full contract</objective>
    </node>
    <node id="4" name="Identify End-of-Section Pattern" type="analysis" depends="[1]" parallel_with="2,3">
      <objective>Examine how the function finds the END of the Implementation Plan section — does the same substring bug affect the end marker?</objective>
    </node>
    <node id="5" name="Synthesize Fix and Test Plan" type="synthesis" depends="[2,3,4]" parallel_with="[]">
      <objective>Design the fix, enumerate edge cases, and define test coverage</objective>
    </node>
  </plan>
</dag>
```

---

▶ NODE 1: Read Current Implementation (depends on: none)

Read `src/plan_extract.rs` — full file (610 lines). The function in question:

```rust
pub fn extract_implementation_plan(body: &str) -> Option<String> {
    let marker = "## Implementation Plan";
    let start_idx = body.find(marker)?;
    let after_marker = start_idx + marker.len();

    // Find the next ## heading after the marker
    let content_after = &body[after_marker..];
    let end_offset = content_after
        .find("\n## ")
        .map(|pos| after_marker + pos)
        .unwrap_or(body.len());

    let section = body[after_marker..end_offset].trim().to_string();
    if section.is_empty() {
        return None;
    }
    Some(section)
}
```

Called at one site: line 471 in the same file.

Quality: 9/10 — Full function visible, bug confirmed at line 186.

Key finding: `body.find("## Implementation Plan")` at line 186 is a substring match — `"## Implementation Planning"`, `"## Implementation Plan Details"`, etc. would all match.

---

▶ PARALLEL BRANCH A — NODE 2: Analyze Match Semantics (depends on: 1)

A markdown `## Implementation Plan` heading is a full line. Valid forms:
- `## Implementation Plan\n` — heading followed by newline
- `## Implementation Plan\r\n` — Windows line endings
- `## Implementation Plan` at end of string (no trailing newline)

What must NOT match:
- `## Implementation Planning` — different heading
- `## Implementation Plan Details` — different heading
- `some text ## Implementation Plan` — not at line start (not a heading)

The correct match requires:
1. The marker appears at the start of a line (preceded by `\n` or at position 0)
2. After `"## Implementation Plan"`, the next character is `\n`, `\r`, or end of string

Quality: 9/10 — Clear definition of valid vs invalid matches.

Key finding: A full heading match requires both a line-start check AND a line-end check — the marker must be bounded on both sides.

---

▶ PARALLEL BRANCH B — NODE 3: Find All Heading Matches (depends on: 1)

Grep found 30+ references to "Implementation Plan" across the codebase:
- `src/plan_extract.rs` — the buggy function (lines 180-201) and its caller (line 470-484)
- `tests/plan_extract.rs` — unit and integration tests (9 test bodies, lines 9, 19, 33, 108, 548, 567, 589, 595)
- `skills/flow-plan/SKILL.md` — references the heading in extraction instructions (lines 164, 253, 258, 263)
- `skills/flow-create-issue/SKILL.md` — creates issues WITH this heading (lines 222, 228, 256, 260, 265)
- `docs/` — documentation references throughout
- `tests/skill_contracts.rs` — contract test assertions (lines 2185-2186, 2491-2492)
- `.claude/rules/filing-issues.md` — mentions the section (line 80)

No other code path uses the same `find()` pattern. The function is the single extraction point.

Quality: 9/10 — Found all references and existing tests.

Key finding: `extract_implementation_plan` is called at one site (line 471) and has extensive tests, but NO test for the substring false-positive case.

---

▶ PARALLEL BRANCH C — NODE 4: Identify End-of-Section Pattern (depends on: 1)

The end-of-section pattern at lines 191-193:
```rust
let content_after = &body[after_marker..];
let end_offset = content_after
    .find("\n## ")
    .map(|pos| after_marker + pos)
    .unwrap_or(body.len());
```

Uses `"\n## "` — requiring a newline before `## `. This pattern is NOT susceptible to the same substring bug because it includes the leading `\n` (ensuring line start) and trailing space (distinguishing from `##something`).

The comment on test line 104-106 documents an accepted limitation: `extract_implementation_plan` uses simple `find("\n## ")` — not code-block-aware. A `##` inside a code block ends extraction early. This is accepted because `flow-create-issue` controls the format.

Quality: 8/10 — End marker pattern is acceptable, does not share the same bug.

Key finding: The end-of-section marker is sound — the bug is isolated to the START marker only.

---

▶ MERGE: Branches A + B + C combine

All three branches confirm:
1. The bug is isolated to the start marker at line 186 (`body.find(marker)`)
2. The fix needs both line-start AND line-end boundary checks
3. The end-of-section pattern is sound
4. There are no other callers to worry about
5. Existing tests don't cover the false-positive case

---

▶ NODE 5: Synthesize Fix and Test Plan (depends on: 2, 3, 4)

### The Fix

Replace the simple `body.find(marker)` with a helper function `find_heading(body, heading)` that checks line-start boundary (preceded by `\n` or at position 0) AND line-end boundary (followed by `\n`, `\r`, or end of string).

A clean approach using byte-scanning (per `.claude/rules/rust-patterns.md` — regex crate doesn't support lookaround):

```rust
fn find_heading(body: &str, heading: &str) -> Option<usize> {
    if body.starts_with(heading) {
        let after = &body[heading.len()..];
        if after.is_empty() || after.starts_with('\n') || after.starts_with('\r') {
            return Some(0);
        }
    }
    let search = format!("\n{}", heading);
    let mut start = 0;
    while let Some(pos) = body[start..].find(&search) {
        let abs_pos = start + pos + 1;
        let after_heading = abs_pos + heading.len();
        if after_heading >= body.len() {
            return Some(abs_pos);
        }
        let next_char = body.as_bytes()[after_heading];
        if next_char == b'\n' || next_char == b'\r' {
            return Some(abs_pos);
        }
        start = start + pos + 1;
    }
    None
}
```

### Test Coverage Needed

1. False positive — heading with suffix: `## Implementation Planning` should NOT match
2. False positive — heading with extra text: `## Implementation Plan Details` should NOT match
3. True positive — heading with trailing newline: `## Implementation Plan\n` should match
4. True positive — heading at end of string: `## Implementation Plan` at EOF should match
5. True positive — heading at start of string: Body starting with `## Implementation Plan\n` should match
6. False positive — not at line start: `text ## Implementation Plan` should NOT match

### Edge Cases

- `## Implementation Plan\r\n` (Windows line endings) — should match
- `## Implementation Plan ` (trailing space) — not matching is safer

### Files to modify

- `src/plan_extract.rs` — add `find_heading` helper, modify `extract_implementation_plan` to use it
- `tests/plan_extract.rs` — add 6 new unit tests for false-positive and true-positive cases

---

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
The bug is in `extract_implementation_plan` at src/plan_extract.rs:186.
`body.find("## Implementation Plan")` is a substring match that will
falsely match headings like `## Implementation Planning`.

Fix: Replace `body.find(marker)` with a helper function
`find_heading(body, heading)` that checks line-start boundary (preceded
by `\n` or at position 0) AND line-end boundary (followed by `\n`, `\r`,
or end of string).

Scope: Single function, single call site (line 471). The end-of-section
marker (`find("\n## ")`) is sound and does not need changes.

Tests needed: 6 cases — 3 true positives (newline, EOF, start of
string) and 3 false positives (suffix text, extra words, not at line start).
The existing test for `## Implementation Plan` embedded in larger bodies
continues to pass — the fix only tightens matching.

Files to modify:
- `src/plan_extract.rs` — add `find_heading` helper, modify
  `extract_implementation_plan` to use it
- `tests/plan_extract.rs` — add 6 new unit tests for false-positive
  and true-positive cases

Confidence: 95%  |  Nodes: 5  |  Parallel branches: 3

vs. Vanilla Claude (what linear reasoning would have missed):
  • End-of-section marker analysis confirmed it's sound — a linear
    pass might have "fixed" both markers unnecessarily
  • Exhaustive codebase grep found all 30+ references to
    "Implementation Plan" — confirmed no other code path uses
    the same fragile pattern
  • Parallel test file analysis surfaced the existing edge case
    test at line 103 and its documented tradeoff (code-block
    unawareness), which the fix must not regress
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 3m |
| Plan | <1m |
| **Total** | **3m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/extractimplementationplan-uses.json</summary>

```json
{
  "schema_version": 1,
  "branch": "extractimplementationplan-uses",
  "repo": "benkruger/flow",
  "pr_number": 978,
  "pr_url": "https://github.com/benkruger/flow/pull/978",
  "started_at": "2026-04-10T00:03:47-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/extractimplementationplan-uses-plan.md",
    "dag": ".flow-states/extractimplementationplan-uses-dag.md",
    "log": ".flow-states/extractimplementationplan-uses.log",
    "state": ".flow-states/extractimplementationplan-uses.json"
  },
  "session_tty": "/dev/ttys007",
  "session_id": "5e919f5a-73b3-4bd8-9583-55fbff5e54f2",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/5e919f5a-73b3-4bd8-9583-55fbff5e54f2.jsonl",
  "notes": [],
  "prompt": "work on issue #947",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T00:03:47-07:00",
      "completed_at": "2026-04-10T00:07:06-07:00",
      "session_started_at": null,
      "cumulative_seconds": 199,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-10T00:07:18-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-10T00:07:18-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T00:07:18-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "_continue_context": "",
  "_continue_pending": "null",
  "_stop_instructed": true,
  "code_tasks_total": 2
}
```

</details>

## Session Log

<details>
<summary>.flow-states/extractimplementationplan-uses.log</summary>

```text
2026-04-10T00:03:46-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T00:03:46-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T00:03:47-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T00:03:47-07:00 [Phase 1] create .flow-states/extractimplementationplan-uses.json (exit 0)
2026-04-10T00:03:47-07:00 [Phase 1] freeze .flow-states/extractimplementationplan-uses-phases.json (exit 0)
2026-04-10T00:03:47-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T00:03:49-07:00 [Phase 1] start-init — label-issues (labeled: [947], failed: [])
2026-04-10T00:03:55-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T00:06:42-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T00:06:42-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T00:06:42-07:00 [Phase 1] start-gate — post-deps CI ("ok")
2026-04-10T00:06:52-07:00 [Phase 1] start-workspace — worktree .worktrees/extractimplementationplan-uses (ok)
2026-04-10T00:06:56-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T00:06:56-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T00:06:56-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T00:07:06-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T00:07:06-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T00:09:31-07:00 [stop-continue] first stop, conditional continue: pending=decompose
```

</details>