### PR TITLE
Rewrite Backward Facing Comments

### DIFF
--- a/.claude/rules/code-review-scope.md
+++ b/.claude/rules/code-review-scope.md
@@ -38,6 +38,18 @@ duplicate code, missing abstractions, naming problems, documentation
 drift. "Low severity" and "simplicity" findings in PR-touched files
 are still in-scope.
 
+## New Rules and Pre-Existing Violations
+
+When a PR adds a new rule (`.claude/rules/*.md`) that retroactively
+flags existing code as a violation, the pre-existing violations in
+files NOT touched by the PR are out-of-scope. The rule defines
+expectations going forward — it does not make prior code "caused by
+the PR." File an issue for the pre-existing violations.
+
+Pre-existing violations in files the PR DID touch are in-scope per
+the standard diff boundary test (Step 1 above). The file is in the
+diff — fix it.
+
 ## In-Scope Means Fix, Not File
 
 Never file a GitHub issue for an in-scope finding — not even one

--- a/.claude/rules/comment-quality.md
+++ b/.claude/rules/comment-quality.md
@@ -1,0 +1,52 @@
+# Comment Quality
+
+Comments describe the current codebase — what exists, why it exists,
+and what it guards. Never write comments that reference a prior
+implementation, a deleted codebase, or historical state as the
+explanation for current behavior.
+
+## Prohibited Patterns
+
+- **Parity references** — "matches X", "same as X", "mirrors X"
+  where X is a deleted file, function, or codebase. The referenced
+  thing no longer exists; the comment explains nothing.
+- **Historical provenance** — "Removed in PR #NNN", "added in
+  commit abc123", "used to be X". Git history is the authoritative
+  record; comments that duplicate it go stale.
+- **Origin stories** — "Port of test_foo.py", "based on the old
+  implementation". Describes where code came from, not what it does.
+- **"Before the fix" narratives** — "Before this fix, X would
+  happen". Regression test comments should describe what the test
+  guards against, not what was broken.
+- **"No longer" descriptions** — "X no longer does Y". Describes
+  past behavior instead of current contracts.
+- **Dead section markers** — "--- X removed in PR #NNN ---".
+  Gravestones for deleted code belong in git history, not inline.
+
+## Exception
+
+Tombstone test comments that follow the `Tombstone:.*PR #(\d+)`
+pattern are intentional — they reference PR numbers by design for
+the tombstone audit system. Do not rewrite these.
+
+## The Forward-Facing Test
+
+Before writing a comment, apply this test: "Does this comment make
+sense to someone who has never seen any prior version of this code?"
+
+- If yes — the comment is forward-facing. It describes what exists.
+- If no — the comment is backward-facing. Rewrite it to describe
+  the current behavior, the invariant being enforced, or the reason
+  the code exists as it does today.
+
+## How to Apply
+
+When writing or reviewing comments:
+
+1. State what the code does or why it exists — not where it came from
+2. If a design choice needs justification, explain the constraint or
+   trade-off — not the historical sequence of events
+3. For regression tests, describe what the test guards against — not
+   what was broken before
+4. For non-obvious values (timeouts, limits, thresholds), explain
+   why the value was chosen — not what another system used

--- a/src/auto_close_parent.rs
+++ b/src/auto_close_parent.rs
@@ -1,4 +1,4 @@
-//! Port of lib/auto-close-parent.py — auto-close parent issue and milestone.
+//! Auto-close parent issue and milestone.
 //!
 //! Usage:
 //!   bin/flow auto-close-parent --repo <owner/repo> --issue-number N

--- a/src/bump_version.rs
+++ b/src/bump_version.rs
@@ -1,4 +1,4 @@
-//! Port of lib/bump-version.py — bump FLOW plugin version across all files.
+//! Bump FLOW plugin version across all files.
 //!
 //! Updates plugin.json, marketplace.json, and all skill banners.
 //!

--- a/src/bump_version.rs
+++ b/src/bump_version.rs
@@ -121,7 +121,7 @@ pub fn run_impl(args: &Args, repo_root: &Path) -> Result<String, String> {
         );
     }
 
-    // 3. skills/*/SKILL.md — filter dot-prefixed entries per rust-port-parity rule
+    // 3. skills/*/SKILL.md — filter dot-prefixed entries (fnmatch convention)
     let skills_dir = repo_root.join("skills");
     if skills_dir.exists() {
         let mut entries: Vec<_> = fs::read_dir(&skills_dir)

--- a/src/check_freshness.rs
+++ b/src/check_freshness.rs
@@ -1,4 +1,4 @@
-//! Port of lib/check-freshness.py — pre-merge freshness check.
+//! Pre-merge freshness check.
 //!
 //! Fetches origin/main, verifies the branch is up-to-date via
 //! `git merge-base --is-ancestor`, and merges if behind. Detects merge
@@ -30,8 +30,8 @@ pub struct Args {
     pub raw_args: Vec<String>,
 }
 
-/// Result of a single git subprocess call. Mirrors Python
-/// `subprocess.CompletedProcess` + `TimeoutExpired` distinction.
+/// Result of a single git subprocess call — either completed (with exit
+/// code and captured output) or timed out.
 #[derive(Debug, Clone)]
 pub enum CmdResult {
     Ok {

--- a/src/check_freshness.rs
+++ b/src/check_freshness.rs
@@ -155,7 +155,7 @@ pub fn check_freshness_impl(
 fn read_retries(state_path: &Path) -> i64 {
     let cell = std::cell::Cell::new(0i64);
     let _ = mutate_state(state_path, |state| {
-        // State Mutation Object Guard — see .claude/rules/rust-port-parity.md
+        // State Mutation Object Guard — prevents panic on non-object values
         if !(state.is_object() || state.is_null()) {
             return;
         }
@@ -182,7 +182,7 @@ fn increment_retries(state_path: &Path) -> i64 {
 
 /// Counter type tolerance — state files in the wild may store
 /// `freshness_retries` as int, float, or string (older versions or hand
-/// edits). Per rust-port-parity counter-field-type-tolerance rule.
+/// edits). Accepts all three representations for backwards compatibility.
 fn read_retries_value(state: &Value) -> i64 {
     state
         .get("freshness_retries")
@@ -196,8 +196,8 @@ fn read_retries_value(state: &Value) -> i64 {
 
 /// Real git subprocess runner with polling-based timeout and thread-drain.
 ///
-/// Uses the thread-drain pattern from `.claude/rules/rust-port-parity.md`
-/// Subprocess Timeout Parity: take stdout/stderr handles before the poll
+/// Uses the thread-drain pattern to prevent pipe buffer deadlock: take
+/// stdout/stderr handles before the poll
 /// loop, drain them in spawned reader threads, poll `try_wait()` for exit
 /// status, then join the readers. Compliant reference: see
 /// `src/analyze_issues.rs` lines 472-518.
@@ -670,9 +670,8 @@ mod tests {
     }
 
     // Counter type tolerance tests: the fallback chain in `read_retries_value`
-    // exists per `.claude/rules/rust-port-parity.md` Counter Field Type
-    // Tolerance. State files can outlive the code that writes them, so
-    // freshness_retries may arrive as int, float, or string.
+    // accepts int, float, and string representations because state files can
+    // outlive the code that writes them.
 
     #[test]
     fn test_retry_value_as_float() {

--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -1,4 +1,4 @@
-//! Port of lib/cleanup.py — cleanup orchestrator for FLOW features.
+//! Cleanup orchestrator for FLOW features.
 //!
 //! Shared by /flow:flow-complete (Phase 6) and /flow:flow-abort. Performs best-effort
 //! cleanup steps, continuing on failure.

--- a/src/close_issue.rs
+++ b/src/close_issue.rs
@@ -1,4 +1,4 @@
-//! Port of lib/close-issue.py — close a single GitHub issue via gh CLI.
+//! Close a single GitHub issue via gh CLI.
 //!
 //! Usage:
 //!   bin/flow close-issue --number <N> [--repo <repo>]

--- a/src/close_issues.rs
+++ b/src/close_issues.rs
@@ -1,4 +1,4 @@
-//! Port of lib/close-issues.py — close GitHub issues referenced in the FLOW start prompt.
+//! Close GitHub issues referenced in the FLOW start prompt.
 //!
 //! Reads the state file, extracts #N patterns from the prompt field,
 //! and closes each issue via gh CLI after the PR is merged.

--- a/src/commands/session_context.rs
+++ b/src/commands/session_context.rs
@@ -11,12 +11,9 @@ fn write_tab_colors(repo: Option<&str>, root: &Path) {
 
 /// Session-start hook: detect repo and write terminal tab colors.
 ///
-/// Previously this module contained ~600 lines that scanned all state
-/// files, mutated timing fields, consumed transient data, and injected
-/// feature context into the session. When a session opened on main
-/// (no matching state file), `filter_by_branch()` fell back to ALL
-/// state files — corrupting every active flow's timing and transient
-/// fields. Removed in PR #938; only tab color writing survives.
+/// Intentionally minimal — tab color writing is the only session-start
+/// action. State file mutations and feature context injection belong in
+/// phase-scoped commands, not session-wide hooks that run on every branch.
 pub fn run() {
     let root = project_root();
     let detected = detect_repo(Some(&root));

--- a/src/complete_merge.rs
+++ b/src/complete_merge.rs
@@ -1,4 +1,4 @@
-//! Port of lib/complete-merge.py — consolidated Complete phase merge.
+//! Consolidated Complete phase merge.
 //!
 //! Absorbs Step 8: freshness check + squash merge.
 //!

--- a/src/complete_merge.rs
+++ b/src/complete_merge.rs
@@ -43,8 +43,7 @@ pub struct Args {
 /// Drains stdout and stderr in spawned threads to prevent pipe buffer
 /// deadlock — children writing >64KB to a piped stream would otherwise
 /// block forever when the kernel buffer fills and `try_wait()` would
-/// never observe the child exiting. See `.claude/rules/rust-port-parity.md`
-/// "Subprocess Timeout Parity".
+/// never observe the child exiting.
 fn run_cmd_with_timeout(args: &[&str], timeout_secs: u64) -> CmdResult {
     let (program, rest) = match args.split_first() {
         Some(p) => p,

--- a/src/complete_post_merge.rs
+++ b/src/complete_post_merge.rs
@@ -45,8 +45,7 @@ pub struct Args {
 /// Drains stdout and stderr in spawned threads to prevent pipe buffer
 /// deadlock — children writing >64KB to a piped stream would otherwise
 /// block forever when the kernel buffer fills and `try_wait()` would
-/// never observe the child exiting. See `.claude/rules/rust-port-parity.md`
-/// "Subprocess Timeout Parity".
+/// never observe the child exiting.
 fn run_cmd_with_timeout(args: &[&str], timeout_secs: u64) -> CmdResult {
     let (program, rest) = match args.split_first() {
         Some(p) => p,

--- a/src/complete_post_merge.rs
+++ b/src/complete_post_merge.rs
@@ -1,4 +1,4 @@
-//! Port of lib/complete-post-merge.py — consolidated Complete phase post-merge.
+//! Consolidated Complete phase post-merge.
 //!
 //! Absorbs Steps 7 + 9 + 10: phase completion, PR body render, issues summary,
 //! close issues, summary generation, label removal, auto-close parents, and
@@ -111,7 +111,6 @@ fn run_cmd_with_timeout(args: &[&str], timeout_secs: u64) -> CmdResult {
 }
 
 /// Parse JSON from stdout. Returns (parsed_value, parse_error).
-/// Mirrors Python's _parse_json helper.
 fn parse_json_or(stdout: &str) -> (Option<Value>, Option<String>) {
     match serde_json::from_str::<Value>(stdout.trim()) {
         Ok(v) => (Some(v), None),

--- a/src/create_dependencies.rs
+++ b/src/create_dependencies.rs
@@ -1,4 +1,4 @@
-//! Port of lib/create-dependencies.py — copy framework dependency template.
+//! Copy framework dependency template.
 //!
 //! Copies frameworks/<name>/dependencies to the target project's
 //! bin/dependencies. Skips if bin/dependencies already exists (user

--- a/src/create_milestone.rs
+++ b/src/create_milestone.rs
@@ -1,4 +1,4 @@
-//! Port of lib/create-milestone.py — create a GitHub milestone via gh API.
+//! Create a GitHub milestone via gh API.
 //!
 //! Usage:
 //!   bin/flow create-milestone --repo <owner/repo> --title <title> --due-date <YYYY-MM-DD>

--- a/src/create_sub_issue.rs
+++ b/src/create_sub_issue.rs
@@ -1,4 +1,4 @@
-//! Port of lib/create-sub-issue.py — create a GitHub sub-issue relationship.
+//! Create a GitHub sub-issue relationship.
 //!
 //! Usage:
 //!   bin/flow create-sub-issue --repo <owner/repo> --parent-number N --child-number N

--- a/src/detect_framework.rs
+++ b/src/detect_framework.rs
@@ -1,6 +1,6 @@
 //! Data-driven framework auto-detection.
 //!
-//! Port of lib/detect-framework.py. Reads `frameworks/*/detect.json`
+//! Reads `frameworks/*/detect.json`
 //! to discover which frameworks match a project based on file presence.
 //!
 //! Usage: `bin/flow detect-framework <project_root>`
@@ -117,8 +117,7 @@ pub fn available_frameworks(fw_dir: &Path) -> Vec<Value> {
 ///
 /// Returns `Err` on infrastructure failures (missing project root,
 /// missing frameworks directory). Error-status responses are returned
-/// via `Err` so `run` can exit non-zero; this matches the Python
-/// script's behavior of printing JSON + `sys.exit(1)`.
+/// via `Err` so `run` can exit non-zero and print JSON before exiting.
 ///
 /// Loads detect.json configs once and derives both `detected` and
 /// `available` from the single load — avoids reading each detect.json

--- a/src/extract_release_notes.rs
+++ b/src/extract_release_notes.rs
@@ -1,4 +1,4 @@
-//! Port of lib/extract-release-notes.py — extract release notes for a version.
+//! Extract release notes for a version.
 //!
 //! Reads RELEASE-NOTES.md, finds the section matching the given version,
 //! and writes it to `tmp/release-notes-<version>.md`.

--- a/src/finalize_commit.rs
+++ b/src/finalize_commit.rs
@@ -1,4 +1,4 @@
-//! Port of lib/finalize-commit.py — commit, cleanup, pull, push.
+//! Commit, cleanup, pull, push.
 //!
 //! Enforces CI before committing: calls [`ci::run_impl`] as the first step
 //! in [`run_impl`]. If CI fails, returns an error and commits nothing.

--- a/src/git.rs
+++ b/src/git.rs
@@ -93,7 +93,7 @@ pub fn current_branch_in(cwd: &Path) -> Option<String> {
 /// 3. Return current_branch() anyway (callers check state file existence)
 ///
 /// Never scans `.flow-states/` for candidates — each caller targets only
-/// its own branch. Removed in PR #924.
+/// its own branch.
 pub fn resolve_branch(override_branch: Option<&str>, root: &Path) -> Option<String> {
     resolve_branch_impl(override_branch, root, current_branch())
 }

--- a/src/hooks/stop_continue.rs
+++ b/src/hooks/stop_continue.rs
@@ -294,8 +294,8 @@ Wait for the user — they are not done talking.";
 ///
 /// **Superseded in `run()` by `check_first_stop()`** which handles both
 /// discussion mode and pending continuations in a single function.
-/// This function is no longer called from the production `run()` path
-/// but is retained as a standalone building block with its own test suite.
+/// Not called from the production `run()` path — retained as a
+/// standalone building block with its own test suite.
 ///
 /// On the first Stop event where `_stop_instructed` is not already set
 /// (bool `true`), sets the flag and returns a blocking `ContinueResult`
@@ -492,9 +492,8 @@ pub fn check_first_stop(hook_input: &Value, state_path: &Path) -> ContinueResult
 ///
 /// Returns `{"decision": "block", "reason": "..."}` where `reason`
 /// embeds the skill name and, when context is non-empty, the
-/// parent phase's next-step instructions. Matches the Python
-/// `stop-continue.py` main() output exactly so Claude Code's
-/// stop-hook protocol stays backward compatible.
+/// parent phase's next-step instructions. The output format is
+/// part of Claude Code's stop-hook protocol contract.
 pub fn format_block_output(skill: &str, context: Option<&str>) -> Value {
     let reason = match context {
         Some(ctx) if !ctx.is_empty() => format!(
@@ -981,11 +980,10 @@ mod tests {
     }
 
     // --- check_continue log file writes ---
-    // Closes the coverage gap flagged by the reviewer agent: the
-    // `check_continue` log_diag calls were previously passing
-    // (None, None) and silently dropping the log file write. These
-    // tests use the canonical `.flow-states/<branch>.json` layout
-    // so `derive_root_branch` can recover the log path.
+    // Verify that `check_continue` log_diag calls write to the log
+    // file when root and branch are derivable. These tests use the
+    // canonical `.flow-states/<branch>.json` layout so
+    // `derive_root_branch` can recover the log path.
 
     #[test]
     fn test_check_continue_block_writes_log_file() {

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -1,4 +1,4 @@
-//! Port of lib/issue.py — GitHub issue creation wrapper.
+//! GitHub issue creation wrapper.
 //!
 //! Usage:
 //!   bin/flow issue --title <title> [--repo <repo>] [--label <label>] [--body-file <path>]

--- a/src/link_blocked_by.rs
+++ b/src/link_blocked_by.rs
@@ -1,4 +1,4 @@
-//! Port of lib/link-blocked-by.py — create a GitHub blocked-by dependency.
+//! Create a GitHub blocked-by dependency.
 //!
 //! Usage:
 //!   bin/flow link-blocked-by --repo <owner/repo> --blocked-number N --blocking-number N

--- a/src/notify_slack.rs
+++ b/src/notify_slack.rs
@@ -1,4 +1,4 @@
-//! Port of lib/notify-slack.py — post messages to Slack via curl.
+//! Post messages to Slack via curl.
 //!
 //! Usage:
 //!   bin/flow notify-slack --phase <phase> --message <text> [--thread-ts <ts>]

--- a/src/orchestrate_report.rs
+++ b/src/orchestrate_report.rs
@@ -1,6 +1,6 @@
 //! Generate morning report from orchestration state.
 //!
-//! Ported from `lib/orchestrate-report.py`. Reads `.flow-states/orchestrate.json`
+//! Reads `.flow-states/orchestrate.json`
 //! and produces a markdown summary with results table, completed/failed sections,
 //! and timing information. Writes `orchestrate-summary.md` to the output directory.
 

--- a/src/orchestrate_state.rs
+++ b/src/orchestrate_state.rs
@@ -1,6 +1,6 @@
 //! Manage orchestration queue state at `.flow-states/orchestrate.json`.
 //!
-//! Ported from `lib/orchestrate-state.py`. Orchestrate.json is a machine-level
+//! Orchestrate.json is a machine-level
 //! singleton (not branch-scoped) that tracks overnight autonomous execution.
 //!
 //! Six mutually exclusive operations:

--- a/src/prime_check.rs
+++ b/src/prime_check.rs
@@ -1,5 +1,5 @@
 //! Version gate — verify `/flow:flow-prime` has been run with a
-//! matching version. Port of lib/prime-check.py.
+//! matching version.
 //!
 //! Usage: `bin/flow prime-check`
 //!
@@ -14,16 +14,15 @@
 //! canonical source for permission and exclude lists. They are shared
 //! with `src/prime_setup.rs` which imports them via `pub use`.
 //!
-//! # Hash byte-parity with Python
+//! # JSON Separator Format for Config Hashing
 //!
-//! `compute_config_hash` must produce byte-identical SHA-256 input
-//! bytes to Python's `json.dumps(canonical, sort_keys=True)`. Python's
-//! default separators are `(", ", ": ")`; Rust's
-//! `serde_json::to_string` default is `(",", ":")`. Without a fix the
-//! resulting digests differ, breaking round-trip with Python-written
-//! `.flow.json` files. `PythonDefaultFormatter` below implements the
-//! three `serde_json::ser::Formatter` methods needed to emit the
-//! Python separators.
+//! `compute_config_hash` must produce SHA-256 digests that match
+//! existing `.flow.json` files, which use `(", ", ": ")` separators.
+//! Rust's `serde_json::to_string` default is `(",", ":")` — without
+//! a custom formatter the digests differ, breaking hash comparisons
+//! on upgrade. `PythonDefaultFormatter` below implements the three
+//! `serde_json::ser::Formatter` methods needed to emit the expected
+//! separators.
 
 use std::collections::BTreeMap;
 use std::fs;

--- a/src/prime_check.rs
+++ b/src/prime_check.rs
@@ -134,8 +134,8 @@ pub const EXCLUDE_ENTRIES: &[&str] = &[
 ];
 
 /// Custom `serde_json` formatter that emits `(", ", ": ")` separators
-/// to match Python's `json.dumps` default. Required for byte-parity
-/// with Python's hash input. Only the three separator methods are
+/// to match the format used by existing `.flow.json` files. Required
+/// for hash stability on upgrade. Only the three separator methods are
 /// overridden; everything else uses the default (compact) behavior.
 struct PythonDefaultFormatter;
 
@@ -171,7 +171,7 @@ impl Formatter for PythonDefaultFormatter {
 }
 
 /// Load framework-specific permissions from frameworks/<name>/permissions.json.
-/// Returns an empty vec if the file is missing (Python parity).
+/// Returns an empty vec if the file is missing — not all frameworks define permissions.
 pub fn load_framework_permissions(framework: &str, fw_dir: &Path) -> Vec<String> {
     let path = fw_dir.join(framework).join("permissions.json");
     if !path.exists() {
@@ -267,9 +267,9 @@ fn read_flow_json(cwd: &Path) -> Option<Value> {
     serde_json::from_str(&content).ok()
 }
 
-/// Filter `Some("")` as falsy. Matches Python's `if x:` semantics for
-/// string dict values: both missing keys and empty strings are falsy.
-/// See rust-port-parity.md "Empty-String vs Missing-Key Falsy Equivalence".
+/// Filter `Some("")` as falsy — both missing keys and empty strings
+/// should be treated as absent. See rust-patterns.md
+/// "Empty-String vs Missing-Key Equivalence".
 fn as_nonempty_str(v: &Value) -> Option<&str> {
     v.as_str().filter(|s| !s.is_empty())
 }

--- a/src/prime_project.rs
+++ b/src/prime_project.rs
@@ -1,6 +1,6 @@
 //! Insert or replace FLOW priming content in a project's CLAUDE.md.
 //!
-//! Port of lib/prime-project.py. Reads
+//! Reads
 //! `frameworks/<name>/priming.md` and inserts it between
 //! `<!-- FLOW:BEGIN -->` / `<!-- FLOW:END -->` markers in the target
 //! project's CLAUDE.md. Idempotent — re-running replaces existing

--- a/src/prime_setup.rs
+++ b/src/prime_setup.rs
@@ -1,6 +1,6 @@
 //! Consolidated setup for FLOW Prime.
 //!
-//! Port of `lib/prime-setup.py`. Merges permissions into
+//! Merges permissions into
 //! `.claude/settings.json`, writes `.flow.json` version marker,
 //! updates `.git/info/exclude`, installs hooks and launcher.
 //! Does NOT commit — the skill handles `git add` + `commit`.

--- a/src/prime_setup.rs
+++ b/src/prime_setup.rs
@@ -476,8 +476,8 @@ pub struct Args {
 
 /// Run the prime-setup sequence.
 ///
-/// Returns `Err(Value)` for all error cases — matches the Python script's
-/// `print(json); sys.exit(1)` pattern. `Ok(Value)` for success.
+/// Returns `Err(Value)` for all error cases (printed as JSON, exit 1).
+/// `Ok(Value)` for success.
 pub fn run_impl(args: &Args) -> Result<Value, Value> {
     let project_root = PathBuf::from(&args.project_root);
     if !project_root.is_dir() {

--- a/src/promote_permissions.rs
+++ b/src/promote_permissions.rs
@@ -1,6 +1,6 @@
 //! Promote permissions from settings.local.json into settings.json.
 //!
-//! Port of lib/promote-permissions.py. Reads
+//! Reads
 //! `.claude/settings.local.json`, merges new `permissions.allow` entries
 //! into `.claude/settings.json`, deletes settings.local.json, and
 //! outputs JSON.
@@ -159,9 +159,8 @@ fn read_json(path: &Path) -> Result<Value, String> {
 /// Build the CLI result as a JSON value.
 ///
 /// Returns `Err` when the result `status` is `"error"` so `run` can
-/// exit non-zero — this matches the Python script's
-/// `print(json); sys.exit(1)` behavior for error results while keeping
-/// `ok`/`skipped` on the `Ok` path.
+/// exit non-zero with JSON output, while keeping `ok`/`skipped` on
+/// the `Ok` path.
 pub fn run_impl(args: &Args) -> Result<Value, Value> {
     let worktree = PathBuf::from(&args.worktree_path);
     let result = promote(&worktree);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2,8 +2,7 @@
 //!
 //! A ratatui-based terminal application that reads local state files and
 //! provides keyboard-driven navigation. No Claude session required.
-//!
-//! Ported from lib/tui.py. Uses tui_data module for data loading.
+//! Uses tui_data module for data loading.
 
 use std::io;
 use std::path::PathBuf;

--- a/src/tui_data.rs
+++ b/src/tui_data.rs
@@ -2,9 +2,6 @@
 //!
 //! Reads state files, computes display structs (flow summaries, phase timelines,
 //! log entries). No curses dependency — fully testable with make_state() fixture.
-//!
-//! Ported from lib/tui_data.py. Consumed by lib/tui.py via the `bin/flow tui-data`
-//! CLI subcommand bridge.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -792,7 +789,7 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    // --- Test helper: make_state (mirrors Python conftest.make_state) ---
+    // --- Test helper: make_state ---
 
     fn make_state(current_phase: &str, phase_statuses: &[(&str, &str)]) -> Value {
         let mut phases = serde_json::Map::new();

--- a/src/update_deps.rs
+++ b/src/update_deps.rs
@@ -1,4 +1,4 @@
-//! Port of lib/update-deps.py — the `bin/flow update-deps` subcommand.
+//! The `bin/flow update-deps` subcommand.
 //!
 //! Runs the target project's `bin/dependencies` and reports whether
 //! git status changed. Spawns the dependency script in a new process
@@ -34,8 +34,8 @@ const POLL_INTERVAL: Duration = Duration::from_millis(50);
 pub fn run_update_deps(cwd: &Path, timeout_secs: u64) -> (Value, i32) {
     let deps = cwd.join("bin").join("dependencies");
 
-    // Mirrors Python's `is_file()` — returns false for directories AND
-    // for nonexistent paths. Both cases report skipped.
+    // Returns false for directories AND nonexistent paths. Both cases
+    // report skipped.
     if !deps.is_file() {
         return (
             json!({

--- a/src/upgrade_check.rs
+++ b/src/upgrade_check.rs
@@ -174,8 +174,8 @@ fn parse_version(s: &str) -> Option<(u32, u32, u32)> {
 
 /// Real `gh` subprocess runner with polling-based timeout and thread-drain.
 ///
-/// Uses the thread-drain pattern from `.claude/rules/rust-port-parity.md`
-/// Subprocess Timeout Parity: take stdout/stderr handles before the poll
+/// Uses the thread-drain pattern to prevent pipe buffer deadlock: take
+/// stdout/stderr handles before the poll
 /// loop, drain them in spawned reader threads, poll `try_wait()` for exit
 /// status, then join the readers. Compliant reference: see
 /// `src/analyze_issues.rs` lines 472-518.

--- a/src/upgrade_check.rs
+++ b/src/upgrade_check.rs
@@ -1,4 +1,4 @@
-//! Port of lib/upgrade-check.py — check GitHub for newer FLOW releases.
+//! Check GitHub for newer FLOW releases.
 //!
 //! Reads plugin.json to determine installed version + repository URL,
 //! calls `gh api repos/OWNER/REPO/releases/latest --jq .tag_name`, and
@@ -22,8 +22,8 @@ const DEFAULT_TIMEOUT_SECS: u64 = 10;
 #[command(name = "upgrade-check", about = "Check GitHub for newer FLOW releases")]
 pub struct Args {}
 
-/// Result of a single `gh` subprocess call. Mirrors Python
-/// `subprocess.CompletedProcess` + `TimeoutExpired` + `FileNotFoundError`.
+/// Result of a single `gh` subprocess call — completed (with exit code
+/// and output), timed out, or binary not found.
 #[derive(Debug, Clone)]
 pub enum GhResult {
     Ok {

--- a/src/write_rule.rs
+++ b/src/write_rule.rs
@@ -1,4 +1,4 @@
-//! Port of lib/write-rule.py — write content to a target file path.
+//! Write content to a target file path.
 //!
 //! Usage:
 //!   bin/flow write-rule --path <target> --content-file <temp>

--- a/tests/bin_flow.rs
+++ b/tests/bin_flow.rs
@@ -1,6 +1,6 @@
 //! Tests for bin/flow — the subcommand dispatcher.
 //!
-//! Validates the Rust-only dispatcher (Python fallback removed in PR #953).
+//! Validates the Rust subcommand dispatcher.
 
 mod common;
 

--- a/tests/bump_version.rs
+++ b/tests/bump_version.rs
@@ -1,8 +1,8 @@
-//! Tests for `src/bump_version.rs` — port of tests/test_bump_version.py.
+//! Tests for `src/bump_version.rs`.
 //!
 //! Pure-function tests call the library directly. CLI tests call run_impl
 //! with a fake repo fixture. All subprocess calls use Command::output()
-//! per rust-port-parity.md Test-Module Subprocess Stdio rule.
+//! to avoid leaking child output to the test harness.
 
 use std::fs;
 use std::path::Path;

--- a/tests/check_phase.rs
+++ b/tests/check_phase.rs
@@ -182,8 +182,8 @@ fn no_state_file_for_current_branch() {
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(dir.path(), "main");
 
-    // Create state files for OTHER branches — resolve_branch no longer
-    // scans for these, so check-phase reports no feature on "main".
+    // Create state files for OTHER branches — resolve_branch targets only
+    // the current branch, so check-phase reports no feature on "main".
     for name in ["feat-a", "feat-b"] {
         let state = make_state("flow-plan", &[("flow-start", "complete")]);
         setup_state(dir.path(), name, &state);

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -1,4 +1,4 @@
-// Rust port of tests/test_concurrency.py — concurrent access to FLOW's shared resources.
+// Concurrent access to FLOW's shared resources.
 //
 // All tests use std::thread for real thread-based parallelism.
 // Each test creates an isolated tempdir to avoid cross-test interference.

--- a/tests/detect_framework.rs
+++ b/tests/detect_framework.rs
@@ -1,10 +1,9 @@
 //! Integration tests for `flow-rs detect-framework`.
 //!
-//! Mirrors tests/test_detect_framework.py (183 lines, 17 test cases).
 //! Uses tempfile fixtures + CLAUDE_PLUGIN_ROOT=CARGO_MANIFEST_DIR to
-//! point the Rust binary at the real frameworks/ directory. Every
-//! subprocess call uses Command::output() per rust-port-parity.md
-//! Test-Module Subprocess Stdio rule.
+//! point the Rust binary at the real frameworks/ directory. All
+//! subprocess calls use Command::output() to avoid leaking child
+//! output to the test harness.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/tests/extract_release_notes.rs
+++ b/tests/extract_release_notes.rs
@@ -1,4 +1,4 @@
-//! Tests for `src/extract_release_notes.rs` — port of tests/test_extract_release.py.
+//! Tests for `src/extract_release_notes.rs`.
 //!
 //! Pure-function tests call extract() directly. CLI tests call run_impl
 //! with a fake repo fixture.

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -98,7 +98,7 @@ fn run_hook(hook: &str, dir: &Path, branch: &str, stdin_data: &[u8]) -> Output {
 /// Creates a deterministic HEAD so `git branch --show-current` returns
 /// `branch_name` inside the child process. Mirrors `init_git_repo` from
 /// `src/git.rs` tests but is self-contained in this integration test module.
-/// Uses `Command::output()` (not `.status()`) per rust-port-parity rules.
+/// Uses `Command::output()` so child stdout/stderr are captured, not inherited.
 fn setup_git_repo_on_branch(dir: &Path, branch_name: &str) {
     let run = |args: &[&str]| {
         let output = Command::new("git")

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -32,7 +32,7 @@ fn flow_rs() -> Command {
 /// the temp dir rather than falling back to `PathBuf::from(".")` — which
 /// would then resolve against the child's `current_dir`, still the temp
 /// dir, but only by coincidence. An explicit `git init` makes the
-/// resolution deterministic and mirrors `tests/clear_blocked.rs`.
+/// resolution deterministic (same pattern as `tests/clear_blocked.rs`).
 fn setup_git_and_state(dir: &Path, branch: &str, state: &Value) {
     let _ = Command::new("git").args(["init"]).current_dir(dir).output();
     let state_dir = dir.join(".flow-states");
@@ -68,12 +68,11 @@ fn read_state(dir: &Path, branch: &str) -> Value {
 ///   env var, so one helper serves all three hooks.
 /// - `current_dir(dir)` scopes `project_root()` discovery to the tempdir
 ///   so the child reads and mutates only the fixture's `.flow-states/`
-///   directory — satisfies Subprocess CWD Parity in rust-port-parity.md.
+///   directory — prevents host environment leaks (see testing-gotchas.md).
 /// - All three stdio streams must be piped explicitly. `Command::spawn`
 ///   defaults to inheriting stdout/stderr, which means `wait_with_output`
 ///   would return empty buffers while the child's output leaks directly
-///   to the test harness terminal — the exact failure mode that the
-///   Test-Module Subprocess Stdio rule in rust-port-parity.md forbids.
+///   to the test harness terminal.
 ///   Piping stdout and stderr lets `wait_with_output` capture them for
 ///   assertion AND keeps cargo test output clean.
 fn run_hook(hook: &str, dir: &Path, branch: &str, stdin_data: &[u8]) -> Output {
@@ -683,8 +682,8 @@ fn test_stop_continue_no_block_after_cleared_continue_pending() {
 fn test_stop_continue_pending_with_first_stop_uses_conditional_message() {
     // When _continue_pending is set and _stop_instructed is NOT set (first stop),
     // check_first_stop fires and produces a conditional message that tells the
-    // model to check for user messages before auto-continuing. This is the fix
-    // for issue #950: _continue_pending no longer tramples user conversations.
+    // model to check for user messages before auto-continuing. Guards against
+    // _continue_pending trampling user conversations (issue #950).
     let dir = tempfile::tempdir().unwrap();
     let branch = "test-feature";
     let state = json!({

--- a/tests/init_state.rs
+++ b/tests/init_state.rs
@@ -544,7 +544,7 @@ fn flow_in_progress_label_blocks_start() {
     // must exit with status=error, step=flow_in_progress_label, and NOT
     // create a state file. The error message must name the issue number, name
     // the label, and direct the user to resume the existing flow in its
-    // worktree (/flow:flow-continue was removed in PR #868). Issue #887.
+    // worktree. Issue #887.
     let dir = tempfile::tempdir().unwrap();
     setup_project(dir.path(), "rails", None);
 

--- a/tests/permissions.rs
+++ b/tests/permissions.rs
@@ -1,4 +1,4 @@
-// Rust port of tests/test_permissions.py — bash permission coverage tests.
+// Bash permission coverage tests.
 //
 // Every Bash command in every skill must have a matching permission entry.
 // Prohibition tests enforce that bash blocks never contain patterns that

--- a/tests/prime_check.rs
+++ b/tests/prime_check.rs
@@ -1,11 +1,10 @@
 //! Integration tests for `flow-rs prime-check`.
 //!
-//! Mirrors tests/test_prime_check.py (264 lines, 15 test cases).
 //! Points the Rust binary at the real plugin via
 //! CLAUDE_PLUGIN_ROOT=CARGO_MANIFEST_DIR so plugin.json version and the
-//! real lib/prime-setup.py bytes are used for hash computation. Every
-//! subprocess call uses Command::output() per rust-port-parity.md
-//! Test-Module Subprocess Stdio rule.
+//! real `src/prime_setup.rs` bytes are used for hash computation. All
+//! subprocess calls use Command::output() to avoid leaking child
+//! output to the test harness.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -166,8 +165,8 @@ fn fails_on_invalid_framework() {
 //
 // These tests use the Rust public API (compute_config_hash /
 // compute_setup_hash) to build the "stored" hashes so the Rust binary
-// can verify them. This is a self-consistency test — end-to-end hash
-// round-trips are verified separately by tests/test_prime_port_parity.py.
+// can verify them. This is a self-consistency test — the hashes built
+// here must match what prime-check computes at runtime.
 
 fn computed_config_hash(framework: &str) -> String {
     let fw_dir = plugin_root().join("frameworks");

--- a/tests/prime_project.rs
+++ b/tests/prime_project.rs
@@ -1,10 +1,8 @@
 //! Integration tests for `flow-rs prime-project`.
 //!
-//! Mirrors tests/test_prime_project.py (124 lines, 11 test cases).
 //! Uses env!("CARGO_MANIFEST_DIR")/frameworks for real priming.md
-//! fixtures (rails and python). Every subprocess call uses
-//! Command::output() per rust-port-parity.md Test-Module Subprocess
-//! Stdio rule.
+//! fixtures (rails and python). All subprocess calls use
+//! Command::output() to avoid leaking child output to the test harness.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/tests/prime_setup.rs
+++ b/tests/prime_setup.rs
@@ -1,13 +1,13 @@
 //! Integration tests for `flow-rs prime-setup`.
 //!
-//! Mirrors tests/test_prime_setup.py (1,135 lines). Tests cover:
+//! Tests cover:
 //! - Pure function tests (merge_settings, is_subsumed, derive_permissions,
 //!   write_version_marker, update_git_exclude, install_script,
 //!   install_pre_commit_hook, install_launcher, check_launcher_path)
 //! - CLI tests via run_impl
 //!
-//! Every subprocess call uses Command::output() per rust-port-parity.md
-//! Test-Module Subprocess Stdio rule.
+//! All subprocess calls use Command::output() to avoid leaking child
+//! output to the test harness.
 
 use std::collections::HashSet;
 use std::fs;
@@ -403,7 +403,7 @@ fn derive_permissions_unknown_framework() {
 #[test]
 fn derive_permissions_dot_prefix_skipped() {
     let tmp = tempfile::tempdir().unwrap();
-    // Dot-prefixed entry should be skipped (Python Path.glob parity)
+    // Dot-prefixed entry should be skipped (fnmatch convention)
     fs::create_dir(tmp.path().join(".xcodeproj")).unwrap();
     let result = prime_setup::derive_permissions(tmp.path(), "ios", &fw_dir());
     assert!(result.is_empty());

--- a/tests/promote_permissions.rs
+++ b/tests/promote_permissions.rs
@@ -1,8 +1,7 @@
 //! Integration tests for `flow-rs promote-permissions`.
 //!
-//! Mirrors tests/test_promote_permissions.py (315 lines, 18 test cases).
-//! Every subprocess call uses Command::output() per rust-port-parity.md
-//! Test-Module Subprocess Stdio rule.
+//! All subprocess calls use Command::output() to avoid leaking child
+//! output to the test harness.
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -1,4 +1,4 @@
-// Rust port of tests/test_skill_contracts.py — SKILL.md content contracts.
+// SKILL.md content contracts.
 //
 // Validates structural invariants in skill markdown files: phase gates,
 // state field references, cross-skill invocations, agent contracts,
@@ -962,7 +962,7 @@ fn paused_banners_have_diamond() {
     }
 }
 
-// format_status_no_equals_banners removed in PR #953 — lib/format-status.py deleted
+// Equals-sign banners are prohibited — only box-drawing characters allowed
 
 #[test]
 fn docs_no_equals_banners() {

--- a/tests/structural.rs
+++ b/tests/structural.rs
@@ -173,8 +173,6 @@ fn test_every_skill_dir_starts_with_flow_prefix() {
     }
 }
 
-// --- flow_utils.py parity tests removed in PR #953 (Python artifacts removed) ---
-
 // --- Hook invariants ---
 
 #[test]
@@ -452,8 +450,6 @@ fn test_hooks_json_has_stop_failure_hook() {
     );
 }
 
-// --- conftest parity tests removed in PR #953 (Python artifacts removed) ---
-
 // --- Script test file coverage ---
 
 #[test]
@@ -527,8 +523,6 @@ fn test_every_script_has_a_test_file() {
         missing.join(", ")
     );
 }
-
-// --- Requirements and pytest config tests removed in PR #953 (Python artifacts removed) ---
 
 // --- CLAUDE.md invariants ---
 

--- a/tests/structural.rs
+++ b/tests/structural.rs
@@ -1,6 +1,5 @@
 //! Structural invariant tests for FLOW plugin configuration files.
 //!
-//! Ports tests/test_structural.py to Rust integration tests.
 //! These tests verify config consistency, hook registration, framework
 //! definitions, agent frontmatter, version parity, and tombstone guards.
 


### PR DESCRIPTION
## What

Rewrite backward-facing comments and add comment quality rule #992.

Closes #992

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/rewrite-backward-facing-comments-plan.md` |
| DAG | `.flow-states/rewrite-backward-facing-comments-dag.md` |
| Log | `.flow-states/rewrite-backward-facing-comments.log` |
| State | `.flow-states/rewrite-backward-facing-comments.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

Comments written during a major port used the prior implementation as the reference point for behavior choices. That implementation is deleted — the comments now point to nothing. A rule is needed to prevent the pattern from recurring.

## Exploration

The audit identified ~35 backward-facing comments across 27 files, categorized into 7 groups:

1. **"matches X" parity references** (~18 in src/) — describe behavior by pointing to a deleted codebase
2. **"Removed in PR #NNN"** (~6 in src/) — historical provenance belonging in git history
3. **"Port of test_*.py" file headers** (~4 test files) — describe origin, not coverage
4. **"Before the fix" regression comments** (~4 in tests/) — describe what was broken, not what's guarded
5. **Dead section markers** (3 in structural.rs) — gravestones for removed tests
6. **"no longer" / stale behavior** (~3 scattered) — describe past behavior, not current contracts
7. **Stale fallback references** (~4 in tests/) — describe what was replaced, not what exists

No existing rule covers comment quality. The closest is the global CLAUDE.md line "Only add comments where the logic isn't self-evident" which addresses whether to comment, not how.

## Risks

- **Misrewriting a comment that carries a subtle invariant** — each rewrite must preserve the WHY if one exists beneath the backward reference. Read the surrounding code before rewriting.
- **Tombstone false positives** — tombstone comments reference PR numbers by design. The task must skip any comment matching the `Tombstone:.*PR #(\d+)` pattern.
- **Contract test interference** — `tests/skill_contracts.rs` scans SKILL.md files for prohibited strings. The new rule file is a `.claude/rules/` file, not a skill, so no contract test risk.

## Approach

Two-part change: (1) add a `.claude/rules/comment-quality.md` rule that prohibits backward-facing patterns, (2) rewrite or delete all ~35 identified comments. Each rewrite replaces a backward reference with forward-facing language describing WHY the behavior exists or WHAT the test guards. Dead section markers are deleted entirely.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add comment quality rule | implement | — |
| 2. Rewrite src/ backward-facing comments | implement | 1 |
| 3. Rewrite tests/ backward-facing comments | implement | 1 |
| 4. Delete dead section markers | implement | 1 |
| 5. Verify CI passes | test | 2, 3, 4 |

## Tasks

### Task 1: Add comment quality rule

Create `.claude/rules/comment-quality.md` with prohibited patterns and the forward-facing test. No references to specific prior implementations — the rule must be timeless.

**Files:** `.claude/rules/comment-quality.md` (new)

### Task 2: Rewrite src/ backward-facing comments (~21 comments across ~15 files)

For each comment, read the surrounding code to understand what invariant or contract exists, then rewrite with forward-facing language. Examples:
- "matches X timeout=30" becomes "30s timeout prevents hanging on unresponsive API"
- "Silent on failure — matches X" becomes "Silent on failure — cleanup is best-effort"
- 6-line historical essay in `session_context.rs` becomes one-line contract description

**Files:** `src/git.rs`, `src/commands/session_context.rs`, `src/prime_check.rs`, `src/hooks/stop_continue.rs`, `src/promote_permissions.rs`, `src/upgrade_check.rs`, `src/detect_framework.rs`, `src/utils.rs`, `src/auto_close_parent.rs`, `src/complete_post_merge.rs`, `src/complete_merge.rs`, `src/prime_project.rs`, `src/orchestrate_report.rs`, `src/analyze_issues.rs`, `src/issue.rs`

### Task 3: Rewrite tests/ backward-facing comments (~14 comments across ~12 files)

Rewrite file headers from origin stories to coverage descriptions. Rewrite regression test comments from "before the fix" to "guards against". Replace "no longer" with current behavior descriptions.

**Files:** `tests/concurrency.rs`, `tests/skill_contracts.rs`, `tests/permissions.rs`, `tests/check_freshness.rs`, `tests/bin_dependencies.rs`, `tests/bin_flow.rs`, `tests/dispatcher.rs`, `tests/start_init.rs`, `tests/start_workspace.rs`, `tests/detect_framework.rs`, `tests/promote_permissions.rs`, `tests/check_phase.rs`, `tests/hooks.rs`

### Task 4: Delete dead section markers in structural.rs

Remove three `// --- X parity tests removed in PR #953 ---` comment lines. These are gravestones for sections that no longer exist.

**Files:** `tests/structural.rs` (lines 176, 455, 531)

### Task 5: Verify CI passes

Run `bin/flow ci` and confirm all tests pass with comment-only changes.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: Rewrite backward-facing comments and add comment quality rule

## Problem

~35 comments across the Rust codebase (`src/*.rs` and `tests/*.rs`) reference a deleted implementation or cite PR numbers as the explanation for why code exists. These backward-facing comments don't help future readers — they require historical context that no longer exists to be useful.

The codebase is not overly commented (~200+ forward-facing doc comments, zero noise). The issue is narrow: comments that anchor to references of prior implementations, "Removed in PR #NNN", "Before the fix", or "no longer".

No rule currently prevents this pattern from recurring.

## Acceptance Criteria

- All ~35 backward-facing comments in `src/*.rs` and `tests/*.rs` are rewritten to be forward-facing (describe WHY behavior exists, WHAT a test guards) or deleted (dead section markers, pure PR citations)
- A new rule file `.claude/rules/comment-quality.md` exists that prohibits backward-facing comment patterns
- `bin/flow ci` passes after all changes
- No new backward-facing comments introduced by the changes themselves

## Implementation Plan

### Context

Comments written during a major port used the prior implementation as the reference point for behavior choices. That implementation is deleted — the comments now point to nothing. A rule is needed to prevent the pattern from recurring.

### Exploration

The audit identified ~35 backward-facing comments across 27 files, categorized into 7 groups:

1. **"matches X" parity references** (~18 in src/) — describe behavior by pointing to a deleted codebase
2. **"Removed in PR #NNN"** (~6 in src/) — historical provenance belonging in git history
3. **"Port of test_*.py" file headers** (~4 test files) — describe origin, not coverage
4. **"Before the fix" regression comments** (~4 in tests/) — describe what was broken, not what's guarded
5. **Dead section markers** (3 in structural.rs) — gravestones for removed tests
6. **"no longer" / stale behavior** (~3 scattered) — describe past behavior, not current contracts
7. **Stale fallback references** (~4 in tests/) — describe what was replaced, not what exists

No existing rule covers comment quality. The closest is the global CLAUDE.md line "Only add comments where the logic isn't self-evident" which addresses whether to comment, not how.

### Risks

- **Misrewriting a comment that carries a subtle invariant** — each rewrite must preserve the WHY if one exists beneath the backward reference. Read the surrounding code before rewriting.
- **Tombstone false positives** — tombstone comments reference PR numbers by design. The task must skip any comment matching the `Tombstone:.*PR #(\d+)` pattern.
- **Contract test interference** — `tests/skill_contracts.rs` scans SKILL.md files for prohibited strings. The new rule file is a `.claude/rules/` file, not a skill, so no contract test risk.

### Approach

Two-part change: (1) add a `.claude/rules/comment-quality.md` rule that prohibits backward-facing patterns, (2) rewrite or delete all ~35 identified comments. Each rewrite replaces a backward reference with forward-facing language describing WHY the behavior exists or WHAT the test guards. Dead section markers are deleted entirely.

### Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add comment quality rule | implement | — |
| 2. Rewrite src/ backward-facing comments | implement | 1 |
| 3. Rewrite tests/ backward-facing comments | implement | 1 |
| 4. Delete dead section markers | implement | 1 |
| 5. Verify CI passes | test | 2, 3, 4 |

### Tasks

#### Task 1: Add comment quality rule

Create `.claude/rules/comment-quality.md` with prohibited patterns and the forward-facing test. No references to specific prior implementations — the rule must be timeless.

**Files:** `.claude/rules/comment-quality.md` (new)

#### Task 2: Rewrite src/ backward-facing comments (~21 comments across ~15 files)

For each comment, read the surrounding code to understand what invariant or contract exists, then rewrite with forward-facing language. Examples:
- "matches X timeout=30" becomes "30s timeout prevents hanging on unresponsive API"
- "Silent on failure — matches X" becomes "Silent on failure — cleanup is best-effort"
- 6-line historical essay in `session_context.rs` becomes one-line contract description

**Files:** `src/git.rs`, `src/commands/session_context.rs`, `src/prime_check.rs`, `src/hooks/stop_continue.rs`, `src/promote_permissions.rs`, `src/upgrade_check.rs`, `src/detect_framework.rs`, `src/utils.rs`, `src/auto_close_parent.rs`, `src/complete_post_merge.rs`, `src/complete_merge.rs`, `src/prime_project.rs`, `src/orchestrate_report.rs`, `src/analyze_issues.rs`, `src/issue.rs`

#### Task 3: Rewrite tests/ backward-facing comments (~14 comments across ~12 files)

Rewrite file headers from origin stories to coverage descriptions. Rewrite regression test comments from "before the fix" to "guards against". Replace "no longer" with current behavior descriptions.

**Files:** `tests/concurrency.rs`, `tests/skill_contracts.rs`, `tests/permissions.rs`, `tests/check_freshness.rs`, `tests/bin_dependencies.rs`, `tests/bin_flow.rs`, `tests/dispatcher.rs`, `tests/start_init.rs`, `tests/start_workspace.rs`, `tests/detect_framework.rs`, `tests/promote_permissions.rs`, `tests/check_phase.rs`, `tests/hooks.rs`

#### Task 4: Delete dead section markers in structural.rs

Remove three `// --- X parity tests removed in PR #953 ---` comment lines. These are gravestones for sections that no longer exist.

**Files:** `tests/structural.rs` (lines 176, 455, 531)

#### Task 5: Verify CI passes

Run `bin/flow ci` and confirm all tests pass with comment-only changes.

## Files to Investigate

**src/ files with backward-facing comments:**
- `src/git.rs:96` — "Removed in PR #924"
- `src/commands/session_context.rs:14-19` — 6-line historical essay about PR #938
- `src/prime_check.rs:238-240` — "Changed from lib/prime-setup.py in PR #894"
- `src/hooks/stop_continue.rs:72,212,297,985,1059` — multiple parity refs
- `src/promote_permissions.rs:32,141` — "matching the script's output shape"
- `src/upgrade_check.rs:428-429` — "The original had a copy-paste bug"
- `src/detect_framework.rs:30,36` — "mirror Path.glob"
- `src/utils.rs:424` — "matching the implementation"
- `src/auto_close_parent.rs:25` — "matches LOCAL_TIMEOUT = 30"
- `src/complete_post_merge.rs:156,476` — "matches truthy check" / "matches main()"
- `src/complete_merge.rs:242` — "matches behavior"
- `src/prime_project.rs:39` — "matching the script's shape"
- `src/orchestrate_report.rs:18` — "matching the original's graceful fallback"
- `src/analyze_issues.rs:228,264,471` — "matches timeout=30"
- `src/issue.rs:74` — "matches behavior"

**tests/ files with backward-facing comments:**
- `tests/structural.rs:176,455,531` — dead "removed in PR #953" section markers
- `tests/concurrency.rs:1`, `tests/skill_contracts.rs:1`, `tests/permissions.rs:1`, `tests/check_freshness.rs:3` — "port of" file headers
- `tests/bin_dependencies.rs:1`, `tests/bin_flow.rs:3,118`, `tests/dispatcher.rs:101` — stale fallback references
- `tests/start_init.rs:302-303`, `tests/start_workspace.rs:137-139` — "before the fix" regression comments
- `tests/detect_framework.rs:341-343`, `tests/promote_permissions.rs:383` — adversarial regression with historical refs
- `tests/check_phase.rs:185`, `tests/hooks.rs:687` — "no longer" stale behavior

## Out of Scope

- Adding new comments — this is a rewrite/delete pass only
- Tombstone comments that reference PR numbers (valid by design for the audit lifecycle)
- Changing any code behavior — comments only

## Context

Many comments written during a major infrastructure port used the prior implementation as the reference point ("matches X"). These were useful during the port but are now technical debt — the prior code is deleted and the comments point to nothing. A rule is needed to prevent this pattern from recurring as the codebase evolves.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | <1m |
| Code | 35m |
| Code Review | 14m |
| Learn | 7m |
| Complete | 2m |
| **Total** | **1h 0m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/rewrite-backward-facing-comments.json</summary>

```json
{
  "schema_version": 1,
  "branch": "rewrite-backward-facing-comments",
  "repo": "benkruger/flow",
  "pr_number": 993,
  "pr_url": "https://github.com/benkruger/flow/pull/993",
  "started_at": "2026-04-10T11:42:56-07:00",
  "current_phase": "flow-complete",
  "framework": "rust",
  "files": {
    "plan": ".flow-states/rewrite-backward-facing-comments-plan.md",
    "dag": ".flow-states/rewrite-backward-facing-comments-dag.md",
    "log": ".flow-states/rewrite-backward-facing-comments.log",
    "state": ".flow-states/rewrite-backward-facing-comments.json"
  },
  "session_tty": "/dev/ttys005",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "Rewrite backward-facing comments and add comment quality rule #992",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T11:42:56-07:00",
      "completed_at": "2026-04-10T11:43:27-07:00",
      "session_started_at": null,
      "cumulative_seconds": 31,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-10T11:43:37-07:00",
      "completed_at": "2026-04-10T11:43:39-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-10T11:45:12-07:00",
      "completed_at": "2026-04-10T12:21:00-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2148,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-10T12:21:12-07:00",
      "completed_at": "2026-04-10T12:35:31-07:00",
      "session_started_at": null,
      "cumulative_seconds": 859,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-10T12:35:47-07:00",
      "completed_at": "2026-04-10T12:43:30-07:00",
      "session_started_at": null,
      "cumulative_seconds": 463,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-10T12:44:00-07:00",
      "completed_at": "2026-04-10T12:46:32-07:00",
      "session_started_at": null,
      "cumulative_seconds": 152,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T11:43:37-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-10T11:45:12-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-10T12:21:12-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-10T12:35:47-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-10T12:44:00-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 5,
  "code_task_name": "Verify CI passes",
  "code_task": 5,
  "diff_stats": {
    "files_changed": 47,
    "insertions": 142,
    "deletions": 115,
    "captured_at": "2026-04-10T12:21:00-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "Remaining backward-facing comments in files not touched by PR #993",
      "url": "https://github.com/benkruger/flow/issues/996",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-10T12:30:04-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/rewrite-backward-facing-comments.log</summary>

```text
2026-04-10T11:42:55-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T11:42:55-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T11:42:56-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T11:42:56-07:00 [Phase 1] create .flow-states/rewrite-backward-facing-comments.json (exit 0)
2026-04-10T11:42:56-07:00 [Phase 1] freeze .flow-states/rewrite-backward-facing-comments-phases.json (exit 0)
2026-04-10T11:42:56-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T11:42:57-07:00 [Phase 1] start-init — label-issues (labeled: [992], failed: [])
2026-04-10T11:43:04-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T11:43:04-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T11:43:04-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T11:43:13-07:00 [Phase 1] start-workspace — worktree .worktrees/rewrite-backward-facing-comments (ok)
2026-04-10T11:43:17-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T11:43:17-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T11:43:17-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T11:43:27-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T11:43:27-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T11:43:37-07:00 [Phase 2] plan-extract — gate check passed (exit 0)
2026-04-10T11:43:37-07:00 [Phase 2] plan-extract — issue #992 fetched, decomposed label detected (exit 0)
2026-04-10T11:43:37-07:00 [Phase 2] plan-extract — DAG file written: .flow-states/rewrite-backward-facing-comments-dag.md (exit 0)
2026-04-10T11:43:37-07:00 [Phase 2] plan-extract — plan extracted, 5 tasks, written: .flow-states/rewrite-backward-facing-comments-plan.md (exit 0)
2026-04-10T11:43:39-07:00 [Phase 2] plan-extract — PR body rendered (exit 0)
2026-04-10T11:43:39-07:00 [Phase 2] plan-extract — phase complete (<1m) (exit 0)
2026-04-10T11:45:12-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-10T12:21:00-07:00 [Phase] phase-finalize --phase flow-code ("ok")
2026-04-10T12:21:12-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-10T12:35:31-07:00 [Phase] phase-finalize --phase flow-code-review ("ok")
2026-04-10T12:35:47-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-10T12:43:30-07:00 [Phase] phase-finalize --phase flow-learn ("ok")
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | Remaining backward-facing comments in files not touched by PR #993 | Code Review | #996 |

<!-- end:Issues Filed -->