### PR TITLE
Testsclearblockedrs Does Not

### DIFF
--- a/tests/clear_blocked.rs
+++ b/tests/clear_blocked.rs
@@ -29,7 +29,9 @@ fn run_clear_blocked(
     cmd.arg("clear-blocked")
         .env("FLOW_SIMULATE_BRANCH", branch)
         .current_dir(dir)
-        .stdin(Stdio::piped());
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
 
     let mut child = cmd.spawn().unwrap();
     {


### PR DESCRIPTION
## What

pipe child stdout stderr in clear blocked tests #885.

Closes #885

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/testsclearblockedrs-does-not-plan.md` |
| Log | `.flow-states/testsclearblockedrs-does-not.log` |
| State | `.flow-states/testsclearblockedrs-does-not.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

Issue #885: `tests/clear_blocked.rs` spawns the `flow-rs clear-blocked`
subprocess with only `.stdin(Stdio::piped())`. stdout and stderr are
inherited from the test harness, violating the Test Subprocess Stdio
rule in `.claude/rules/rust-patterns.md`. This is a latent defect —
today `clear-blocked` emits no output, but the moment it does, tests
will silently break.

## Exploration

- `tests/clear_blocked.rs:28-32` — the `run_clear_blocked` helper builds
  the command with only `.stdin(Stdio::piped())`. All four tests use this
  helper.
- `tests/hooks.rs:82-87` and `tests/hooks.rs:135-140` — reference pattern
  that pipes all three streams: `.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped())`.
- The fix is a single line addition in the helper function. All four tests
  already call `run_clear_blocked` — fixing the helper fixes all tests.

## Risks

None. Adding `.stdout(Stdio::piped()).stderr(Stdio::piped())` is strictly
additive — it changes buffer ownership from inherited to captured. Existing
assertions on `output.stdout.is_empty()` continue to pass because the
subprocess produces no stdout. The only behavioral change is that IF
stdout/stderr were ever produced, they would now be captured in the
`Output` struct instead of leaking to the terminal.

## Approach

Add `.stdout(Stdio::piped()).stderr(Stdio::piped())` to the command
builder in `run_clear_blocked`, matching the pattern established in
`tests/hooks.rs`.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add stdout/stderr piping to run_clear_blocked | implement | — |

## Tasks

### Task 1 — Add stdout/stderr piping to run_clear_blocked

**Files to modify:** `tests/clear_blocked.rs`

**Change:** Add `.stdout(Stdio::piped()).stderr(Stdio::piped())` after
the existing `.stdin(Stdio::piped())` call on line 32.

**Verification:** Run `bin/flow test -- clear_blocked` — all four existing
tests must pass. No new tests needed; the existing tests already assert on
`output.stdout.is_empty()` which exercises the captured buffer.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 3m |
| Plan | <1m |
| **Total** | **3m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/testsclearblockedrs-does-not.json</summary>

```json
{
  "schema_version": 1,
  "branch": "testsclearblockedrs-does-not",
  "repo": "benkruger/flow",
  "pr_number": 982,
  "pr_url": "https://github.com/benkruger/flow/pull/982",
  "started_at": "2026-04-10T08:26:25-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/testsclearblockedrs-does-not-plan.md",
    "dag": null,
    "log": ".flow-states/testsclearblockedrs-does-not.log",
    "state": ".flow-states/testsclearblockedrs-does-not.json"
  },
  "session_tty": "/dev/ttys005",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "pipe child stdout stderr in clear blocked tests #885",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T08:26:25-07:00",
      "completed_at": "2026-04-10T08:29:48-07:00",
      "session_started_at": null,
      "cumulative_seconds": 203,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-10T08:29:58-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-10T08:29:58-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T08:29:58-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 1
}
```

</details>

## Session Log

<details>
<summary>.flow-states/testsclearblockedrs-does-not.log</summary>

```text
2026-04-10T08:26:25-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T08:26:25-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T08:26:25-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T08:26:25-07:00 [Phase 1] create .flow-states/testsclearblockedrs-does-not.json (exit 0)
2026-04-10T08:26:25-07:00 [Phase 1] freeze .flow-states/testsclearblockedrs-does-not-phases.json (exit 0)
2026-04-10T08:26:25-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T08:26:27-07:00 [Phase 1] start-init — label-issues (labeled: [885], failed: [])
2026-04-10T08:26:33-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T08:29:24-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T08:29:24-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T08:29:24-07:00 [Phase 1] start-gate — post-deps CI ("ok")
2026-04-10T08:29:27-07:00 [Phase 1] start-gate — commit deps (ok)
2026-04-10T08:29:35-07:00 [Phase 1] start-workspace — worktree .worktrees/testsclearblockedrs-does-not (ok)
2026-04-10T08:29:39-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T08:29:39-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T08:29:39-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T08:29:48-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T08:29:48-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
```

</details>