### PR TITLE
Code Phase Should Verify Plan

### DIFF
--- a/.claude/rules/skill-authoring.md
+++ b/.claude/rules/skill-authoring.md
@@ -399,3 +399,31 @@ task, verify whether existing tests at the entry-point level already
 cover the new delegation path. If yes, replace the migration task
 with a single verification task (run the existing tests and confirm
 they pass against the new implementation).
+
+## Cross-Framework Completeness
+
+When a skill instruction references framework-specific syntax (test
+function names, import statements, class definitions, build commands),
+enumerate patterns for all supported frameworks — not just the one
+the current task targets. FLOW supports Rails, Python, iOS, Go, and
+Rust. An instruction that shows examples for two frameworks silently
+breaks for the other three.
+
+How to apply: during the Code phase, when writing a skill instruction
+that includes framework-specific syntax examples, check the
+`frameworks/` directory for the full list of supported frameworks and
+add a pattern for each. If a framework's convention cannot be expressed
+concisely, note the framework name and link to its convention.
+
+## Purpose Preamble for Behavioral Sections
+
+Every new behavioral subsection in a SKILL.md (a subsection with
+decision logic, conditional branches, or tool invocations) must open
+with a 2-3 sentence preamble explaining why the step exists and what
+problem it solves. The preamble answers "Why does this step exist?"
+before the mechanics of "How does it work?"
+
+Without the preamble, a newcomer reading the skill sees the mechanics
+but cannot judge whether the step is still relevant after a refactor.
+The preamble makes the intent explicit so future sessions can evaluate
+whether the step still serves its purpose.

--- a/docs/phases/phase-3-code.md
+++ b/docs/phases/phase-3-code.md
@@ -26,8 +26,9 @@ For the current task:
 2. **TDD cycle** — write failing test, confirm it fails, write code, confirm it passes, refactor
 3. **Diff review** — show the changes, AskUserQuestion approval before `bin/flow ci`. After the first task, the user can opt into streamline mode which auto-proceeds through remaining tasks
 4. **`bin/flow ci`** — must be green, 100% coverage
-5. **`/flow-commit`** — commit this task
-6. **Self-invoke** for next task
+5. **Plan test verification** — confirm every test function the plan names for this task exists in the codebase
+6. **`/flow-commit`** — commit this task
+7. **Self-invoke** for next task
 
 ---
 

--- a/docs/skills/flow-code.md
+++ b/docs/skills/flow-code.md
@@ -30,8 +30,9 @@ For the current task:
 3. Write code → confirm test passes → refactor
 4. Show diff → AskUserQuestion review (streamline available after first task)
 5. `bin/flow ci` green (required)
-6. `/flow-commit` for this task
-7. Self-invoke for next task
+6. Plan test verification — confirm all plan-named test functions exist
+7. `/flow-commit` for this task
+8. Self-invoke for next task
 
 ---
 

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -19,7 +19,7 @@ These skills correspond directly to a workflow phase. Each one starts and ends w
 |-------|-------|-------------|
 | [`/flow-start`](flow-start.md) | 1 — Start | Create the worktree, upgrade dependencies, open the PR |
 | [`/flow-plan`](flow-plan.md) | 2 — Plan | Explore codebase, design approach, produce ordered tasks via plan mode |
-| [`/flow-code`](flow-code.md) | 3 — Code | TDD task by task, diff review, `bin/flow ci` gate before each commit |
+| [`/flow-code`](flow-code.md) | 3 — Code | TDD task by task, diff review, `bin/flow ci` gate, plan test verification before each commit |
 | [`/flow-code-review`](flow-code-review.md) | 4 — Code Review | Six tenants assessed by four agents (reviewer, pre-mortem, adversarial, documentation) — gather, launch, triage, fix |
 | [`/flow-learn`](flow-learn.md) | 5 — Learn | Extract learnings, update CLAUDE.md, note plugin gaps |
 | [`/flow-complete`](flow-complete.md) | 6 — Complete | Merge PR, remove worktree, delete state file — final phase |

--- a/skills/flow-code/SKILL.md
+++ b/skills/flow-code/SKILL.md
@@ -362,25 +362,34 @@ Do NOT commit and do NOT move to the next task until `bin/flow ci` is green.
 
 ### Plan Test Verification
 
+The plan decomposes work into specific test functions. This step verifies
+that every test the plan promised was actually written during the TDD
+cycle — CI proves tests pass, but cannot prove missing tests exist.
+
 After CI passes and before committing, verify that every test function
 the plan explicitly names for this task exists in the codebase.
 
 Re-read the current task's description from the plan file. Look for
-explicitly named test functions — identifiers prefixed with `test_`
-(e.g., `test_parser_handles_empty_input`, `test_login_timeout`). These
-appear as comma-separated lists, under headings like "Rust tests:" or
-"Tests:", or inline in the task description.
+explicitly named test functions. These appear as comma-separated lists,
+under headings like "Rust tests:" or "Tests:", or inline in the task
+description. Test naming conventions vary by framework:
+
+- **Rust** — `test_` prefix (e.g., `test_parser_handles_empty_input`)
+- **Python** — `test_` prefix (e.g., `test_login_timeout`)
+- **Go** — `Test` prefix with capital T (e.g., `TestParseConfig`)
+- **Swift/iOS** — `test` prefix in camelCase (e.g., `testLoginTimeout`)
+- **Rails/Ruby** — `test_` prefix for minitest; `it` or `describe` blocks for RSpec
 
 If the task description names specific test functions, use the Grep
-tool to verify each one exists as a function definition in the
-codebase. For Rust, search for `fn <test_name>`. For Python, search
-for `def <test_name>`.
+tool to verify each one exists as a function or method definition in
+the codebase. Match the framework convention: `fn <name>` for Rust,
+`def <name>` for Python/Ruby, `func <name>` for Go/Swift.
 
 - If all named tests are found → proceed to Commit
 - If the task does not name specific test functions → proceed to Commit
 - If any named test is missing → list the missing tests, write them,
-  re-run `bin/flow ci`, and only proceed to Commit once all named
-  tests exist and CI is green
+  re-run CI, and only proceed to Commit once all named tests exist
+  and CI is green
 
 ---
 

--- a/skills/flow-code/SKILL.md
+++ b/skills/flow-code/SKILL.md
@@ -200,6 +200,11 @@ combined diff.
 **Single CI gate.** Run `bin/flow ci` once for the entire group.
 If it fails, fix and retry following the standard CI failure process.
 
+**Plan Test Verification.** After CI passes, run the Plan Test
+Verification check (see the section below) for ALL tasks in the
+group — not just the last one. Verify that every test function
+named in any task's plan description exists in the codebase.
+
 **Single commit.** Use the standard Commit section flow: set the
 continuation context and `_continue_pending`, then invoke
 `/flow:flow-commit`. The commit message should reference the group:
@@ -352,6 +357,30 @@ ${CLAUDE_PLUGIN_ROOT}/bin/flow add-issue --label "Flaky Test" --title "<issue_ti
 <HARD-GATE>
 Do NOT commit and do NOT move to the next task until `bin/flow ci` is green.
 </HARD-GATE>
+
+---
+
+### Plan Test Verification
+
+After CI passes and before committing, verify that every test function
+the plan explicitly names for this task exists in the codebase.
+
+Re-read the current task's description from the plan file. Look for
+explicitly named test functions — identifiers prefixed with `test_`
+(e.g., `test_parser_handles_empty_input`, `test_login_timeout`). These
+appear as comma-separated lists, under headings like "Rust tests:" or
+"Tests:", or inline in the task description.
+
+If the task description names specific test functions, use the Grep
+tool to verify each one exists as a function definition in the
+codebase. For Rust, search for `fn <test_name>`. For Python, search
+for `def <test_name>`.
+
+- If all named tests are found → proceed to Commit
+- If the task does not name specific test functions → proceed to Commit
+- If any named test is missing → list the missing tests, write them,
+  re-run `bin/flow ci`, and only proceed to Commit once all named
+  tests exist and CI is green
 
 ---
 

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -1814,6 +1814,15 @@ fn code_skill_has_atomic_group_handling() {
     );
 }
 
+#[test]
+fn code_has_plan_test_verification() {
+    let c = common::read_skill("flow-code");
+    assert!(
+        c.contains("Plan Test Verification"),
+        "Code skill must have Plan Test Verification subsection"
+    );
+}
+
 // --- Learn phase ---
 
 #[test]


### PR DESCRIPTION
## What

work on issue #859.

Closes #859

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/code-phase-should-verify-plan-plan.md` |
| DAG | `.flow-states/code-phase-should-verify-plan-dag.md` |
| Log | `.flow-states/code-phase-should-verify-plan.log` |
| State | `.flow-states/code-phase-should-verify-plan.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

Issue #859: The Code phase has no mechanism to verify that plan-specified
test names exist in the committed code before marking a task complete. In
`commit=auto` mode, tasks ship with missing plan-required tests and CI
still passes — because tests that don't exist can't fail. The gap only
surfaces in Code Review when an agent notices the discrepancy.

## Exploration

**Code phase task loop** (`skills/flow-code/SKILL.md`): The execution
flow is Resume Check → Execute Next Task → Before Starting → Architecture
Check → TDD Cycle → Review → bin/flow ci Gate → Commit → Self-invoke.
The insertion point for verification is between the CI Gate (line 355,
closing `</HARD-GATE>`) and the Commit section (line 358, `### Commit`).

**Atomic task groups** (lines 154-212): Groups have a "Single CI gate"
paragraph followed by "Single commit." The verification instruction must
also appear between these two paragraphs (after line 201, before line 203).

**CI implementation** (`src/ci.rs`): CI runs format → lint → build → test
via framework tools. It does NOT verify specific test names — it only
runs the test suite and checks exit codes. Confirmation: the issue's
claim is correct.

**Issue stale reference**: `lib/ci.py` no longer exists (Python-to-Rust
migration complete). The Rust equivalent is `src/ci.rs`. This does not
affect the design — CI is not being modified.

**Plan format** (`skills/flow-plan/SKILL.md` lines 369-373): Tasks have
description, files, and TDD notes. Test names are embedded in prose —
there is no structured field. The issue explicitly says "out of scope:
changing the plan format."

**Existing contract tests** (`tests/skill_contracts.rs`): Eight existing
flow-code tests. Pattern: `common::read_skill("flow-code")` +
`assert!(c.contains("..."))`. No existing test covers verification.

**Doc files**: `docs/skills/flow-code.md` (lines 28-34 list the task
steps), `docs/phases/phase-3-code.md` (lines 25-30 list the task cycle),
`docs/skills/index.md` (line 22 describes flow-code).

## Risks

1. **Claude may not reliably extract test names from prose.** Mitigated
   by instructing Claude to look for `test_`-prefixed identifiers and
   comma-separated lists. The instruction should give concrete examples.

2. **False positive on partial matches.** Mitigated by requiring whole
   function name matching via Grep (anchored pattern like `fn test_foo`
   or `def test_foo`).

3. **Tasks with no named tests.** Many tasks have TDD notes that describe
   behavior without naming specific functions. The verification must be
   conditional — only block when the plan explicitly names test functions.

4. **Atomic group verification scope.** The instruction must verify all
   tasks in the group, not just the last one.

## Approach

Pure skill instruction change — no new Rust code, no new state fields.
Add a "Plan Test Verification" subsection to `skills/flow-code/SKILL.md`
between the CI Gate and Commit sections. The instruction tells Claude to
re-read the current task's plan description, identify any explicitly
named test functions, Grep for each in the codebase, and block the commit
if any are missing.

This is consistent with other skill verification patterns (DAG Freshness
Check in flow-plan) — Claude reads artifacts and uses tools, no
computation.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add contract test for plan test verification | test | — |
| 2. Add Plan Test Verification to SKILL.md + update docs | implement | 1 |

## Tasks

### Task 1: Add contract test for plan test verification

Add `code_has_plan_test_verification` to `tests/skill_contracts.rs` near
the existing flow-code tests (around line 1818).

**Files to modify:** `tests/skill_contracts.rs`

**Test assertion:** `c.contains("Plan Test Verification")` with message
"Code skill must have Plan Test Verification subsection".

**TDD note:** This test fails initially (SKILL.md doesn't have the
subsection yet). Task 2 makes it pass.

### Task 2: Add Plan Test Verification to SKILL.md and update docs

**Files to modify:**
- `skills/flow-code/SKILL.md` — add verification subsection
- `docs/skills/flow-code.md` — add verification step to task list
- `docs/phases/phase-3-code.md` — add verification to cycle description

**SKILL.md change:** Add a new `### Plan Test Verification` subsection
between the `bin/flow ci Gate` HARD-GATE closing tag (line 355) and the
`---` separator before `### Commit` (line 356). The subsection instructs
Claude to:

- Re-read the current task description from the plan file
- Identify any explicitly named test functions (look for `test_`-prefixed
  identifiers, comma-separated test name lists, and "Rust tests:" or
  "Tests:" headers)
- For each named test, use Grep to verify a function with that exact name
  exists in the codebase
- If all named tests are found, or if no specific test names were listed
  in the task, proceed to Commit
- If any named tests are missing, list them and do not proceed to Commit
  until they are written and CI passes again

**Atomic group addition:** Add a matching paragraph between "Single CI
gate" (line 201) and "Single commit" (line 203) that says to verify
plan-specified test names for ALL tasks in the group before the combined
commit.

**docs/skills/flow-code.md change:** Add step 5.5 (between CI gate and
commit) mentioning plan test verification. Update the numbered list at
lines 28-34.

**docs/phases/phase-3-code.md change:** Add verification mention to the
task cycle at lines 25-30.

**TDD note:** Task 1's contract test passes after this change.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Code phase should verify plan-specified test names

## DAG Plan

```xml
<dag goal="Design verification mechanism for plan-specified test names in Code phase" mode="full">
  <plan>
    <node id="1" name="Plan Format Analysis" type="research" depends="[]" parallel_with="2">
      <objective>Analyze how plan files specify test names — examine real plan files and the plan skill to determine extraction patterns</objective>
    </node>
    <node id="2" name="Code Phase Task Loop" type="research" depends="[]" parallel_with="1">
      <objective>Map the exact Code phase execution loop, identify the insertion point for verification, and understand commit gating</objective>
    </node>
    <node id="3" name="Skill vs Subcommand Decision" type="decision" depends="[1,2]">
      <objective>Decide whether verification should be a skill instruction (Claude reads plan + greps) or a bin/flow subcommand (Rust parses + verifies)</objective>
    </node>
    <node id="4" name="Contract Test Impact" type="analysis" depends="[2]" parallel_with="3">
      <objective>Identify which skill_contracts tests will be affected and what new tests are needed</objective>
    </node>
    <node id="5" name="Synthesis" type="synthesis" depends="[3,4]">
      <objective>Produce the final design: mechanism, insertion point, test plan, and risk assessment</objective>
    </node>
  </plan>
</dag>
```

## Node 1: Plan Format Analysis

Plans use `### Task N:` headings with prose descriptions. Test names appear in two locations:
- Task description text (e.g., "add tests: test_foo, test_bar, test_baz")
- TDD notes (e.g., "TDD notes: verify parser handles all token types")

The plan format (`skills/flow-plan/SKILL.md` lines 369-373) specifies each task has:
- Description of what to build
- Files to create or modify
- TDD notes (what the test should verify)

There is NO structured "test names" field — test names are embedded in prose. The plan format is not changing (per issue scope).

Real plan example (`.flow-states/plan-phase-should-detect-pre-plan.md`) shows tasks like:
```
### Task 1: Add contract test for DAG freshness check
Test assertion: `c.contains("DAG Freshness") || c.contains("dag freshness")`
```

Quality: 8/10 — confirmed test names are prose, not structured

## Node 2: Code Phase Task Loop

The `skills/flow-code/SKILL.md` execution flow:

1. **Resume Check** — reads plan file, determines next task
2. **Execute Next Task** (or Atomic Task Group)
3. **Before Starting a Task** — banner, persist task name
4. **Architecture Check** — framework conventions
5. **TDD Cycle** — Step A (failing test), Step B (implementation), Step C (refactor)
6. **Review** — show diff, ask for approval (or auto if commit=auto)
7. **bin/flow ci Gate** — must be green
8. **Commit** — record task, set continuation, invoke flow:flow-commit, self-invoke

The natural insertion point for test name verification is between steps 7 (CI Gate) and 8 (Commit). At this point all tests are written and passing.

For atomic task groups, the verification should run after the combined CI gate but before the single commit.

Quality: 9/10 — complete loop mapping with clear insertion point

## Node 3: Skill vs Subcommand Decision

**Decision: Skill instruction, not Rust subcommand.**

Rationale:
1. Test names are free-form prose — a Rust parser would be fragile
2. The verification is Grep tool use (reading + searching), not computation
3. FLOW's "skills say run this command" convention is about timestamps, counters, and arithmetic — not about tool use
4. Claude already reads the plan file at Resume Check and extracts task descriptions
5. Adding a Grep-based verification step is consistent with existing patterns like "DAG Freshness Check" in flow-plan

Quality: 9/10 — principled decision aligned with FLOW philosophy

## Node 4: Contract Test Impact

Existing flow-code contract tests in `tests/skill_contracts.rs`:
- `code_files_flaky_test_issues` — asserts flaky test issue filing
- `code_skill_sets_continue_pending_before_commit` — asserts continuation flags
- `code_has_resume_check` — asserts Resume Check section exists
- `code_has_self_invocation_check` — asserts self-invocation check
- `code_commit_self_invokes` — asserts self-invocation pattern
- `code_commit_records_task` — asserts task counter update
- `code_skill_uses_single_task_framing` — asserts single-task framing
- `code_skill_has_atomic_group_handling` — asserts atomic group support

New test needed:
- `code_has_plan_test_verification` — asserts the verification instruction exists (e.g., `c.contains("plan-specified test") || c.contains("plan test verification")`)

Quality: 8/10 — clear test addition with no conflicts

## Synthesis

### Design: Skill Instruction Change

Add a "Plan Test Verification" subsection to `skills/flow-code/SKILL.md` between the `bin/flow ci Gate` and `Commit` sections.

The instruction tells Claude to:
1. Re-read the current task description from the plan file
2. Identify explicitly named test functions (patterns like `test_foo`)
3. Grep for each named test in the codebase
4. Block commit if any are missing

### Files

1. `skills/flow-code/SKILL.md` — add verification subsection
2. `tests/skill_contracts.rs` — add contract test
3. `docs/skills/flow-code.md` — update description
4. `docs/phases/phase-3-code.md` — update phase description

### Risks

1. Claude may not reliably identify test names from prose — mitigated by explicit instruction to look for `test_` prefixed function names
2. False positives on partial name matches — mitigated by using exact function name grep
3. Atomic group path may miss the verification — mitigated by adding the instruction to both standard and atomic flows
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 5m |
| Plan | 6m |
| Code | 7m |
| Code Review | 11m |
| Learn | 8m |
| Complete | <1m |
| **Total** | **40m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/code-phase-should-verify-plan.json</summary>

```json
{
  "schema_version": 1,
  "branch": "code-phase-should-verify-plan",
  "repo": "benkruger/flow",
  "pr_number": 990,
  "pr_url": "https://github.com/benkruger/flow/pull/990",
  "started_at": "2026-04-10T11:06:16-07:00",
  "current_phase": "flow-complete",
  "framework": "rust",
  "files": {
    "plan": ".flow-states/code-phase-should-verify-plan-plan.md",
    "dag": ".flow-states/code-phase-should-verify-plan-dag.md",
    "log": ".flow-states/code-phase-should-verify-plan.log",
    "state": ".flow-states/code-phase-should-verify-plan.json"
  },
  "session_tty": "/dev/ttys006",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #859",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T11:06:16-07:00",
      "completed_at": "2026-04-10T11:11:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 304,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-10T11:11:29-07:00",
      "completed_at": "2026-04-10T11:18:23-07:00",
      "session_started_at": null,
      "cumulative_seconds": 414,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-10T11:18:51-07:00",
      "completed_at": "2026-04-10T11:26:39-07:00",
      "session_started_at": null,
      "cumulative_seconds": 468,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-10T11:26:50-07:00",
      "completed_at": "2026-04-10T11:38:23-07:00",
      "session_started_at": null,
      "cumulative_seconds": 693,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-10T11:38:36-07:00",
      "completed_at": "2026-04-10T11:47:01-07:00",
      "session_started_at": null,
      "cumulative_seconds": 505,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-10T11:47:24-07:00",
      "completed_at": "2026-04-10T11:47:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 19,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T11:11:29-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-10T11:18:51-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-10T11:26:50-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-10T11:38:36-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-10T11:47:24-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 2,
  "code_task_name": "Add Plan Test Verification to SKILL.md and update docs",
  "code_task": 2,
  "diff_stats": {
    "files_changed": 4,
    "insertions": 44,
    "deletions": 4,
    "captured_at": "2026-04-10T11:26:39-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/code-phase-should-verify-plan.log</summary>

```text
2026-04-10T11:06:16-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T11:06:16-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T11:06:16-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T11:06:16-07:00 [Phase 1] create .flow-states/code-phase-should-verify-plan.json (exit 0)
2026-04-10T11:06:16-07:00 [Phase 1] freeze .flow-states/code-phase-should-verify-plan-phases.json (exit 0)
2026-04-10T11:06:16-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T11:06:18-07:00 [Phase 1] start-init — label-issues (labeled: [859], failed: [])
2026-04-10T11:06:25-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T11:09:33-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T11:09:34-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T11:10:58-07:00 [Phase 1] start-gate — post-deps CI ("ok")
2026-04-10T11:11:00-07:00 [Phase 1] start-gate — commit deps (ok)
2026-04-10T11:11:08-07:00 [Phase 1] start-workspace — worktree .worktrees/code-phase-should-verify-plan (ok)
2026-04-10T11:11:12-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T11:11:12-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T11:11:12-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T11:11:20-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T11:11:20-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T11:18:51-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-10T11:26:39-07:00 [Phase] phase-finalize --phase flow-code ("ok")
2026-04-10T11:26:50-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-10T11:38:23-07:00 [Phase] phase-finalize --phase flow-code-review ("ok")
2026-04-10T11:38:36-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-10T11:47:01-07:00 [Phase] phase-finalize --phase flow-learn ("ok")
```

</details>