### PR TITLE
Plan Phase Should Enforce

### DIFF
--- a/docs/phases/phase-2-plan.md
+++ b/docs/phases/phase-2-plan.md
@@ -23,7 +23,7 @@ single process call.
 the "decomposed" label and an `## Implementation Plan` section,
 `plan-extract` completes the entire phase in one call: extracts the
 plan, promotes headings, writes DAG and plan files, updates state,
-renders the PR body, and completes the phase. Steps 2–6 below are
+renders the PR body, and completes the phase. Steps 2–7 below are
 skipped.
 
 **Standard path** — when the fast path does not apply:

--- a/docs/phases/phase-2-plan.md
+++ b/docs/phases/phase-2-plan.md
@@ -35,9 +35,11 @@ skipped.
 4. Claude explores the codebase to validate the DAG against reality
 5. Claude verifies script behavior assertions from issue bodies by
    reading the relevant source code
-6. Claude writes the plan file with a Dependency Graph section and
+6. Claude enforces that risks marked "Must verify" or "Must confirm"
+   have corresponding verification tasks in the plan
+7. Claude writes the plan file with a Dependency Graph section and
    ordered tasks derived from the DAG
-7. The plan file path is stored in the state file and the phase completes
+8. The plan file path is stored in the state file and the phase completes
 
 DAG decomposition is configurable via `skills.flow-plan.dag` in
 `.flow.json` — set to `"never"` to skip it.

--- a/docs/skills/flow-plan.md
+++ b/docs/skills/flow-plan.md
@@ -49,9 +49,11 @@ planning process:
 4. Claude verifies script behavior assertions from issue bodies by
    reading the relevant source code
 5. Claude validates that file targets are inside the repo working tree
-6. Claude writes the plan file with a Dependency Graph and ordered tasks
-7. Renders the full plan content inline in the conversation for review
-8. Stores the plan file path in state and transitions to Code
+6. Claude enforces that risks marked "Must verify" or "Must confirm"
+   have corresponding verification tasks in the plan
+7. Claude writes the plan file with a Dependency Graph and ordered tasks
+8. Renders the full plan content inline in the conversation for review
+9. Stores the plan file path in state and transitions to Code
 
 ---
 

--- a/skills/flow-plan/SKILL.md
+++ b/skills/flow-plan/SKILL.md
@@ -117,9 +117,10 @@ complete. Render the plan and transition.
 
 Use the `plan_content` from the plan-extract response. Render it inline in
 your response — the complete Context, Exploration, Risks, Approach,
-Dependency Graph, and Tasks sections. Run Script Behavior Verification and
-Target Path Validation on the plan content (see Step 3 for definitions).
-Use Glob and Read to verify files referenced in the Tasks section exist.
+Dependency Graph, and Tasks sections. Run Script Behavior Verification,
+Target Path Validation, and Risk Verification Enforcement on the plan
+content (see Step 3 for definitions). Use Glob and Read to verify files
+referenced in the Tasks section exist.
 
 Then skip to "Done — Banner and transition", using `formatted_time` and
 `continue_action` from the plan-extract response.
@@ -270,8 +271,9 @@ in the content.
 - Light validation: use Glob and Read to verify that files referenced in
   the Tasks section exist. Note any missing files (they may need to be
   created by the implementation) but do not block or re-derive the plan.
-- Run Script Behavior Verification and Target Path Validation (below)
-  on the extracted plan content, then proceed to Step 4.
+- Run Script Behavior Verification, Target Path Validation, and Risk
+  Verification Enforcement (below) on the extracted plan content, then
+  proceed to Step 4.
 
 **If not found** — the issue is an older-format decomposed issue without
 a plan. Use the issue body content from the DAG file as a head start
@@ -324,6 +326,29 @@ For other out-of-repo paths: if the prompt or issue body contains
 keywords like "repo", "version-controlled", "shared", "committed", or
 "tracked", default to the repo-local equivalent. Otherwise, note the
 out-of-repo path in the plan's Risks section so the user is aware.
+
+### Risk Verification Enforcement
+
+After writing the plan (or extracting a pre-planned plan), scan the
+Risks section for any risk containing "Must verify" or "Must confirm"
+language. For each such risk:
+
+**Identify.** Extract the specific claim or behavior that must be
+verified.
+
+**Search.** Check the Tasks section for a task that addresses this
+verification — either directly (a dedicated verification task) or
+indirectly (a test task whose TDD notes cover the claim).
+
+**Add if missing.** If no corresponding task exists, add a
+verification task to the Tasks section and update the Dependency
+Graph. The verification task should produce evidence that the risk
+has been checked — a test, a manual check, or a targeted
+exploration.
+
+A plan with unaddressed verification risks is incomplete. Every risk
+that says something must be verified needs at least one task that
+produces evidence the verification happened.
 
 ### Standard Exploration
 

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2278,6 +2278,15 @@ fn plan_verifies_script_behavior_assertions() {
 }
 
 #[test]
+fn plan_enforces_must_verify_risk_tasks() {
+    let c = common::read_skill("flow-plan");
+    assert!(
+        c.contains("Risk Verification Enforcement"),
+        "Plan must have Risk Verification Enforcement subsection"
+    );
+}
+
+#[test]
 fn prime_presets_include_dag_config() {
     let c = common::read_skill("flow-prime");
     let re = Regex::new(r"```json\n(\{[\s\S]*?\})\n```").unwrap();

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2281,7 +2281,7 @@ fn plan_verifies_script_behavior_assertions() {
 fn plan_enforces_must_verify_risk_tasks() {
     let c = common::read_skill("flow-plan");
     assert!(
-        c.contains("Risk Verification Enforcement"),
+        c.contains("Risk Verification Enforcement") || c.contains("risk verification enforcement"),
         "Plan must have Risk Verification Enforcement subsection"
     );
 }


### PR DESCRIPTION
## What

work on issue #798.

Closes #798

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/plan-phase-should-enforce-plan.md` |
| DAG | `.flow-states/plan-phase-should-enforce-dag.md` |
| Log | `.flow-states/plan-phase-should-enforce.log` |
| State | `.flow-states/plan-phase-should-enforce.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/ae5beeaf-4a01-4afb-9751-cb63b6ce140c.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

When a plan risk says "Must verify X" or "Must confirm X", no mechanism ensures a corresponding verification task exists in the plan. Risks acknowledged without verification tasks create false confidence — the risk is documented but not mitigated. The Plan phase should enforce that every such risk has at least one task in the dependency graph that addresses the verification.

Issue: benkruger/flow#798

## Exploration

**Current validation sub-sections in `skills/flow-plan/SKILL.md` Step 3:**
- Script Behavior Verification (line 290): instructs Claude to verify issue assertions against actual code
- Target Path Validation (line 308): instructs Claude to verify file paths are inside the repo

**Fast Path Done section (line 120-121):** References both validation sub-sections for extracted/resumed plans: "Run Script Behavior Verification and Target Path Validation on the plan content"

**Contract tests in `tests/skill_contracts.rs`:**
- `plan_validates_target_file_paths` (line 2263): asserts SKILL.md contains "Target Path"
- `plan_verifies_script_behavior_assertions` (line 2272): asserts SKILL.md contains "Script Behavior"

**Documentation files:**
- `docs/skills/flow-plan.md` (line 49-51): lists validation steps in the standard path
- `docs/phases/phase-2-plan.md` (line 36-37): mentions script behavior verification in standard path
- `docs/skills/index.md` (line 21): one-line description — no validation detail, no change needed

**Design decision:** Pure instructional enforcement in SKILL.md (not Rust). Plan content is free-form markdown written by the model. All existing plan validations follow the instructional pattern. The model writes the plan, so the model validates the plan.

## Risks

- **Risk 1:** The enforcement is advisory (instructional), not mechanical — Claude could skip it under token pressure. Acceptable because all other plan validations follow the same pattern and work reliably in practice.
- **Risk 2:** "Must verify" pattern matching is semantic, not syntactic. Claude interprets intent, which is more flexible than regex but less deterministic. This is the correct trade-off for natural language plan prose.

## Approach

Add a "Risk Verification Enforcement" sub-section to Step 3 of `skills/flow-plan/SKILL.md`, after Target Path Validation. This instructs Claude to scan the Risks section for "Must verify" / "Must confirm" language and ensure each has a corresponding task. Update the Fast Path Done section to also reference the new validation. Add a contract test and update docs.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write contract test | test | — |
| 2. Add SKILL.md sub-section and update Fast Path Done, update docs | implement | 1 |

## Tasks

### Task 1: Write contract test

Add `plan_enforces_must_verify_risk_tasks` to `tests/skill_contracts.rs`, following the pattern of `plan_validates_target_file_paths` and `plan_verifies_script_behavior_assertions`.

**Files:** `tests/skill_contracts.rs`
**TDD:** Test asserts SKILL.md contains "Risk Verification Enforcement". Will fail until Task 2 adds the sub-section.

### Task 2: Add Risk Verification Enforcement sub-section, update Fast Path Done, update docs

Add the "Risk Verification Enforcement" sub-section to `skills/flow-plan/SKILL.md` Step 3, after Target Path Validation (after line 326). Update the Fast Path Done section (line 120-121) to reference the new validation alongside the existing two. Update `docs/skills/flow-plan.md` and `docs/phases/phase-2-plan.md` to mention risk verification enforcement.

**Files:** `skills/flow-plan/SKILL.md` (2 locations), `docs/skills/flow-plan.md`, `docs/phases/phase-2-plan.md`
**TDD:** Task 1's contract test passes. Existing contract tests remain green.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Plan phase should enforce verification tasks for Must verify risks

```xml
<dag goal="Add Must-verify risk enforcement to FLOW Plan phase" mode="full">
  <plan>
    <node id="1" name="Understand current plan validation" type="research"
          depends="[]" parallel_with="[]">
      <objective>Map all existing validation steps in flow-plan SKILL.md and plan_extract.rs to understand where Must-verify enforcement fits</objective>
    </node>
    <node id="2" name="Analyze enforcement mechanism options" type="analysis"
          depends="[1]" parallel_with="[]">
      <objective>Determine whether enforcement should be instructional (SKILL.md), programmatic (Rust), or hybrid — considering FLOW's design philosophy that skills are Markdown, not code</objective>
    </node>
    <node id="3" name="Identify contract test requirements" type="research"
          depends="[1]" parallel_with="2">
      <objective>Review existing skill_contracts.rs patterns for plan validation tests to determine what new contract tests are needed</objective>
    </node>
    <node id="4" name="Design the enforcement mechanism" type="decision"
          depends="[2,3]" parallel_with="[]">
      <objective>Produce the specific SKILL.md changes, test assertions, and any Rust changes needed, with exact insertion points</objective>
    </node>
    <node id="5" name="Synthesis" type="synthesis"
          depends="[4]" parallel_with="[]">
      <objective>Merge all findings into a complete implementation specification with risks, file targets, and task ordering</objective>
    </node>
  </plan>
</dag>
```

---

▶ NODE 1: Understand current plan validation (depends on: none)

The exploration agent has already mapped the architecture thoroughly. Key findings:

**Current validation in flow-plan SKILL.md (Step 3):**
- **Script Behavior Verification** (lines 290–306): Instructional — tells Claude to verify issue assertions against actual code. Discrepancies go into the Risks section.
- **Target Path Validation** (lines 308–326): Instructional — tells Claude to verify file paths are inside the repo. Out-of-repo paths noted in Risks section.
- **File Existence Verification** (lines 271–272): Instructional — tells Claude to Glob/Read files referenced in Tasks.

**Current validation in plan_extract.rs (extracted path):**
- `extract_implementation_plan()` (lines 222–239): Extracts the plan section from decomposed issues.
- `count_tasks()` (lines 291–306): Counts `#### Task N:` headings for TUI display.
- No content validation on the extracted plan — it's trusted as pre-validated.

**Fast Path Done section** (SKILL.md): For extracted/resumed plans, the skill says to "Run Script Behavior Verification and Target Path Validation on the plan content." So all validation sub-sections in Step 3 also apply to the fast path.

**Critical gap:** The Risks section is defined as a required plan section, but there is zero enforcement that risks marked "Must verify" or "Must confirm" have corresponding verification tasks. No existing validation — instructional or programmatic — addresses this.

Quality: 9/10 — Complete mapping of all validation touch points with line numbers.
Key finding: All current plan validation is instructional (SKILL.md), not programmatic, and none addresses risk-task linkage.

---

▶ PARALLEL BRANCH A — NODE 2: Analyze enforcement mechanism options (depends on: 1)

FLOW's design philosophy is clear: **"Skills are Markdown instructions, not executable code."** The only executable code is `bin/flow` and `src/*.rs`. Plan content validation falls squarely in the instructional domain because:

1. The model writes the plan — so the model validates the plan. This is self-consistency checking, not external enforcement.
2. "Must verify" is a semantic pattern in natural language prose — regex matching would be brittle and over/under-match.
3. The existing validation patterns (Script Behavior Verification, Target Path Validation) are all instructional sub-sections in Step 3.

**Decision: Pure instructional enforcement in SKILL.md.**

Why not Rust:
- Plan files are free-form markdown written by the model — parsing them for semantic risk-task linkage requires NLP, not regex
- `plan_extract.rs` handles the extracted fast-path, but even there, the SKILL.md already says to run validations on extracted plans
- Adding Rust validation would require defining a rigid risk format, which constrains plan expressiveness

**Mechanism design:**
- Add a "Risk Verification Enforcement" sub-section to Step 3, after Target Path Validation
- The instruction tells Claude to scan the Risks section for "Must verify" / "Must confirm" patterns
- For each match, verify a corresponding task exists in the Tasks section that addresses the verification
- If any "Must verify" risk lacks a corresponding task, add the task before proceeding
- This also applies to the Fast Path Done section (extracted plans)

Quality: 8/10 — Clear rationale aligned with FLOW's design philosophy.
Key finding: Instructional enforcement is the correct mechanism — Rust validation would fight the architecture.

---

▶ PARALLEL BRANCH B — NODE 3: Identify contract test requirements (depends on: 1)

Existing contract test patterns for plan validation sub-sections:

```
plan_validates_target_file_paths (line 2263): asserts SKILL.md contains "Target Path Validation"
plan_verifies_script_behavior_assertions (line 2272): asserts SKILL.md contains "Script Behavior Verification"
```

These are simple content-presence assertions — they verify the SKILL.md contains the subsection heading, confirming the instruction exists.

**New contract tests needed:**

1. **`plan_enforces_must_verify_risk_tasks`** — Assert the SKILL.md contains the "Risk Verification Enforcement" subsection (or equivalent heading). This follows the exact pattern of the two existing tests.

2. **Negative-assertion compatibility:** Per `.claude/rules/skill-authoring.md` "Negative-Assertion Test Compatibility" — the SKILL.md instruction must not contain literal prohibited strings that would trip existing contract tests. The new sub-section uses positive language ("ensure each Must verify risk has a corresponding task") so this is not a concern.

3. **Fast path coverage:** The Fast Path Done section already says "Run Script Behavior Verification and Target Path Validation on the plan content." Adding Risk Verification Enforcement to that list should be verified by a test or by inclusion in the existing assertion.

Quality: 8/10 — Clear test requirements following established patterns.
Key finding: One new contract test following the existing `plan_validates_*` pattern, plus updating the Fast Path Done reference.

---

▶ MERGE: Nodes 2 + 3

Both branches converge: the enforcement is instructional (SKILL.md sub-section in Step 3), verified by a contract test in `tests/skill_contracts.rs`. The fast path must also reference the new validation. No Rust changes needed.

---

▶ NODE 4: Design the enforcement mechanism (depends on: 2, 3)

**Exact changes needed:**

### 1. `skills/flow-plan/SKILL.md` — Step 3 sub-section (after Target Path Validation, ~line 326)

Add a new sub-section:

```markdown
### Risk Verification Enforcement

After writing the plan (or extracting a pre-planned plan), scan the
Risks section for any risk containing "Must verify" or "Must confirm"
language. For each such risk:

1. Identify what must be verified (the specific claim or behavior)
2. Search the Tasks section for a task that addresses this verification
3. If no corresponding task exists, add a verification task to the
   Tasks section and update the Dependency Graph

A plan with unaddressed "Must verify" risks is incomplete. Every
"Must verify" risk must have at least one task that produces evidence
the risk has been checked.
```

### 2. `skills/flow-plan/SKILL.md` — Fast Path Done section (~line 196)

The current text reads:
> "Run Script Behavior Verification and Target Path Validation on the plan content"

Update to:
> "Run Script Behavior Verification, Target Path Validation, and Risk Verification Enforcement on the plan content"

### 3. `tests/skill_contracts.rs` — New contract test

```rust
#[test]
fn plan_enforces_must_verify_risk_tasks() {
    let content = common::read_skill("flow-plan");
    assert!(
        content.contains("Risk Verification Enforcement"),
        "Plan skill must contain Risk Verification Enforcement subsection"
    );
}
```

### 4. Documentation — `docs/skills/flow-plan.md`

Update the description to mention risk verification enforcement as a plan validation step.

**Files to modify:**
- `skills/flow-plan/SKILL.md` (2 locations)
- `tests/skill_contracts.rs` (1 new test)
- `docs/skills/flow-plan.md` (description update)

Quality: 9/10 — Precise insertion points, follows all existing patterns.
Key finding: Three files, four changes, no Rust code changes needed.

---

▶ NODE 5: Synthesis (depends on: 4)

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

**Implementation specification for "Must verify" risk enforcement:**

**Mechanism:** Instructional enforcement via SKILL.md sub-section, consistent with FLOW's "skills are Markdown, not code" architecture. All existing plan validations (Script Behavior Verification, Target Path Validation) follow this pattern.

**Changes:**

1. **`skills/flow-plan/SKILL.md` — New sub-section in Step 3** (after Target Path Validation): "Risk Verification Enforcement" — instructs Claude to scan Risks for "Must verify" / "Must confirm" patterns and ensure each has a corresponding verification task in the Tasks section. Missing tasks must be added before proceeding.

2. **`skills/flow-plan/SKILL.md` — Fast Path Done update**: Add "Risk Verification Enforcement" to the list of validations run on extracted/resumed plans.

3. **`tests/skill_contracts.rs` — New contract test**: `plan_enforces_must_verify_risk_tasks` — asserts the SKILL.md contains the sub-section heading.

4. **`docs/skills/flow-plan.md` — Description update**: Mention risk verification enforcement.

**Risks:**
- The enforcement is advisory (instructional), not mechanical. Claude may skip it under token pressure. This is acceptable because all other plan validations follow the same pattern and work reliably.
- "Must verify" pattern matching is semantic, not syntactic. Claude interprets intent, which is more flexible than regex but less deterministic.

**Not in scope:**
- Rust-level plan validation (fights the architecture)
- New state file fields for risk tracking (unnecessary complexity)
- Changes to plan_extract.rs (the fast path delegates validation to the skill)

Confidence: 92% | Nodes: 5 | Parallel branches: 1

vs. Vanilla Claude (what linear reasoning would have missed):
- Would have jumped to Rust validation without analyzing FLOW's Markdown-first architecture
- Would have missed the Fast Path Done section that also needs updating
- Would have missed the negative-assertion test compatibility consideration from `.claude/rules/skill-authoring.md`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 2m |
| Plan | 21m |
| Code | 11m |
| Code Review | 14m |
| Learn | 3m |
| Complete | 5m |
| **Total** | **59m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/plan-phase-should-enforce.json</summary>

```json
{
  "schema_version": 1,
  "branch": "plan-phase-should-enforce",
  "repo": "benkruger/flow",
  "pr_number": 991,
  "pr_url": "https://github.com/benkruger/flow/pull/991",
  "started_at": "2026-04-10T11:17:56-07:00",
  "current_phase": "flow-complete",
  "framework": "rust",
  "files": {
    "plan": ".flow-states/plan-phase-should-enforce-plan.md",
    "dag": ".flow-states/plan-phase-should-enforce-dag.md",
    "log": ".flow-states/plan-phase-should-enforce.log",
    "state": ".flow-states/plan-phase-should-enforce.json"
  },
  "session_tty": "/dev/ttys004",
  "session_id": "ae5beeaf-4a01-4afb-9751-cb63b6ce140c",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/ae5beeaf-4a01-4afb-9751-cb63b6ce140c.jsonl",
  "notes": [],
  "prompt": "work on issue #798",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T11:17:56-07:00",
      "completed_at": "2026-04-10T11:20:29-07:00",
      "session_started_at": null,
      "cumulative_seconds": 153,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-10T11:20:42-07:00",
      "completed_at": "2026-04-10T11:42:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1283,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-10T11:42:52-07:00",
      "completed_at": "2026-04-10T11:54:33-07:00",
      "session_started_at": null,
      "cumulative_seconds": 701,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-10T11:54:47-07:00",
      "completed_at": "2026-04-10T12:09:17-07:00",
      "session_started_at": null,
      "cumulative_seconds": 870,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-10T12:09:30-07:00",
      "completed_at": "2026-04-10T12:13:02-07:00",
      "session_started_at": null,
      "cumulative_seconds": 212,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-10T12:13:32-07:00",
      "completed_at": "2026-04-10T12:19:11-07:00",
      "session_started_at": null,
      "cumulative_seconds": 339,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T11:20:42-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-10T11:42:52-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-10T11:54:47-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-10T12:09:30-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-10T12:13:32-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 2,
  "code_task_name": "Write contract test",
  "code_task": 2,
  "diff_stats": {
    "files_changed": 4,
    "insertions": 48,
    "deletions": 10,
    "captured_at": "2026-04-10T11:54:33-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "",
  "_continue_pending": "",
  "_stop_instructed": true,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/plan-phase-should-enforce.log</summary>

```text
2026-04-10T11:17:55-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T11:17:55-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T11:17:56-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T11:17:56-07:00 [Phase 1] create .flow-states/plan-phase-should-enforce.json (exit 0)
2026-04-10T11:17:56-07:00 [Phase 1] freeze .flow-states/plan-phase-should-enforce-phases.json (exit 0)
2026-04-10T11:17:56-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T11:17:57-07:00 [Phase 1] start-init — label-issues (labeled: [798], failed: [])
2026-04-10T11:18:04-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T11:20:08-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T11:20:08-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T11:20:17-07:00 [Phase 1] start-workspace — worktree .worktrees/plan-phase-should-enforce (ok)
2026-04-10T11:20:21-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T11:20:21-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T11:20:21-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T11:20:29-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T11:20:29-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T11:38:38-07:00 [stop-continue] first stop, conditional continue: pending=decompose
2026-04-10T11:42:13-07:00 [Phase 2] Step 3-4 — Explored codebase, wrote plan, stored plan file, completed phase (exit 0)
2026-04-10T11:42:52-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-10T11:54:15-07:00 [stop-continue] first stop, conditional continue: pending=commit
2026-04-10T11:54:33-07:00 [Phase] phase-finalize --phase flow-code ("ok")
2026-04-10T11:54:47-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-10T11:55:33-07:00 [Phase 4] Step 1 — Gather artifacts (exit 0)
2026-04-10T12:02:45-07:00 [Phase 4] Step 2 — Launched 4 agents (reviewer, pre-mortem, adversarial, documentation) (exit 0)
2026-04-10T12:04:52-07:00 [Phase 4] Step 3 — Triage: 2 real in-scope, 0 out-of-scope, 7 false positives (exit 0)
2026-04-10T12:08:52-07:00 [stop-continue] first stop, conditional continue: pending=commit
2026-04-10T12:09:00-07:00 [Phase 4] Step 4 — Fixed 2 findings, committed (exit 0)
2026-04-10T12:09:17-07:00 [Phase] phase-finalize --phase flow-code-review ("ok")
2026-04-10T12:09:30-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-10T12:13:02-07:00 [Phase] phase-finalize --phase flow-learn ("ok")
2026-04-10T12:17:48-07:00 [stop-continue] first stop, conditional continue: pending=commit
```

</details>