### PR TITLE
Make Adversarial Agent Framework

### DIFF
--- a/.claude/rules/skill-authoring.md
+++ b/.claude/rules/skill-authoring.md
@@ -415,6 +415,24 @@ that includes framework-specific syntax examples, check the
 add a pattern for each. If a framework's convention cannot be expressed
 concisely, note the framework name and link to its convention.
 
+## Framework Table Placeholder Consistency
+
+When a SKILL.md includes a framework table that parameterizes behavior
+(paths, commands, configuration), every framework row must use the
+same placeholder names for equivalent columns. If one framework uses
+`<temp_test_file>` in a command column, all frameworks that include a
+command must use the same placeholder — not `<path>` or other aliases.
+
+Why: placeholder names are contracts with downstream consumers (agents,
+permission tests, placeholder substitution in `tests/permissions.rs`).
+Inconsistent naming means only one variant gets tested and the others
+silently substitute wrong values or skip validation entirely.
+
+How to apply: after writing a framework table, scan every cell for
+angle-bracket placeholders and verify every row uses identical names
+for the same semantic value. If Code Review fixes a placeholder in one
+row, verify all rows in the same pass.
+
 ## Purpose Preamble for Behavioral Sections
 
 Every new behavioral subsection in a SKILL.md (a subsection with

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,19 +42,11 @@
       "Bash(rm .flow-*)",
       "Bash(rm -rf *.qa-repos*)",
       "Bash(rm .claude/settings.local.json)",
-      "Bash(rm tests/test_adversarial_*)",
       "Bash(chmod +x *)",
       "Bash(cd *)",
       "Bash(pwd)",
       "Bash(make *)",
       "Bash(diff *)",
-      "Bash(cargo build *)",
-      "Bash(cargo test *)",
-      "Bash(cargo nextest *)",
-      "Bash(cargo check *)",
-      "Bash(cargo clippy *)",
-      "Bash(cargo fmt *)",
-      "Bash(cargo version)",
       "Bash(curl *)",
       "Bash(open:*)",
       "Read(~/Desktop/*.png)",
@@ -92,7 +84,9 @@
       "Bash(gh * --admin*)",
       "Bash(* && *)",
       "Bash(* ; *)",
-      "Bash(* | *)"
+      "Bash(* | *)",
+      "Bash(cargo *)",
+      "Bash(rustc *)"
     ]
   },
   "attribution": {

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@ target/
 
 # Python / test artifacts
 __pycache__/
-tests/test_adversarial_*.py
-tests/adversarial_*.rs
 .venv
 .venv/
 .pytest_cache/

--- a/agents/adversarial.md
+++ b/agents/adversarial.md
@@ -21,7 +21,8 @@ it. Only failures matter.
 The substantive diff (`git diff origin/main...HEAD -w`) is provided in
 your prompt — whitespace-only changes are filtered out so your turn
 budget is spent on behavioral analysis, not formatting noise. The branch
-name and project CLAUDE.md path are also provided. Use the
+name, project CLAUDE.md path, temp test file path (`<temp_test_file>`),
+and test command (`<test_command>`) are also provided. Use the
 Read tool to read the CLAUDE.md for test conventions and patterns. Use
 Read, Glob, and Grep to investigate the codebase.
 
@@ -57,10 +58,11 @@ patterns, imports, targeted test command).
 
 Write the test file using the Write tool to `<temp_test_file>`.
 
-**Run the tests.** Execute only your adversarial test file:
+**Run the tests.** Execute only your adversarial test file using the
+test command provided in your prompt:
 
 ```bash
-bin/test <temp_test_file>
+<test_command>
 ```
 
 **Collect results.** For each test:
@@ -91,7 +93,7 @@ For each finding (failing test), produce a structured block:
 **Finding N: [Short title]**
 
 - **Test code:** The failing test function (complete, runnable)
-- **Failure output:** The pytest failure message
+- **Failure output:** The test failure output
 - **What it proves:** Which code path is insufficiently tested
 - **Severity:** Critical / High / Medium / Low
 
@@ -116,15 +118,21 @@ function, branch, or guard you traverse. Use Read or Grep to verify
 each step — do not assume behavior from names alone. If the path is
 already guarded or tested, discard the candidate.
 
+**Verify.** Before writing the test, use the Read tool to confirm
+that every file and function referenced in the Premise and Trace
+actually exists in the codebase. If a file was deleted, renamed, or
+a function signature changed, the edge case may no longer apply.
+Discard candidates where the verify step reveals stale references.
+
 **Conclude.** State whether the gap is confirmed — the path is
 reachable with the stated input and no existing test covers it.
 Only write a test for confirmed gaps. Discard speculative edge
-cases that the trace refutes.
+cases that the trace or verify step refutes.
 
 ## Rules
 
 - Only use the Write tool to write to `<temp_test_file>` — no other path
-- Only use Bash for `bin/test`, `rm`, `git log`, `git show`, and `git diff`
+- Only use Bash for `<test_command>`, `rm`, `git log`, `git show`, and `git diff`
 - Never use `cd <path> && git` — use `git -C <path>` if needed
 - Never use piped commands (|) — use separate Bash calls
 - Never use cat, head, tail, grep, rg, find, or ls via Bash

--- a/docs/skills/flow-code-review.md
+++ b/docs/skills/flow-code-review.md
@@ -34,8 +34,9 @@ from agents — the parent session never reviews the diff itself.
 
 Collect all artifacts: full branch diff, substantive diff (whitespace
 changes filtered via `git diff -w`), plan file, CLAUDE.md, rules files,
-check for `bin/test`, run `tombstone-audit` to identify stale tombstones
-for removal in Step 4. No analysis.
+derive adversarial test setup from `framework` (per-framework temp file
+path and test command), run `tombstone-audit` to identify stale
+tombstones for removal in Step 4. No analysis.
 
 ### Step 2 — Launch
 

--- a/skills/flow-code-review/SKILL.md
+++ b/skills/flow-code-review/SKILL.md
@@ -33,7 +33,8 @@ Parse the JSON output. If `"status": "error"`, STOP and show the error.
 
 If `"status": "ok"`, capture the returned fields:
 `project_root`, `branch`, `worktree_path`, `pr_number`, `pr_url`,
-`feature`, `slack_thread_ts`, `plan_file`, and `mode` (commit + continue).
+`feature`, `slack_thread_ts`, `plan_file`, `framework`, and `mode`
+(commit + continue).
 
 </HARD-GATE>
 
@@ -169,15 +170,23 @@ prettier, black) reformat many files, the substantive diff excludes
 formatting noise and preserves the agents' turn budget for behavioral
 analysis.
 
-**Check for test runner.**
+**Derive adversarial test setup from framework.**
 
-```bash
-test -f bin/flow
-```
+The `framework` field from `phase-enter` determines the adversarial
+agent's temp file path and test command. This ensures tests are written
+in the project's language and run with the correct tool.
 
-If the command succeeds (exit 0), `bin/flow` exists — the adversarial
-agent should be launched in Step 2. If it fails (exit non-zero), skip
-the adversarial agent in Step 2.
+| Framework | Temp file | Test command | Skip? |
+|-----------|-----------|-------------|-------|
+| rust | `.flow-states/<branch>-adversarial_test.rs` | `${CLAUDE_PLUGIN_ROOT}/bin/flow test --file <path>` | No |
+| python | `.flow-states/<branch>-adversarial_test.py` | `bin/test <path>` | No |
+| rails | `.flow-states/<branch>-adversarial_test.py` | `bin/test <path>` | No |
+| go | — | — | Yes |
+| ios | — | — | Yes |
+| (missing/unknown) | — | — | Yes |
+
+Capture `<temp_test_file>` and `<test_command>` for Step 2. If the
+framework is skipped, do not launch the adversarial agent in Step 2.
 
 **Audit tombstone staleness.**
 
@@ -262,15 +271,10 @@ Provide the substantive diff output in the prompt, prefixed with:
 > explicitly in scope."
 
 **Adversarial agent** — context-sparse (receives substantive diff, temp
-file path, CLAUDE.md path, branch name). Only launch if `bin/flow` exists:
+file path, test command, CLAUDE.md path, branch name). Only launch if the
+framework supports adversarial testing (see the table in Step 1).
 
-Determine the temp test file path using the branch name from the state file:
-
-```text
-tests/test_adversarial_<branch>.py
-```
-
-Replace `<branch>` with the actual branch name (hyphens are fine in filenames).
+Use the `<temp_test_file>` and `<test_command>` derived in Step 1.
 
 Use the Agent tool with:
 
@@ -279,7 +283,8 @@ Use the Agent tool with:
 
 Provide the substantive diff output in the prompt, along with:
 
-- The temp test file path
+- The temp test file path (`<temp_test_file>`)
+- The test command (`<test_command>`)
 - The path to the project CLAUDE.md
 - The branch name
 
@@ -304,11 +309,11 @@ Prefix the prompt with:
 
 Wait for all agents to return.
 
-If the adversarial agent was launched (`bin/flow` exists), verify the
-temp test file was deleted. If it still exists, delete it:
+If the adversarial agent was launched, verify the temp test file was
+deleted. If it still exists, delete it:
 
 ```bash
-rm tests/test_adversarial_<branch>.py
+rm <temp_test_file>
 ```
 
 Record step completion:

--- a/skills/flow-code-review/SKILL.md
+++ b/skills/flow-code-review/SKILL.md
@@ -178,9 +178,9 @@ in the project's language and run with the correct tool.
 
 | Framework | Temp file | Test command | Skip? |
 |-----------|-----------|-------------|-------|
-| rust | `.flow-states/<branch>-adversarial_test.rs` | `${CLAUDE_PLUGIN_ROOT}/bin/flow test --file <path>` | No |
+| rust | `.flow-states/<branch>-adversarial_test.rs` | `${CLAUDE_PLUGIN_ROOT}/bin/flow test --file <temp_test_file>` | No |
 | python | `.flow-states/<branch>-adversarial_test.py` | `bin/test <path>` | No |
-| rails | `.flow-states/<branch>-adversarial_test.py` | `bin/test <path>` | No |
+| rails | `.flow-states/<branch>-adversarial_test.rb` | `bin/test <path>` | No |
 | go | — | — | Yes |
 | ios | — | — | Yes |
 | (missing/unknown) | — | — | Yes |

--- a/skills/flow-prime/SKILL.md
+++ b/skills/flow-prime/SKILL.md
@@ -281,7 +281,6 @@ All permissions (universal + all framework sets) for reference:
       "Bash(gh -C *)",
       "Bash(*bin/flow *)",
       "Bash(rm .flow-*)",
-      "Bash(rm tests/test_adversarial_*)",
       "Bash(test -f *)",
       "Bash(claude plugin list)",
       "Bash(claude plugin marketplace add *)",

--- a/src/phase_enter.rs
+++ b/src/phase_enter.rs
@@ -178,6 +178,12 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         .and_then(|v| v.as_str())
         .map(String::from);
 
+    let framework = state
+        .get("framework")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
     // Plan file: check files.plan first, fall back to plan_file
     let plan_file = state
         .get("files")
@@ -272,6 +278,9 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     }
     if let Some(ref pf) = plan_file {
         response["plan_file"] = json!(pf);
+    }
+    if let Some(ref fw) = framework {
+        response["framework"] = json!(fw);
     }
 
     Ok(response)

--- a/src/prime_check.rs
+++ b/src/prime_check.rs
@@ -78,7 +78,6 @@ pub const UNIVERSAL_ALLOW: &[&str] = &[
     "Bash(gh -C *)",
     "Bash(*bin/flow *)",
     "Bash(rm .flow-*)",
-    "Bash(rm tests/test_adversarial_*)",
     "Bash(test -f *)",
     "Bash(claude plugin list)",
     "Bash(claude plugin marketplace add *)",

--- a/tests/permissions.rs
+++ b/tests/permissions.rs
@@ -183,6 +183,14 @@ const PLACEHOLDER_SUBS: &[(&str, &str)] = &[
     ("<topic>", "testing-gotchas"),
     ("<description>", "Update contract tests"),
     ("<slack_thread_ts>", "1234567890.123456"),
+    (
+        "<temp_test_file>",
+        ".flow-states/test-branch-adversarial_test.py",
+    ),
+    (
+        "<test_command>",
+        "bin/test .flow-states/test-branch-adversarial_test.py",
+    ),
 ];
 
 fn substitute_placeholders(line: &str) -> Option<String> {

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2853,6 +2853,65 @@ fn code_review_no_plugin_config_axis() {
     );
 }
 
+// --- Adversarial framework-awareness (PR #998) ---
+
+#[test]
+fn code_review_no_hardcoded_python_adversarial_path() {
+    // Tombstone: hardcoded Python test path removed in PR #998. Must not return.
+    let c = common::read_skill("flow-code-review");
+    assert!(
+        !c.contains("test_adversarial_"),
+        "SKILL.md must not contain hardcoded test_adversarial_ Python path"
+    );
+}
+
+#[test]
+fn adversarial_agent_no_pytest_reference() {
+    // Tombstone: pytest reference removed in PR #998. Must not return.
+    let c = common::read_agent("adversarial.md");
+    assert!(
+        !c.contains("pytest"),
+        "adversarial.md must not contain literal pytest reference"
+    );
+}
+
+#[test]
+fn adversarial_agent_no_hardcoded_bin_test() {
+    // Tombstone: hardcoded bin/test runner removed in PR #998. Must not return.
+    let c = common::read_agent("adversarial.md");
+    assert!(
+        !c.contains("bin/test"),
+        "adversarial.md must not contain hardcoded bin/test runner"
+    );
+}
+
+#[test]
+fn adversarial_agent_has_verify_step() {
+    let c = common::read_agent("adversarial.md");
+    assert!(
+        c.contains("**Verify."),
+        "adversarial.md Reasoning Discipline must contain a Verify step"
+    );
+}
+
+#[test]
+fn code_review_step_2_references_framework() {
+    let c = common::read_skill("flow-code-review");
+    assert!(
+        c.contains("framework"),
+        "SKILL.md Step 2 must reference framework for adversarial setup"
+    );
+}
+
+#[test]
+fn adversarial_agent_uses_test_command_placeholder() {
+    let c = common::read_agent("adversarial.md");
+    assert!(
+        c.contains("<test_command>"),
+        "adversarial.md must reference <test_command> parameterized runner"
+    );
+}
+
 // --- Tombstone audit fixture contamination prevention ---
 
 /// `scan_test_files()` reads ALL `tests/*.rs` files and runs `extract_pr_numbers()`


### PR DESCRIPTION
## What

Make adversarial agent framework-aware and lock down FLOW repo cargo permissions #994.

Closes #994

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/make-adversarial-agent-framework-plan.md` |
| DAG | `.flow-states/make-adversarial-agent-framework-dag.md` |
| Log | `.flow-states/make-adversarial-agent-framework.log` |
| State | `.flow-states/make-adversarial-agent-framework.json` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
## Context

`bin/flow test` already exists (`src/test_runner.rs`, registered in `src/main.rs`). The flow-prime target project deny list already has `Bash(cargo *)` and `Bash(rustc *)`. What remains is: (a) applying the same deny to the FLOW repo's own settings, (b) making the code review skill and adversarial agent framework-aware, and (c) adding contract tests.

## Exploration

- `agents/adversarial.md` — hardcodes `bin/test <temp_test_file>` (line 63), "pytest failure message" (line 94), `bin/test` in Rules (line 127). Reasoning Discipline has Premise/Trace/Conclude but no Verify step (lines 103-122). Input section (lines 19-26) does not mention `<test_command>`.
- `skills/flow-code-review/SKILL.md` — Step 1 checks `test -f bin/flow` (line 175) as adversarial gate. Step 2 hardcodes `tests/test_adversarial_<branch>.py` (line 270) and cleanup `rm tests/test_adversarial_<branch>.py` (line 311). No framework field read. No `<test_command>` derivation.
- `.claude/settings.json` — allows `cargo build *`, `cargo test *`, `cargo nextest *`, `cargo check *`, `cargo clippy *`, `cargo fmt *`, `cargo version` (lines 51-57). No cargo/rustc deny entries. `rm tests/test_adversarial_*` on allow list (line 45).
- `skills/flow-prime/SKILL.md` — already has `Bash(cargo *)` and `Bash(rustc *)` on deny (lines 310-311). Still has `Bash(rm tests/test_adversarial_*)` on allow (line 284).
- `docs/skills/flow-code-review.md` — line 37 says "check for `bin/test`", stale (SKILL.md checks `bin/flow`).
- `tests/skill_contracts.rs` — existing adversarial assertions at lines 356, 400, 422, 472, 2654, 2741, 2832. None enforce the framework-awareness acceptance criteria.
- `src/test_runner.rs` — exists, implements `bin/flow test` with `--filter` and `--file` modes. Already registered in `src/main.rs`.
- Framework detection: state file `framework` field written by `start_setup.rs`. Five frameworks: python, rails, rust, go, ios.

## Risks

1. **FLOW repo cargo deny breaks development** — Deny list applies only to Claude's Bash tool calls, not internal subprocesses in `bin/flow` or `bin/ci`. All legitimate cargo usage goes through these wrappers. Low risk. Must verify: run `bin/flow ci` after lockdown to confirm no regression.
2. **flow-prime `rm tests/test_adversarial_*` removal** — removing this from flow-prime means target projects won't have the permission. But the new path is `.flow-states/` which is covered by `Bash(rm .flow-*)`. Low risk.

## Approach

Four sequential pieces:

**Piece 1: Contract tests** — tombstones and positive assertions in `tests/skill_contracts.rs`. Written first (TDD), will fail until pieces 2-3 land.

**Piece 2: Permission lockdown** — remove granular cargo allows from `.claude/settings.json`, add `Bash(cargo *)` and `Bash(rustc *)` to deny. Remove `Bash(rm tests/test_adversarial_*)` from both `.claude/settings.json` and `skills/flow-prime/SKILL.md`.

**Piece 3: SKILL.md + adversarial.md framework-awareness** — Step 1 reads `framework` from phase-enter. Step 2 derives temp path and test command per framework. Agent parameterized with `<test_command>`. Verify step added to Reasoning Discipline.

**Piece 4: Documentation** — update `docs/skills/flow-code-review.md` to reflect current behavior.

## Dependency Graph

```
Task 1 (contract tests)
  └─> Task 2 (permission lockdown)
  └─> Task 3 (SKILL.md + adversarial.md) ─> Task 4 (docs)
```

Tasks 2 and 3 depend on Task 1. Task 4 depends on Task 3. Tasks 2 and 3 are independent of each other.

## Tasks

### Task 1: Contract tests

Add to `tests/skill_contracts.rs`:

- Tombstone: SKILL.md must NOT contain `test_adversarial_` combined with `.py`
- Tombstone: `adversarial.md` must NOT contain literal `pytest`
- Tombstone: `adversarial.md` must NOT contain literal `bin/test` (hardcoded runner)
- Positive: `adversarial.md` Reasoning Discipline must contain `Verify`
- Positive: SKILL.md Step 2 must reference `framework` for adversarial setup
- Positive: `adversarial.md` must reference `<test_command>` (parameterized runner)

**Files:** `tests/skill_contracts.rs`

### Task 2: Permission lockdown — FLOW repo settings

`.claude/settings.json`:
- Remove: `Bash(cargo build *)`, `Bash(cargo test *)`, `Bash(cargo nextest *)`, `Bash(cargo check *)`, `Bash(cargo clippy *)`, `Bash(cargo fmt *)`, `Bash(cargo version)` from allow
- Remove: `Bash(rm tests/test_adversarial_*)` from allow
- Add to deny: `Bash(cargo *)`, `Bash(rustc *)`

`skills/flow-prime/SKILL.md`:
- Remove: `Bash(rm tests/test_adversarial_*)` from allow (line 284)

Run `bin/flow ci` after to verify no regression.

**Files:** `.claude/settings.json`, `skills/flow-prime/SKILL.md`

### Task 3: Framework-aware adversarial (SKILL.md + agent)

`skills/flow-code-review/SKILL.md`:
- Step 1: read `framework` from `phase-enter` response fields
- Step 2: replace hardcoded `tests/test_adversarial_<branch>.py` with framework-derived `.flow-states/<branch>-adversarial_test.<ext>` (`.rs` for Rust, `.py` for Python/Rails)
- Step 2: derive `<test_command>`: Rust uses `${CLAUDE_PLUGIN_ROOT}/bin/flow test --file <path>`, Python/Rails use `bin/test <path>`, Go/iOS/unknown skip adversarial
- Step 2: pass both `<temp_test_file>` and `<test_command>` in adversarial agent prompt
- Step 2: cleanup uses derived path

`agents/adversarial.md`:
- Input section: document `<test_command>` parameter
- Line 63: replace `bin/test <temp_test_file>` with `<test_command>`
- Line 94: replace "pytest failure message" with "test failure output"
- Line 127: replace `bin/test` with `<test_command>` in allowed Bash commands
- Reasoning Discipline: add Verify step between Trace and Conclude requiring file-existence checks

**Files:** `skills/flow-code-review/SKILL.md`, `agents/adversarial.md`

### Task 4: Documentation

- `docs/skills/flow-code-review.md` line 37: update "check for `bin/test`" to reflect current behavior (checks for `bin/flow`, framework-aware adversarial)

**Files:** `docs/skills/flow-code-review.md`
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# Pre-Decomposed Analysis: Make adversarial agent framework-aware and lock down FLOW repo cargo permissions

## Problem

The adversarial agent (`agents/adversarial.md`) and its invocation in `skills/flow-code-review/SKILL.md` Step 2 are still Python-hardcoded in ways that cause failures on non-Python projects. `bin/flow test` was shipped in a prior PR but the adversarial agent and code review skill were never updated to use it.

Additionally, `.claude/settings.json` for the FLOW repo itself still allows direct `cargo *` commands — the flow-prime target project deny was added but the FLOW repo's own permissions were not updated.

Remaining from #955 (which also tracked the completed `bin/flow test` subcommand and flow-prime permission lockdown):

1. **FLOW repo `.claude/settings.json`** — still allows `Bash(cargo build *)`, `Bash(cargo test *)`, `Bash(cargo nextest *)`, `Bash(cargo check *)`, `Bash(cargo clippy *)`, `Bash(cargo fmt *)`, `Bash(cargo version)` (lines 51-57). No `Bash(cargo *)` or `Bash(rustc *)` deny entries. `Bash(rm tests/test_adversarial_*)` still in allow list (line 45).

2. **SKILL.md Step 2 hardcodes Python** — temp file path is `tests/test_adversarial_<branch>.py` (line 270). Cleanup is `rm tests/test_adversarial_<branch>.py` (line 311). No framework detection. No `<test_command>` derivation.

3. **adversarial.md hardcodes Python** — `bin/test <temp_test_file>` (line 63), "pytest failure message" (line 94), no Verify step in Reasoning Discipline (lines 103-122). Rules section (line 127) hardcodes `bin/test` in allowed Bash commands.

4. **Documentation** — `docs/skills/flow-code-review.md` line 37 says "check for `bin/test`" but the actual SKILL.md checks for `bin/flow` (line 175).

## Acceptance Criteria

- `.claude/settings.json`: granular `cargo *` allows removed, `Bash(cargo *)` and `Bash(rustc *)` on deny list, `rm tests/test_adversarial_*` removed
- `skills/flow-code-review/SKILL.md` Step 1 reads `framework` from `phase-enter` response
- SKILL.md Step 2 derives temp file path as `.flow-states/<branch>-adversarial_test.<ext>` based on framework
- SKILL.md Step 2 derives `<test_command>` per framework (Rust: `${CLAUDE_PLUGIN_ROOT}/bin/flow test --file <path>`, Python/Rails: `bin/test <path>`, Go/iOS/unknown: skip adversarial)
- SKILL.md Step 2 passes both `<temp_test_file>` and `<test_command>` to adversarial agent prompt
- `agents/adversarial.md` uses `<test_command>` instead of hardcoded `bin/test`
- `agents/adversarial.md` says "test failure output" instead of "pytest failure message"
- `agents/adversarial.md` Reasoning Discipline contains a Verify step requiring file-existence checks before reporting findings
- `agents/adversarial.md` Rules section uses `<test_command>` instead of hardcoded `bin/test`
- `docs/skills/flow-code-review.md` updated to reflect current behavior
- Contract tests enforce all of the above
- All existing CI passes

## Implementation Plan

### Context

`bin/flow test` already exists (`src/test_runner.rs`, registered in `src/main.rs`). The flow-prime target project deny list already has `Bash(cargo *)` and `Bash(rustc *)`. What remains is: (a) applying the same deny to the FLOW repo's own settings, (b) making the code review skill and adversarial agent framework-aware, and (c) adding contract tests.

### Exploration

- `agents/adversarial.md` — hardcodes `bin/test <temp_test_file>` (line 63), "pytest failure message" (line 94), `bin/test` in Rules (line 127). Reasoning Discipline has Premise/Trace/Conclude but no Verify step (lines 103-122). Input section (lines 19-26) does not mention `<test_command>`.
- `skills/flow-code-review/SKILL.md` — Step 1 checks `test -f bin/flow` (line 175) as adversarial gate. Step 2 hardcodes `tests/test_adversarial_<branch>.py` (line 270) and cleanup `rm tests/test_adversarial_<branch>.py` (line 311). No framework field read. No `<test_command>` derivation.
- `.claude/settings.json` — allows `cargo build *`, `cargo test *`, `cargo nextest *`, `cargo check *`, `cargo clippy *`, `cargo fmt *`, `cargo version` (lines 51-57). No cargo/rustc deny entries. `rm tests/test_adversarial_*` on allow list (line 45).
- `skills/flow-prime/SKILL.md` — already has `Bash(cargo *)` and `Bash(rustc *)` on deny (lines 310-311). Still has `Bash(rm tests/test_adversarial_*)` on allow (line 284).
- `docs/skills/flow-code-review.md` — line 37 says "check for `bin/test`", stale (SKILL.md checks `bin/flow`).
- `tests/skill_contracts.rs` — existing adversarial assertions at lines 356, 400, 422, 472, 2654, 2741, 2832. None enforce the framework-awareness acceptance criteria.
- `src/test_runner.rs` — exists, implements `bin/flow test` with `--filter` and `--file` modes. Already registered in `src/main.rs`.
- Framework detection: state file `framework` field written by `start_setup.rs`. Five frameworks: python, rails, rust, go, ios.

### Risks

1. **FLOW repo cargo deny breaks development** — Deny list applies only to Claude's Bash tool calls, not internal subprocesses in `bin/flow` or `bin/ci`. All legitimate cargo usage goes through these wrappers. Low risk. Must verify: run `bin/flow ci` after lockdown to confirm no regression.
2. **flow-prime `rm tests/test_adversarial_*` removal** — removing this from flow-prime means target projects won't have the permission. But the new path is `.flow-states/` which is covered by `Bash(rm .flow-*)`. Low risk.

### Approach

Four sequential pieces:

**Piece 1: Contract tests** — tombstones and positive assertions in `tests/skill_contracts.rs`. Written first (TDD), will fail until pieces 2-3 land.

**Piece 2: Permission lockdown** — remove granular cargo allows from `.claude/settings.json`, add `Bash(cargo *)` and `Bash(rustc *)` to deny. Remove `Bash(rm tests/test_adversarial_*)` from both `.claude/settings.json` and `skills/flow-prime/SKILL.md`.

**Piece 3: SKILL.md + adversarial.md framework-awareness** — Step 1 reads `framework` from phase-enter. Step 2 derives temp path and test command per framework. Agent parameterized with `<test_command>`. Verify step added to Reasoning Discipline.

**Piece 4: Documentation** — update `docs/skills/flow-code-review.md` to reflect current behavior.

### Dependency Graph

```
Task 1 (contract tests)
  └─> Task 2 (permission lockdown)
  └─> Task 3 (SKILL.md + adversarial.md) ─> Task 4 (docs)
```

Tasks 2 and 3 depend on Task 1. Task 4 depends on Task 3. Tasks 2 and 3 are independent of each other.

### Tasks

#### Task 1: Contract tests

Add to `tests/skill_contracts.rs`:

- Tombstone: SKILL.md must NOT contain `test_adversarial_` combined with `.py`
- Tombstone: `adversarial.md` must NOT contain literal `pytest`
- Tombstone: `adversarial.md` must NOT contain literal `bin/test` (hardcoded runner)
- Positive: `adversarial.md` Reasoning Discipline must contain `Verify`
- Positive: SKILL.md Step 2 must reference `framework` for adversarial setup
- Positive: `adversarial.md` must reference `<test_command>` (parameterized runner)

**Files:** `tests/skill_contracts.rs`

#### Task 2: Permission lockdown — FLOW repo settings

`.claude/settings.json`:
- Remove: `Bash(cargo build *)`, `Bash(cargo test *)`, `Bash(cargo nextest *)`, `Bash(cargo check *)`, `Bash(cargo clippy *)`, `Bash(cargo fmt *)`, `Bash(cargo version)` from allow
- Remove: `Bash(rm tests/test_adversarial_*)` from allow
- Add to deny: `Bash(cargo *)`, `Bash(rustc *)`

`skills/flow-prime/SKILL.md`:
- Remove: `Bash(rm tests/test_adversarial_*)` from allow (line 284)

Run `bin/flow ci` after to verify no regression.

**Files:** `.claude/settings.json`, `skills/flow-prime/SKILL.md`

#### Task 3: Framework-aware adversarial (SKILL.md + agent)

`skills/flow-code-review/SKILL.md`:
- Step 1: read `framework` from `phase-enter` response fields
- Step 2: replace hardcoded `tests/test_adversarial_<branch>.py` with framework-derived `.flow-states/<branch>-adversarial_test.<ext>` (`.rs` for Rust, `.py` for Python/Rails)
- Step 2: derive `<test_command>`: Rust uses `${CLAUDE_PLUGIN_ROOT}/bin/flow test --file <path>`, Python/Rails use `bin/test <path>`, Go/iOS/unknown skip adversarial
- Step 2: pass both `<temp_test_file>` and `<test_command>` in adversarial agent prompt
- Step 2: cleanup uses derived path

`agents/adversarial.md`:
- Input section: document `<test_command>` parameter
- Line 63: replace `bin/test <temp_test_file>` with `<test_command>`
- Line 94: replace "pytest failure message" with "test failure output"
- Line 127: replace `bin/test` with `<test_command>` in allowed Bash commands
- Reasoning Discipline: add Verify step between Trace and Conclude requiring file-existence checks

**Files:** `skills/flow-code-review/SKILL.md`, `agents/adversarial.md`

#### Task 4: Documentation

- `docs/skills/flow-code-review.md` line 37: update "check for `bin/test`" to reflect current behavior (checks for `bin/flow`, framework-aware adversarial)

**Files:** `docs/skills/flow-code-review.md`

## Files to Investigate

- `agents/adversarial.md` — hardcodes `bin/test` (line 63), `pytest` (line 94), no Verify step
- `skills/flow-code-review/SKILL.md` — hardcodes `.py` temp path (line 270), cleanup (line 311), no framework detection
- `.claude/settings.json` — granular cargo allows (lines 51-57), no cargo/rustc deny
- `skills/flow-prime/SKILL.md` — stale `rm tests/test_adversarial_*` allow (line 284)
- `docs/skills/flow-code-review.md` — stale `bin/test` reference (line 37)
- `tests/skill_contracts.rs` — existing adversarial assertions, needs new contract tests

## Supersedes

Supersedes #955 (which also tracked the completed `bin/flow test` subcommand and flow-prime cargo/rustc deny — both already shipped).
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 1m |
| Plan | <1m |
| Code | 2h 38m |
| Code Review | 14m |
| Learn | 12m |
| Complete | 5m |
| **Total** | **3h 13m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/make-adversarial-agent-framework.json</summary>

```json
{
  "schema_version": 1,
  "branch": "make-adversarial-agent-framework",
  "repo": "benkruger/flow",
  "pr_number": 998,
  "pr_url": "https://github.com/benkruger/flow/pull/998",
  "started_at": "2026-04-10T12:33:28-07:00",
  "current_phase": "flow-complete",
  "framework": "rust",
  "files": {
    "plan": ".flow-states/make-adversarial-agent-framework-plan.md",
    "dag": ".flow-states/make-adversarial-agent-framework-dag.md",
    "log": ".flow-states/make-adversarial-agent-framework.log",
    "state": ".flow-states/make-adversarial-agent-framework.json"
  },
  "session_tty": "/dev/ttys006",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "Make adversarial agent framework-aware and lock down FLOW repo cargo permissions #994",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T12:33:28-07:00",
      "completed_at": "2026-04-10T12:34:40-07:00",
      "session_started_at": null,
      "cumulative_seconds": 72,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-10T12:34:59-07:00",
      "completed_at": "2026-04-10T12:37:44-07:00",
      "session_started_at": null,
      "cumulative_seconds": 3,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-10T12:38:27-07:00",
      "completed_at": "2026-04-10T15:16:57-07:00",
      "session_started_at": null,
      "cumulative_seconds": 9510,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-10T15:17:22-07:00",
      "completed_at": "2026-04-10T15:32:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 898,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-10T15:32:33-07:00",
      "completed_at": "2026-04-10T15:45:14-07:00",
      "session_started_at": null,
      "cumulative_seconds": 761,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-10T15:45:41-07:00",
      "completed_at": "2026-04-10T15:51:28-07:00",
      "session_started_at": null,
      "cumulative_seconds": 347,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T12:34:59-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-10T12:38:27-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-10T15:17:22-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-10T15:32:33-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-10T15:45:41-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 4,
  "code_task_name": "Documentation",
  "code_task": 4,
  "diff_stats": {
    "files_changed": 9,
    "insertions": 121,
    "deletions": 39,
    "captured_at": "2026-04-10T15:16:57-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/make-adversarial-agent-framework.log</summary>

```text
2026-04-10T12:30:56-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T12:31:27-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T12:32:25-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T12:33:28-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T12:33:28-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T12:33:28-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T12:33:28-07:00 [Phase 1] create .flow-states/make-adversarial-agent-framework.json (exit 0)
2026-04-10T12:33:28-07:00 [Phase 1] freeze .flow-states/make-adversarial-agent-framework-phases.json (exit 0)
2026-04-10T12:33:28-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T12:33:30-07:00 [Phase 1] start-init — label-issues (labeled: [994], failed: [])
2026-04-10T12:34:00-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T12:34:00-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T12:34:01-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T12:34:18-07:00 [Phase 1] start-workspace — worktree .worktrees/make-adversarial-agent-framework (ok)
2026-04-10T12:34:22-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T12:34:22-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T12:34:22-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T12:34:40-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T12:34:40-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T12:34:59-07:00 [Phase 2] plan-extract — gate check passed (exit 0)
2026-04-10T12:34:59-07:00 [Phase 2] plan-extract — issue #994 fetched, decomposed label detected (exit 0)
2026-04-10T12:34:59-07:00 [Phase 2] plan-extract — DAG file written: .flow-states/make-adversarial-agent-framework-dag.md (exit 0)
2026-04-10T12:34:59-07:00 [Phase 2] plan-extract — plan extracted, 4 tasks, written: .flow-states/make-adversarial-agent-framework-plan.md (exit 0)
2026-04-10T12:35:02-07:00 [Phase 2] plan-extract — PR body rendered (exit 0)
2026-04-10T12:35:02-07:00 [Phase 2] plan-extract — phase complete (<1m) (exit 0)
2026-04-10T12:38:27-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-10T15:16:57-07:00 [Phase] phase-finalize --phase flow-code ("ok")
2026-04-10T15:17:22-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-10T15:31:55-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-10T15:31:59-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-10T15:32:20-07:00 [Phase] phase-finalize --phase flow-code-review ("ok")
2026-04-10T15:32:33-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-10T15:44:08-07:00 [Phase 5] finalize-commit — ci (ok)
2026-04-10T15:44:12-07:00 [Phase 5] finalize-commit — done ("ok")
2026-04-10T15:45:14-07:00 [Phase] phase-finalize --phase flow-learn ("ok")
2026-04-10T15:45:25-07:00 [Phase 5] finalize-commit — ci (ok)
2026-04-10T15:45:25-07:00 [Phase 5] finalize-commit — done ("error")
2026-04-10T15:51:28-07:00 [Phase 6] complete-finalize — starting
2026-04-10T15:51:28-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-10T15:51:29-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>