### PR TITLE
Tombstone Audit Add Integration

### DIFF
--- a/tests/tombstone_audit.rs
+++ b/tests/tombstone_audit.rs
@@ -13,8 +13,11 @@ use flow_rs::tombstone_audit::{
     build_merge_query, classify_tombstones, extract_pr_numbers, parse_merge_response,
     scan_test_files, MergeInfo, TombstoneEntry,
 };
+use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
 
 /// Build a tombstone comment line at runtime to avoid the literal pattern
 /// appearing in this test file's source (which would contaminate scan results).
@@ -388,4 +391,374 @@ fn classify_missing_pr_in_merge_data_skipped() {
         classify_tombstones(&entries, &merge_dates, Some("2024-06-01T00:00:00Z"));
     assert!(stale.is_empty());
     assert!(current.is_empty());
+}
+
+// ============================================================
+// Integration tests — run_impl via CLI binary with gh stubs
+// ============================================================
+
+/// Build a `Command` targeting the compiled `flow-rs` test binary.
+fn flow_rs() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+}
+
+/// Parse JSON from the subprocess stdout, panicking with diagnostics on failure.
+fn parse_stdout(output: &std::process::Output) -> Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "Failed to parse JSON: {}\nstdout: {}\nstderr: {}",
+            e,
+            stdout,
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+/// Initialize a minimal git repo so `project_root()` can resolve via
+/// `git worktree list --porcelain`.
+fn setup_tombstone_repo(dir: &std::path::Path) {
+    Command::new("git")
+        .args(["init"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+}
+
+/// Write a multi-dispatch `gh` stub script that routes on `$1`:
+/// - `pr` → echo threshold_response, exit threshold_exit
+/// - `api` → echo graphql_response, exit graphql_exit
+/// - `repo` → echo repo_response, exit repo_exit
+///
+/// Returns the stub directory path (to prepend to PATH).
+fn write_gh_multi_stub(
+    dir: &std::path::Path,
+    threshold_response: &str,
+    threshold_exit: i32,
+    graphql_response: &str,
+    graphql_exit: i32,
+    repo_response: &str,
+    repo_exit: i32,
+) -> std::path::PathBuf {
+    let stub_dir = dir.join("stubs");
+    fs::create_dir_all(&stub_dir).unwrap();
+    let stub_path = stub_dir.join("gh");
+    // Escape single quotes for safe embedding in bash
+    let thresh_escaped = threshold_response.replace('\'', "'\\''");
+    let gql_escaped = graphql_response.replace('\'', "'\\''");
+    let repo_escaped = repo_response.replace('\'', "'\\''");
+    let script = format!(
+        r#"#!/bin/bash
+case "$1" in
+  pr)
+    echo '{thresh}'
+    exit {thresh_exit}
+    ;;
+  api)
+    echo '{gql}'
+    exit {gql_exit}
+    ;;
+  repo)
+    echo '{repo}'
+    exit {repo_exit}
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+"#,
+        thresh = thresh_escaped,
+        thresh_exit = threshold_exit,
+        gql = gql_escaped,
+        gql_exit = graphql_exit,
+        repo = repo_escaped,
+        repo_exit = repo_exit,
+    );
+    fs::write(&stub_path, script).unwrap();
+    let mut perms = fs::metadata(&stub_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&stub_path, perms).unwrap();
+    stub_dir
+}
+
+/// Convenience: write a gh stub with default repo detection (always fails).
+fn write_gh_stub_simple(
+    dir: &std::path::Path,
+    threshold_response: &str,
+    threshold_exit: i32,
+    graphql_response: &str,
+    graphql_exit: i32,
+) -> std::path::PathBuf {
+    write_gh_multi_stub(
+        dir,
+        threshold_response,
+        threshold_exit,
+        graphql_response,
+        graphql_exit,
+        "",
+        1,
+    )
+}
+
+#[test]
+fn run_impl_no_tombstones() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_tombstone_repo(dir.path());
+    // Create an empty tests/ directory — no .rs files with tombstones
+    fs::create_dir(dir.path().join("tests")).unwrap();
+
+    let output = flow_rs()
+        .args(["tombstone-audit", "--repo", "owner/repo"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "Should exit 0 with no tombstones");
+    let data = parse_stdout(&output);
+    assert_eq!(data["total_tombstones"], 0);
+    assert_eq!(data["unique_prs"], 0);
+    assert_eq!(data["stale"].as_array().unwrap().len(), 0);
+    assert_eq!(data["current"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn run_impl_stale_tombstones() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_tombstone_repo(dir.path());
+    let tests_dir = dir.path().join("tests");
+    fs::create_dir(&tests_dir).unwrap();
+    fs::write(
+        tests_dir.join("tombstones.rs"),
+        tombstone_line(839, " Must not return."),
+    )
+    .unwrap();
+
+    let graphql = r#"{"data":{"repository":{"pr_839":{"mergedAt":"2024-01-15T10:00:00Z"}}}}"#;
+    let stub_dir = write_gh_stub_simple(dir.path(), "2024-06-01T00:00:00Z", 0, graphql, 0);
+
+    let output = flow_rs()
+        .args(["tombstone-audit", "--repo", "owner/repo"])
+        .current_dir(dir.path())
+        .env("PATH", format!("{}:/usr/bin:/bin", stub_dir.display()))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let data = parse_stdout(&output);
+    assert_eq!(data["total_tombstones"], 1);
+    assert_eq!(data["stale"].as_array().unwrap().len(), 1);
+    assert_eq!(data["stale"][0]["pr"], 839);
+    assert_eq!(data["current"].as_array().unwrap().len(), 0);
+    assert_eq!(data["threshold"], "2024-06-01T00:00:00Z");
+}
+
+#[test]
+fn run_impl_current_tombstones() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_tombstone_repo(dir.path());
+    let tests_dir = dir.path().join("tests");
+    fs::create_dir(&tests_dir).unwrap();
+    fs::write(
+        tests_dir.join("tombstones.rs"),
+        tombstone_line(924, " Must not return."),
+    )
+    .unwrap();
+
+    let graphql = r#"{"data":{"repository":{"pr_924":{"mergedAt":"2024-08-01T10:00:00Z"}}}}"#;
+    let stub_dir = write_gh_stub_simple(dir.path(), "2024-06-01T00:00:00Z", 0, graphql, 0);
+
+    let output = flow_rs()
+        .args(["tombstone-audit", "--repo", "owner/repo"])
+        .current_dir(dir.path())
+        .env("PATH", format!("{}:/usr/bin:/bin", stub_dir.display()))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let data = parse_stdout(&output);
+    assert_eq!(data["total_tombstones"], 1);
+    assert_eq!(data["stale"].as_array().unwrap().len(), 0);
+    assert_eq!(data["current"].as_array().unwrap().len(), 1);
+    assert_eq!(data["current"][0]["pr"], 924);
+}
+
+#[test]
+fn run_impl_mixed_stale_and_current() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_tombstone_repo(dir.path());
+    let tests_dir = dir.path().join("tests");
+    fs::create_dir(&tests_dir).unwrap();
+    let content = format!(
+        "{}\n{}",
+        tombstone_line(839, " Must not return."),
+        tombstone_line(924, " Must not return."),
+    );
+    fs::write(tests_dir.join("tombstones.rs"), content).unwrap();
+
+    let graphql = r#"{"data":{"repository":{"pr_839":{"mergedAt":"2024-01-15T10:00:00Z"},"pr_924":{"mergedAt":"2024-08-01T10:00:00Z"}}}}"#;
+    let stub_dir = write_gh_stub_simple(dir.path(), "2024-06-01T00:00:00Z", 0, graphql, 0);
+
+    let output = flow_rs()
+        .args(["tombstone-audit", "--repo", "owner/repo"])
+        .current_dir(dir.path())
+        .env("PATH", format!("{}:/usr/bin:/bin", stub_dir.display()))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let data = parse_stdout(&output);
+    assert_eq!(data["total_tombstones"], 2);
+    assert_eq!(data["unique_prs"], 2);
+
+    let stale = data["stale"].as_array().unwrap();
+    let current = data["current"].as_array().unwrap();
+    assert_eq!(stale.len(), 1);
+    assert_eq!(current.len(), 1);
+
+    let stale_prs: Vec<u64> = stale.iter().map(|e| e["pr"].as_u64().unwrap()).collect();
+    let current_prs: Vec<u64> = current.iter().map(|e| e["pr"].as_u64().unwrap()).collect();
+    assert!(stale_prs.contains(&839));
+    assert!(current_prs.contains(&924));
+}
+
+#[test]
+fn run_impl_no_open_prs_all_stale() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_tombstone_repo(dir.path());
+    let tests_dir = dir.path().join("tests");
+    fs::create_dir(&tests_dir).unwrap();
+    fs::write(
+        tests_dir.join("tombstones.rs"),
+        tombstone_line(839, " Must not return."),
+    )
+    .unwrap();
+
+    let graphql = r#"{"data":{"repository":{"pr_839":{"mergedAt":"2024-01-15T10:00:00Z"}}}}"#;
+    // Empty threshold response means no open PRs
+    let stub_dir = write_gh_stub_simple(dir.path(), "", 0, graphql, 0);
+
+    let output = flow_rs()
+        .args(["tombstone-audit", "--repo", "owner/repo"])
+        .current_dir(dir.path())
+        .env("PATH", format!("{}:/usr/bin:/bin", stub_dir.display()))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let data = parse_stdout(&output);
+    assert_eq!(data["stale"].as_array().unwrap().len(), 1);
+    assert_eq!(data["current"].as_array().unwrap().len(), 0);
+    assert!(data["threshold"].is_null());
+}
+
+#[test]
+fn run_impl_threshold_fetch_error() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_tombstone_repo(dir.path());
+    let tests_dir = dir.path().join("tests");
+    fs::create_dir(&tests_dir).unwrap();
+    fs::write(
+        tests_dir.join("tombstones.rs"),
+        tombstone_line(839, " Must not return."),
+    )
+    .unwrap();
+
+    // gh pr list exits 1 → fetch_threshold returns Err → run_impl returns Ok with threshold_error
+    let stub_dir = write_gh_stub_simple(dir.path(), "", 1, "", 0);
+
+    let output = flow_rs()
+        .args(["tombstone-audit", "--repo", "owner/repo"])
+        .current_dir(dir.path())
+        .env("PATH", format!("{}:/usr/bin:/bin", stub_dir.display()))
+        .output()
+        .unwrap();
+
+    // threshold_error is NOT a run_impl error — it returns Ok with a special status
+    assert!(
+        output.status.success(),
+        "threshold_error should exit 0, not 1"
+    );
+    let data = parse_stdout(&output);
+    assert_eq!(data["status"], "threshold_error");
+    assert!(data["message"].as_str().unwrap().contains("failed"));
+    assert_eq!(data["total_tombstones"], 1);
+}
+
+#[test]
+fn run_impl_detect_repo_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_tombstone_repo(dir.path());
+    let tests_dir = dir.path().join("tests");
+    fs::create_dir(&tests_dir).unwrap();
+    fs::write(
+        tests_dir.join("tombstones.rs"),
+        tombstone_line(839, " Must not return."),
+    )
+    .unwrap();
+
+    // No --repo flag → detect_repo runs → gh repo view fails → run_impl returns Err
+    let stub_dir = write_gh_multi_stub(dir.path(), "", 0, "", 0, "", 1);
+
+    let output = flow_rs()
+        .args(["tombstone-audit"])
+        .current_dir(dir.path())
+        .env("PATH", format!("{}:/usr/bin:/bin", stub_dir.display()))
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "detect_repo failure should exit non-zero"
+    );
+    let data = parse_stdout(&output);
+    assert_eq!(data["status"], "error");
+    assert!(data["message"]
+        .as_str()
+        .unwrap()
+        .contains("detect repository"));
+}
+
+#[test]
+fn run_impl_graphql_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_tombstone_repo(dir.path());
+    let tests_dir = dir.path().join("tests");
+    fs::create_dir(&tests_dir).unwrap();
+    fs::write(
+        tests_dir.join("tombstones.rs"),
+        tombstone_line(839, " Must not return."),
+    )
+    .unwrap();
+
+    // gh api graphql exits 1 → fetch_merge_dates returns empty map → entries skipped
+    let stub_dir = write_gh_stub_simple(dir.path(), "2024-06-01T00:00:00Z", 0, "", 1);
+
+    let output = flow_rs()
+        .args(["tombstone-audit", "--repo", "owner/repo"])
+        .current_dir(dir.path())
+        .env("PATH", format!("{}:/usr/bin:/bin", stub_dir.display()))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let data = parse_stdout(&output);
+    assert_eq!(data["total_tombstones"], 1);
+    // No merge data → entries are skipped in classify_tombstones
+    assert_eq!(data["stale"].as_array().unwrap().len(), 0);
+    assert_eq!(data["current"].as_array().unwrap().len(), 0);
 }

--- a/tests/tombstone_audit.rs
+++ b/tests/tombstone_audit.rs
@@ -434,6 +434,11 @@ fn setup_tombstone_repo(dir: &std::path::Path) {
         .output()
         .unwrap();
     Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    Command::new("git")
         .args(["commit", "--allow-empty", "-m", "init"])
         .current_dir(dir)
         .output()
@@ -525,6 +530,7 @@ fn run_impl_no_tombstones() {
     let output = flow_rs()
         .args(["tombstone-audit", "--repo", "owner/repo"])
         .current_dir(dir.path())
+        .env("PATH", "/usr/bin:/bin")
         .output()
         .unwrap();
 
@@ -595,6 +601,7 @@ fn run_impl_current_tombstones() {
     assert_eq!(data["stale"].as_array().unwrap().len(), 0);
     assert_eq!(data["current"].as_array().unwrap().len(), 1);
     assert_eq!(data["current"][0]["pr"], 924);
+    assert_eq!(data["threshold"], "2024-06-01T00:00:00Z");
 }
 
 #[test]


### PR DESCRIPTION
## What

work on issue #973.

Closes #973

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/tombstone-audit-add-integration-plan.md` |
| DAG | `.flow-states/tombstone-audit-add-integration-dag.md` |
| Log | `.flow-states/tombstone-audit-add-integration.log` |
| State | `.flow-states/tombstone-audit-add-integration.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/03e39351-ea43-4c23-adef-56671f226319.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

The `tombstone-audit` subcommand (`src/tombstone_audit.rs`) has 25 unit tests covering pure functions (PR extraction, GraphQL query/response parsing, classification), but `run_impl` — which orchestrates the full flow including three `gh` subprocess calls (`detect_repo`, `fetch_threshold`, `fetch_merge_dates`) — has zero test coverage. Issue #973 asks for mock-based integration tests that exercise `run_impl` with simulated `gh` CLI responses.

## Exploration

**Production code (`src/tombstone_audit.rs`):**
- `run_impl` calls `project_root()` (needs git repo), `scan_test_files`, then conditionally `detect_repo`, `fetch_threshold`, `fetch_merge_dates`, and `classify_tombstones`
- All three network functions spawn `gh` via `Command::new("gh")` — no injectable path
- `run` wrapper prints JSON on success (exit 0) or error JSON + `process::exit(1)` on `Err`
- `fetch_threshold` `Err` returns `Ok(json!({"status": "threshold_error", ...}))` — NOT a `run_impl` error

**Existing test patterns (`tests/init_state.rs`):**
- `flow_rs()` → `Command::new(env!("CARGO_BIN_EXE_flow-rs"))`
- `write_gh_stub()` writes a bash script to `stubs/gh`, sets `chmod 0o755`
- `.env("PATH", format!("{}:/usr/bin:/bin", stub_dir.display()))` scopes PATH to subprocess only (no env var race)
- `parse_stdout()` extracts JSON from stdout with panic-on-failure diagnostics
- `setup_project()` uses `git init` + empty commit for `project_root()`

**Existing test file (`tests/tombstone_audit.rs`):**
- 25 pure-function tests organized in sections by function
- `tombstone_line()`, `tombstone_doc_line()`, `tombstone_str_line()` helpers for fixture content
- Uses `tempfile::tempdir()` for filesystem fixtures

## Risks

1. **`project_root()` resolution** — `project_root()` runs `git worktree list --porcelain` and returns the first `worktree` path. Tests must use a git repo fixture with `.current_dir(repo)` so this resolves correctly. Verified: `git init` + empty commit suffices (matches `init_state.rs` `setup_project` pattern).

2. **Multi-dispatch stub complexity** — Unlike `init_state.rs` which needs a single-response stub, `tombstone-audit` calls `gh` 2-3 times per invocation with different first arguments (`pr`, `api`, `repo`). The stub must dispatch on `$1`. Risk: if argument structure changes in production code, stubs silently return wrong responses. Mitigated by testing each path independently.

3. **`threshold_error` is not a `run_impl` error** — `fetch_threshold` failure returns `Ok(json!({"status": "threshold_error"}))`, not `Err(...)`. Test must check exit code 0 (not 1) with the `threshold_error` status field.

## Approach

Subprocess-based integration tests using the compiled `flow-rs` binary with multi-dispatch `gh` stub scripts and PATH scoping. Each test:
1. Creates a temp git repo with `tests/*.rs` files containing tombstone fixtures
2. Writes a custom `gh` stub script that dispatches on `$1` (pr/api/repo)
3. Runs `flow-rs tombstone-audit --repo owner/repo` with scoped PATH
4. Parses stdout JSON and asserts on the expected fields

Using `--repo owner/repo` in most tests to skip `detect_repo`. One dedicated test exercises `detect_repo` failure without `--repo`.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add integration test helpers and all 8 tests | test | — |

## Tasks

### Task 1 — Add integration tests for run_impl

**Description:** Add helper functions and 8 integration tests to the existing `tests/tombstone_audit.rs` file, in a new section after the existing pure-function tests.

**Files to modify:**
- `tests/tombstone_audit.rs`

**Helpers to add:**
- `flow_rs()` → `Command::new(env!("CARGO_BIN_EXE_flow-rs"))`
- `parse_stdout(output: &Output) -> Value` — JSON parse with diagnostic panic
- `setup_tombstone_repo(dir: &Path)` — `git init` + empty commit (for `project_root()`)
- `write_gh_multi_stub(dir: &Path, threshold_response: &str, threshold_exit: i32, graphql_response: &str, graphql_exit: i32) -> PathBuf` — writes a bash stub script that dispatches on `$1`: `pr` → threshold, `api` → graphql, `repo` → exit 1 (default fail for detect_repo). Returns the stub directory path.

**Tests to add (8 total):**

| # | Test name | What it verifies |
|---|-----------|-----------------|
| 1 | `run_impl_no_tombstones` | Empty tests dir → `total_tombstones: 0`, exit 0, no gh calls needed |
| 2 | `run_impl_stale_tombstones` | Tombstone merged before threshold → appears in `stale` array |
| 3 | `run_impl_current_tombstones` | Tombstone merged after threshold → appears in `current` array |
| 4 | `run_impl_mixed_stale_and_current` | Multiple tombstones with mixed dates → correct classification in both arrays |
| 5 | `run_impl_no_open_prs_all_stale` | `gh pr list` returns empty → threshold is null → all merged tombstones stale |
| 6 | `run_impl_threshold_fetch_error` | `gh pr list` exits 1 → `status: "threshold_error"`, exit 0 (not exit 1) |
| 7 | `run_impl_detect_repo_failure` | No `--repo` flag + `gh repo view` fails → exit 1 with error message |
| 8 | `run_impl_graphql_failure` | `gh api graphql` exits 1 → empty stale and current arrays (merge data missing, entries skipped) |

**TDD notes:** This is a test-only task — no production code changes. Each test exercises a distinct code path through `run_impl` via the CLI binary. Assert on: exit code, JSON structure, array contents (PR numbers, file paths), and specific status fields.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# DAG Analysis: Add integration tests for tombstone-audit run_impl

<dag goal="Add integration tests for tombstone-audit run_impl with simulated gh CLI responses" mode="full">
  <plan>
    <node id="1" name="Analyze run_impl execution paths" type="research" depends="[]" parallel_with="[]">
      <objective>Map every code path through run_impl that involves network calls, identify what each gh subprocess call expects and returns</objective>
    </node>
    <node id="2" name="Survey existing integration test patterns" type="research" depends="[]" parallel_with="1">
      <objective>Find how other FLOW tests handle subprocess mocking (fake binaries, PATH scoping, create_git_repo_with_remote patterns)</objective>
    </node>
    <node id="3" name="Design mock strategy" type="analysis" depends="[1,2]" parallel_with="[]">
      <objective>Choose the approach for mocking gh CLI: fake script with subprocess PATH scoping vs refactoring vs other, considering env var race constraints</objective>
    </node>
    <node id="4" name="Enumerate test cases" type="analysis" depends="[1,3]" parallel_with="[]">
      <objective>List every run_impl scenario that needs coverage: happy path, threshold_error, detect_repo failure, empty tombstones, mixed stale/current</objective>
    </node>
    <node id="5" name="Synthesis" type="synthesis" depends="[3,4]" parallel_with="[]">
      <objective>Produce final implementation plan with task ordering, file targets, and dependency graph</objective>
    </node>
  </plan>
</dag>

## Node Executions

### NODE 1: Analyze run_impl execution paths

`run_impl` has these distinct code paths based on network responses:

1. **Empty tombstones** (line 287–294): `scan_test_files` returns empty → early return with zeros. No network calls.
2. **detect_repo failure** (line 305–308): `args.repo` is None AND `detect_repo()` returns None → `Err("Could not detect repository from git remote")`.
3. **detect_repo success** (line 306): `args.repo` is None AND `gh repo view` returns valid `owner/repo`. Bypassed when `args.repo = Some(...)`.
4. **fetch_threshold error** (line 312–325): `gh pr list` fails (non-zero exit) → returns Ok with `status: "threshold_error"`.
5. **fetch_threshold Ok(None)** (line 234–238): empty or "null" response → no open PRs → all merged tombstones are stale.
6. **fetch_threshold Ok(Some)** (line 235–236): valid date string → used as threshold.
7. **fetch_merge_dates** (line 242–278): GraphQL call via `gh api graphql`. Returns empty HashMap on any failure.
8. **Happy path**: scan → detect → threshold → merge dates → classify → JSON output.

Key: all three network functions spawn `gh` via `std::process::Command::new("gh")`. They don't accept a configurable path.

Quality: 9/10 — Complete path enumeration with line references.

### NODE 2: Survey existing integration test patterns

Found the established pattern in `tests/init_state.rs`:
- Subprocess via `env!("CARGO_BIN_EXE_flow-rs")`
- `write_gh_stub` for fake `gh` scripts
- `.env("PATH", format!("{}:/usr/bin:/bin", stub_dir.display()))` on the subprocess Command
- No env var mutation needed — PATH is scoped to the subprocess only
- `create_git_repo_with_remote` for fixture repos

Quality: 9/10 — Found the proven pattern matching all constraints.

### NODE 3: Design mock strategy

**Approach: Multi-response gh stub script**

The `gh` stub script needs to handle two different calls:
1. `gh pr list ...` → return threshold date or empty
2. `gh api graphql ...` → return merge date JSON

The script dispatches based on `$1` (first argument):
- If `$1` is `pr` → it's `fetch_threshold` → echo threshold response
- If `$1` is `api` → it's `fetch_merge_dates` → echo GraphQL response
- If `$1` is `repo` → it's `detect_repo` → echo `owner/repo`

A single bash script with a case statement on `$1` handles all three. Each test writes a custom stub with the responses it needs.

Using `--repo owner/repo` flag skips `detect_repo` for most tests. A separate test exercises `detect_repo` via the `repo` stub.

**Fixture setup:** Use `create_git_repo_with_remote()` for git repo (needed for `project_root()`). Create `tests/*.rs` files with tombstone comments using the `tombstone_line()` helper pattern.

Quality: 9/10 — Matches existing patterns perfectly, avoids env var races.

### NODE 4: Enumerate test cases

Test cases for `run_impl` integration (9 total):

| # | Test name | gh stub behavior | Expected output |
|---|-----------|-----------------|-----------------|
| 1 | `run_impl_no_tombstones` | n/a (no gh calls) | `total_tombstones: 0` |
| 2 | `run_impl_stale_tombstones` | threshold=2024-06-01, merged=2024-01-15 | stale=[PR] |
| 3 | `run_impl_current_tombstones` | threshold=2024-06-01, merged=2024-08-01 | current=[PR] |
| 4 | `run_impl_mixed_stale_current` | threshold=2024-06-01, mixed dates | both arrays populated |
| 5 | `run_impl_no_open_prs_all_stale` | threshold=empty/"null" | all in stale |
| 6 | `run_impl_threshold_error` | `gh pr list` exits 1 | `threshold_error` |
| 7 | `run_impl_with_repo_flag` | threshold+graphql only | verify `--repo` bypasses detect |
| 8 | `run_impl_detect_repo_failure` | no `--repo` flag AND `gh repo view` exits 1 | error message |
| 9 | `run_impl_graphql_failure` | `gh api` exits 1 | empty stale/current |

Quality: 9/10 — Covers all meaningful paths through run_impl.

## DAG Synthesis

**Approach:** Subprocess-based integration tests using `env!("CARGO_BIN_EXE_flow-rs")` with multi-dispatch `gh` stub scripts and PATH scoping. Tests exercise `run_impl` through the CLI binary (`bin/flow tombstone-audit`), matching the established `init_state.rs` pattern.

**Files to modify:**
- `tests/tombstone_audit.rs` — add integration tests after existing pure-function tests

**Key design decisions:**
1. Use `--repo owner/repo` to skip `detect_repo` in most tests (one test exercises detect_repo separately)
2. Multi-dispatch `gh` stub script: routes on `$1` (`pr` → threshold, `api` → graphql, `repo` → detect)
3. `create_git_repo_with_remote` for fixture repos (needed for `project_root()`)
4. Each test creates its own tombstone fixture files in `tests/*.rs` under the fixture repo
5. The `tombstone_line()` helper already exists — reuse it for fixture content

**Test cases (9 total):**

| # | Test name | gh stub behavior | Expected output |
|---|-----------|-----------------|-----------------|
| 1 | `run_impl_no_tombstones` | n/a (no gh calls) | `total_tombstones: 0` |
| 2 | `run_impl_stale_tombstones` | threshold=2024-06-01, merged=2024-01-15 | stale=[PR] |
| 3 | `run_impl_current_tombstones` | threshold=2024-06-01, merged=2024-08-01 | current=[PR] |
| 4 | `run_impl_mixed_stale_current` | threshold=2024-06-01, mixed dates | both arrays populated |
| 5 | `run_impl_no_open_prs_all_stale` | threshold=empty/"null" | all in stale |
| 6 | `run_impl_threshold_error` | `gh pr list` exits 1 | `threshold_error` |
| 7 | `run_impl_with_repo_flag` | threshold+graphql only | verify `--repo` bypasses detect |
| 8 | `run_impl_detect_repo_failure` | no `--repo` flag AND `gh repo view` exits 1 | error message |
| 9 | `run_impl_graphql_failure` | `gh api` exits 1 | empty stale/current |

Confidence: 92% | Nodes: 5 | Parallel branches: 1

vs. Vanilla Claude:
- The env var race constraint would have led to `set_var("PATH", ...)` which breaks in parallel test execution
- The multi-dispatch stub need — a single-response stub from `init_state.rs` doesn't work for tombstone-audit's 2-3 sequential gh calls
- The `project_root()` dependency — tests need a real git repo fixture, not just a temp dir with test files
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 2m |
| Plan | <1m |
| **Total** | **2m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/tombstone-audit-add-integration.json</summary>

```json
{
  "schema_version": 1,
  "branch": "tombstone-audit-add-integration",
  "repo": "benkruger/flow",
  "pr_number": 983,
  "pr_url": "https://github.com/benkruger/flow/pull/983",
  "started_at": "2026-04-10T08:30:16-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/tombstone-audit-add-integration-plan.md",
    "dag": ".flow-states/tombstone-audit-add-integration-dag.md",
    "log": ".flow-states/tombstone-audit-add-integration.log",
    "state": ".flow-states/tombstone-audit-add-integration.json"
  },
  "session_tty": "/dev/ttys009",
  "session_id": "03e39351-ea43-4c23-adef-56671f226319",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/03e39351-ea43-4c23-adef-56671f226319.jsonl",
  "notes": [],
  "prompt": "work on issue #973",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T08:30:16-07:00",
      "completed_at": "2026-04-10T08:32:27-07:00",
      "session_started_at": null,
      "cumulative_seconds": 131,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-10T08:32:50-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-10T08:32:50-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T08:32:50-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "_continue_context": "",
  "_continue_pending": "null",
  "_stop_instructed": true,
  "code_tasks_total": 1
}
```

</details>

## Session Log

<details>
<summary>.flow-states/tombstone-audit-add-integration.log</summary>

```text
2026-04-10T08:27:09-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T08:27:17-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T08:27:42-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T08:27:55-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T08:28:20-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T08:28:27-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T08:29:17-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T08:29:24-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T08:30:15-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T08:30:15-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T08:30:16-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T08:30:16-07:00 [Phase 1] create .flow-states/tombstone-audit-add-integration.json (exit 0)
2026-04-10T08:30:16-07:00 [Phase 1] freeze .flow-states/tombstone-audit-add-integration-phases.json (exit 0)
2026-04-10T08:30:16-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T08:30:18-07:00 [Phase 1] start-init — label-issues (labeled: [973], failed: [])
2026-04-10T08:30:31-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T08:31:53-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T08:31:54-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T08:32:06-07:00 [Phase 1] start-workspace — worktree .worktrees/tombstone-audit-add-integration (ok)
2026-04-10T08:32:11-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T08:32:11-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T08:32:11-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T08:32:27-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T08:32:27-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T08:36:17-07:00 [stop-continue] first stop, conditional continue: pending=decompose
```

</details>