### PR TITLE
Render Pr Body Missing   State

### DIFF
--- a/src/complete_post_merge.rs
+++ b/src/complete_post_merge.rs
@@ -221,7 +221,9 @@ pub fn post_merge_inner(
         }
     }
 
-    // Render PR body
+    // Render PR body — pass state_file explicitly because render-pr-body's
+    // auto-detection uses current_branch(), which returns "main" when the
+    // Complete skill runs from the project root after merge.
     let pr_str = pr_number.to_string();
     let render_args = [
         bin_flow,

--- a/src/complete_post_merge.rs
+++ b/src/complete_post_merge.rs
@@ -223,7 +223,14 @@ pub fn post_merge_inner(
 
     // Render PR body
     let pr_str = pr_number.to_string();
-    let render_args = [bin_flow, "render-pr-body", "--pr", &pr_str];
+    let render_args = [
+        bin_flow,
+        "render-pr-body",
+        "--pr",
+        &pr_str,
+        "--state-file",
+        state_file,
+    ];
     match runner(&render_args, NETWORK_TIMEOUT) {
         Err(e) => {
             failures.insert("render_pr_body".to_string(), json!(e));
@@ -882,6 +889,49 @@ mod tests {
         assert!(pt_call.contains(&"flow-complete".to_string()));
         assert!(pt_call.contains(&"--branch".to_string()));
         assert!(pt_call.contains(&"test-feature".to_string()));
+    }
+
+    #[test]
+    fn render_pr_body_called_with_state_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = setup(dir.path(), "test-feature", None, None);
+
+        let calls: Rc<RefCell<Vec<Vec<String>>>> = Rc::new(RefCell::new(Vec::new()));
+        let runner = tracking_runner(
+            vec![
+                ok(PT_COMPLETE_OK),
+                ok(RENDER_PR_OK),
+                ok(ISSUES_SUMMARY_NO_ISSUES),
+                ok(CLOSE_ISSUES_EMPTY),
+                ok(SUMMARY_OK),
+                ok(LABEL_OK),
+            ],
+            calls.clone(),
+        );
+
+        post_merge_inner(
+            42,
+            state_path.to_str().unwrap(),
+            "test-feature",
+            dir.path(),
+            "/fake/bin/flow",
+            &runner,
+        );
+
+        let render_call = calls
+            .borrow()
+            .iter()
+            .find(|c| c.iter().any(|a| a == "render-pr-body"))
+            .cloned()
+            .expect("render-pr-body call not found");
+        assert!(
+            render_call.contains(&"--state-file".to_string()),
+            "render-pr-body must receive --state-file arg"
+        );
+        assert!(
+            render_call.contains(&state_path.to_str().unwrap().to_string()),
+            "render-pr-body must receive the state file path"
+        );
     }
 
     // --- step counter persistence ---


### PR DESCRIPTION
## What

work on issue #985.

Closes #985

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/render-pr-body-missing---state-plan.md` |
| DAG | `.flow-states/render-pr-body-missing---state-dag.md` |
| Log | `.flow-states/render-pr-body-missing---state.log` |
| State | `.flow-states/render-pr-body-missing---state.json` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
## Context

Every merged PR (#982, #983, #984) has Phase Timings, State File, and Session Log frozen at the Plan phase snapshot. The Complete phase's `render-pr-body` subprocess call in `complete_post_merge.rs` does not pass `--state-file`, causing auto-detection to resolve against `main` instead of the feature branch when running from the project root.

## Exploration

**Production code (`src/complete_post_merge.rs`):**
- `post_merge_inner` receives `state_file: &str` as a parameter (available throughout the function)
- Line 226: `render_args` is `[bin_flow, "render-pr-body", "--pr", &pr_str]` — missing `--state-file`
- The `state_file` value is used elsewhere in the function (line 131 for reading state, line 147-154 for state path) but not forwarded to this subprocess

**Subprocess behavior (`src/render_pr_body.rs`):**
- Lines 242-249: without `--state-file`, `run()` calls `current_branch()` to auto-detect — returns `main` when cwd is project root
- Lines 251-257: missing state file triggers `json_error()` + `return` — exit code 0, no `process::exit(1)`

**Call chain (`src/complete_finalize.rs`):**
- Line 145: `complete_post_merge::post_merge(args.pr, &args.state_file, &args.branch)` — state file path is passed through correctly from CLI args

**Existing test patterns (`src/complete_post_merge.rs` tests):**
- `tracking_runner` (lines 507-521): wraps a response queue with call log (`Rc<RefCell<Vec<Vec<String>>>>`)
- `phase_transition_called_with_next_phase` (lines 849-885): uses `tracking_runner` to verify subprocess args — finds the call by matching on a subprocess name, then asserts specific args are present
- `render-pr-body` is the 2nd subprocess call (after phase-transition)

**Other callers of render-pr-body:**
- `skills/flow-plan/SKILL.md:406`: calls without `--state-file` — works correctly because Plan runs from the worktree where `current_branch()` returns the feature branch. No change needed.

## Risks

1. **Array type change** — `render_args` changes from `[&str; 4]` to `[&str; 6]`. The `runner` accepts `&[&str]` so this is transparent — no type annotation changes needed.
2. **No other callers affected** — the Plan skill's `render-pr-body` call works correctly without `--state-file` (runs from worktree). Only the Complete path is broken.

## Approach

Single-line production fix: add `"--state-file", state_file` to the `render_args` array. Add one `tracking_runner` test mirroring the existing `phase_transition_called_with_next_phase` pattern to lock the fix.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add `--state-file` arg and regression test | implement + test | — |

## Tasks

### Task 1: Add --state-file arg to render-pr-body call and regression test

**Files to modify:** `src/complete_post_merge.rs`

**Production change (line 226):**

Change:
```rust
let render_args = [bin_flow, "render-pr-body", "--pr", &pr_str];
```

To:
```rust
let render_args = [bin_flow, "render-pr-body", "--pr", &pr_str, "--state-file", state_file];
```

**Test addition:**

Add `render_pr_body_called_with_state_file` test after the existing `phase_transition_called_with_next_phase` test (line 885), using `tracking_runner` to capture subprocess calls and verify `render-pr-body` receives both `--state-file` and the correct state file path value.

**TDD notes:**
- The test should use `tracking_runner` with the standard 6-response mock queue
- Find the render-pr-body call in the captured calls by matching on `"render-pr-body"`
- Assert the call contains both `"--state-file"` and the state path string
- Verify existing tests still pass — they use `mock_runner` which ignores args
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# Pre-Decomposed Analysis: render-pr-body missing --state-file in complete-post-merge

## Problem

Every merged PR has Phase Timings, State File, and Session Log frozen at the Plan phase snapshot. Confirmed on PRs #982, #983, and #984 — all show identical symptoms:

- **Phase Timings** only lists Start and Plan (missing Code, Code Review, Learn, Complete)
- **State File** shows `current_phase: "flow-plan"` with Plan as `in_progress` and all subsequent phases as `pending`
- **Session Log** only contains Phase 1 (Start) entries — missing all entries from phases 2-6

The root cause is in `src/complete_post_merge.rs:226`. The `render-pr-body` subprocess is called without `--state-file`:

```rust
let render_args = [bin_flow, "render-pr-body", "--pr", &pr_str];
```

The Complete skill (Step 6) runs `cd <project_root>` before calling `complete-finalize`. At the project root, `current_branch()` returns `main`. Without `--state-file`, `render_pr_body::run()` auto-detects by looking for `.flow-states/main.json` — which doesn't exist. The render fails silently because:

1. `render_pr_body::run()` uses `json_error()` + `return` on missing state file — exits with code 0
2. `complete_post_merge` (line 231) only checks `code != 0`, so the failure is never recorded

The `state_file` parameter is already available in `post_merge_inner` (it's a function parameter) but is never forwarded to the `render-pr-body` subprocess.

## Acceptance Criteria

1. `render-pr-body` subprocess call in `complete_post_merge.rs` passes `--state-file` with the state file path
2. A `tracking_runner` test verifies the `render-pr-body` call includes `--state-file` and the correct path value
3. `bin/flow ci` passes
4. Next full FLOW lifecycle produces a PR body with all 6 phases in Phase Timings, complete State File, and full Session Log

## Implementation Plan

### Context

Every merged PR (#982, #983, #984) has Phase Timings, State File, and Session Log frozen at the Plan phase snapshot. The Complete phase's `render-pr-body` subprocess call in `complete_post_merge.rs` does not pass `--state-file`, causing auto-detection to resolve against `main` instead of the feature branch when running from the project root.

### Exploration

**Production code (`src/complete_post_merge.rs`):**
- `post_merge_inner` receives `state_file: &str` as a parameter (available throughout the function)
- Line 226: `render_args` is `[bin_flow, "render-pr-body", "--pr", &pr_str]` — missing `--state-file`
- The `state_file` value is used elsewhere in the function (line 131 for reading state, line 147-154 for state path) but not forwarded to this subprocess

**Subprocess behavior (`src/render_pr_body.rs`):**
- Lines 242-249: without `--state-file`, `run()` calls `current_branch()` to auto-detect — returns `main` when cwd is project root
- Lines 251-257: missing state file triggers `json_error()` + `return` — exit code 0, no `process::exit(1)`

**Call chain (`src/complete_finalize.rs`):**
- Line 145: `complete_post_merge::post_merge(args.pr, &args.state_file, &args.branch)` — state file path is passed through correctly from CLI args

**Existing test patterns (`src/complete_post_merge.rs` tests):**
- `tracking_runner` (lines 507-521): wraps a response queue with call log (`Rc<RefCell<Vec<Vec<String>>>>`)
- `phase_transition_called_with_next_phase` (lines 849-885): uses `tracking_runner` to verify subprocess args — finds the call by matching on a subprocess name, then asserts specific args are present
- `render-pr-body` is the 2nd subprocess call (after phase-transition)

**Other callers of render-pr-body:**
- `skills/flow-plan/SKILL.md:406`: calls without `--state-file` — works correctly because Plan runs from the worktree where `current_branch()` returns the feature branch. No change needed.

### Risks

1. **Array type change** — `render_args` changes from `[&str; 4]` to `[&str; 6]`. The `runner` accepts `&[&str]` so this is transparent — no type annotation changes needed.
2. **No other callers affected** — the Plan skill's `render-pr-body` call works correctly without `--state-file` (runs from worktree). Only the Complete path is broken.

### Approach

Single-line production fix: add `"--state-file", state_file` to the `render_args` array. Add one `tracking_runner` test mirroring the existing `phase_transition_called_with_next_phase` pattern to lock the fix.

### Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add `--state-file` arg and regression test | implement + test | — |

### Tasks

#### Task 1: Add --state-file arg to render-pr-body call and regression test

**Files to modify:** `src/complete_post_merge.rs`

**Production change (line 226):**

Change:
```rust
let render_args = [bin_flow, "render-pr-body", "--pr", &pr_str];
```

To:
```rust
let render_args = [bin_flow, "render-pr-body", "--pr", &pr_str, "--state-file", state_file];
```

**Test addition:**

Add `render_pr_body_called_with_state_file` test after the existing `phase_transition_called_with_next_phase` test (line 885), using `tracking_runner` to capture subprocess calls and verify `render-pr-body` receives both `--state-file` and the correct state file path value.

**TDD notes:**
- The test should use `tracking_runner` with the standard 6-response mock queue
- Find the render-pr-body call in the captured calls by matching on `"render-pr-body"`
- Assert the call contains both `"--state-file"` and the state path string
- Verify existing tests still pass — they use `mock_runner` which ignores args

## Files to Investigate

- `src/complete_post_merge.rs` — line 226: the `render_args` array missing `--state-file`. Line 225: `state_file` is in scope. Lines 507-521: `tracking_runner` pattern for test.
- `src/render_pr_body.rs` — lines 242-249: auto-detection path that fails when `--state-file` is absent. Lines 251-257: `json_error` + `return` (exit 0) on missing state file.
- `src/complete_finalize.rs` — line 145: passes `&args.state_file` to `post_merge`, confirming the value is available throughout the chain.

## Out of Scope

- The silent failure issue (`render_pr_body::run()` exits 0 on error) — the root cause fix eliminates the failure path entirely. Error handling consistency is a separate concern.
- The Plan skill's `render-pr-body` call (line 406 of `flow-plan/SKILL.md`) — it runs from the worktree where `current_branch()` correctly returns the feature branch.

## Context

The PR body is the primary artifact a user reviews after a flow completes. With Phase Timings frozen at Plan, engineers have no visibility into how long each phase took — defeating the purpose of the timing system. The Session Log and State File snapshots are similarly stale, making post-mortem analysis impossible.
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | <1m |
| **Total** | **<1m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/render-pr-body-missing---state.json</summary>

```json
{
  "schema_version": 1,
  "branch": "render-pr-body-missing---state",
  "repo": "benkruger/flow",
  "pr_number": 986,
  "pr_url": "https://github.com/benkruger/flow/pull/986",
  "started_at": "2026-04-10T09:42:51-07:00",
  "current_phase": "flow-plan",
  "framework": "python",
  "files": {
    "plan": ".flow-states/render-pr-body-missing---state-plan.md",
    "dag": ".flow-states/render-pr-body-missing---state-dag.md",
    "log": ".flow-states/render-pr-body-missing---state.log",
    "state": ".flow-states/render-pr-body-missing---state.json"
  },
  "session_tty": "/dev/ttys004",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #985",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T09:42:51-07:00",
      "completed_at": "2026-04-10T09:43:23-07:00",
      "session_started_at": null,
      "cumulative_seconds": 32,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-10T09:43:32-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-10T09:43:32-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T09:43:32-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 1
}
```

</details>

## Session Log

<details>
<summary>.flow-states/render-pr-body-missing---state.log</summary>

```text
2026-04-10T09:42:51-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T09:42:51-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T09:42:51-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T09:42:51-07:00 [Phase 1] create .flow-states/render-pr-body-missing---state.json (exit 0)
2026-04-10T09:42:51-07:00 [Phase 1] freeze .flow-states/render-pr-body-missing---state-phases.json (exit 0)
2026-04-10T09:42:51-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T09:42:53-07:00 [Phase 1] start-init — label-issues (labeled: [985], failed: [])
2026-04-10T09:42:59-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T09:43:00-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T09:43:00-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T09:43:09-07:00 [Phase 1] start-workspace — worktree .worktrees/render-pr-body-missing---state (ok)
2026-04-10T09:43:13-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T09:43:13-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T09:43:13-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T09:43:23-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T09:43:23-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T09:43:33-07:00 [Phase 2] plan-extract — gate check passed (exit 0)
2026-04-10T09:43:33-07:00 [Phase 2] plan-extract — issue #985 fetched, decomposed label detected (exit 0)
2026-04-10T09:43:33-07:00 [Phase 2] plan-extract — DAG file written: .flow-states/render-pr-body-missing---state-dag.md (exit 0)
2026-04-10T09:43:33-07:00 [Phase 2] plan-extract — plan extracted, 1 tasks, written: .flow-states/render-pr-body-missing---state-plan.md (exit 0)
```

</details>