### PR TITLE
Add   Label And   Milestone

### DIFF
--- a/docs/skills/flow-issues.md
+++ b/docs/skills/flow-issues.md
@@ -16,9 +16,13 @@ parent: Skills
 /flow-issues --blocked
 /flow-issues --decomposed
 /flow-issues --quick-start
+/flow-issues --label Bug
+/flow-issues --label Bug --label "Tech Debt"
+/flow-issues --milestone v1.2
+/flow-issues --label Bug --ready
 ```
 
-Fetches all open issues for the current repository, analyzes them via `bin/flow analyze-issues` (file paths, labels, stale detection), ranks by impact using LLM judgment, and displays a dashboard with a recommended work order. Supports optional readiness filters to narrow results. Read-only — never creates, edits, or closes issues.
+Fetches all open issues for the current repository, analyzes them via `bin/flow analyze-issues` (file paths, labels, stale detection), ranks by impact using LLM judgment, and displays a dashboard with a recommended work order. Supports optional readiness filters and server-side narrowing filters (`--label`, `--milestone`) to focus results. Read-only — never creates, edits, or closes issues.
 
 ---
 
@@ -44,6 +48,19 @@ Optional flags filter the issue list by readiness. Flags are mutually exclusive 
 | `--quick-start` | Decomposed issues that are not blocked — best candidates for autonomous execution |
 
 No flag returns all issues (default behavior).
+
+---
+
+## Narrowing Filters
+
+Server-side filters passed directly to `gh issue list` that reduce the issue set before analysis.
+
+| Flag | Shows |
+|------|-------|
+| `--label <name>` | Issues with the specified GitHub label (repeatable; multiple labels use AND logic) |
+| `--milestone <title>` | Issues in the specified milestone (by title or number) |
+
+Narrowing filters compose with readiness filters. For example, `--label Bug --ready` fetches only "Bug"-labeled issues, then shows only the non-blocked ones.
 
 ---
 

--- a/docs/skills/flow-issues.md
+++ b/docs/skills/flow-issues.md
@@ -58,7 +58,7 @@ Server-side filters passed directly to `gh issue list` that reduce the issue set
 | Flag | Shows |
 |------|-------|
 | `--label <name>` | Issues with the specified GitHub label (repeatable; multiple labels use AND logic) |
-| `--milestone <title>` | Issues in the specified milestone (by title or number) |
+| `--milestone <title>` | Issues in the specified milestone (by title or number; single value only) |
 
 Narrowing filters compose with readiness filters. For example, `--label Bug --ready` fetches only "Bug"-labeled issues, then shows only the non-blocked ones.
 

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -40,7 +40,7 @@ These skills are available at any point in the workflow, regardless of phase.
 | [`/flow-reset`](flow-reset.md) | Remove all FLOW artifacts — close PRs, delete worktrees/branches/state files/lock entries |
 | [`/flow-config`](flow-config.md) | Display current configuration — version, framework, per-skill autonomy |
 | [`/flow-doc-sync`](flow-doc-sync.md) | Full codebase documentation accuracy review — reports drift between code and docs |
-| [`/flow-issues`](flow-issues.md) | Fetch open issues, categorize, prioritize, and display a dashboard with recommended work order. Supports readiness filters (`--ready`, `--blocked`, `--decomposed`, `--quick-start`) |
+| [`/flow-issues`](flow-issues.md) | Fetch open issues, categorize, prioritize, and display a dashboard with recommended work order. Supports readiness filters (`--ready`, `--blocked`, `--decomposed`, `--quick-start`) and narrowing filters (`--label`, `--milestone`) |
 | [`/flow-create-issue`](flow-create-issue.md) | Capture a brainstormed solution as a pre-planned issue with an Implementation Plan for fast-tracking through Plan |
 | [`/flow-decompose-project`](flow-decompose-project.md) | Decompose a large project into linked GitHub issues with sub-issue relationships, blocked-by dependencies, and milestones |
 | [`/flow-orchestrate`](flow-orchestrate.md) | Process decomposed issues sequentially overnight via flow-start --auto |

--- a/skills/flow-issues/SKILL.md
+++ b/skills/flow-issues/SKILL.md
@@ -44,8 +44,8 @@ the number of issues fetched, not just displayed.
 
 - `--label <name>` — filter by GitHub label (repeatable; multiple labels
   use AND logic). Can combine with any readiness filter.
-- `--milestone <title>` — filter by GitHub milestone (by title or number).
-  Can combine with any readiness filter.
+- `--milestone <title>` — filter by GitHub milestone (by title or number;
+  single value only). Can combine with any readiness filter.
 
 Narrowing filters compose with readiness filters. For example,
 `--label Bug --ready` fetches only issues labeled "Bug" from GitHub,

--- a/skills/flow-issues/SKILL.md
+++ b/skills/flow-issues/SKILL.md
@@ -18,6 +18,10 @@ close issues.
 /flow:flow-issues --blocked
 /flow:flow-issues --decomposed
 /flow:flow-issues --quick-start
+/flow:flow-issues --label Bug
+/flow:flow-issues --label Bug --label "Tech Debt"
+/flow:flow-issues --milestone v1.2
+/flow:flow-issues --label Bug --ready
 ```
 
 ## Readiness Filters
@@ -31,6 +35,21 @@ exclusive — pass at most one.
 - `--quick-start` — decomposed issues that are not blocked (best candidates for autonomous execution)
 
 No flag returns all issues (current default behavior).
+
+## Narrowing Filters
+
+Optional flags that narrow the issue set before analysis. These are
+server-side filters passed directly to `gh issue list` — they reduce
+the number of issues fetched, not just displayed.
+
+- `--label <name>` — filter by GitHub label (repeatable; multiple labels
+  use AND logic). Can combine with any readiness filter.
+- `--milestone <title>` — filter by GitHub milestone (by title or number).
+  Can combine with any readiness filter.
+
+Narrowing filters compose with readiness filters. For example,
+`--label Bug --ready` fetches only issues labeled "Bug" from GitHub,
+then shows only the non-blocked ones.
 
 ## Concurrency
 
@@ -83,8 +102,25 @@ ${CLAUDE_PLUGIN_ROOT}/bin/flow analyze-issues --decomposed
 ${CLAUDE_PLUGIN_ROOT}/bin/flow analyze-issues --quick-start
 ```
 
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow analyze-issues --label Bug
+```
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow analyze-issues --label Bug --label "Tech Debt"
+```
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow analyze-issues --milestone v1.2
+```
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow analyze-issues --label Bug --ready
+```
+
 Use the first form when no filter flag was passed. Use the matching form
-when a flag was passed.
+when a flag was passed. Narrowing filters (`--label`, `--milestone`) can
+be combined with each other and with any readiness filter.
 
 Parse the JSON output. The structure is:
 
@@ -108,7 +144,8 @@ Parse the JSON output. The structure is:
       "stale": false,
       "stale_missing": 0,
       "file_paths": ["lib/foo.py"],
-      "brief": "First ~200 chars of body..."
+      "brief": "First ~200 chars of body...",
+      "milestone": "v1.2.0"
     }
   ]
 }

--- a/src/analyze_issues.rs
+++ b/src/analyze_issues.rs
@@ -365,6 +365,13 @@ pub fn analyze_issues(issues: &[Value], blocker_map: &HashMap<i64, Vec<i64>>) ->
         let blocked_by = blocker_map.get(&number).cloned().unwrap_or_default();
         let native_blocked = !blocked_by.is_empty();
 
+        let milestone = issue
+            .get("milestone")
+            .and_then(|m| m.get("title"))
+            .and_then(|t| t.as_str())
+            .map(|s| Value::String(s.to_string()))
+            .unwrap_or(Value::Null);
+
         available.push(serde_json::json!({
             "number": number,
             "title": issue["title"],
@@ -380,6 +387,7 @@ pub fn analyze_issues(issues: &[Value], blocker_map: &HashMap<i64, Vec<i64>>) ->
             "stale_missing": stale_info.stale_missing,
             "file_paths": file_paths,
             "brief": truncate_body(body, 200),
+            "milestone": milestone,
         }));
     }
 
@@ -431,6 +439,14 @@ pub struct Args {
     /// Show only decomposed issues without Blocked label
     #[arg(long = "quick-start", group = "filter_group")]
     pub quick_start: bool,
+
+    /// Filter by GitHub label (server-side, repeatable)
+    #[arg(long, short = 'l')]
+    pub label: Vec<String>,
+
+    /// Filter by GitHub milestone (server-side, by title or number)
+    #[arg(long, short = 'm')]
+    pub milestone: Option<String>,
 }
 
 /// Run the analyze-issues CLI.
@@ -445,17 +461,26 @@ pub fn run(args: Args) {
         }
     } else {
         // Call gh issue list
+        let mut gh_args = vec![
+            "issue".to_string(),
+            "list".to_string(),
+            "--state".to_string(),
+            "open".to_string(),
+            "--json".to_string(),
+            "number,title,labels,createdAt,body,url,milestone".to_string(),
+            "--limit".to_string(),
+            "100".to_string(),
+        ];
+        for l in &args.label {
+            gh_args.push("--label".to_string());
+            gh_args.push(l.clone());
+        }
+        if let Some(ref m) = args.milestone {
+            gh_args.push("--milestone".to_string());
+            gh_args.push(m.clone());
+        }
         let mut child = match std::process::Command::new("gh")
-            .args([
-                "issue",
-                "list",
-                "--state",
-                "open",
-                "--json",
-                "number,title,labels,createdAt,body,url",
-                "--limit",
-                "100",
-            ])
+            .args(&gh_args)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()
@@ -944,6 +969,34 @@ mod tests {
         chrono::Local::now().to_rfc3339()
     }
 
+    /// Create an issue with an optional milestone object.
+    fn make_issue_with_milestone(
+        number: i64,
+        title: &str,
+        body: &str,
+        labels: &[&str],
+        created_at: &str,
+        milestone_title: Option<&str>,
+    ) -> Value {
+        let label_arr: Vec<Value> = labels
+            .iter()
+            .map(|n| serde_json::json!({"name": n}))
+            .collect();
+        let milestone = match milestone_title {
+            Some(t) => serde_json::json!({"title": t, "number": 1}),
+            None => Value::Null,
+        };
+        serde_json::json!({
+            "number": number,
+            "title": title,
+            "body": body,
+            "labels": label_arr,
+            "createdAt": created_at,
+            "url": format!("https://github.com/test/repo/issues/{}", number),
+            "milestone": milestone,
+        })
+    }
+
     // --- analyze_issues ---
 
     #[test]
@@ -1233,5 +1286,102 @@ mod tests {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let parsed: Value = serde_json::from_str(&stdout).unwrap();
         assert_eq!(parsed["status"], "error");
+    }
+
+    // --- --label and --milestone CLI args ---
+
+    #[test]
+    fn cli_label_single() {
+        let issues =
+            serde_json::to_string(&vec![make_issue(1, "Bug fix", "", &["Bug"], &now_iso())])
+                .unwrap();
+        let (code, stdout) = run_with_file(&issues, &["--label", "Bug"]);
+        assert_eq!(code, 0, "stdout: {}", stdout);
+    }
+
+    #[test]
+    fn cli_label_multiple() {
+        let issues =
+            serde_json::to_string(&vec![make_issue(1, "Bug fix", "", &["Bug"], &now_iso())])
+                .unwrap();
+        let (code, stdout) = run_with_file(&issues, &["--label", "Bug", "--label", "Enhancement"]);
+        assert_eq!(code, 0, "stdout: {}", stdout);
+    }
+
+    #[test]
+    fn cli_milestone() {
+        let issues =
+            serde_json::to_string(&vec![make_issue(1, "Feature", "", &[], &now_iso())]).unwrap();
+        let (code, stdout) = run_with_file(&issues, &["--milestone", "v1.0"]);
+        assert_eq!(code, 0, "stdout: {}", stdout);
+    }
+
+    #[test]
+    fn cli_label_combines_with_ready() {
+        let issues = serde_json::to_string(&vec![
+            make_issue(1, "Ready bug", "", &["Bug"], &now_iso()),
+            make_issue(2, "Blocked bug", "", &["Bug", "Blocked"], &now_iso()),
+        ])
+        .unwrap();
+        let (code, stdout) = run_with_file(&issues, &["--label", "Bug", "--ready"]);
+        assert_eq!(code, 0, "stdout: {}", stdout);
+        let output: Value = serde_json::from_str(&stdout).unwrap();
+        let numbers: Vec<i64> = output["issues"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| i["number"].as_i64().unwrap())
+            .collect();
+        assert!(numbers.contains(&1));
+        assert!(!numbers.contains(&2));
+    }
+
+    // --- milestone in analyze_issues output ---
+
+    #[test]
+    fn analyze_milestone_present() {
+        let issues = vec![make_issue_with_milestone(
+            1,
+            "Milestone issue",
+            "",
+            &[],
+            &now_iso(),
+            Some("v1.2.0"),
+        )];
+        let result = analyze_issues(&issues, &HashMap::new());
+        let issue = &result["issues"][0];
+        assert_eq!(issue["milestone"], "v1.2.0");
+    }
+
+    #[test]
+    fn analyze_milestone_null() {
+        let issues = vec![make_issue_with_milestone(
+            1,
+            "No milestone",
+            "",
+            &[],
+            &now_iso(),
+            None,
+        )];
+        let result = analyze_issues(&issues, &HashMap::new());
+        let issue = &result["issues"][0];
+        assert!(issue["milestone"].is_null());
+    }
+
+    #[test]
+    fn cli_issues_json_with_milestone() {
+        let issues = serde_json::to_string(&vec![make_issue_with_milestone(
+            1,
+            "With milestone",
+            "",
+            &[],
+            &now_iso(),
+            Some("v2.0"),
+        )])
+        .unwrap();
+        let (code, stdout) = run_with_file(&issues, &[]);
+        assert_eq!(code, 0, "stdout: {}", stdout);
+        let output: Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(output["issues"][0]["milestone"], "v2.0");
     }
 }

--- a/src/analyze_issues.rs
+++ b/src/analyze_issues.rs
@@ -369,6 +369,7 @@ pub fn analyze_issues(issues: &[Value], blocker_map: &HashMap<i64, Vec<i64>>) ->
             .get("milestone")
             .and_then(|m| m.get("title"))
             .and_then(|t| t.as_str())
+            .filter(|s| !s.is_empty())
             .map(|s| Value::String(s.to_string()))
             .unwrap_or(Value::Null);
 
@@ -951,26 +952,11 @@ mod tests {
         labels: &[&str],
         created_at: &str,
     ) -> Value {
-        let label_arr: Vec<Value> = labels
-            .iter()
-            .map(|n| serde_json::json!({"name": n}))
-            .collect();
-        serde_json::json!({
-            "number": number,
-            "title": title,
-            "body": body,
-            "labels": label_arr,
-            "createdAt": created_at,
-            "url": format!("https://github.com/test/repo/issues/{}", number),
-        })
-    }
-
-    fn now_iso() -> String {
-        chrono::Local::now().to_rfc3339()
+        make_issue_opt(number, title, body, labels, created_at, None)
     }
 
     /// Create an issue with an optional milestone object.
-    fn make_issue_with_milestone(
+    fn make_issue_opt(
         number: i64,
         title: &str,
         body: &str,
@@ -995,6 +981,10 @@ mod tests {
             "url": format!("https://github.com/test/repo/issues/{}", number),
             "milestone": milestone,
         })
+    }
+
+    fn now_iso() -> String {
+        chrono::Local::now().to_rfc3339()
     }
 
     // --- analyze_issues ---
@@ -1340,7 +1330,7 @@ mod tests {
 
     #[test]
     fn analyze_milestone_present() {
-        let issues = vec![make_issue_with_milestone(
+        let issues = vec![make_issue_opt(
             1,
             "Milestone issue",
             "",
@@ -1355,22 +1345,34 @@ mod tests {
 
     #[test]
     fn analyze_milestone_null() {
-        let issues = vec![make_issue_with_milestone(
-            1,
-            "No milestone",
-            "",
-            &[],
-            &now_iso(),
-            None,
-        )];
+        let issues = vec![make_issue_opt(1, "No milestone", "", &[], &now_iso(), None)];
         let result = analyze_issues(&issues, &HashMap::new());
         let issue = &result["issues"][0];
         assert!(issue["milestone"].is_null());
     }
 
     #[test]
+    fn analyze_milestone_empty_string_is_null() {
+        let label_arr: Vec<Value> = vec![];
+        let issue = serde_json::json!({
+            "number": 1,
+            "title": "Empty milestone title",
+            "body": "",
+            "labels": label_arr,
+            "createdAt": now_iso(),
+            "url": "https://github.com/test/repo/issues/1",
+            "milestone": {"title": "", "number": 1},
+        });
+        let result = analyze_issues(&[issue], &HashMap::new());
+        assert!(
+            result["issues"][0]["milestone"].is_null(),
+            "Empty milestone title should be null"
+        );
+    }
+
+    #[test]
     fn cli_issues_json_with_milestone() {
-        let issues = serde_json::to_string(&vec![make_issue_with_milestone(
+        let issues = serde_json::to_string(&vec![make_issue_opt(
             1,
             "With milestone",
             "",


### PR DESCRIPTION
## What

Add --label and --milestone filtering to flow-issues #1003.

Closes #1003

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/add---label-and---milestone-plan.md` |
| DAG | `.flow-states/add---label-and---milestone-dag.md` |
| Log | `.flow-states/add---label-and---milestone.log` |
| State | `.flow-states/add---label-and---milestone.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

Users need to filter the flow-issues dashboard by GitHub label or milestone to focus on subsets of work. Both filters are natively supported by `gh issue list` as server-side filters, making the implementation a clean pass-through from skill invocation to CLI args to `gh` command construction.

## Exploration

- **`src/analyze_issues.rs`** — `Args` struct (line 414) uses `group = "filter_group"` for the 4 readiness filters. `run()` (line 437) builds the `gh issue list` command with hardcoded args (line 449-458) requesting `number,title,labels,createdAt,body,url` JSON fields. `analyze_issues()` enriches each issue with label flags, category, staleness, blockers. `filter_issues()` applies client-side readiness filtering.
- **`skills/flow-issues/SKILL.md`** — Step 1 passes readiness filter flags as literal CLI args to `bin/flow analyze-issues`. Usage section documents the 4 existing filters. JSON schema in Step 1 does not include a `milestone` field.
- **`gh issue list`** — Supports `-l/--label strings` (repeatable, server-side AND filter) and `-m/--milestone string` (single value, by number or title). Supports `milestone` as a JSON output field.

## Risks

1. **`--label` is a repeatable flag** — `clap` handles `Vec<String>` natively, but each value must be passed as a separate `--label` arg to `gh`. Must loop over values when building the command.
2. **Milestone JSON shape** — The `milestone` JSON field from `gh` is an object (`{"title": "v1.2.0", ...}`), not a string. The `analyze_issues()` function must extract the title for the per-issue output.
3. **Empty results** — When a label or milestone matches zero issues, the output should be a valid empty result, not an error.
4. **`--issues-json` test path** — The `--issues-json` flag bypasses `gh` entirely, so server-side filters don't apply in tests. Tests for the `--label`/`--milestone` arg construction need to verify the `gh` command args are built correctly, separate from the analysis logic.

## Approach

Server-side filtering: pass `--label` and `--milestone` directly to `gh issue list` command construction in `run()`. This reduces the number of issues fetched (fewer blocker GraphQL calls) and leverages GitHub's native filtering. The new args are orthogonal to the existing `filter_group` — they narrow the input set, while readiness filters classify the output set. Add `milestone` to the `--json` fields list and include milestone title in per-issue output.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add tests for --label and --milestone CLI args and milestone output | test | — |
| 2. Add --label and --milestone to Args and gh command construction | implement | 1 |
| 3. Add milestone to JSON fields and per-issue output | implement | 2 |
| 4. Update SKILL.md with new flags, examples, and JSON schema | docs | 3 |

## Tasks

### Task 1: Add tests for new CLI args and milestone output

Add unit tests to `src/analyze_issues.rs` test module:

- Test that `--label` accepts a single value and multiple values (repeatable)
- Test that `--milestone` accepts a string value
- Test that `--label` and `--milestone` are NOT in `filter_group` (can combine with `--ready`, etc.)
- Test that `analyze_issues()` output includes `milestone` field (title string or null) when milestone data is present in input
- Test CLI integration with `--issues-json` fixture containing milestone data

**Files:** `src/analyze_issues.rs` (test module)

**TDD:** Tests should fail initially because the Args struct doesn't have `--label`/`--milestone` fields yet and `analyze_issues()` doesn't output milestone data.

### Task 2: Add --label and --milestone to Args and gh command construction

Add to `Args` struct:
- `label: Vec<String>` with `#[arg(long, short = 'l')]` — NOT in `filter_group`
- `milestone: Option<String>` with `#[arg(long, short = 'm')]` — NOT in `filter_group`

In `run()`, build the `gh issue list` args dynamically:
- Start with the existing hardcoded args
- For each value in `args.label`, append `["--label", &value]`
- If `args.milestone` is `Some(m)`, append `["--milestone", &m]`

**Files:** `src/analyze_issues.rs` (Args struct, run function)

### Task 3: Add milestone to JSON fields and per-issue output

In `run()`, add `milestone` to the `--json` fields string: `"number,title,labels,createdAt,body,url,milestone"`.

In `analyze_issues()`, extract milestone title from each issue's `milestone` field (which is an object with a `title` key when present, or null) and include it in the per-issue output as `"milestone": "title"` or `"milestone": null`.

**Files:** `src/analyze_issues.rs` (run function, analyze_issues function)

### Task 4: Update SKILL.md and docs with new flags and documentation

Update `skills/flow-issues/SKILL.md`:
- Add `--label` and `--milestone` to Usage section with examples
- Add a "Narrowing Filters" section explaining these compose with readiness filters
- Add `--label` and `--milestone` variants to Step 1 command examples
- Add `milestone` field to the JSON schema example in Step 1

Update `docs/skills/flow-issues.md`:
- Add `--label` and `--milestone` to Usage code block
- Add a "Narrowing Filters" row or section explaining label/milestone filtering
- Update the description to mention narrowing filters

Update `docs/skills/index.md`:
- Add `--label`, `--milestone` to the flow-issues description column

**Files:** `skills/flow-issues/SKILL.md`, `docs/skills/flow-issues.md`, `docs/skills/index.md`
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: Add --label and --milestone filtering to flow-issues

## Problem

`/flow:flow-issues` supports 4 mutually-exclusive readiness filters (`--ready`, `--blocked`, `--decomposed`, `--quick-start`) but has no way to narrow results by GitHub label or milestone. Users with many open issues cannot focus the dashboard on a specific label (e.g., "Bug", "Tech Debt") or milestone (e.g., "v1.2.0") without manually scanning the full list.

The `gh issue list` CLI natively supports `--label` (repeatable) and `--milestone` (single value) for server-side filtering, but `analyze_issues::run()` currently fetches all open issues without passing these filters through.

Additionally, the `milestone` JSON field is not requested from `gh issue list`, so even when milestone data exists on issues, it is not available in the analysis output.

## Acceptance Criteria

- `bin/flow analyze-issues --label "Bug"` returns only issues with the "Bug" label
- `bin/flow analyze-issues --label "Bug" --label "Enhancement"` returns issues matching both labels
- `bin/flow analyze-issues --milestone "v1.2.0"` returns only issues in that milestone
- `--label` and `--milestone` compose with existing readiness filters: `--label "Bug" --ready` returns non-blocked Bug issues
- `--label` and `--milestone` are NOT in the mutually-exclusive `filter_group` — they are orthogonal narrowing filters
- Per-issue output JSON includes `milestone` field (title string or null)
- SKILL.md documents the new flags with usage examples
- All new behavior has unit and CLI integration tests

## Implementation Plan

### Context

Users need to filter the flow-issues dashboard by GitHub label or milestone to focus on subsets of work. Both filters are natively supported by `gh issue list` as server-side filters, making the implementation a clean pass-through from skill invocation to CLI args to `gh` command construction.

### Exploration

- **`src/analyze_issues.rs`** — `Args` struct (line 414) uses `group = "filter_group"` for the 4 readiness filters. `run()` (line 437) builds the `gh issue list` command with hardcoded args (line 449-458) requesting `number,title,labels,createdAt,body,url` JSON fields. `analyze_issues()` enriches each issue with label flags, category, staleness, blockers. `filter_issues()` applies client-side readiness filtering.
- **`skills/flow-issues/SKILL.md`** — Step 1 passes readiness filter flags as literal CLI args to `bin/flow analyze-issues`. Usage section documents the 4 existing filters. JSON schema in Step 1 does not include a `milestone` field.
- **`gh issue list`** — Supports `-l/--label strings` (repeatable, server-side AND filter) and `-m/--milestone string` (single value, by number or title). Supports `milestone` as a JSON output field.

### Risks

1. **`--label` is a repeatable flag** — `clap` handles `Vec<String>` natively, but each value must be passed as a separate `--label` arg to `gh`. Must loop over values when building the command.
2. **Milestone JSON shape** — The `milestone` JSON field from `gh` is an object (`{"title": "v1.2.0", ...}`), not a string. The `analyze_issues()` function must extract the title for the per-issue output.
3. **Empty results** — When a label or milestone matches zero issues, the output should be a valid empty result, not an error.
4. **`--issues-json` test path** — The `--issues-json` flag bypasses `gh` entirely, so server-side filters don't apply in tests. Tests for the `--label`/`--milestone` arg construction need to verify the `gh` command args are built correctly, separate from the analysis logic.

### Approach

Server-side filtering: pass `--label` and `--milestone` directly to `gh issue list` command construction in `run()`. This reduces the number of issues fetched (fewer blocker GraphQL calls) and leverages GitHub's native filtering. The new args are orthogonal to the existing `filter_group` — they narrow the input set, while readiness filters classify the output set. Add `milestone` to the `--json` fields list and include milestone title in per-issue output.

### Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add tests for --label and --milestone CLI args and milestone output | test | — |
| 2. Add --label and --milestone to Args and gh command construction | implement | 1 |
| 3. Add milestone to JSON fields and per-issue output | implement | 2 |
| 4. Update SKILL.md with new flags, examples, and JSON schema | docs | 3 |

### Tasks

#### Task 1: Add tests for new CLI args and milestone output

Add unit tests to `src/analyze_issues.rs` test module:

- Test that `--label` accepts a single value and multiple values (repeatable)
- Test that `--milestone` accepts a string value
- Test that `--label` and `--milestone` are NOT in `filter_group` (can combine with `--ready`, etc.)
- Test that `analyze_issues()` output includes `milestone` field (title string or null) when milestone data is present in input
- Test CLI integration with `--issues-json` fixture containing milestone data

**Files:** `src/analyze_issues.rs` (test module)

**TDD:** Tests should fail initially because the Args struct doesn't have `--label`/`--milestone` fields yet and `analyze_issues()` doesn't output milestone data.

#### Task 2: Add --label and --milestone to Args and gh command construction

Add to `Args` struct:
- `label: Vec<String>` with `#[arg(long, short = 'l')]` — NOT in `filter_group`
- `milestone: Option<String>` with `#[arg(long, short = 'm')]` — NOT in `filter_group`

In `run()`, build the `gh issue list` args dynamically:
- Start with the existing hardcoded args
- For each value in `args.label`, append `["--label", &value]`
- If `args.milestone` is `Some(m)`, append `["--milestone", &m]`

**Files:** `src/analyze_issues.rs` (Args struct, run function)

#### Task 3: Add milestone to JSON fields and per-issue output

In `run()`, add `milestone` to the `--json` fields string: `"number,title,labels,createdAt,body,url,milestone"`.

In `analyze_issues()`, extract milestone title from each issue's `milestone` field (which is an object with a `title` key when present, or null) and include it in the per-issue output as `"milestone": "title"` or `"milestone": null`.

**Files:** `src/analyze_issues.rs` (run function, analyze_issues function)

#### Task 4: Update SKILL.md with new flags and documentation

Update `skills/flow-issues/SKILL.md`:
- Add `--label` and `--milestone` to Usage section with examples
- Add a "Narrowing Filters" section explaining these compose with readiness filters
- Add `--label` and `--milestone` variants to Step 1 command examples
- Add `milestone` field to the JSON schema example in Step 1

**Files:** `skills/flow-issues/SKILL.md`

## Files to Investigate

- `src/analyze_issues.rs` — CLI args (`Args` struct, line 414), `gh issue list` command construction (line 448-458), `analyze_issues()` output builder, `filter_issues()`, tests (line 583+)
- `skills/flow-issues/SKILL.md` — usage section, readiness filters section, Step 1 command examples, JSON schema

## Out of Scope

- Client-side label/milestone filtering (server-side via `gh` is the right layer)
- Milestone creation or management
- Changes to other issue-related commands (`issue.rs`, `label_issues.rs`, etc.)
- Display changes beyond showing milestone data in output

## Context

Users managing projects with many open issues need to focus the flow-issues dashboard on subsets of work. Label and milestone filtering are the two most common GitHub issue organization axes and are natively supported by `gh issue list`.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | <1m |
| Code | 21m |
| Code Review | 20m |
| Learn | 3m |
| Complete | 8m |
| **Total** | **55m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/add---label-and---milestone.json</summary>

```json
{
  "schema_version": 1,
  "branch": "add---label-and---milestone",
  "repo": "benkruger/flow",
  "pr_number": 1006,
  "pr_url": "https://github.com/benkruger/flow/pull/1006",
  "started_at": "2026-04-10T17:07:35-07:00",
  "current_phase": "flow-complete",
  "framework": "rust",
  "files": {
    "plan": ".flow-states/add---label-and---milestone-plan.md",
    "dag": ".flow-states/add---label-and---milestone-dag.md",
    "log": ".flow-states/add---label-and---milestone.log",
    "state": ".flow-states/add---label-and---milestone.json"
  },
  "session_tty": "/dev/ttys007",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "Add --label and --milestone filtering to flow-issues #1003",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-10T17:07:35-07:00",
      "completed_at": "2026-04-10T17:08:30-07:00",
      "session_started_at": null,
      "cumulative_seconds": 55,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-10T17:08:41-07:00",
      "completed_at": "2026-04-10T17:10:19-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-10T17:11:03-07:00",
      "completed_at": "2026-04-10T17:32:31-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1288,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-10T17:32:51-07:00",
      "completed_at": "2026-04-10T17:52:58-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1207,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-10T17:53:13-07:00",
      "completed_at": "2026-04-10T17:57:07-07:00",
      "session_started_at": null,
      "cumulative_seconds": 234,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-10T17:57:39-07:00",
      "completed_at": "2026-04-10T18:06:18-07:00",
      "session_started_at": null,
      "cumulative_seconds": 519,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-10T17:08:41-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-10T17:11:03-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-10T17:32:51-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-10T17:53:13-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-10T17:57:39-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 4,
  "code_task_name": "Update SKILL.md and docs with new flags and documentation",
  "code_task": 4,
  "diff_stats": {
    "files_changed": 4,
    "insertions": 218,
    "deletions": 14,
    "captured_at": "2026-04-10T17:32:31-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "issues_filed": [
    {
      "label": "Flaky Test",
      "title": "Flaky: thundering_herd_zero_delay times out under load",
      "url": "https://github.com/benkruger/flow/issues/1014",
      "phase": "flow-complete",
      "phase_name": "Complete",
      "timestamp": "2026-04-10T18:05:29-07:00"
    }
  ],
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/add---label-and---milestone.log</summary>

```text
2026-04-10T17:05:53-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T17:06:35-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-10T17:07:35-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-10T17:07:35-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-10T17:07:35-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-10T17:07:35-07:00 [Phase 1] create .flow-states/add---label-and---milestone.json (exit 0)
2026-04-10T17:07:35-07:00 [Phase 1] freeze .flow-states/add---label-and---milestone-phases.json (exit 0)
2026-04-10T17:07:35-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-10T17:07:37-07:00 [Phase 1] start-init — label-issues (labeled: [1003], failed: [])
2026-04-10T17:07:59-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-10T17:07:59-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-10T17:08:01-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-10T17:08:13-07:00 [Phase 1] start-workspace — worktree .worktrees/add---label-and---milestone (ok)
2026-04-10T17:08:17-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-10T17:08:17-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-10T17:08:17-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-10T17:08:30-07:00 [Phase] phase-finalize --phase flow-start ("ok")
2026-04-10T17:08:30-07:00 [Phase] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-10T17:08:41-07:00 [Phase 2] plan-extract — gate check passed (exit 0)
2026-04-10T17:08:41-07:00 [Phase 2] plan-extract — issue #1003 fetched, decomposed label detected (exit 0)
2026-04-10T17:08:41-07:00 [Phase 2] plan-extract — DAG file written: .flow-states/add---label-and---milestone-dag.md (exit 0)
2026-04-10T17:08:41-07:00 [Phase 2] plan-extract — plan extracted, 4 tasks, written: .flow-states/add---label-and---milestone-plan.md (exit 0)
2026-04-10T17:08:43-07:00 [Phase 2] plan-extract — PR body rendered (exit 0)
2026-04-10T17:08:43-07:00 [Phase 2] plan-extract — phase complete (<1m) (exit 0)
2026-04-10T17:10:19-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-10T17:11:03-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-10T17:24:38-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-10T17:24:41-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-10T17:31:45-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-10T17:31:49-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-10T17:32:31-07:00 [Phase] phase-finalize --phase flow-code ("ok")
2026-04-10T17:32:51-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-10T17:52:24-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-10T17:52:28-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-10T17:52:58-07:00 [Phase] phase-finalize --phase flow-code-review ("ok")
2026-04-10T17:53:13-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-10T17:57:07-07:00 [Phase] phase-finalize --phase flow-learn ("ok")
2026-04-10T18:06:18-07:00 [Phase 6] complete-finalize — starting
2026-04-10T18:06:18-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-10T18:06:18-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Flaky Test | Flaky: thundering_herd_zero_delay times out under load | Complete | #1014 |

<!-- end:Issues Filed -->