### PR TITLE
Flow Decompose Project Creates

### DIFF
--- a/skills/flow-decompose-project/SKILL.md
+++ b/skills/flow-decompose-project/SKILL.md
@@ -216,7 +216,9 @@ ${CLAUDE_PLUGIN_ROOT}/bin/flow create-milestone --repo <repo> --title "<project_
 
 Parse the JSON output. Record the milestone number.
 
-Create the parent epic issue. Write the epic body to
+Create the parent epic issue. The `--milestone` flag accepts the milestone
+title (not the numeric ID) — use the same `<project_name>` that was passed
+to `create-milestone --title`. Write the epic body to
 `.flow-states/decompose-project-<id>-epic-body` using the Write tool, then:
 
 ```bash

--- a/skills/flow-decompose-project/SKILL.md
+++ b/skills/flow-decompose-project/SKILL.md
@@ -220,7 +220,7 @@ Create the parent epic issue. Write the epic body to
 `.flow-states/decompose-project-<id>-epic-body` using the Write tool, then:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/bin/flow issue --repo <repo> --title "Epic: <project_name>" --body-file .flow-states/decompose-project-<id>-epic-body
+${CLAUDE_PLUGIN_ROOT}/bin/flow issue --repo <repo> --title "Epic: <project_name>" --body-file .flow-states/decompose-project-<id>-epic-body --milestone "<project_name>"
 ```
 
 Parse the JSON output. Record the epic issue number and database ID.
@@ -253,7 +253,7 @@ Write the issue body to `.flow-states/decompose-project-<id>-issue-body`
 using the Write tool, then create the issue:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/bin/flow issue --repo <repo> --title "<title>" --body-file .flow-states/decompose-project-<id>-issue-body --label decomposed
+${CLAUDE_PLUGIN_ROOT}/bin/flow issue --repo <repo> --title "<title>" --body-file .flow-states/decompose-project-<id>-issue-body --label decomposed --milestone "<project_name>"
 ```
 
 Parse the JSON output and record `{title, number, id}` in the mapping.

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -1,7 +1,7 @@
 //! GitHub issue creation wrapper.
 //!
 //! Usage:
-//!   bin/flow issue --title <title> [--repo <repo>] [--label <label>] [--body-file <path>]
+//!   bin/flow issue --title <title> [--repo <repo>] [--label <label>] [--milestone <title>] [--body-file <path>]
 //!
 //! Body text is always passed via a file to avoid shell escaping issues
 //! with special characters (|, &&, ;) that trigger the Bash hook validator.
@@ -120,6 +120,7 @@ pub fn create_issue(
     title: &str,
     label: Option<&str>,
     body: Option<&str>,
+    milestone: Option<&str>,
 ) -> Result<IssueResult, String> {
     let timeout = Duration::from_secs(LOCAL_TIMEOUT);
 
@@ -142,6 +143,10 @@ pub fn create_issue(
         cmd_args.push("--body".into());
         cmd_args.push(b.into());
     }
+    if let Some(m) = milestone {
+        cmd_args.push("--milestone".into());
+        cmd_args.push(m.into());
+    }
 
     let cmd_refs: Vec<&str> = cmd_args.iter().map(|s| s.as_str()).collect();
     match run_gh_cmd(&cmd_refs, Some(timeout)) {
@@ -151,7 +156,7 @@ pub fn create_issue(
             if let Some(l) = label {
                 let err_lower = error.to_lowercase();
                 if err_lower.contains("label") && err_lower.contains("not found") {
-                    return retry_with_label(repo, title, l, body, timeout);
+                    return retry_with_label(repo, title, l, body, milestone, timeout);
                 }
             }
             Err(error)
@@ -164,6 +169,7 @@ fn retry_with_label(
     title: &str,
     label: &str,
     body: Option<&str>,
+    milestone: Option<&str>,
     timeout: Duration,
 ) -> Result<IssueResult, String> {
     // Try creating the label
@@ -190,6 +196,10 @@ fn retry_with_label(
     if let Some(b) = body {
         retry_args.push("--body".into());
         retry_args.push(b.into());
+    }
+    if let Some(m) = milestone {
+        retry_args.push("--milestone".into());
+        retry_args.push(m.into());
     }
 
     let retry_refs: Vec<&str> = retry_args.iter().map(|s| s.as_str()).collect();
@@ -304,7 +314,13 @@ pub fn run(args: Args) {
         None
     };
 
-    match create_issue(&repo, &args.title, args.label.as_deref(), body.as_deref()) {
+    match create_issue(
+        &repo,
+        &args.title,
+        args.label.as_deref(),
+        body.as_deref(),
+        args.milestone.as_deref(),
+    ) {
         Ok(result) => {
             json_ok(&[
                 ("url", json!(result.url)),

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -48,6 +48,10 @@ pub struct Args {
     /// Path to state file for repo lookup
     #[arg(long = "state-file")]
     pub state_file: Option<String>,
+
+    /// Milestone title to assign the issue to
+    #[arg(long)]
+    pub milestone: Option<String>,
 }
 
 pub struct IssueResult {
@@ -505,5 +509,20 @@ mod tests {
     #[test]
     fn resolve_repo_from_missing_state() {
         assert_eq!(resolve_repo_from_state("/nonexistent/state.json"), None);
+    }
+
+    // --- Args milestone parsing ---
+
+    #[test]
+    fn args_parses_milestone() {
+        let args = Args::try_parse_from(["issue", "--title", "Test issue", "--milestone", "v1.0"])
+            .unwrap();
+        assert_eq!(args.milestone.as_deref(), Some("v1.0"));
+    }
+
+    #[test]
+    fn args_milestone_defaults_to_none() {
+        let args = Args::try_parse_from(["issue", "--title", "Test issue"]).unwrap();
+        assert!(args.milestone.is_none());
     }
 }


### PR DESCRIPTION
## What

flow-decompose-project creates milestone but never assigns issues to it #829.

Closes #829

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/flow-decompose-project-creates-plan.md` |
| DAG | `.flow-states/flow-decompose-project-creates-dag.md` |
| Log | `.flow-states/flow-decompose-project-creates.log` |
| State | `.flow-states/flow-decompose-project-creates.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

The `flow-decompose-project` skill creates milestones and issues as part of a project decomposition pipeline, but the two are never connected. The milestone is created and its number recorded, but the issue-creation commands never reference it. The underlying `src/issue.rs` Rust module lacks milestone support entirely.

## Exploration

- `src/issue.rs:29-51` — `Args` struct uses clap `#[derive(Parser)]` with `repo`, `title`, `label`, `body_file`, `state_file`. No `milestone` field.
- `src/issue.rs:114-156` — `create_issue(repo, title, label, body)` builds `gh issue create` args. Pushes `--label` and `--body` when present. No milestone handling.
- `src/issue.rs:158-194` — `retry_with_label()` reconstructs the full `gh issue create` command for label-not-found retries. Also has no milestone parameter — if milestone were added to `create_issue()` but not threaded through retry, milestone assignment would be silently dropped on label errors.
- `src/issue.rs:278-316` — `run()` is the only caller of `create_issue()`. Passes `args.label.as_deref()` and `body.as_deref()`. Would need `args.milestone.as_deref()`.
- `skills/flow-decompose-project/SKILL.md:211-231` — Step 3 creates the milestone via `create-milestone`, records the number, then creates the epic via `bin/flow issue` without `--milestone`.
- `skills/flow-decompose-project/SKILL.md:238-268` — Step 4 creates child issues in a loop via `bin/flow issue` without `--milestone`.
- `gh issue create --milestone` takes the milestone **title** (string), not the number. The `<project_name>` string is already available in the SKILL.md — it's the same string used for `create-milestone --title`.
- No other callers of `create_issue()` exist in `src/`. No other skills need milestone support.

## Risks

- **Retry path milestone preservation** — `retry_with_label()` is a separate function that reconstructs `gh issue create` args independently. If milestone is added to `create_issue()` but not threaded to `retry_with_label()`, milestone assignment is silently lost on label-not-found retries.
- **Milestone title vs number** — `gh issue create --milestone` takes the title string, not the milestone number. The SKILL.md must pass `<project_name>` (the milestone title), not `milestone_number`. Verified via `gh issue create --help`.

## Approach

Add `milestone: Option<String>` to the `Args` struct with `#[arg(long)]`. Add `milestone: Option<&str>` as a 5th parameter to `create_issue()` — when present, push `"--milestone"` and the value into `cmd_args`. Thread the same parameter through `retry_with_label()`. Update `run()` to pass `args.milestone.as_deref()`. Update the SKILL.md bash blocks in Steps 3 and 4 to append `--milestone "<project_name>"`.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Test: Args parses `--milestone` | test | — |
| 2. Add milestone to Args, `create_issue()`, `retry_with_label()`, `run()` | implement | 1 |
| 3. Update SKILL.md Step 3 and Step 4 bash blocks | skill | 2 |

## Tasks

### Task 1: Test Args parses --milestone

Add tests to `src/issue.rs` `mod tests` that verify:
- `Args::try_parse_from` with `--milestone "v1.0"` succeeds and populates the field
- `Args::try_parse_from` without `--milestone` succeeds with `None`

Files: `src/issue.rs`

### Task 2: Add milestone support to src/issue.rs

- Add `pub milestone: Option<String>` with `#[arg(long)]` to the `Args` struct
- Add `milestone: Option<&str>` parameter to `create_issue()`. When `Some`, push `"--milestone"` and the value into `cmd_args`
- Add `milestone: Option<&str>` parameter to `retry_with_label()`. When `Some`, push `"--milestone"` and the value into `retry_args`
- Update `run()` to pass `args.milestone.as_deref()` to `create_issue()`

Files: `src/issue.rs`

### Task 3: Update flow-decompose-project SKILL.md

Update the bash blocks:
- Step 3 epic creation (line 223): add `--milestone "<project_name>"` to the `bin/flow issue` command
- Step 4 child issue creation (line 256): add `--milestone "<project_name>"` to the `bin/flow issue` command

Files: `skills/flow-decompose-project/SKILL.md`
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: flow-decompose-project creates milestone but never assigns issues to it

## Problem

`flow-decompose-project` creates a milestone in Step 3 via `bin/flow create-milestone` and records `milestone_number` in the session state, but never assigns any issues to it. Neither Step 3 (epic creation) nor Step 4 (child issue creation) passes a `--milestone` flag when calling `bin/flow issue`.

The underlying Rust implementation in `src/issue.rs` has no milestone support at all — the `Args` struct has no `--milestone` field, and the `create_issue()` function signature has no milestone parameter.

Evidence:
- `src/issue.rs:29-51` — `Args` struct has no milestone field
- `src/issue.rs:114-119` — `create_issue(repo, title, label, body)` — no milestone parameter
- `src/issue.rs:158-163` — `retry_with_label()` also has no milestone parameter
- `skills/flow-decompose-project/SKILL.md:223` — Step 3 epic creation has no `--milestone` flag
- `skills/flow-decompose-project/SKILL.md:256` — Step 4 child issue creation has no `--milestone` flag
- `gh issue create` natively supports `--milestone <name>` (takes milestone title, not number)

## Acceptance Criteria

- `src/issue.rs` `Args` struct accepts an optional `--milestone` flag
- `create_issue()` accepts an optional `milestone` parameter and passes `--milestone <title>` to `gh issue create`
- `retry_with_label()` preserves `--milestone` when retrying without a label
- `flow-decompose-project` Step 3 passes `--milestone "<project_name>"` when creating the epic
- `flow-decompose-project` Step 4 passes `--milestone "<project_name>"` when creating each child issue
- After running `flow-decompose-project`, all created issues appear in the milestone

## Implementation Plan

### Context

The `flow-decompose-project` skill creates milestones and issues as part of a project decomposition pipeline, but the two are never connected. The milestone is created and its number recorded, but the issue-creation commands never reference it. The underlying `src/issue.rs` Rust module lacks milestone support entirely.

### Exploration

- `src/issue.rs:29-51` — `Args` struct uses clap `#[derive(Parser)]` with `repo`, `title`, `label`, `body_file`, `state_file`. No `milestone` field.
- `src/issue.rs:114-156` — `create_issue(repo, title, label, body)` builds `gh issue create` args. Pushes `--label` and `--body` when present. No milestone handling.
- `src/issue.rs:158-194` — `retry_with_label()` reconstructs the full `gh issue create` command for label-not-found retries. Also has no milestone parameter — if milestone were added to `create_issue()` but not threaded through retry, milestone assignment would be silently dropped on label errors.
- `src/issue.rs:278-316` — `run()` is the only caller of `create_issue()`. Passes `args.label.as_deref()` and `body.as_deref()`. Would need `args.milestone.as_deref()`.
- `skills/flow-decompose-project/SKILL.md:211-231` — Step 3 creates the milestone via `create-milestone`, records the number, then creates the epic via `bin/flow issue` without `--milestone`.
- `skills/flow-decompose-project/SKILL.md:238-268` — Step 4 creates child issues in a loop via `bin/flow issue` without `--milestone`.
- `gh issue create --milestone` takes the milestone **title** (string), not the number. The `<project_name>` string is already available in the SKILL.md — it's the same string used for `create-milestone --title`.
- No other callers of `create_issue()` exist in `src/`. No other skills need milestone support.

### Risks

- **Retry path milestone preservation** — `retry_with_label()` is a separate function that reconstructs `gh issue create` args independently. If milestone is added to `create_issue()` but not threaded to `retry_with_label()`, milestone assignment is silently lost on label-not-found retries.
- **Milestone title vs number** — `gh issue create --milestone` takes the title string, not the milestone number. The SKILL.md must pass `<project_name>` (the milestone title), not `milestone_number`. Verified via `gh issue create --help`.

### Approach

Add `milestone: Option<String>` to the `Args` struct with `#[arg(long)]`. Add `milestone: Option<&str>` as a 5th parameter to `create_issue()` — when present, push `"--milestone"` and the value into `cmd_args`. Thread the same parameter through `retry_with_label()`. Update `run()` to pass `args.milestone.as_deref()`. Update the SKILL.md bash blocks in Steps 3 and 4 to append `--milestone "<project_name>"`.

### Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Test: Args parses `--milestone` | test | — |
| 2. Add milestone to Args, `create_issue()`, `retry_with_label()`, `run()` | implement | 1 |
| 3. Update SKILL.md Step 3 and Step 4 bash blocks | skill | 2 |

### Tasks

#### Task 1: Test Args parses --milestone

Add tests to `src/issue.rs` `mod tests` that verify:
- `Args::try_parse_from` with `--milestone "v1.0"` succeeds and populates the field
- `Args::try_parse_from` without `--milestone` succeeds with `None`

Files: `src/issue.rs`

#### Task 2: Add milestone support to src/issue.rs

- Add `pub milestone: Option<String>` with `#[arg(long)]` to the `Args` struct
- Add `milestone: Option<&str>` parameter to `create_issue()`. When `Some`, push `"--milestone"` and the value into `cmd_args`
- Add `milestone: Option<&str>` parameter to `retry_with_label()`. When `Some`, push `"--milestone"` and the value into `retry_args`
- Update `run()` to pass `args.milestone.as_deref()` to `create_issue()`

Files: `src/issue.rs`

#### Task 3: Update flow-decompose-project SKILL.md

Update the bash blocks:
- Step 3 epic creation (line 223): add `--milestone "<project_name>"` to the `bin/flow issue` command
- Step 4 child issue creation (line 256): add `--milestone "<project_name>"` to the `bin/flow issue` command

Files: `skills/flow-decompose-project/SKILL.md`

## Files to Investigate

- `src/issue.rs` — `Args` struct (lines 29-51), `create_issue()` (lines 114-156), `retry_with_label()` (lines 158-194), `run()` (lines 278-316)
- `skills/flow-decompose-project/SKILL.md` — Step 3 epic creation (line 223), Step 4 child issue creation (line 256)

## Out of Scope

- Changing how `create-milestone` works (it already works correctly)
- Adding milestone support to `flow-create-issue` (single-issue filing; milestones are a project-level concept)
- Retroactively fixing existing issues (the Rust port milestone was manually fixed)
- Other callers of `bin/flow issue` (they don't use milestones)
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | <1m |
| Code | 20m |
| Code Review | 12m |
| Learn | 3m |
| Complete | 3m |
| **Total** | **40m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/flow-decompose-project-creates.json</summary>

```json
{
  "schema_version": 1,
  "branch": "flow-decompose-project-creates",
  "repo": "benkruger/flow",
  "pr_number": 1000,
  "pr_url": "https://github.com/benkruger/flow/pull/1000",
  "started_at": "2026-04-10T16:25:16-07:00",
  "current_phase": "flow-complete",
  "framework": "rust",
  "files": {
    "plan": ".flow-states/flow-decompose-project-creates-plan.md",
    "dag": ".flow-states/flow-decompose-project-creates-dag.md",
    "log": ".flow-states/flow-decompose-project-creates.log",
    "state": ".flow-states/flow-decompose-project-creates.json"
  },
  "session_tty": "/dev/ttys005",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "flow-decompose-project creates milestone but never assigns issues to it #829",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T16:25:16-07:00",
      "completed_at": "2026-04-10T16:25:53-07:00",
      "session_started_at": null,
      "cumulative_seconds": 37,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-10T16:26:05-07:00",
      "completed_at": "2026-04-10T16:26:08-07:00",
      "session_started_at": null,
      "cumulative_seconds": 3,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-10T16:28:33-07:00",
      "completed_at": "2026-04-10T16:48:54-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1221,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-10T16:49:08-07:00",
      "completed_at": "2026-04-10T17:01:36-07:00",
      "session_started_at": null,
      "cumulative_seconds": 748,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-10T17:01:49-07:00",
      "completed_at": "2026-04-10T17:04:49-07:00",
      "session_started_at": null,
      "cumulative_seconds": 180,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-10T17:05:20-07:00",
      "completed_at": "2026-04-10T17:09:18-07:00",
      "session_started_at": null,
      "cumulative_seconds": 238,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T16:26:05-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-10T16:28:33-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-10T16:49:08-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-10T17:01:49-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-10T17:05:20-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 3,
  "code_task_name": "Update flow-decompose-project SKILL.md",
  "code_task": 3,
  "diff_stats": {
    "files_changed": 2,
    "insertions": 40,
    "deletions": 5,
    "captured_at": "2026-04-10T16:48:54-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/flow-decompose-project-creates.log</summary>

```text
2026-04-10T16:25:16-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T16:25:16-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T16:25:16-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T16:25:16-07:00 [Phase 1] create .flow-states/flow-decompose-project-creates.json (exit 0)
2026-04-10T16:25:16-07:00 [Phase 1] freeze .flow-states/flow-decompose-project-creates-phases.json (exit 0)
2026-04-10T16:25:16-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T16:25:17-07:00 [Phase 1] start-init — label-issues (labeled: [829], failed: [])
2026-04-10T16:25:26-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T16:25:26-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T16:25:27-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T16:25:37-07:00 [Phase 1] start-workspace — worktree .worktrees/flow-decompose-project-creates (ok)
2026-04-10T16:25:41-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T16:25:41-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T16:25:41-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T16:25:53-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T16:25:53-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T16:26:06-07:00 [Phase 2] plan-extract — gate check passed (exit 0)
2026-04-10T16:26:06-07:00 [Phase 2] plan-extract — issue #829 fetched, decomposed label detected (exit 0)
2026-04-10T16:26:06-07:00 [Phase 2] plan-extract — DAG file written: .flow-states/flow-decompose-project-creates-dag.md (exit 0)
2026-04-10T16:26:06-07:00 [Phase 2] plan-extract — plan extracted, 3 tasks, written: .flow-states/flow-decompose-project-creates-plan.md (exit 0)
2026-04-10T16:26:08-07:00 [Phase 2] plan-extract — PR body rendered (exit 0)
2026-04-10T16:26:08-07:00 [Phase 2] plan-extract — phase complete (<1m) (exit 0)
2026-04-10T16:28:33-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-10T16:39:29-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-10T16:39:33-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-10T16:44:19-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-10T16:44:22-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-10T16:48:08-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-10T16:48:11-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-10T16:48:54-07:00 [Phase] phase-finalize --phase flow-code ("ok")
2026-04-10T16:49:08-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-10T17:01:07-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-10T17:01:11-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-10T17:01:36-07:00 [Phase] phase-finalize --phase flow-code-review ("ok")
2026-04-10T17:01:49-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-10T17:04:49-07:00 [Phase] phase-finalize --phase flow-learn ("ok")
2026-04-10T17:09:17-07:00 [Phase 6] complete-finalize — starting
2026-04-10T17:09:18-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-10T17:09:18-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>