### PR TITLE
Plan Phase Should Detect Pre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 # Python / test artifacts
 __pycache__/
 tests/test_adversarial_*.py
+tests/adversarial_*.rs
 .venv
 .venv/
 .pytest_cache/

--- a/docs/phases/phase-2-plan.md
+++ b/docs/phases/phase-2-plan.md
@@ -33,11 +33,13 @@ skipped.
    (nodes, dependencies, topological ordering)
 3. The DAG output is stored to `.flow-states/<branch>-dag.md`
 4. Claude explores the codebase to validate the DAG against reality
-5. Claude verifies script behavior assertions from issue bodies by
+5. For pre-produced DAGs, Claude verifies that files referenced in the
+   DAG still match the DAG's assumptions at their current worktree state
+6. Claude verifies script behavior assertions from issue bodies by
    reading the relevant source code
-6. Claude writes the plan file with a Dependency Graph section and
+7. Claude writes the plan file with a Dependency Graph section and
    ordered tasks derived from the DAG
-7. The plan file path is stored in the state file and the phase completes
+8. The plan file path is stored in the state file and the phase completes
 
 DAG decomposition is configurable via `skills.flow-plan.dag` in
 `.flow.json` — set to `"never"` to skip it.

--- a/docs/skills/flow-plan.md
+++ b/docs/skills/flow-plan.md
@@ -33,7 +33,9 @@ completes the entire phase in a single CLI call:
 3. Detects the "decomposed" label and `## Implementation Plan` section
 4. Writes the DAG file and extracts the plan with heading promotion
 5. Updates state, logs, renders the PR body, and completes the phase
-6. Returns the plan content to the skill for inline rendering
+6. Returns the plan content to the skill for inline rendering and
+   freshness verification (DAG assumptions are checked against the
+   current worktree state before the plan is accepted)
 
 ### Standard path (non-decomposed issues)
 
@@ -46,12 +48,14 @@ planning process:
    (configurable via `dag` mode — see below), then self-invokes with
    `--continue-step` to continue after the turn boundary
 3. Claude explores the codebase to validate the DAG against reality
-4. Claude verifies script behavior assertions from issue bodies by
+4. For pre-produced DAGs, Claude verifies that files referenced in the
+   DAG still match the DAG's assumptions at their current worktree state
+5. Claude verifies script behavior assertions from issue bodies by
    reading the relevant source code
-5. Claude validates that file targets are inside the repo working tree
-6. Claude writes the plan file with a Dependency Graph and ordered tasks
-7. Renders the full plan content inline in the conversation for review
-8. Stores the plan file path in state and transitions to Code
+6. Claude validates that file targets are inside the repo working tree
+7. Claude writes the plan file with a Dependency Graph and ordered tasks
+8. Renders the full plan content inline in the conversation for review
+9. Stores the plan file path in state and transitions to Code
 
 ---
 

--- a/skills/flow-plan/SKILL.md
+++ b/skills/flow-plan/SKILL.md
@@ -271,8 +271,9 @@ in the content.
 - Light validation: use Glob and Read to verify that files referenced in
   the Tasks section exist. Note any missing files (they may need to be
   created by the implementation) but do not block or re-derive the plan.
-- Run Script Behavior Verification and Target Path Validation (below)
-  on the extracted plan content, then proceed to Step 4.
+- Run DAG Freshness Check, Script Behavior Verification, and Target
+  Path Validation (below) on the extracted plan content, then proceed
+  to Step 4.
 
 **If not found** — the issue is an older-format decomposed issue without
 a plan. Use the issue body content from the DAG file as a head start
@@ -290,14 +291,15 @@ Continue with the standard exploration and plan-writing flow below.
 
 ### DAG Freshness Check
 
-When the DAG comes from a pre-produced source — plan-extract wrote it
-from a pre-planned or pre-decomposed issue, or the Resume Check
-dispatched here from a dag_file resume — the analysis may be stale.
-Main can advance between DAG generation and Plan phase execution,
-changing files the DAG references.
+**When to run:** The DAG comes from a pre-produced source — plan-extract
+wrote it from a pre-planned or pre-decomposed issue, the "if found"
+extraction path above used a pre-existing Implementation Plan, or the
+Resume Check dispatched here from a dag_file resume. In all these cases,
+main may have advanced since the analysis was produced, changing files
+the DAG references.
 
-Skip this check when Step 2 decompose just ran in the current session
-(the DAG explored the worktree minutes ago and is fresh).
+**When to skip:** Step 2 decompose just ran in the current session. The
+DAG explored the worktree minutes ago and is fresh.
 
 For pre-produced DAGs, verify the DAG's assumptions against reality:
 

--- a/skills/flow-plan/SKILL.md
+++ b/skills/flow-plan/SKILL.md
@@ -117,9 +117,10 @@ complete. Render the plan and transition.
 
 Use the `plan_content` from the plan-extract response. Render it inline in
 your response — the complete Context, Exploration, Risks, Approach,
-Dependency Graph, and Tasks sections. Run Script Behavior Verification and
-Target Path Validation on the plan content (see Step 3 for definitions).
-Use Glob and Read to verify files referenced in the Tasks section exist.
+Dependency Graph, and Tasks sections. Run DAG Freshness Check, Script
+Behavior Verification, and Target Path Validation on the plan content
+(see Step 3 for definitions). Use Glob and Read to verify files
+referenced in the Tasks section exist.
 
 Then skip to "Done — Banner and transition", using `formatted_time` and
 `continue_action` from the plan-extract response.
@@ -286,6 +287,30 @@ for plan writing:
   re-evaluate the problem statement
 
 Continue with the standard exploration and plan-writing flow below.
+
+### DAG Freshness Check
+
+When the DAG comes from a pre-produced source — plan-extract wrote it
+from a pre-planned or pre-decomposed issue, or the Resume Check
+dispatched here from a dag_file resume — the analysis may be stale.
+Main can advance between DAG generation and Plan phase execution,
+changing files the DAG references.
+
+Skip this check when Step 2 decompose just ran in the current session
+(the DAG explored the worktree minutes ago and is fresh).
+
+For pre-produced DAGs, verify the DAG's assumptions against reality:
+
+- Read the DAG file and identify all file paths mentioned in backticks
+- For each referenced file, use the Read tool to read the current
+  version in the worktree
+- Compare the DAG's characterization of each file (language, structure,
+  content assumptions) against its current state
+- If any file contradicts the DAG's assumptions — rewritten in a
+  different language, deleted, or completely restructured — note the
+  discrepancy in the plan's Risks section and adjust plan tasks to
+  target the current implementation, not the DAG's stale description
+- If no discrepancies are found, proceed normally
 
 ### Script Behavior Verification
 

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2278,6 +2278,15 @@ fn plan_verifies_script_behavior_assertions() {
 }
 
 #[test]
+fn plan_has_dag_freshness_check() {
+    let c = common::read_skill("flow-plan");
+    assert!(
+        c.contains("DAG Freshness") || c.contains("dag freshness"),
+        "Plan must have DAG Freshness Check subsection"
+    );
+}
+
+#[test]
 fn prime_presets_include_dag_config() {
     let c = common::read_skill("flow-prime");
     let re = Regex::new(r"```json\n(\{[\s\S]*?\})\n```").unwrap();


### PR DESCRIPTION
## What

work on issue #869.

Closes #869

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/plan-phase-should-detect-pre-plan.md` |
| DAG | `.flow-states/plan-phase-should-detect-pre-dag.md` |
| Log | `.flow-states/plan-phase-should-detect-pre.log` |
| State | `.flow-states/plan-phase-should-detect-pre.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

Issue #869: The Plan phase has no mechanism to detect when a pre-produced DAG
(from a prior `/decompose:decompose` run or a pre-planned issue) is stale due
to main advancing between DAG generation and Plan phase execution.

The observable symptom (PR #868): a DAG assumed `hooks/session-start.sh` was a
Python heredoc, but by the time flow-plan ran, PR #853 had merged and the hook
was already a Rust shim. The plan caught this during manual exploration, but the
detection was accidental — not systematic.

## Exploration

**SKILL.md Step 3 structure** (lines 245–375): Four subsections — Pre-Planned
Issue Extraction, Script Behavior Verification, Target Path Validation, Standard
Exploration. The freshness check slots between Pre-Planned Issue Extraction and
Script Behavior Verification.

**Fast Path Done** (lines 113–125): Runs Script Behavior Verification and
Target Path Validation on extracted plans. Needs the same freshness check added
— extracted plans are equally susceptible to staleness.

**No DAG-creation timestamp exists.** The state file stores `files.dag` (path)
but no `dag_created_at`. `phases.flow-plan.started_at` is set by `phase_enter()`
before the DAG write, but for pre-planned issues plan-extract writes the DAG
file fresh even though the analysis may be days old. Setting a timestamp at
write time would NOT catch the actual staleness window.

**Issue's `lib/start-setup.py` reference is outdated** — Python-to-Rust migration
completed; the file does not exist.

**Contract test pattern:** `common::read_skill("flow-plan")` + `assert!(c.contains("keyword"))`.
Existing tests: `plan_validates_target_file_paths`, `plan_verifies_script_behavior_assertions`.

**No inline time computation allowed** — `phase_skills_no_inline_time_computation`
rejects `date -u`, `date +`, `datetime.now`, `time.time` patterns. Instructions
must avoid these.

## Risks

1. **DAG produced in the same session (Step 2 decompose) triggers false positives.**
   Mitigation: the instruction explicitly scopes the check to pre-produced DAGs only
   (plan-extract extracted path, older-format decomposed issues, dag_file resume) — not
   fresh Step 2 decompose output that just explored the worktree.

2. **Claude may miss subtle file changes when comparing prose descriptions.**
   Mitigation: the instruction tells Claude to read each file referenced in the DAG
   and compare. Dramatic changes (Python→Rust, file deleted, file completely rewritten)
   are easily caught. Subtle changes within the same implementation style are less likely
   to produce stale DAG assumptions.

3. **Contract test keyword must not overlap with existing test assertions.**
   Mitigation: using "DAG Freshness" as the keyword — no existing test or subsection
   uses this phrase.

## Approach

Pure skill instruction change — no new Rust code, no new state fields, no new
`bin/flow` subcommands. The check instructs Claude to read the files the DAG
references and compare their current worktree state against the DAG's assumptions.
This is simpler than the issue's proposed `git log --since` approach (which has a
fundamental timestamp gap for pre-planned issues) and catches all staleness
regardless of cause or timing.

Three insertion points:
1. **Step 3** — new "DAG Freshness Check" subsection after Pre-Planned Issue Extraction
2. **Fast Path Done** — add freshness check to the existing verification list
3. **Contract test** — assert the subsection exists

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add contract test for DAG freshness check | test | — |
| 2. Add DAG Freshness Check to SKILL.md Step 3 + Fast Path Done | implement | 1 |
| 3. Update docs/skills/flow-plan.md | docs | 2 |

## Tasks

### Task 1: Add contract test for DAG freshness check

Add `plan_has_dag_freshness_check` to `tests/skill_contracts.rs` near the
existing `plan_validates_target_file_paths` and
`plan_verifies_script_behavior_assertions` tests (around line 2278).

**Files to modify:** `tests/skill_contracts.rs`

**Test assertion:** `c.contains("DAG Freshness") || c.contains("dag freshness")`
with message "Plan must have DAG Freshness Check subsection".

**TDD note:** This test will fail initially (SKILL.md doesn't have the subsection
yet). Task 2 makes it pass.

### Task 2: Add DAG Freshness Check to SKILL.md Step 3 + Fast Path Done

**Files to modify:** `skills/flow-plan/SKILL.md`

**Step 3 change:** Add a new `### DAG Freshness Check` subsection between
Pre-Planned Issue Extraction (line 288) and Script Behavior Verification
(line 290). The subsection instructs Claude to:

- Only run the check when the DAG comes from a pre-produced source
  (plan-extract's extracted path, older-format pre-decomposed issue, or
  dag_file resume) — skip when Step 2 decompose just ran in the current session
- Read the DAG file and identify all file paths mentioned in backticks
- For each referenced file, read the current version in the worktree using
  the Read tool
- Compare the DAG's characterization of each file (language, structure,
  content assumptions) against its current state
- If any file contradicts the DAG's assumptions (e.g., rewritten in a
  different language, deleted, completely restructured), note the discrepancy
  in the plan's Risks section and adjust plan tasks to target the current
  implementation instead of the DAG's stale assumptions
- If no discrepancies are found, proceed normally

**Fast Path Done change:** Add "DAG Freshness Check" to the list of
verifications that run on extracted/resumed plans (line 120–122), alongside
Script Behavior Verification and Target Path Validation.

**TDD note:** Task 1's contract test passes after this change.

### Task 3: Update docs/skills/flow-plan.md

**Files to modify:** `docs/skills/flow-plan.md`

Add a mention of the DAG freshness check to the Standard Path description
(step 4 in the numbered list, after "Claude explores the codebase to validate
the DAG against reality"). Add a sentence like: "Claude verifies that files
referenced in pre-produced DAGs still match the DAG's assumptions at their
current worktree state."

Also add a brief mention in the Fast Path section noting that even extracted
plans are verified for freshness.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# DAG Analysis: Plan phase should detect pre-produced DAGs that are stale

<dag goal="Add stale-DAG detection to Plan phase Step 3" mode="full">
  <plan>
    <node id="1" name="Codebase Discovery" type="research" depends="[]" parallel_with="[]">
      <objective>Map the current flow-plan SKILL.md structure, plan-extract Rust source, and state file schema to understand where the check must be inserted and what data is available</objective>
    </node>
    <node id="2" name="DAG Timestamp Availability" type="research" depends="[1]" parallel_with="3">
      <objective>Determine how and where the DAG creation timestamp is recorded — state file fields, file mtime, git log, or embedded in the DAG file itself</objective>
    </node>
    <node id="3" name="File Reference Extraction" type="research" depends="[1]" parallel_with="2">
      <objective>Determine how to extract the list of files the DAG references — parsing the DAG markdown, state file metadata, or plan-extract output</objective>
    </node>
    <node id="4" name="Existing Staleness Patterns" type="research" depends="[1]" parallel_with="2,3">
      <objective>Check if FLOW already has any staleness detection patterns (version checks, hash comparisons, timestamp diffs) that can be reused or extended</objective>
    </node>
    <node id="5" name="Implementation Design" type="analysis" depends="[2,3,4]" parallel_with="[]">
      <objective>Design the stale-DAG check: where in Step 3 it fires, what command produces the staleness signal, how Claude is instructed to act on it</objective>
    </node>
    <node id="6" name="Synthesis" type="synthesis" depends="[5]" parallel_with="[]">
      <objective>Produce the final task breakdown with dependency graph, risks, and approach</objective>
    </node>
  </plan>
</dag>

## Node Executions

### NODE 1: Codebase Discovery
Quality: 9/10 — Comprehensive mapping

Key findings:
- Step 3 has four subsections: Pre-Planned Issue Extraction (lines 251-288), Script Behavior Verification (290-306), Target Path Validation (308-326), Standard Exploration (328-345)
- plan-extract returns three paths: "extracted" (full phase done), "resumed" (plan exists), "standard" (model-driven)
- State file has `files.dag` (path) but no dedicated DAG-creation timestamp
- `phases.flow-plan.started_at` is set by phase_enter() before DAG write, never updated on re-entry
- 8 existing Plan contract tests enforce structural properties

### NODE 2: DAG Timestamp Availability
Quality: 9/10 — Definitive answer

Key findings:
- No dedicated `dag_created_at` field exists anywhere in state or source
- `phases.flow-plan.started_at` is set once by phase_enter() BEFORE DAG write
- set-timestamp only generates timestamps when passed the magic value `NOW`
- For pre-planned issues, plan-extract writes the DAG file from the issue body — the file is fresh but the analysis is old
- Setting dag_created_at to "now" at write time would NOT catch staleness for pre-planned issues (the analysis was done days earlier)

### NODE 3: File Reference Extraction
Quality: 8/10 — Good analysis of extraction approaches

Key findings:
- DAG files are markdown with decompose XML output + node executions + synthesis
- File references are embedded in prose (backtick-enclosed paths), no structured list
- No existing Rust code extracts file paths from DAG content
- Current SKILL.md tells Claude to "validate that files the DAG references exist" (manual, unstructured)
- Hybrid Rust+skill approach possible but adds complexity

### NODE 4: Existing Staleness Patterns
Quality: 8/10 — Found reusable pattern

Key findings:
- tombstone_audit.rs has ISO 8601 string comparison for temporal staleness (directly reusable)
- prime_check.rs uses SHA-256 hash comparison (not temporal, not reusable)
- No `git log --since` usage exists anywhere in the codebase
- start_gate.rs uses boolean state flags, not timestamps

### NODE 5: Implementation Design
Quality: 9/10 — Clean design decision

Key findings:
- The git log approach has a fundamental gap: for pre-planned issues, the DAG analysis timestamp is unknowable without an API call to get issue creation date
- Simpler approach: instruct Claude to read DAG-referenced files and compare their current state against the DAG's assumptions
- This catches all staleness regardless of cause or timing
- No new Rust code needed — pure skill instruction change
- Fast Path Done section also needs the check (extracted plans are equally susceptible)

## Synthesis

Design Decision: Skill Instruction over Rust Subcommand

The issue proposes `git log --since=<dag-created-at>`, but investigation revealed that `dag-created-at` doesn't exist and can't be reliably derived — for pre-planned issues, plan-extract writes the DAG file fresh even though the analysis was done days earlier. Setting the timestamp to "now" misses the staleness window entirely.

The simpler, more robust approach: instruct Claude to read the files the DAG references and compare their current state against the DAG's assumptions. This catches all staleness regardless of when or how it occurred — main advances, direct edits, or branch rebases. No new Rust code, no new state fields, no timestamp gymnastics.

Scope: Three files to modify:
1. skills/flow-plan/SKILL.md — add "DAG Freshness Check" subsection
2. tests/skill_contracts.rs — add contract test
3. docs/skills/flow-plan.md — update Standard Path description

Task Breakdown:
| Task | Type | Depends On |
|------|------|------------|
| 1. Contract test for DAG freshness check | test | — |
| 2. Add DAG Freshness Check to SKILL.md Step 3 + Fast Path | implement | 1 |
| 3. Update docs/skills/flow-plan.md | docs | 2 |

Confidence: 90% | Nodes: 6 | Parallel branches: 3
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 1h 17m |
| Code | 12m |
| Code Review | 16m |
| Learn | 3m |
| Complete | 8m |
| **Total** | **1h 59m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/plan-phase-should-detect-pre.json</summary>

```json
{
  "schema_version": 1,
  "branch": "plan-phase-should-detect-pre",
  "repo": "benkruger/flow",
  "pr_number": 989,
  "pr_url": "https://github.com/benkruger/flow/pull/989",
  "started_at": "2026-04-10T09:54:08-07:00",
  "current_phase": "flow-complete",
  "framework": "rust",
  "files": {
    "plan": ".flow-states/plan-phase-should-detect-pre-plan.md",
    "dag": ".flow-states/plan-phase-should-detect-pre-dag.md",
    "log": ".flow-states/plan-phase-should-detect-pre.log",
    "state": ".flow-states/plan-phase-should-detect-pre.json"
  },
  "session_tty": "/dev/ttys007",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #869",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T09:54:08-07:00",
      "completed_at": "2026-04-10T09:54:49-07:00",
      "session_started_at": null,
      "cumulative_seconds": 41,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-10T09:54:59-07:00",
      "completed_at": "2026-04-10T11:12:32-07:00",
      "session_started_at": null,
      "cumulative_seconds": 4653,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-10T11:12:58-07:00",
      "completed_at": "2026-04-10T11:25:38-07:00",
      "session_started_at": null,
      "cumulative_seconds": 760,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-10T11:25:48-07:00",
      "completed_at": "2026-04-10T11:42:42-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1014,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-10T11:42:54-07:00",
      "completed_at": "2026-04-10T11:46:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 206,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-10T11:47:05-07:00",
      "completed_at": "2026-04-10T11:55:33-07:00",
      "session_started_at": null,
      "cumulative_seconds": 508,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T09:54:59-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-10T11:12:58-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-10T11:25:48-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-10T11:42:54-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-10T11:47:05-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 3,
  "code_task_name": "Add contract test for DAG freshness check",
  "code_task": 3,
  "diff_stats": {
    "files_changed": 3,
    "insertions": 47,
    "deletions": 9,
    "captured_at": "2026-04-10T11:25:38-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "freshness_retries": 1,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/plan-phase-should-detect-pre.log</summary>

```text
2026-04-10T09:54:07-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T09:54:07-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T09:54:08-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T09:54:08-07:00 [Phase 1] create .flow-states/plan-phase-should-detect-pre.json (exit 0)
2026-04-10T09:54:08-07:00 [Phase 1] freeze .flow-states/plan-phase-should-detect-pre-phases.json (exit 0)
2026-04-10T09:54:08-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T09:54:10-07:00 [Phase 1] start-init — label-issues (labeled: [869], failed: [])
2026-04-10T09:54:19-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T09:54:19-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T09:54:20-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T09:54:30-07:00 [Phase 1] start-workspace — worktree .worktrees/plan-phase-should-detect-pre (ok)
2026-04-10T09:54:35-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T09:54:35-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T09:54:35-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T09:54:49-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T09:54:49-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T11:12:58-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-10T11:25:38-07:00 [Phase] phase-finalize --phase flow-code ("ok")
2026-04-10T11:25:48-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-10T11:42:42-07:00 [Phase] phase-finalize --phase flow-code-review ("ok")
2026-04-10T11:42:54-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-10T11:46:20-07:00 [Phase] phase-finalize --phase flow-learn ("ok")
```

</details>