### PR TITLE
Skip Remote Branch Deletion In

### DIFF
--- a/docs/phases/phase-6-complete.md
+++ b/docs/phases/phase-6-complete.md
@@ -91,7 +91,7 @@ By the end of Phase 6:
 
 - PR squash-merged into main
 - Referenced GitHub issues closed (extracted from the start prompt)
-- Remote branch deleted
+- Remote branch auto-deleted by GitHub after merge
 - Worktree and all its contents removed
 - Business-friendly summary displayed in Done banner: feature name, prompt,
   per-phase timeline, and artifact counts (issues filed, notes captured)

--- a/docs/skills/flow-abort.md
+++ b/docs/skills/flow-abort.md
@@ -56,7 +56,7 @@ already closed, worktree already removed), it continues to the next.
 |---|---|---|
 | **When** | After Learn (Phase 5) | Any phase |
 | **PR** | Squash-merged into main | Closed |
-| **Remote branch** | Deleted (via cleanup) | Deleted (via cleanup) |
+| **Remote branch** | Auto-deleted by GitHub | Deleted (via cleanup) |
 | **Worktree** | Removed | Removed |
 | **State file** | Deleted | Deleted |
 | **Missing state** | Warns, proceeds | Warns, proceeds |

--- a/skills/flow-abort/SKILL.md
+++ b/skills/flow-abort/SKILL.md
@@ -113,7 +113,7 @@ Run the cleanup script from the project root with abort flags:
 ${CLAUDE_PLUGIN_ROOT}/bin/flow cleanup <project_root> --branch <branch> --worktree <worktree_path> --pr <pr_number>
 ```
 
-If `pr_number` is unknown, omit `--pr`. The cleanup script deletes remote and local branches.
+If `pr_number` is unknown, omit `--pr`. The cleanup script deletes local branches and attempts remote branch deletion when `--pr` is provided.
 
 The script outputs JSON with a `steps` dict showing what happened to each resource (pr\_close, worktree, remote\_branch, local\_branch, state\_file, log\_file, ci\_sentinel). Each step reports "closed"/"removed"/"deleted", "skipped", or "failed: reason".
 
@@ -130,8 +130,7 @@ Then output the following banner in your response (not via Bash) inside a fenced
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   Feature '<feature>' has been abandoned.
-  PR closed, remote branch deleted,
-  worktree removed, state file and log deleted.
+  Cleanup complete — see results above for details.
 ```
 ````
 

--- a/skills/flow-abort/SKILL.md
+++ b/skills/flow-abort/SKILL.md
@@ -113,7 +113,7 @@ Run the cleanup script from the project root with abort flags:
 ${CLAUDE_PLUGIN_ROOT}/bin/flow cleanup <project_root> --branch <branch> --worktree <worktree_path> --pr <pr_number>
 ```
 
-If `pr_number` is unknown, omit `--pr`. The cleanup script always deletes remote and local branches.
+If `pr_number` is unknown, omit `--pr`. The cleanup script deletes remote and local branches.
 
 The script outputs JSON with a `steps` dict showing what happened to each resource (pr\_close, worktree, remote\_branch, local\_branch, state\_file, log\_file, ci\_sentinel). Each step reports "closed"/"removed"/"deleted", "skipped", or "failed: reason".
 

--- a/skills/flow-complete/SKILL.md
+++ b/skills/flow-complete/SKILL.md
@@ -542,7 +542,7 @@ Parse the JSON output. Keep `formatted_time`, `cumulative_seconds`,
 `summary`, `issues_links`, and `banner_line` for the Done banner.
 
 The `cleanup` field contains the results of Step 7 (cleanup operations):
-worktree removal, state file and log deletion, branch cleanup, and
+worktree removal, state file and log deletion, local branch cleanup, and
 git pull. Report the results to the user: what was cleaned, what was
 already gone, and what failed.
 

--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -172,16 +172,20 @@ pub fn cleanup(
         steps.insert("worktree".to_string(), "skipped".to_string());
     }
 
-    // Delete remote branch
-    let (ok, output) = run_cmd(&["git", "push", "origin", "--delete", branch], project_root);
-    steps.insert(
-        "remote_branch".to_string(),
-        if ok {
-            "deleted".to_string()
-        } else {
-            format!("failed: {}", output)
-        },
-    );
+    // Delete remote branch (abort only — GitHub auto-deletes after merge)
+    if pr_number.is_some() {
+        let (ok, output) = run_cmd(&["git", "push", "origin", "--delete", branch], project_root);
+        steps.insert(
+            "remote_branch".to_string(),
+            if ok {
+                "deleted".to_string()
+            } else {
+                format!("failed: {}", output)
+            },
+        );
+    } else {
+        steps.insert("remote_branch".to_string(), "skipped".to_string());
+    }
 
     // Delete local branch
     let (ok, output) = run_cmd(&["git", "branch", "-D", branch], project_root);
@@ -579,13 +583,25 @@ mod tests {
     // --- Branch deletion ---
 
     #[test]
-    fn test_cleanup_always_attempts_remote_branch() {
+    fn test_cleanup_skips_remote_branch_on_complete() {
         let dir = tempfile::tempdir().unwrap();
         setup_git_repo(dir.path());
         let wt_rel = setup_feature(dir.path(), "test-feature");
 
+        // Complete path (pr_number=None) skips remote branch deletion
         let steps = cleanup(dir.path(), "test-feature", &wt_rel, None, false);
-        // No remote configured, so push --delete will fail
+        assert_eq!(steps["remote_branch"], "skipped");
+    }
+
+    #[test]
+    fn test_abort_attempts_remote_branch_deletion() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_git_repo(dir.path());
+        let wt_rel = setup_feature(dir.path(), "test-feature");
+
+        // Abort path (pr_number=Some) attempts remote branch deletion
+        let steps = cleanup(dir.path(), "test-feature", &wt_rel, Some(999), false);
+        // No remote configured, so push --delete will fail — but it tried
         assert!(steps["remote_branch"].starts_with("failed:"));
     }
 
@@ -657,7 +673,7 @@ mod tests {
 
         assert_eq!(steps["pr_close"], "skipped");
         assert_eq!(steps["worktree"], "removed");
-        assert!(steps["remote_branch"].starts_with("failed:")); // no remote
+        assert_eq!(steps["remote_branch"], "skipped");
         assert_eq!(steps["local_branch"], "deleted");
         assert_eq!(steps["state_file"], "deleted");
         assert_eq!(steps["plan_file"], "skipped");


### PR DESCRIPTION
## What

work on issue #987.

Closes #987

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/skip-remote-branch-deletion-in-plan.md` |
| DAG | `.flow-states/skip-remote-branch-deletion-in-dag.md` |
| Log | `.flow-states/skip-remote-branch-deletion-in.log` |
| State | `.flow-states/skip-remote-branch-deletion-in.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

The user wants to stop redundantly deleting the remote branch during the Complete phase. GitHub handles this automatically after squash merge. The Abort phase must retain remote branch deletion since GitHub does not auto-delete on PR close.

## Exploration

The `cleanup()` function in `src/cleanup.rs:115` is the shared cleanup orchestrator for both Complete and Abort. It already uses `pr_number: Option<i64>` to discriminate the two paths — the `pr_close` step at lines 124-137 conditionally closes the PR only when `pr_number.is_some()`. The remote branch deletion at lines 175-184 is currently unconditional.

Callers:
- `src/complete_finalize.rs:146` passes `None` for `pr_number`
- `skills/flow-abort/SKILL.md:113` passes `--pr <n>` (maps to `Some(n)`)

Tests:
- `test_cleanup_always_attempts_remote_branch` (line 582) — asserts `starts_with("failed:")`
- `test_cleanup_full_happy_path` (line 660) — asserts `starts_with("failed:")`
- `test_step_key_order_matches_python` (line 748) — asserts key order including `remote_branch`
- `test_step_key_order_with_pull` (line 778) — same

Documentation references:
- `docs/phases/phase-6-complete.md:94` — "Remote branch deleted"
- `docs/skills/flow-abort.md:57` — comparison table showing both phases delete remote branch
- `skills/flow-complete/SKILL.md:545` — "branch cleanup"
- `skills/flow-abort/SKILL.md:116` — "The cleanup script always deletes remote and local branches"

## Risks

- **Repos without "Automatically delete head branches"**: Remote branch lingers after merge. Acceptable — the setting is standard practice. Manual cleanup available via `git fetch --prune`.
- **Abort without --pr**: When abort omits `--pr` (unknown PR number), `pr_number` is `None` and remote deletion will now be skipped. This is a rare path (abort SKILL.md only omits `--pr` when the state file is missing AND the PR number can't be determined). Acceptable trade-off vs. adding a new flag.

## Approach

Use the existing `pr_number` discriminator. When `pr_number.is_some()` (Abort), attempt remote branch deletion as before. When `pr_number.is_none()` (Complete), skip and report `"skipped"`. This mirrors the `pr_close` pattern already established at lines 124-137. No new flags, no signature changes, no caller changes.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Update tests for new behavior | test | — |
| 2. Conditional remote branch deletion | implement | 1 |
| 3. Update documentation | docs | 2 |

## Tasks

### Task 1: Update tests for new Complete-path behavior and add abort-path test

**Files:** `src/cleanup.rs`

- Rename `test_cleanup_always_attempts_remote_branch` (line 582) to `test_cleanup_skips_remote_branch_on_complete`. Change assertion from `starts_with("failed:")` to `== "skipped"`.
- Update `test_cleanup_full_happy_path` (line 660): change `starts_with("failed:")` to `== "skipped"`.
- Add `test_abort_attempts_remote_branch_deletion`: call `cleanup(..., Some(999), false)`, assert `steps["remote_branch"].starts_with("failed:")` (no remote in test repo, but proves attempt was made).
- Key order tests (`test_step_key_order_matches_python`, `test_step_key_order_with_pull`) need no changes — `remote_branch` key is still emitted.

**TDD:** Tests should fail before Task 2 (the production code still unconditionally attempts deletion, so the "skipped" assertions fail). After Task 2, all pass.

### Task 2: Conditional remote branch deletion in cleanup()

**Files:** `src/cleanup.rs` (lines 175-184)

Wrap the `git push origin --delete` block in `if pr_number.is_some()`. In the `else` branch, insert `"remote_branch" => "skipped"`. Add a comment: `// Delete remote branch (abort only — GitHub auto-deletes after merge)`.

No changes to `src/complete_finalize.rs` (already passes `None`) or abort SKILL.md (already passes `--pr`).

### Task 3: Update documentation

**Files:**
- `docs/phases/phase-6-complete.md` line 94: Change `- Remote branch deleted` to `- Remote branch auto-deleted by GitHub after merge`
- `docs/skills/flow-abort.md` line 57: Update comparison table — Complete column from `Deleted (via cleanup)` to `Auto-deleted by GitHub`
- `skills/flow-complete/SKILL.md` line 545: Change `"branch cleanup"` to `"local branch cleanup"`
- `skills/flow-abort/SKILL.md` line 116: Remove "always" — `"The cleanup script deletes remote and local branches."`
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: Skip remote branch deletion in Complete phase — rely on GitHub auto-delete

## Problem

The Complete phase (Phase 6) runs `git push origin --delete <branch>` after merging the PR via `cleanup()` in `src/cleanup.rs:175-184`. GitHub already auto-deletes the head branch after a squash merge (when "Automatically delete head branches" is enabled — standard configuration). This makes the remote branch deletion redundant in the Complete path. Worse, when GitHub wins the race and deletes the branch first, cleanup reports a noisy `"failed: remote ref does not exist"` error that obscures the otherwise clean output.

The `cleanup()` function is shared between Complete and Abort. The Abort phase still needs remote branch deletion because the PR is closed (not merged), so GitHub does not auto-delete. The existing `pr_number` parameter already discriminates these paths: `None` for Complete (line 146 of `complete_finalize.rs`), `Some(n)` for Abort (via `--pr` flag from `flow-abort/SKILL.md:113`).

## Acceptance Criteria

- When `cleanup()` is called with `pr_number: None` (Complete path), remote branch deletion is skipped and the `remote_branch` step reports `"skipped"`
- When `cleanup()` is called with `pr_number: Some(n)` (Abort path), remote branch deletion is attempted as before
- Local branch deletion remains unconditional in both paths
- The `remote_branch` key is still present in the cleanup JSON output (as `"skipped"` in Complete, preserving key order)
- All existing tests pass after updates; new test covers the abort path
- Documentation accurately reflects that GitHub handles remote branch deletion after merge

## Implementation Plan

### Context

The user wants to stop redundantly deleting the remote branch during the Complete phase. GitHub handles this automatically after squash merge. The Abort phase must retain remote branch deletion since GitHub does not auto-delete on PR close.

### Exploration

The `cleanup()` function in `src/cleanup.rs:115` is the shared cleanup orchestrator for both Complete and Abort. It already uses `pr_number: Option<i64>` to discriminate the two paths — the `pr_close` step at lines 124-137 conditionally closes the PR only when `pr_number.is_some()`. The remote branch deletion at lines 175-184 is currently unconditional.

Callers:
- `src/complete_finalize.rs:146` passes `None` for `pr_number`
- `skills/flow-abort/SKILL.md:113` passes `--pr <n>` (maps to `Some(n)`)

Tests:
- `test_cleanup_always_attempts_remote_branch` (line 582) — asserts `starts_with("failed:")`
- `test_cleanup_full_happy_path` (line 660) — asserts `starts_with("failed:")`
- `test_step_key_order_matches_python` (line 748) — asserts key order including `remote_branch`
- `test_step_key_order_with_pull` (line 778) — same

Documentation references:
- `docs/phases/phase-6-complete.md:94` — "Remote branch deleted"
- `docs/skills/flow-abort.md:57` — comparison table showing both phases delete remote branch
- `skills/flow-complete/SKILL.md:545` — "branch cleanup"
- `skills/flow-abort/SKILL.md:116` — "The cleanup script always deletes remote and local branches"

### Risks

- **Repos without "Automatically delete head branches"**: Remote branch lingers after merge. Acceptable — the setting is standard practice. Manual cleanup available via `git fetch --prune`.
- **Abort without --pr**: When abort omits `--pr` (unknown PR number), `pr_number` is `None` and remote deletion will now be skipped. This is a rare path (abort SKILL.md only omits `--pr` when the state file is missing AND the PR number can't be determined). Acceptable trade-off vs. adding a new flag.

### Approach

Use the existing `pr_number` discriminator. When `pr_number.is_some()` (Abort), attempt remote branch deletion as before. When `pr_number.is_none()` (Complete), skip and report `"skipped"`. This mirrors the `pr_close` pattern already established at lines 124-137. No new flags, no signature changes, no caller changes.

### Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Update tests for new behavior | test | — |
| 2. Conditional remote branch deletion | implement | 1 |
| 3. Update documentation | docs | 2 |

### Tasks

#### Task 1: Update tests for new Complete-path behavior and add abort-path test

**Files:** `src/cleanup.rs`

- Rename `test_cleanup_always_attempts_remote_branch` (line 582) to `test_cleanup_skips_remote_branch_on_complete`. Change assertion from `starts_with("failed:")` to `== "skipped"`.
- Update `test_cleanup_full_happy_path` (line 660): change `starts_with("failed:")` to `== "skipped"`.
- Add `test_abort_attempts_remote_branch_deletion`: call `cleanup(..., Some(999), false)`, assert `steps["remote_branch"].starts_with("failed:")` (no remote in test repo, but proves attempt was made).
- Key order tests (`test_step_key_order_matches_python`, `test_step_key_order_with_pull`) need no changes — `remote_branch` key is still emitted.

**TDD:** Tests should fail before Task 2 (the production code still unconditionally attempts deletion, so the "skipped" assertions fail). After Task 2, all pass.

#### Task 2: Conditional remote branch deletion in cleanup()

**Files:** `src/cleanup.rs` (lines 175-184)

Wrap the `git push origin --delete` block in `if pr_number.is_some()`. In the `else` branch, insert `"remote_branch" => "skipped"`. Add a comment: `// Delete remote branch (abort only — GitHub auto-deletes after merge)`.

No changes to `src/complete_finalize.rs` (already passes `None`) or abort SKILL.md (already passes `--pr`).

#### Task 3: Update documentation

**Files:**
- `docs/phases/phase-6-complete.md` line 94: Change `- Remote branch deleted` to `- Remote branch auto-deleted by GitHub after merge`
- `docs/skills/flow-abort.md` line 57: Update comparison table — Complete column from `Deleted (via cleanup)` to `Auto-deleted by GitHub`
- `skills/flow-complete/SKILL.md` line 545: Change `"branch cleanup"` to `"local branch cleanup"`
- `skills/flow-abort/SKILL.md` line 116: Remove "always" — `"The cleanup script deletes remote and local branches."`

## Files to Investigate

- `src/cleanup.rs` — the `cleanup()` function (line 115), remote branch deletion block (lines 175-184), tests (lines 582-806)
- `src/complete_finalize.rs` — calls `cleanup::cleanup()` with `None` at line 146
- `skills/flow-abort/SKILL.md` — calls `bin/flow cleanup` with `--pr` at line 113
- `skills/flow-complete/SKILL.md` — references "branch cleanup" at line 545
- `docs/phases/phase-6-complete.md` — "Remote branch deleted" at line 94
- `docs/skills/flow-abort.md` — comparison table at line 57, abort steps at lines 35-36

## Out of Scope

- Changing the Abort phase behavior — abort still needs remote branch deletion
- Adding new CLI flags to `cleanup` — the existing `pr_number` discriminator is sufficient
- Changing local branch deletion behavior — local cleanup stays unconditional
- The `flow-reset` skill — it has its own independent branch deletion logic

## Context

GitHub's "Automatically delete head branches" setting is standard practice. Relying on it simplifies Complete phase cleanup, eliminates a race condition that produces noisy error output, and removes one network call from the critical path. The `pr_close` step in cleanup already uses the identical `pr_number.is_some()` pattern (lines 124-137), establishing the convention.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | <1m |
| Code | 13m |
| Code Review | 12m |
| Learn | 2m |
| Complete | 2m |
| **Total** | **31m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/skip-remote-branch-deletion-in.json</summary>

```json
{
  "schema_version": 1,
  "branch": "skip-remote-branch-deletion-in",
  "repo": "benkruger/flow",
  "pr_number": 988,
  "pr_url": "https://github.com/benkruger/flow/pull/988",
  "started_at": "2026-04-10T09:44:55-07:00",
  "current_phase": "flow-complete",
  "framework": "rust",
  "files": {
    "plan": ".flow-states/skip-remote-branch-deletion-in-plan.md",
    "dag": ".flow-states/skip-remote-branch-deletion-in-dag.md",
    "log": ".flow-states/skip-remote-branch-deletion-in.log",
    "state": ".flow-states/skip-remote-branch-deletion-in.json"
  },
  "session_tty": "/dev/ttys006",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #987",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T09:44:55-07:00",
      "completed_at": "2026-04-10T09:45:27-07:00",
      "session_started_at": null,
      "cumulative_seconds": 32,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-10T09:45:38-07:00",
      "completed_at": "2026-04-10T09:45:40-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-10T09:46:37-07:00",
      "completed_at": "2026-04-10T10:00:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 823,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-10T10:00:33-07:00",
      "completed_at": "2026-04-10T10:12:36-07:00",
      "session_started_at": null,
      "cumulative_seconds": 723,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-10T10:12:52-07:00",
      "completed_at": "2026-04-10T10:15:39-07:00",
      "session_started_at": null,
      "cumulative_seconds": 167,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-10T10:16:06-07:00",
      "completed_at": "2026-04-10T10:18:53-07:00",
      "session_started_at": null,
      "cumulative_seconds": 167,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T09:45:38-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-10T09:46:37-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-10T10:00:33-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-10T10:12:52-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-10T10:16:06-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 3,
  "code_task_name": "Update documentation",
  "code_task": 3,
  "diff_stats": {
    "files_changed": 5,
    "insertions": 33,
    "deletions": 17,
    "captured_at": "2026-04-10T10:00:20-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/skip-remote-branch-deletion-in.log</summary>

```text
2026-04-10T09:44:55-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T09:44:55-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T09:44:55-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T09:44:55-07:00 [Phase 1] create .flow-states/skip-remote-branch-deletion-in.json (exit 0)
2026-04-10T09:44:55-07:00 [Phase 1] freeze .flow-states/skip-remote-branch-deletion-in-phases.json (exit 0)
2026-04-10T09:44:55-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T09:44:57-07:00 [Phase 1] start-init — label-issues (labeled: [987], failed: [])
2026-04-10T09:45:03-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T09:45:03-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T09:45:04-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T09:45:12-07:00 [Phase 1] start-workspace — worktree .worktrees/skip-remote-branch-deletion-in (ok)
2026-04-10T09:45:16-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T09:45:16-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T09:45:16-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T09:45:27-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T09:45:27-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T09:45:39-07:00 [Phase 2] plan-extract — gate check passed (exit 0)
2026-04-10T09:45:39-07:00 [Phase 2] plan-extract — issue #987 fetched, decomposed label detected (exit 0)
2026-04-10T09:45:39-07:00 [Phase 2] plan-extract — DAG file written: .flow-states/skip-remote-branch-deletion-in-dag.md (exit 0)
2026-04-10T09:45:39-07:00 [Phase 2] plan-extract — plan extracted, 3 tasks, written: .flow-states/skip-remote-branch-deletion-in-plan.md (exit 0)
2026-04-10T09:45:40-07:00 [Phase 2] plan-extract — PR body rendered (exit 0)
2026-04-10T09:45:40-07:00 [Phase 2] plan-extract — phase complete (<1m) (exit 0)
2026-04-10T09:46:37-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-10T10:00:20-07:00 [Phase] phase-finalize --phase flow-code ("ok")
2026-04-10T10:00:33-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-10T10:12:36-07:00 [Phase] phase-finalize --phase flow-code-review ("ok")
2026-04-10T10:12:52-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-10T10:15:39-07:00 [Phase] phase-finalize --phase flow-learn ("ok")
```

</details>