### PR TITLE
Tombstone Audit Add Ci Test

### DIFF
--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -11,6 +11,7 @@ mod common;
 use std::collections::HashSet;
 use std::fs;
 
+use flow_rs::tombstone_audit::extract_pr_numbers;
 use regex::Regex;
 use serde_json::Value;
 
@@ -2822,6 +2823,24 @@ fn code_review_no_plugin_config_axis() {
     assert!(
         !c.contains("code_review_plugin"),
         "Tombstone: code_review_plugin config removed"
+    );
+}
+
+// --- Tombstone audit fixture contamination prevention ---
+
+#[test]
+fn tombstone_audit_fixture_no_literal_tombstone_patterns() {
+    let path = common::repo_root().join("tests/tombstone_audit.rs");
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {}", path.display(), e));
+    let prs = extract_pr_numbers(&content);
+    assert!(
+        prs.is_empty(),
+        "tests/tombstone_audit.rs contains literal tombstone patterns matching the scanner regex. \
+         Found PR references: {:?}. Use tombstone_line() / tombstone_doc_line() / \
+         tombstone_str_line() builders instead of literal patterns to avoid contaminating \
+         scan_test_files() results.",
+        prs
     );
 }
 

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2828,6 +2828,11 @@ fn code_review_no_plugin_config_axis() {
 
 // --- Tombstone audit fixture contamination prevention ---
 
+/// `scan_test_files()` reads ALL `tests/*.rs` files and runs `extract_pr_numbers()`
+/// on each. Literal `Tombstone:...PR #N` patterns in `tests/tombstone_audit.rs`
+/// would be detected as real tombstones during `bin/flow tombstone-audit`, producing
+/// phantom stale entries. The builders in that file (`tombstone_line()`, etc.)
+/// construct patterns at runtime to keep the source clean.
 #[test]
 fn tombstone_audit_fixture_no_literal_tombstone_patterns() {
     let path = common::repo_root().join("tests/tombstone_audit.rs");
@@ -2837,9 +2842,9 @@ fn tombstone_audit_fixture_no_literal_tombstone_patterns() {
     assert!(
         prs.is_empty(),
         "tests/tombstone_audit.rs contains literal tombstone patterns matching the scanner regex. \
-         Found PR references: {:?}. Use tombstone_line() / tombstone_doc_line() / \
-         tombstone_str_line() builders instead of literal patterns to avoid contaminating \
-         scan_test_files() results.",
+         Found PR references: {:?}. Use the runtime builders defined in tests/tombstone_audit.rs \
+         (tombstone_line, tombstone_doc_line, tombstone_str_line) instead of literal patterns \
+         to avoid contaminating scan_test_files() results.",
         prs
     );
 }


### PR DESCRIPTION
## What

work on issue #974.

Closes #974

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/tombstone-audit-add-ci-test-plan.md` |
| DAG | `.flow-states/tombstone-audit-add-ci-test-dag.md` |
| Log | `.flow-states/tombstone-audit-add-ci-test.log` |
| State | `.flow-states/tombstone-audit-add-ci-test.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/ae1fda2b-f066-4ec2-9206-a8196dc1ba4d.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

Issue #974: The `tests/tombstone_audit.rs` test file uses runtime string builder functions (`tombstone_line()`, `tombstone_doc_line()`, `tombstone_str_line()`) instead of literal tombstone patterns to avoid contaminating `scan_test_files()` results. This convention is documented in comments (lines 6-8) but has no CI enforcement. If a contributor adds a literal `Tombstone:...PR #N` pattern, `bin/flow tombstone-audit` will pick it up as a real tombstone during Code Review, producing phantom stale entries.

## Exploration

- **Scanner regex**: `Tombstone:.*?PR #(\d+)` at `src/tombstone_audit.rs:46`, in `extract_pr_numbers()`. Called by `scan_test_files()` which reads all `tests/*.rs` files.
- **Fixture convention**: Three `format!`-based builders at lines 21-33 of `tests/tombstone_audit.rs` construct patterns at runtime. Line 102 has `"// Tombstone: this feature was removed."` which is safe — lacks `PR #` so the scanner won't match.
- **Library export**: `pub mod tombstone_audit` in `src/lib.rs:65`. `extract_pr_numbers` is `pub fn`. Import path: `flow_rs::tombstone_audit::extract_pr_numbers`.
- **Target file**: `tests/skill_contracts.rs` — 2974 lines. Already has tombstone-related tests at line 2828+. Uses `std::fs`, `regex::Regex`, `common::repo_root()`. Does NOT currently import from `flow_rs`.
- **Existing pattern**: `tests/tombstone_audit.rs` imports `flow_rs::tombstone_audit::extract_pr_numbers` (line 12-14), confirming the function is integration-test-accessible.

## Risks

- **Self-contamination**: The CI test itself must not contain a literal tombstone pattern. Since we only call `extract_pr_numbers` and assert emptiness, the test source contains no matching pattern. Safe.
- **Line 102 false positive**: `"// Tombstone: this feature was removed."` lacks `PR #`, so `extract_pr_numbers` returns an empty set. No false positive.
- **New import in skill_contracts.rs**: Adding `use flow_rs::tombstone_audit::extract_pr_numbers;` introduces a first `flow_rs` import. This is identical to what `tests/tombstone_audit.rs` does and carries no risk.

## Approach

Add a single CI test to `tests/skill_contracts.rs` that reads `tests/tombstone_audit.rs` source at runtime, runs the production `extract_pr_numbers()` function against it, and asserts the result is empty. Using the actual scanner function (not a duplicated regex) ensures zero drift — if the scanner regex changes, this test automatically tracks it.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add CI enforcement test | implement | — |

## Tasks

### Task 1: Add CI enforcement test for tombstone_audit.rs fixture contamination

**Files to modify:**
- `tests/skill_contracts.rs` — add import and test function

**Changes:**
- Add `use flow_rs::tombstone_audit::extract_pr_numbers;` to the imports section (after the existing `use` statements)
- Add test function `tombstone_audit_fixture_no_literal_tombstone_patterns` near the "Code Review tombstone audit integration" section (after line 2837)
- The test reads `tests/tombstone_audit.rs` via `fs::read_to_string(common::repo_root().join("tests/tombstone_audit.rs"))`, calls `extract_pr_numbers(&content)`, and asserts the result is empty
- Error message explains the convention: use `tombstone_line()` / `tombstone_doc_line()` / `tombstone_str_line()` builders instead of literal patterns

**TDD notes:**
- This IS the test — no separate implementation task needed. The entire change is a CI enforcement test.
- Verify the test passes on the current codebase (no existing contamination).
- Verify the test would fail if a literal pattern were present (the scanner function is already tested in `tests/tombstone_audit.rs`, confirming regex correctness).
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# DAG Analysis: Add CI enforcement test for tombstone_audit.rs fixture contamination prevention

<dag goal="Add CI enforcement test for tombstone_audit.rs fixture contamination prevention" mode="full">
  <plan>
    <node id="1" name="Scanner Regex Discovery" type="research" depends="[]" parallel_with="2">
      <objective>Find the exact regex pattern used by tombstone-audit scanning in Rust source to know what the CI test must match against</objective>
    </node>
    <node id="2" name="Fixture Convention Analysis" type="research" depends="[]" parallel_with="1">
      <objective>Read tests/tombstone_audit.rs to understand the existing contamination prevention convention and how fixtures avoid triggering the scanner</objective>
    </node>
    <node id="3" name="Existing Contract Test Patterns" type="research" depends="[]" parallel_with="1,2">
      <objective>Read tests/skill_contracts.rs to understand existing test patterns, especially similar content-assertion tests that scan test files</objective>
    </node>
    <node id="4" name="Test Design Synthesis" type="synthesis" depends="[1,2,3]" parallel_with="[]">
      <objective>Design the CI enforcement test: exact regex to scan for, file to scan, assertion logic, test name, and placement in skill_contracts.rs</objective>
    </node>
  </plan>
</dag>

▶ PARALLEL BRANCH A — NODE 1: Scanner Regex Discovery

The scanner regex is `Tombstone:.*?PR #(\d+)` at `src/tombstone_audit.rs:46`, used by `extract_pr_numbers()` which is called by `scan_test_files()` on all `tests/*.rs` files.

Quality: 9/10 — exact regex and call chain identified

Key finding: The scanner matches `Tombstone:` followed by `PR #` and digits in any `tests/*.rs` file — the CI test must assert this pattern does not appear literally in `tests/tombstone_audit.rs`.

▶ PARALLEL BRANCH B — NODE 2: Fixture Convention Analysis

The convention is well-implemented: three `format!`-based builders (`tombstone_line`, `tombstone_doc_line`, `tombstone_str_line`) construct patterns at runtime. Line 102 has `"// Tombstone: this feature was removed."` which is safe — no `PR #` suffix, so the scanner regex won't match it.

Quality: 9/10 — convention fully understood, edge case (line 102) identified as safe

Key finding: The CI test must match the full scanner regex `Tombstone:.*?PR #(\d+)`, not just the `Tombstone:` prefix — line 102 is a deliberate non-matching test case.

▶ PARALLEL BRANCH C — NODE 3: Existing Contract Test Patterns

The test follows the `repo_root().join(path)` + `fs::read_to_string` + assertion pattern used throughout. No regex crate is currently used in `skill_contracts.rs` — and none is needed since we can use the `extract_pr_numbers` function directly from the library.

Quality: 8/10 — patterns understood, placement confirmed

▶ MERGE: Branches A + B + C

All three branches converge on the same picture:
1. The scanner regex is `Tombstone:.*?PR #(\d+)` (Node 1)
2. The fixture avoids contamination via `format!`-based builders (Node 2)
3. The test file uses `repo_root().join()` + `fs::read_to_string` patterns (Node 3)

**The test can directly reuse `extract_pr_numbers()` from the library** instead of reimplementing the regex. This is stronger than a regex match — it tests against the exact same function the scanner uses, so if the regex changes, the CI test automatically tracks the change.

▶ NODE 4: Test Design Synthesis

**Test name:** `tombstone_audit_fixture_no_literal_tombstone_patterns`

**Placement:** `tests/skill_contracts.rs` — the issue suggests it, and it already contains tombstone-related tests (lines 2565+).

**Logic:**
1. Read `tests/tombstone_audit.rs` source at runtime via `fs::read_to_string(repo_root().join("tests/tombstone_audit.rs"))`
2. Call `extract_pr_numbers(&content)` — the same function the scanner uses
3. Assert the returned set is empty
4. Error message explains the convention: use `tombstone_line()` builders

**Why `extract_pr_numbers` instead of regex:**
- Tests against the exact production scanner — zero drift risk
- No need to add `regex` as a test dependency
- If the scanner regex changes, this test automatically tracks the change

**Self-contamination risk:** The test file itself (`skill_contracts.rs`) would contain no literal tombstone patterns — it only calls `extract_pr_numbers` and asserts emptiness. Safe.

**Edge case — line 102:** `"// Tombstone: this feature was removed."` in `tombstone_audit.rs` does NOT match the scanner regex (no `PR #`), so `extract_pr_numbers` returns empty for it. The test passes correctly.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
A single CI test in `tests/skill_contracts.rs` that reads
`tests/tombstone_audit.rs` at runtime and runs `extract_pr_numbers()`
on its content, asserting the result is empty. This catches any literal
`Tombstone:.*PR #(\d+)` pattern that a contributor might add.

Key design decisions:
- Reuse `extract_pr_numbers()` from the library — zero regex drift
- Place in `skill_contracts.rs` alongside existing tombstone tests
- Error message explains the runtime-builder convention
- One test, one file read, one assertion — minimal

Files to modify:
- `tests/skill_contracts.rs` — add the test

Files to read/validate:
- `tests/tombstone_audit.rs` — verify no existing contamination
- `src/tombstone_audit.rs` — confirm `extract_pr_numbers` is public
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 1m |
| Plan | <1m |
| **Total** | **1m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/tombstone-audit-add-ci-test.json</summary>

```json
{
  "schema_version": 1,
  "branch": "tombstone-audit-add-ci-test",
  "repo": "benkruger/flow",
  "pr_number": 984,
  "pr_url": "https://github.com/benkruger/flow/pull/984",
  "started_at": "2026-04-10T08:46:00-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/tombstone-audit-add-ci-test-plan.md",
    "dag": ".flow-states/tombstone-audit-add-ci-test-dag.md",
    "log": ".flow-states/tombstone-audit-add-ci-test.log",
    "state": ".flow-states/tombstone-audit-add-ci-test.json"
  },
  "session_tty": "/dev/ttys006",
  "session_id": "ae1fda2b-f066-4ec2-9206-a8196dc1ba4d",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/ae1fda2b-f066-4ec2-9206-a8196dc1ba4d.jsonl",
  "notes": [],
  "prompt": "work on issue #974",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T08:46:00-07:00",
      "completed_at": "2026-04-10T08:47:55-07:00",
      "session_started_at": null,
      "cumulative_seconds": 115,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-10T08:48:04-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-10T08:48:04-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T08:48:04-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "_continue_context": "",
  "_continue_pending": "",
  "_stop_instructed": true,
  "code_tasks_total": 1
}
```

</details>

## Session Log

<details>
<summary>.flow-states/tombstone-audit-add-ci-test.log</summary>

```text
2026-04-10T08:45:59-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T08:45:59-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T08:46:00-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T08:46:00-07:00 [Phase 1] create .flow-states/tombstone-audit-add-ci-test.json (exit 0)
2026-04-10T08:46:00-07:00 [Phase 1] freeze .flow-states/tombstone-audit-add-ci-test-phases.json (exit 0)
2026-04-10T08:46:00-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T08:46:02-07:00 [Phase 1] start-init — label-issues (labeled: [974], failed: [])
2026-04-10T08:46:07-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T08:47:33-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T08:47:34-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T08:47:42-07:00 [Phase 1] start-workspace — worktree .worktrees/tombstone-audit-add-ci-test (ok)
2026-04-10T08:47:46-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T08:47:46-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T08:47:46-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T08:47:55-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T08:47:55-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T08:51:06-07:00 [stop-continue] first stop, conditional continue: pending=decompose
```

</details>