### PR TITLE
Permissiontoregex Only Handles

### DIFF
--- a/src/prime_setup.rs
+++ b/src/prime_setup.rs
@@ -154,9 +154,9 @@ pub fn derive_permissions(project_root: &Path, framework: &str, fw_dir: &Path) -
 /// Check if any entry in `existing_set` pattern-subsumes `candidate`.
 ///
 /// Uses `permission_to_regex()` to test whether an existing broader pattern
-/// (e.g. `Bash(git *)`) matches the candidate's concrete form (e.g.
-/// `Bash(git add *)`). Only checks same-type entries (Bash vs Bash, not
-/// Agent vs Bash).
+/// (e.g. `Agent(*)`) matches the candidate's concrete form (e.g.
+/// `Agent(flow:ci-fixer)`). Only checks same-type entries (e.g. Agent vs
+/// Agent, Read vs Read); never matches across types (Agent vs Bash).
 pub fn is_subsumed(candidate: &str, existing_set: &HashSet<String>) -> bool {
     let outer_re = Regex::new(r"^(\w+)\((.+)\)$").unwrap();
     let cand_caps = match outer_re.captures(candidate) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -571,6 +571,11 @@ pub fn parse_conflict_files(porcelain_output: &str) -> Vec<String> {
 /// `Read(~/.claude/rules/*)` → `^~/\.claude/rules/.*$`
 ///
 /// Returns `None` for entries that don't match the `Type(pattern)` format.
+///
+/// Note: `src/hooks/mod.rs` has a Bash-only variant used by
+/// `build_permission_regexes` for PreToolUse hook validation.
+/// That version is intentionally restricted to `Bash(...)` entries
+/// because the hook only validates Bash tool commands.
 pub fn permission_to_regex(perm: &str) -> Option<Regex> {
     let outer_re = Regex::new(r"^\w+\((.+)\)$").unwrap();
     let cap = outer_re.captures(perm)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -560,14 +560,19 @@ pub fn parse_conflict_files(porcelain_output: &str) -> Vec<String> {
 
 // --- Permission regex ---
 
-/// Convert a Bash(pattern) permission to a compiled regex.
+/// Convert a `Type(pattern)` permission to a compiled regex.
 ///
-/// Bash(git push) -> ^git push$
-/// Bash(git push *) -> ^git push .*$
+/// Extracts the inner pattern from any permission type and converts
+/// glob wildcards to regex:
 ///
-/// Returns None for non-Bash entries.
+/// `Bash(git push)` → `^git push$`
+/// `Bash(git push *)` → `^git push .*$`
+/// `Agent(*)` → `^.*$`
+/// `Read(~/.claude/rules/*)` → `^~/\.claude/rules/.*$`
+///
+/// Returns `None` for entries that don't match the `Type(pattern)` format.
 pub fn permission_to_regex(perm: &str) -> Option<Regex> {
-    let outer_re = Regex::new(r"^Bash\((.+)\)$").unwrap();
+    let outer_re = Regex::new(r"^\w+\((.+)\)$").unwrap();
     let cap = outer_re.captures(perm)?;
     let pattern = &cap[1];
     let escaped = regex::escape(pattern).replace(r"\*", ".*");
@@ -1000,7 +1005,37 @@ mod tests {
 
     #[test]
     fn permission_to_regex_non_bash() {
-        assert!(permission_to_regex("Read(file.txt)").is_none());
+        let re = permission_to_regex("Read(file.txt)").unwrap();
+        assert!(re.is_match("file.txt"));
+        assert!(!re.is_match("other.txt"));
+    }
+
+    #[test]
+    fn permission_to_regex_read_wildcard() {
+        let re = permission_to_regex("Read(~/.claude/rules/*)").unwrap();
+        assert!(re.is_match("~/.claude/rules/foo.md"));
+        assert!(!re.is_match("~/.claude/other/bar.md"));
+    }
+
+    #[test]
+    fn permission_to_regex_agent() {
+        let re = permission_to_regex("Agent(*)").unwrap();
+        assert!(re.is_match("flow:ci-fixer"));
+        assert!(re.is_match("anything"));
+    }
+
+    #[test]
+    fn permission_to_regex_skill() {
+        let re = permission_to_regex("Skill(decompose:decompose)").unwrap();
+        assert!(re.is_match("decompose:decompose"));
+        assert!(!re.is_match("decompose:other"));
+    }
+
+    #[test]
+    fn permission_to_regex_double_star() {
+        let re = permission_to_regex("Read(~/.claude/projects/**/tool-results/*)").unwrap();
+        assert!(re.is_match("~/.claude/projects/foo/bar/tool-results/abc"));
+        assert!(!re.is_match("~/.claude/other/tool-results/abc"));
     }
 
     #[test]

--- a/tests/permissions.rs
+++ b/tests/permissions.rs
@@ -779,8 +779,11 @@ fn permission_to_regex_known_conversions() {
     assert!(r.is_match("git show HEAD:file.py | sed 's/foo/bar/'"));
     assert!(!r.is_match("git status"));
 
-    // Non-Bash entries return None
-    assert!(permission_to_regex("Write(*)").is_none());
+    // Non-Bash Type(pattern) entries now return a regex
+    let r = permission_to_regex("Write(*)").unwrap();
+    assert!(r.is_match("anything"));
+
+    // Malformed entries (no Type(pattern) format) return None
     assert!(permission_to_regex("plain string").is_none());
 }
 

--- a/tests/prime_setup.rs
+++ b/tests/prime_setup.rs
@@ -337,6 +337,38 @@ fn is_subsumed_skips_exact_match() {
     ));
 }
 
+#[test]
+fn is_subsumed_agent_wildcard_subsumes_specific() {
+    assert!(prime_setup::is_subsumed(
+        "Agent(flow:ci-fixer)",
+        &HashSet::from(["Agent(*)".to_string()])
+    ));
+}
+
+#[test]
+fn is_subsumed_read_wildcard_subsumes_specific() {
+    assert!(prime_setup::is_subsumed(
+        "Read(~/.claude/rules/*)",
+        &HashSet::from(["Read(~/.claude/*)".to_string()])
+    ));
+}
+
+#[test]
+fn is_subsumed_skill_wildcard_subsumes_specific() {
+    assert!(prime_setup::is_subsumed(
+        "Skill(decompose:decompose)",
+        &HashSet::from(["Skill(*)".to_string()])
+    ));
+}
+
+#[test]
+fn is_subsumed_cross_type_no_match() {
+    assert!(!prime_setup::is_subsumed(
+        "Skill(decompose:decompose)",
+        &HashSet::from(["Agent(*)".to_string()])
+    ));
+}
+
 // ── Derived permissions ─────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## What

work on issue #896.

Closes #896

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/permissiontoregex-only-handles-plan.md` |
| DAG | `.flow-states/permissiontoregex-only-handles-dag.md` |
| Log | `.flow-states/permissiontoregex-only-handles.log` |
| State | `.flow-states/permissiontoregex-only-handles.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/68f73185-a648-4872-aa20-1b3b56697657.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

Issue #896: `permission_to_regex()` in `src/utils.rs` only handles `Bash(...)` permission patterns. When `is_subsumed()` in `src/prime_setup.rs` checks whether a candidate permission is subsumed by a broader existing entry, non-Bash types like `Agent(*)`, `Read(~/.claude/*)`, and `Skill(*)` always return `None` from `permission_to_regex()`, so subsumption is never detected. This causes redundant entries in `.claude/settings.json` (e.g., `Agent(flow:ci-fixer)` added alongside `Agent(*)`).

The issue body also references `lib/flow_utils.py` — this file no longer exists. The Python-to-Rust migration is complete.

## Exploration

**Two `permission_to_regex` functions exist:**

1. `src/utils.rs:569` — used by `is_subsumed()` in `src/prime_setup.rs` for additive-merge subsumption detection. Uses regex-based extraction: `^Bash\((.+)\)$`. This is the one that needs generalizing.

2. `src/hooks/mod.rs:133` — used by `build_permission_regexes()` for hook deny-list and whitelist validation of Bash tool commands. Uses `strip_prefix("Bash(")?.strip_suffix(')')`. This one correctly stays Bash-only because hooks only validate Bash commands.

**`is_subsumed()` at `src/prime_setup.rs:160-189`** already:
- Extracts the type prefix from both candidate and existing entries using `^(\w+)\((.+)\)$`
- Filters by same-type (line 179)
- Builds a test string from the candidate's inner content
- The only gap: calls `permission_to_regex(existing)` which returns `None` for non-Bash

**Non-Bash types in `UNIVERSAL_ALLOW` (`src/prime_check.rs:44-95`):**
- `Read(~/.claude/rules/*)`, `Read(~/.claude/projects/**/tool-results/*)`, `Read(//tmp/*.txt)`, `Read(//tmp/*.diff)`, `Read(//tmp/*.patch)`, `Read(//tmp/*.md)`
- `Agent(flow:ci-fixer)`
- `Skill(decompose:decompose)`

**Existing tests:**
- `src/utils.rs`: 5 unit tests for `permission_to_regex` — `permission_to_regex_non_bash` (line 1002) explicitly asserts `Read(file.txt)` returns `None` — must be updated
- `tests/prime_setup.rs`: 2 `is_subsumed` tests (malformed candidate, exact match) — no non-Bash subsumption tests
- `tests/hooks_shared.rs`: 6 tests for the hooks' `permission_to_regex` — correctly assert non-Bash returns `None` — must NOT be changed

## Risks

- **Hooks version stays Bash-only.** Changing the wrong function would break hook validation. The two functions are separate — `utils.rs` vs `hooks/mod.rs`.
- **`**` glob patterns.** `Read(~/.claude/projects/**/tool-results/*)` contains `**`. After `regex::escape` this becomes `\*\*`, and `.replace(r"\*", ".*")` produces `.*.*`, which is functionally identical to `.*`. No special handling needed.
- **Greedy `(.+)` and nested parens.** Patterns like `Bash(echo (foo))` — the greedy `(.+)` in the outer regex captures to the last `)`, which is correct existing behavior and unchanged by this fix.

## Approach

Change the outer regex in `utils.rs::permission_to_regex` from `^Bash\((.+)\)$` to `^\w+\((.+)\)$`. The inner pattern extraction (escape + wildcard conversion) is already type-agnostic. This is a one-line regex change. Update the doc comment to reflect the generalized behavior.

Do NOT touch `hooks/mod.rs::permission_to_regex` — it is intentionally Bash-only for hook validation.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write tests for generalized permission_to_regex | test | — |
| 2. Write is_subsumed non-Bash subsumption tests | test | — |
| 3. Generalize permission_to_regex in src/utils.rs | implement | 1, 2 |

## Tasks

### Task 1: Write tests for generalized permission_to_regex

**Files:** `src/utils.rs` (test module at bottom)

- Update `permission_to_regex_non_bash` test (line 1002): change from asserting `is_none()` to asserting the regex matches correctly. Test `Read(file.txt)` produces a regex matching `file.txt`.
- Add `permission_to_regex_read_wildcard`: test `Read(~/.claude/rules/*)` matches `~/.claude/rules/foo.md` but not `~/.claude/other/bar.md`
- Add `permission_to_regex_agent`: test `Agent(*)` matches `flow:ci-fixer` and any other string
- Add `permission_to_regex_skill`: test `Skill(decompose:decompose)` matches exactly `decompose:decompose` but not `decompose:other`
- Add `permission_to_regex_double_star`: test `Read(~/.claude/projects/**/tool-results/*)` matches paths like `~/.claude/projects/foo/bar/tool-results/abc`

### Task 2: Write is_subsumed non-Bash subsumption tests

**Files:** `tests/prime_setup.rs`

- Add `is_subsumed_agent_wildcard_subsumes_specific`: `Agent(*)` in existing set subsumes `Agent(flow:ci-fixer)` → returns true
- Add `is_subsumed_read_wildcard_subsumes_specific`: `Read(~/.claude/*)` in existing set subsumes `Read(~/.claude/rules/*)` → returns true
- Add `is_subsumed_skill_wildcard_subsumes_specific`: `Skill(*)` in existing set subsumes `Skill(decompose:decompose)` → returns true
- Add `is_subsumed_cross_type_no_match`: `Agent(*)` does NOT subsume `Skill(*)` → returns false (verifying type filtering)

### Task 3: Generalize permission_to_regex in src/utils.rs

**Files:** `src/utils.rs`

- Change the outer regex on line 570 from `r"^Bash\((.+)\)$"` to `r"^\w+\((.+)\)$"`
- Update the doc comment (lines 563-568): change "Convert a Bash(pattern) permission" to "Convert a Type(pattern) permission" and remove "Returns None for non-Bash entries." Replace with "Returns None for entries that don't match the Type(pattern) format."
- Update the examples in the doc comment to include a non-Bash example like `Agent(*) -> ^.*$`
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Extend permission_to_regex() to handle all permission types

```xml
<dag goal="Extend permission_to_regex() to handle all permission types for correct subsumption detection" mode="full">
  <plan>
    <node id="1" name="Current Implementation Analysis" type="research" depends="[]" parallel_with="[]">
      <objective>Read permission_to_regex() in src/utils.rs and is_subsumed() in src/prime_setup.rs to understand the current Bash-only pattern and how subsumption works</objective>
    </node>
    <node id="2" name="Permission Type Inventory" type="research" depends="[1]" parallel_with="3">
      <objective>Catalog all permission types used across the codebase (UNIVERSAL_ALLOW, FLOW_DENY, framework permissions) to know the full set that permission_to_regex must handle</objective>
    </node>
    <node id="3" name="Test Coverage Analysis" type="research" depends="[1]" parallel_with="2">
      <objective>Find existing tests for permission_to_regex and is_subsumed to understand test patterns and identify what new tests are needed</objective>
    </node>
    <node id="4" name="Python Parity Check" type="research" depends="[1]" parallel_with="2,3">
      <objective>Read lib/flow_utils.py permission_to_regex to understand the Python equivalent and what needs to change there</objective>
    </node>
    <node id="5" name="Synthesis" type="synthesis" depends="[2,3,4]">
      <objective>Merge findings into a complete implementation approach: what to change, what patterns to handle, what tests to write, risks and edge cases</objective>
    </node>
  </plan>
</dag>
```

## NODE 1: Current Implementation Analysis

`permission_to_regex()` at `src/utils.rs:569-576`:
- Uses `^Bash\((.+)\)$` as outer regex — Bash-only
- Extracts inner pattern, escapes it, converts `*` to `.*`, wraps in `^...$`
- Returns `None` for non-Bash entries

`is_subsumed()` at `src/prime_setup.rs:160-189`:
- Already extracts type from both candidate and existing entries using `^(\w+)\((.+)\)$`
- Correctly filters by same-type (line 179: `if &ex_caps[1] != cand_type { continue; }`)
- Builds test string from candidate's inner content with `*` replaced by `XXXPLACEHOLDERXXX`
- Calls `permission_to_regex(existing)` on line 182 — returns `None` for non-Bash, so subsumption is never detected

Key finding: `is_subsumed` already handles type filtering correctly. The only problem is `permission_to_regex` rejecting non-Bash types.

Quality: 9/10

## NODE 2: Permission Type Inventory

Non-Bash types in `UNIVERSAL_ALLOW` (`src/prime_check.rs:44-95`):
- `Read(~/.claude/rules/*)`
- `Read(~/.claude/projects/**/tool-results/*)`
- `Read(//tmp/*.txt)`, `Read(//tmp/*.diff)`, `Read(//tmp/*.patch)`, `Read(//tmp/*.md)`
- `Agent(flow:ci-fixer)`
- `Skill(decompose:decompose)`

Framework permissions (`frameworks/*/permissions.json`) are all empty `{"allow": []}`.

Real-world scenario: target project with `Agent(*)` in allow list → `Agent(flow:ci-fixer)` from UNIVERSAL_ALLOW should be subsumed but isn't.

Quality: 9/10

## NODE 3: Test Coverage Analysis

Existing tests in `src/utils.rs`:
- `permission_to_regex_basic` — Bash exact match
- `permission_to_regex_wildcard` — Bash wildcard
- `permission_to_regex_semicolon_wildcard` — Bash semicolon wildcard
- `permission_to_regex_non_bash` — **asserts `Read(file.txt)` returns `None`** — must be updated
- `permission_to_regex_exact_match_only` — Bash no partial match

Existing tests in `tests/prime_setup.rs`:
- `is_subsumed_malformed_candidate` — plain string returns false
- `is_subsumed_skips_exact_match` — exact match returns false
- No tests for non-Bash subsumption

Quality: 9/10

## NODE 4: Python Parity Check

`lib/flow_utils.py` does not exist. The Python-to-Rust migration is complete (per `.claude/rules/rust-patterns.md` — "Promoted from `.claude/rules/rust-port-parity.md` in PR #953 after completing the Python-to-Rust migration"). No Python changes needed. The issue body's reference to Python is stale.

Quality: 10/10

## SYNTHESIS

**Root cause:** `permission_to_regex()` uses `^Bash\((.+)\)$` as its outer regex, so it only extracts the inner pattern from `Bash(...)` entries. `is_subsumed()` already correctly handles type filtering and test string building, but gets `None` back from `permission_to_regex()` for non-Bash entries.

**Fix:** Change the outer regex from `^Bash\((.+)\)$` to `^\w+\((.+)\)$`. The inner pattern extraction and wildcard conversion logic is already type-agnostic.

**Edge cases:**
- Nested parentheses (e.g. `Bash(echo (foo))`) — greedy `(.+)` captures to last `)`, handles this
- Path patterns like `Read(~/.claude/rules/*)` — `/` and `~` not regex-special after `regex::escape`
- Double-slash patterns like `Read(//tmp/*.txt)` — `//` escaped correctly

**Python parity:** Not needed — `lib/flow_utils.py` no longer exists.

**Test changes:**
1. Update `permission_to_regex_non_bash` — assert `Some` instead of `None`
2. Add tests: `Read(...)` with wildcard, `Agent(...)`, `Skill(...)` types
3. Add `is_subsumed` tests: `Agent(*)` subsumes `Agent(flow:ci-fixer)`, `Read(~/.claude/*)` subsumes `Read(~/.claude/rules/*)`, `Skill(*)` subsumes `Skill(decompose:decompose)`
4. Update doc comment on `permission_to_regex` to remove "Returns None for non-Bash entries"

Confidence: 95% | Nodes: 5 | Parallel branches: 3
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 3m |
| Plan | <1m |
| **Total** | **3m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/permissiontoregex-only-handles.json</summary>

```json
{
  "schema_version": 1,
  "branch": "permissiontoregex-only-handles",
  "repo": "benkruger/flow",
  "pr_number": 979,
  "pr_url": "https://github.com/benkruger/flow/pull/979",
  "started_at": "2026-04-10T00:09:44-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/permissiontoregex-only-handles-plan.md",
    "dag": ".flow-states/permissiontoregex-only-handles-dag.md",
    "log": ".flow-states/permissiontoregex-only-handles.log",
    "state": ".flow-states/permissiontoregex-only-handles.json"
  },
  "session_tty": "/dev/ttys004",
  "session_id": "68f73185-a648-4872-aa20-1b3b56697657",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/68f73185-a648-4872-aa20-1b3b56697657.jsonl",
  "notes": [],
  "prompt": "work on issue #896",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T00:09:44-07:00",
      "completed_at": "2026-04-10T00:12:44-07:00",
      "session_started_at": null,
      "cumulative_seconds": 180,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-10T00:12:55-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-10T00:12:55-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T00:12:55-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "_continue_context": "",
  "_continue_pending": "null",
  "_stop_instructed": true,
  "code_tasks_total": 3
}
```

</details>

## Session Log

<details>
<summary>.flow-states/permissiontoregex-only-handles.log</summary>

```text
2026-04-10T00:09:44-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T00:09:44-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T00:09:44-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T00:09:44-07:00 [Phase 1] create .flow-states/permissiontoregex-only-handles.json (exit 0)
2026-04-10T00:09:44-07:00 [Phase 1] freeze .flow-states/permissiontoregex-only-handles-phases.json (exit 0)
2026-04-10T00:09:44-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T00:09:46-07:00 [Phase 1] start-init — label-issues (labeled: [896], failed: [])
2026-04-10T00:09:53-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T00:12:17-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T00:12:22-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T00:12:22-07:00 [Phase 1] start-gate — post-deps CI ("ok")
2026-04-10T00:12:30-07:00 [Phase 1] start-workspace — worktree .worktrees/permissiontoregex-only-handles (ok)
2026-04-10T00:12:34-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T00:12:34-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T00:12:34-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T00:12:44-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T00:12:44-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T00:16:34-07:00 [stop-continue] first stop, conditional continue: pending=decompose
```

</details>