### PR TITLE
Extract Shared Toleranti64

### DIFF
--- a/.claude/rules/rust-patterns.md
+++ b/.claude/rules/rust-patterns.md
@@ -92,6 +92,25 @@ and string representations when reading counters.
 When other modules need the same tolerance, import from `crate::utils`
 — do not inline the fallback chain.
 
+## Saturating Arithmetic on Counter Reads
+
+Counter reads via `tolerant_i64` can return values at or near `i64::MAX`
+when state files carry corrupt or legacy values (hand edits, external
+writers, or integer overflow from a prior session). Raw `+ 1` or
+`+ elapsed` arithmetic on those values panics in debug builds and wraps
+silently to `i64::MIN` in release builds, corrupting the counter.
+
+Use `saturating_add` at every counter-increment callsite:
+
+```rust
+let visit_count = tolerant_i64(&phase_data["visit_count"]).saturating_add(1);
+let cumulative = existing.saturating_add(elapsed);
+```
+
+The helper itself cannot defend against this — the caller chooses the
+arithmetic. Apply the guard wherever a counter read is followed by an
+increment or accumulation.
+
 ## Empty-String vs Missing-Key Equivalence
 
 `Some("".to_string())` is distinct from `None` in Rust. When porting
@@ -116,6 +135,25 @@ paths.
 Any non-obvious design decision (custom formatters, shared constants,
 unusual return types) must have a local doc comment on the definition
 site summarizing why it exists in one sentence.
+
+## Test Module Section Markers
+
+Group related tests inside a `#[cfg(test)] mod tests` block using
+single-topic section markers: `// --- primary_name ---` where
+`primary_name` is the core function or feature being tested. When a
+test group covers multiple related functions (e.g. a helper and its
+wrapper), use the top-level abstraction name, not a slash-separated
+list or a parenthesized signature.
+
+- Correct: `// --- tolerant_i64 ---` (covers `tolerant_i64` and
+  `tolerant_i64_opt`)
+- Wrong: `// --- tolerant_i64_opt() / tolerant_i64() ---`
+- Wrong: `// --- tolerant_i64(v: &Value) ---`
+
+Before adding a new marker, grep the file for existing `// --- ` lines
+and match their style. A marker that deviates from the file's
+convention is a maintainability regression — the pattern is
+discoverable only by reading the file, so consistency matters.
 
 ## Session Log Message Format
 

--- a/.claude/rules/rust-patterns.md
+++ b/.claude/rules/rust-patterns.md
@@ -77,13 +77,20 @@ return value, not the caller's interpretation.
 ## Counter and State Field Type Tolerance
 
 State files can outlive the code that writes them. Accept int, float,
-and string representations when reading counters:
-`.as_i64().or_else(|| v.as_f64().map(|f| f as i64)).or_else(|| v.as_str().and_then(|s| s.parse().ok()))`.
+and string representations when reading counters.
 
-`phase_transition.rs` defines `tolerant_i64()` as a named helper
-encapsulating this pattern for `visit_count` and `cumulative_seconds`.
-When other modules need the same tolerance, extract a shared helper
-or reference this implementation.
+`src/utils.rs` exposes two functions for this tolerance:
+
+- `tolerant_i64_opt(v: &Value) -> Option<i64>` — primary form. Returns
+  `None` when the value cannot be interpreted as a number. Use when the
+  caller needs to distinguish "field missing / unparseable" from "present
+  with value 0".
+- `tolerant_i64(v: &Value) -> i64` — thin `unwrap_or(0)` wrapper over
+  `tolerant_i64_opt`. Use for counter fields where a missing or
+  unparseable value should mean zero.
+
+When other modules need the same tolerance, import from `crate::utils`
+— do not inline the fallback chain.
 
 ## Empty-String vs Missing-Key Equivalence
 

--- a/src/check_freshness.rs
+++ b/src/check_freshness.rs
@@ -15,7 +15,7 @@ use serde_json::{json, Value};
 
 use crate::complete_preflight::{LOCAL_TIMEOUT, NETWORK_TIMEOUT};
 use crate::lock::mutate_state;
-use crate::utils::parse_conflict_files;
+use crate::utils::{parse_conflict_files, tolerant_i64};
 const MAX_RETRIES: i64 = 3;
 
 #[derive(Parser, Debug)]
@@ -157,7 +157,7 @@ fn read_retries(state_path: &Path) -> i64 {
         if !(state.is_object() || state.is_null()) {
             return;
         }
-        cell.set(read_retries_value(state));
+        cell.set(tolerant_i64(&state["freshness_retries"]));
     });
     cell.get()
 }
@@ -171,25 +171,11 @@ fn increment_retries(state_path: &Path) -> i64 {
         if !(state.is_object() || state.is_null()) {
             return;
         }
-        let next = read_retries_value(state) + 1;
+        let next = tolerant_i64(&state["freshness_retries"]) + 1;
         state["freshness_retries"] = json!(next);
         cell.set(next);
     });
     cell.get()
-}
-
-/// Counter type tolerance — state files in the wild may store
-/// `freshness_retries` as int, float, or string (older versions or hand
-/// edits). Accepts all three representations for backwards compatibility.
-fn read_retries_value(state: &Value) -> i64 {
-    state
-        .get("freshness_retries")
-        .and_then(|v| {
-            v.as_i64()
-                .or_else(|| v.as_f64().map(|f| f as i64))
-                .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
-        })
-        .unwrap_or(0)
 }
 
 /// Real git subprocess runner with polling-based timeout and thread-drain.
@@ -667,9 +653,9 @@ mod tests {
         assert_eq!(state["freshness_retries"], 1);
     }
 
-    // Counter type tolerance tests: the fallback chain in `read_retries_value`
-    // accepts int, float, and string representations because state files can
-    // outlive the code that writes them.
+    // Counter type tolerance tests: `tolerant_i64` (imported from utils)
+    // accepts int, float, and string representations for `freshness_retries`
+    // because state files can outlive the code that writes them.
 
     #[test]
     fn test_retry_value_as_float() {

--- a/src/check_freshness.rs
+++ b/src/check_freshness.rs
@@ -171,7 +171,7 @@ fn increment_retries(state_path: &Path) -> i64 {
         if !(state.is_object() || state.is_null()) {
             return;
         }
-        let next = tolerant_i64(&state["freshness_retries"]) + 1;
+        let next = tolerant_i64(&state["freshness_retries"]).saturating_add(1);
         state["freshness_retries"] = json!(next);
         cell.set(next);
     });

--- a/src/format_pr_timings.rs
+++ b/src/format_pr_timings.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 
 use crate::output::{json_error, json_ok};
 use crate::phase_config::{self, PHASE_ORDER};
-use crate::utils::format_time;
+use crate::utils::{format_time, tolerant_i64};
 
 /// Build a markdown timings table from state dict.
 ///
@@ -38,7 +38,7 @@ pub fn format_timings_table(state: &Value, started_only: bool) -> String {
             .filter(|s| !s.is_empty());
         let seconds = phase
             .and_then(|p| p.get("cumulative_seconds"))
-            .and_then(|v| v.as_i64().or_else(|| v.as_f64().map(|f| f as i64)))
+            .map(tolerant_i64)
             .unwrap_or(0);
 
         if started_only && started.is_none() && seconds == 0 {
@@ -260,6 +260,29 @@ mod tests {
         let result = format_timings_table(&state, false);
         // 3700 seconds = 1h 1m
         assert!(result.contains("1h 1m"), "Result:\n{}", result);
+    }
+
+    #[test]
+    fn test_cumulative_seconds_as_string() {
+        // tolerant_i64 accepts string-numeric counter values, so a state
+        // file with cumulative_seconds stored as "945" (e.g. from an
+        // external edit or legacy writer) must render the same timing
+        // as the integer 945.
+        let all_phases = [
+            "flow-start",
+            "flow-plan",
+            "flow-code",
+            "flow-code-review",
+            "flow-learn",
+            "flow-complete",
+        ];
+        let statuses: Vec<(&str, &str)> = all_phases.iter().map(|&p| (p, "complete")).collect();
+        let mut state = make_state("flow-complete", &statuses);
+        state["phases"]["flow-plan"]["cumulative_seconds"] = json!("945");
+
+        let result = format_timings_table(&state, false);
+        // 945 seconds = 15m
+        assert!(result.contains("15m"), "Result:\n{}", result);
     }
 
     #[test]

--- a/src/hooks/post_compact.rs
+++ b/src/hooks/post_compact.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 
 use crate::git::{project_root, resolve_branch};
 use crate::lock::mutate_state;
+use crate::utils::tolerant_i64;
 
 /// Capture compaction data into the state file.
 ///
@@ -33,18 +34,11 @@ pub fn capture_compact_data(hook_input: &Value, state_path: &Path) {
         if let Some(cwd) = hook_input.get("cwd").and_then(|v| v.as_str()) {
             state["compact_cwd"] = Value::String(cwd.to_string());
         }
-        // Accept compact_count written by any prior version: integers,
-        // floats (3.0 from older Python writes), or strings ("3" from
-        // corrupted/foreign edits). All resolve to the same canonical
-        // i64 increment instead of silently resetting to 1.
-        let count = state
-            .get("compact_count")
-            .and_then(|v| {
-                v.as_i64()
-                    .or_else(|| v.as_f64().map(|f| f as i64))
-                    .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
-            })
-            .unwrap_or(0);
+        // Accept compact_count stored as int, float, or string — state
+        // files may carry any of these shapes from external edits or
+        // legacy writers. All three resolve to the same canonical i64
+        // increment instead of silently resetting to 1.
+        let count = state.get("compact_count").map(tolerant_i64).unwrap_or(0);
         state["compact_count"] = Value::Number((count + 1).into());
     });
 }

--- a/src/hooks/post_compact.rs
+++ b/src/hooks/post_compact.rs
@@ -39,7 +39,7 @@ pub fn capture_compact_data(hook_input: &Value, state_path: &Path) {
         // legacy writers. All three resolve to the same canonical i64
         // increment instead of silently resetting to 1.
         let count = state.get("compact_count").map(tolerant_i64).unwrap_or(0);
-        state["compact_count"] = Value::Number((count + 1).into());
+        state["compact_count"] = Value::Number(count.saturating_add(1).into());
     });
 }
 

--- a/src/phase_transition.rs
+++ b/src/phase_transition.rs
@@ -4,19 +4,7 @@ use indexmap::IndexMap;
 use serde_json::{json, Value};
 
 use crate::phase_config::{self, PHASE_ORDER};
-use crate::utils::{elapsed_since, format_time, now};
-
-/// Read a JSON value as i64, tolerating int, float, and string representations.
-///
-/// State files can outlive the code that writes them. This function accepts
-/// all three representations so counter fields survive round-trips through
-/// external editors or legacy writers that store numbers as strings or floats.
-fn tolerant_i64(v: &Value) -> i64 {
-    v.as_i64()
-        .or_else(|| v.as_f64().map(|f| f as i64))
-        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-        .unwrap_or(0)
-}
+use crate::utils::{elapsed_since, format_time, now, tolerant_i64};
 
 /// Apply phase entry mutations to the state Value in-place.
 ///

--- a/src/phase_transition.rs
+++ b/src/phase_transition.rs
@@ -31,7 +31,7 @@ pub fn phase_enter(state: &mut Value, phase: &str, reason: Option<&str>) -> Valu
     }
     phase_data["session_started_at"] = json!(now());
 
-    let visit_count = tolerant_i64(&phase_data["visit_count"]) + 1;
+    let visit_count = tolerant_i64(&phase_data["visit_count"]).saturating_add(1);
     phase_data["visit_count"] = json!(visit_count);
 
     state["current_phase"] = json!(phase);
@@ -118,7 +118,7 @@ pub fn phase_complete(
     let elapsed = elapsed_since(session_started.as_deref(), None);
 
     let existing = tolerant_i64(&state["phases"][phase]["cumulative_seconds"]);
-    let cumulative = existing + elapsed;
+    let cumulative = existing.saturating_add(elapsed);
 
     // Update phase state
     state["phases"][phase]["cumulative_seconds"] = json!(cumulative);

--- a/src/tui_data.rs
+++ b/src/tui_data.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use crate::phase_config::{self, PHASE_ORDER};
 use crate::utils::{
     derive_feature, derive_worktree, elapsed_since, extract_issue_numbers, format_time,
-    short_issue_ref,
+    short_issue_ref, tolerant_i64_opt,
 };
 
 /// Static mapping of (phase_key, display_step_number) → short step name.
@@ -753,19 +753,8 @@ pub fn load_account_metrics(repo_root: &Path, home_override: Option<&Path>) -> A
                 if age.as_secs() <= STALE_THRESHOLD_SECONDS {
                     if let Ok(content) = std::fs::read_to_string(&rl_path) {
                         if let Ok(data) = serde_json::from_str::<Value>(&content) {
-                            // int(data["five_hour_pct"]) — handle null via TypeError parity
-                            if let Some(v) = data.get("five_hour_pct") {
-                                if let Some(n) = v.as_i64().or_else(|| v.as_f64().map(|f| f as i64))
-                                {
-                                    rl_5h = Some(n);
-                                }
-                            }
-                            if let Some(v) = data.get("seven_day_pct") {
-                                if let Some(n) = v.as_i64().or_else(|| v.as_f64().map(|f| f as i64))
-                                {
-                                    rl_7d = Some(n);
-                                }
-                            }
+                            rl_5h = data.get("five_hour_pct").and_then(tolerant_i64_opt);
+                            rl_7d = data.get("seven_day_pct").and_then(tolerant_i64_opt);
                             if rl_5h.is_some() && rl_7d.is_some() {
                                 stale = false;
                             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1410,7 +1410,7 @@ mod tests {
         assert_eq!(read_version_from(&path), "?");
     }
 
-    // --- tolerant_i64_opt() / tolerant_i64() ---
+    // --- tolerant_i64 ---
 
     #[test]
     fn tolerant_i64_opt_accepts_int() {
@@ -1477,7 +1477,7 @@ mod tests {
 
     #[test]
     fn tolerant_i64_zero_for_missing_via_index() {
-        // `IndexMut` on a missing key returns Value::Null; tolerant_i64 should
+        // `Index` on a missing key returns &Value::Null; tolerant_i64 should
         // coerce to 0 so callers can use `state["missing"]` directly.
         let state = serde_json::json!({"branch": "test"});
         assert_eq!(tolerant_i64(&state["missing_key"]), 0);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -731,6 +731,31 @@ pub fn detect_dev_mode(root: &Path) -> bool {
     }
 }
 
+// --- tolerant_i64 ---
+
+/// Read a JSON value as i64, tolerating int, float, and string representations.
+///
+/// State files can outlive the code that writes them. Accepts all three
+/// representations so counter fields survive round-trips through external
+/// editors or legacy writers that store numbers as strings or floats.
+/// Returns `None` when the value cannot be interpreted as a number (bool,
+/// null, object, array, or unparseable string). Callers that need "data
+/// not available" vs "present with value 0" should use this function.
+pub fn tolerant_i64_opt(v: &serde_json::Value) -> Option<i64> {
+    v.as_i64()
+        .or_else(|| v.as_f64().map(|f| f as i64))
+        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+}
+
+/// Read a JSON value as i64 with 0 as the default.
+///
+/// Thin `unwrap_or(0)` wrapper over [`tolerant_i64_opt`] for counter fields
+/// where a missing or unparseable value should mean zero rather than "data
+/// not available".
+pub fn tolerant_i64(v: &serde_json::Value) -> i64 {
+    tolerant_i64_opt(v).unwrap_or(0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1383,5 +1408,78 @@ mod tests {
         let path = dir.path().join("plugin.json");
         fs::write(&path, r#"{"name": "flow"}"#).unwrap();
         assert_eq!(read_version_from(&path), "?");
+    }
+
+    // --- tolerant_i64_opt() / tolerant_i64() ---
+
+    #[test]
+    fn tolerant_i64_opt_accepts_int() {
+        assert_eq!(tolerant_i64_opt(&serde_json::json!(42)), Some(42));
+        assert_eq!(tolerant_i64_opt(&serde_json::json!(-7)), Some(-7));
+        assert_eq!(tolerant_i64_opt(&serde_json::json!(0)), Some(0));
+    }
+
+    #[test]
+    fn tolerant_i64_opt_accepts_float_truncates() {
+        assert_eq!(tolerant_i64_opt(&serde_json::json!(3.7)), Some(3));
+        assert_eq!(tolerant_i64_opt(&serde_json::json!(1.0)), Some(1));
+        assert_eq!(tolerant_i64_opt(&serde_json::json!(-2.9)), Some(-2));
+    }
+
+    #[test]
+    fn tolerant_i64_opt_accepts_string_numeric() {
+        assert_eq!(tolerant_i64_opt(&serde_json::json!("123")), Some(123));
+        assert_eq!(tolerant_i64_opt(&serde_json::json!("0")), Some(0));
+    }
+
+    #[test]
+    fn tolerant_i64_opt_accepts_negative_string() {
+        assert_eq!(tolerant_i64_opt(&serde_json::json!("-5")), Some(-5));
+    }
+
+    #[test]
+    fn tolerant_i64_opt_returns_none_for_bool() {
+        assert_eq!(tolerant_i64_opt(&serde_json::json!(true)), None);
+        assert_eq!(tolerant_i64_opt(&serde_json::json!(false)), None);
+    }
+
+    #[test]
+    fn tolerant_i64_opt_returns_none_for_null() {
+        assert_eq!(tolerant_i64_opt(&serde_json::json!(null)), None);
+    }
+
+    #[test]
+    fn tolerant_i64_opt_returns_none_for_unparseable_string() {
+        assert_eq!(tolerant_i64_opt(&serde_json::json!("garbage")), None);
+        assert_eq!(tolerant_i64_opt(&serde_json::json!("")), None);
+    }
+
+    #[test]
+    fn tolerant_i64_opt_returns_none_for_array() {
+        assert_eq!(tolerant_i64_opt(&serde_json::json!([1, 2, 3])), None);
+        assert_eq!(tolerant_i64_opt(&serde_json::json!({})), None);
+    }
+
+    #[test]
+    fn tolerant_i64_passes_through_when_opt_returns_some() {
+        assert_eq!(tolerant_i64(&serde_json::json!(42)), 42);
+        assert_eq!(tolerant_i64(&serde_json::json!("5")), 5);
+        assert_eq!(tolerant_i64(&serde_json::json!(7.9)), 7);
+    }
+
+    #[test]
+    fn tolerant_i64_defaults_zero_when_opt_returns_none() {
+        assert_eq!(tolerant_i64(&serde_json::json!(null)), 0);
+        assert_eq!(tolerant_i64(&serde_json::json!(true)), 0);
+        assert_eq!(tolerant_i64(&serde_json::json!("garbage")), 0);
+        assert_eq!(tolerant_i64(&serde_json::json!([])), 0);
+    }
+
+    #[test]
+    fn tolerant_i64_zero_for_missing_via_index() {
+        // `IndexMut` on a missing key returns Value::Null; tolerant_i64 should
+        // coerce to 0 so callers can use `state["missing"]` directly.
+        let state = serde_json::json!({"branch": "test"});
+        assert_eq!(tolerant_i64(&state["missing_key"]), 0);
     }
 }


### PR DESCRIPTION
## What

work on issue #1016.

Closes #1016

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/extract-shared-toleranti64-plan.md` |
| DAG | `.flow-states/extract-shared-toleranti64-dag.md` |
| Log | `.flow-states/extract-shared-toleranti64.log` |
| State | `.flow-states/extract-shared-toleranti64.json` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Plan: Extract shared tolerant_i64 helper (issue #1016)

## Context

Issue #1016 identifies that `tolerant_i64` (the counter-tolerance pattern documented in `.claude/rules/rust-patterns.md`) is a named helper in `src/phase_transition.rs` but at least two other modules inline a two-variant form of the same pattern without the string fallback. The inlined sites silently return 0 for string-typed counter values that `tolerant_i64` would handle correctly.

Goal: extract `tolerant_i64` into `src/utils.rs`, replace all duplicated/inline forms, and rewire the rust-patterns rule to point at the new canonical home.

## Exploration

**Canonical helper — `src/phase_transition.rs:14-19`:**

```rust
fn tolerant_i64(v: &Value) -> i64 {
    v.as_i64()
        .or_else(|| v.as_f64().map(|f| f as i64))
        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
        .unwrap_or(0)
}
```

Currently private. Used at `phase_transition.rs:46` and `:132`.

**Callsite map (grep across `src/`):**

| File | Lines | Form | Fallback variants | Return shape | Notes |
|------|-------|------|-------------------|--------------|-------|
| `src/phase_transition.rs` | 14-19, 46, 132 | Named local fn | int, float, string | `i64` (unwrap_or 0) | Canonical helper |
| `src/check_freshness.rs` | 184-193 (`fn read_retries_value`), 160, 174 | Named local fn (duplicate) | int, float, string | `i64` (unwrap_or 0) | **Scope expansion** — issue didn't list this |
| `src/hooks/post_compact.rs` | 40-48 (reads `compact_count`) | Inline | int, float, string | `i64` (unwrap_or 0) | **Scope expansion** — issue didn't list this |
| `src/format_pr_timings.rs` | 39-42 (reads `cumulative_seconds`) | Inline | int, float | `i64` (unwrap_or 0) | Missing string fallback |
| `src/tui_data.rs` | 757-762 (`five_hour_pct`), 763-768 (`seven_day_pct`) | Inline | int, float | `Option<i64>` | Missing string fallback; **different return shape** |

The scope-enumeration grep turned up two callsites that the issue body did not name. `.claude/rules/docs-with-behavior.md` Scope Enumeration requires those to be in-scope.

**Home module — `src/utils.rs`:**

Already imports `serde_json::Value` (line 10). Has an existing `#[cfg(test)] mod tests` block at line 734. Already imported by `phase_transition.rs` via `use crate::utils::{elapsed_since, format_time, now};`. Zero refactor needed — just append new `pub fn` and new tests.

**Existing test coverage:** No direct unit tests for `tolerant_i64`. Integration tests in `check_freshness.rs:674-714` (`test_retry_value_as_float`, `test_retry_value_as_string`, `test_retry_value_as_unparseable_string_defaults_to_zero`) exercise the fallback chain end-to-end via `check_freshness_impl`. These stay as regression coverage when `read_retries_value` is replaced.

**Rule references:**

- `.claude/rules/rust-patterns.md:78-86` — "Counter and State Field Type Tolerance" section names `phase_transition.rs` as the file that "defines `tolerant_i64()` as a named helper" and tells modules to "extract a shared helper or reference this implementation." Must be rewritten.
- `.claude/rules/state-files.md:41-45` — mentions `tolerant_i64()` generically with no file location. No change needed.

## Risks

1. **Different return shape at `tui_data.rs` callsites.** The inline forms there return `Option<i64>` because the consumer distinguishes "field missing / unparseable" (stays `None`, marks data stale) from "present" (`Some(n)`). A single `tolerant_i64 -> i64` helper with `unwrap_or(0)` would break this contract by conflating missing with zero. **Mitigation:** define TWO functions — `tolerant_i64_opt(v) -> Option<i64>` as primary and `tolerant_i64(v) -> i64` as a thin wrapper. Callsites choose the flavor that matches their contract.

2. **Contract change at `tui_data.rs` callsites (more-permissive direction).** The new `tolerant_i64_opt` accepts string-numeric values where the old inline form rejected them. Must verify: does `~/.claude/rate-limits.json` (the source file the callsites read) ever produce string values? This file is written by Claude Code, not by this repo, so we cannot inspect the writer. The refactor direction is more permissive (accepting more representations), which is strictly safer for a tolerance helper — if string values appear in the wild, we now interpret them correctly instead of marking the data stale. Flag as verified-safe and proceed.

3. **CI intermediate states.** If a commit removes the private `fn tolerant_i64` in `phase_transition.rs` before `phase_transition.rs` imports the shared version, the build breaks. **Mitigation:** add `pub fn tolerant_i64` and `pub fn tolerant_i64_opt` to `utils.rs` FIRST (Node A commit). Callsite migrations land in subsequent commits in any order. The private `fn tolerant_i64` in `phase_transition.rs` and `fn read_retries_value` in `check_freshness.rs` are only deleted within the same commit that rewires their internal callers.

4. **docs-with-behavior atomicity.** The rule rewrite in `.claude/rules/rust-patterns.md` describes the *post-refactor* reality ("defined in `utils.rs`"). If the rule update lands in a separate commit from the helper definition, there is an intermediate state where the rule points at a helper that doesn't exist yet. **Mitigation:** rule update and helper definition land in the same atomic commit (Node A).

5. **Stale comment at `tui_data.rs:756`** — `// int(data["five_hour_pct"]) — handle null via TypeError parity`. This is a historical-provenance comment referencing a prior Python port, which violates `.claude/rules/comment-quality.md` (prohibited pattern: origin stories). Since `tui_data.rs` is already in the PR diff, `.claude/rules/code-review-scope.md` makes the comment in-scope to delete in the same pass.

6. **Stale doc comment at `check_freshness.rs:670`** — `// Counter type tolerance tests: the fallback chain in read_retries_value ...`. After `read_retries_value` is deleted, this comment references a non-existent helper. Must update to reference `utils::tolerant_i64` or drop the file-specific reference.

7. **Config chain / state-files rule consistency.** The `.claude/rules/state-files.md:43` generic reference to `tolerant_i64()` remains accurate regardless of location. No change.

## Approach

Two-function API in `src/utils.rs`, with `tolerant_i64_opt` as the primary form and `tolerant_i64` as a thin `unwrap_or(0)` wrapper. Helper definition + unit tests + rule update land in a single atomic commit; callsite migrations follow in any order.

### Final signature

```rust
/// Read a JSON value as i64, tolerating int, float, and string representations.
///
/// State files can outlive the code that writes them. Accepts all three
/// representations so counter fields survive round-trips through external
/// editors or legacy writers that store numbers as strings or floats.
/// Returns None when the value cannot be interpreted as a number (e.g. bool,
/// null, object, array, unparseable string).
pub fn tolerant_i64_opt(v: &Value) -> Option<i64> {
    v.as_i64()
        .or_else(|| v.as_f64().map(|f| f as i64))
        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
}

/// Read a JSON value as i64 with 0 as the default.
///
/// Thin wrapper over `tolerant_i64_opt` for counter fields where a missing
/// or unparseable value should mean zero rather than "data not available".
pub fn tolerant_i64(v: &Value) -> i64 {
    tolerant_i64_opt(v).unwrap_or(0)
}
```

### Callsite migration patterns

- **`phase_transition.rs`:** drop the private `fn tolerant_i64`, extend the existing `use crate::utils::{...}` line with `tolerant_i64`. No callsite syntax change.
- **`check_freshness.rs`:** drop the private `fn read_retries_value`, import `tolerant_i64` from utils. Rewire callers from `read_retries_value(state)` to `tolerant_i64(&state["freshness_retries"])`. Update the doc comment at line 670 to remove the `read_retries_value` reference.
- **`hooks/post_compact.rs`:** replace the inline `.and_then(|v| v.as_i64().or_else(...).or_else(...)).unwrap_or(0)` chain with `tolerant_i64(state.get("compact_count").unwrap_or(&Value::Null))` or equivalent cleaner form. Keep the existing comment describing tolerance semantics.
- **`format_pr_timings.rs`:** replace `.and_then(|v| v.as_i64().or_else(|| v.as_f64().map(|f| f as i64))).unwrap_or(0)` with `.map(tolerant_i64).unwrap_or(0)`. The `Option<&Value>` → `Option<i64>` → `i64` chain stays the same shape.
- **`tui_data.rs`:** replace the `if let Some(v) = ... { if let Some(n) = v.as_i64().or_else(...) { rl_X = Some(n); } }` pattern with `rl_5h = data.get("five_hour_pct").and_then(tolerant_i64_opt);` and `rl_7d = data.get("seven_day_pct").and_then(tolerant_i64_opt);`. Remove the historical-provenance comment at line 756.

### Rule rewrite

`.claude/rules/rust-patterns.md` Counter and State Field Type Tolerance section, after rewrite:

```markdown
State files can outlive the code that writes them. Accept int, float,
and string representations when reading counters.

`src/utils.rs` exposes two functions for this tolerance:

- `tolerant_i64_opt(v: &Value) -> Option<i64>` — primary form. Returns
  `None` when the value cannot be interpreted as a number. Use when the
  caller needs to distinguish "field missing / unparseable" from "present
  with value 0".
- `tolerant_i64(v: &Value) -> i64` — thin `unwrap_or(0)` wrapper over
  `tolerant_i64_opt`. Use for counter fields where a missing or
  unparseable value should mean zero.

When other modules need the same tolerance, import from `crate::utils`
— do not inline the fallback chain.
```

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write unit tests for `tolerant_i64_opt` and `tolerant_i64` in `utils::tests` | test | — |
| 2. Add `pub fn tolerant_i64_opt` and `pub fn tolerant_i64` to `src/utils.rs` | implement | 1 |
| 3. Rewrite `.claude/rules/rust-patterns.md` Counter section to point at `utils` | docs | 2 (atomic: same commit) |
| 4. Migrate `src/phase_transition.rs` — remove private fn, import from utils | refactor | 2 |
| 5. Migrate `src/check_freshness.rs` — remove `read_retries_value`, rewire callers, update doc comment at line 670 | refactor | 2 |
| 6. Migrate `src/hooks/post_compact.rs` — replace inline form | refactor | 2 |
| 7. Migrate `src/format_pr_timings.rs` — replace inline form via `.map(tolerant_i64)` | refactor | 2 |
| 8. Migrate `src/tui_data.rs` — replace inline forms via `.and_then(tolerant_i64_opt)`, remove stale Python-parity comment at line 756 | refactor | 2 |
| 9. Verify `bin/flow ci` green and no remaining `.as_i64().or_else(` occurrences in `src/` | validate | 4–8 |

Tasks 1, 2, 3 are **atomically coupled** — they land in a single commit (the docs-with-behavior rule forbids splitting the behavior change from its doc update). Tasks 4–8 can commit in any order after task 3, one commit each, or bundled.

## Tasks

### Task 1. Write unit tests for `tolerant_i64_opt` and `tolerant_i64`

**Files:** `src/utils.rs` (extend existing `#[cfg(test)] mod tests` block at line 734)

**TDD notes:**

Add 11 tests to the existing `mod tests` block (section header `// --- tolerant_i64 ---`):

For `tolerant_i64_opt`:

1. `tolerant_i64_opt_accepts_int` — `json!(42)` → `Some(42)`
2. `tolerant_i64_opt_accepts_float_truncates` — `json!(3.7)` → `Some(3)` (float truncation, matches existing `as f64 as i64` semantics)
3. `tolerant_i64_opt_accepts_string_numeric` — `json!("123")` → `Some(123)`
4. `tolerant_i64_opt_accepts_negative_string` — `json!("-5")` → `Some(-5)`
5. `tolerant_i64_opt_returns_none_for_bool` — `json!(true)` → `None`
6. `tolerant_i64_opt_returns_none_for_null` — `json!(null)` → `None`
7. `tolerant_i64_opt_returns_none_for_unparseable_string` — `json!("garbage")` → `None`
8. `tolerant_i64_opt_returns_none_for_array` — `json!([1, 2])` → `None`

For `tolerant_i64`:

9. `tolerant_i64_passes_through_when_opt_returns_some` — `json!(42)` → `42`, `json!("5")` → `5`, `json!(7.9)` → `7`
10. `tolerant_i64_defaults_zero_when_opt_returns_none` — `json!(null)` → `0`, `json!(true)` → `0`, `json!("garbage")` → `0`, `json!([])` → `0`
11. `tolerant_i64_zero_for_missing_via_index` — reads `state["missing_key"]` which returns `Value::Null` via `IndexMut` → `0`

All tests take a `serde_json::Value` constructed via `json!` and assert the return value directly. Follow the existing file's test style: bare `#[test]` functions inside `mod tests` with `use super::*;` already in scope.

### Task 2. Add `pub fn tolerant_i64_opt` and `pub fn tolerant_i64` to `src/utils.rs`

**Files:** `src/utils.rs`

**What to build:**

Append the two functions (with the doc comments from the Approach section) to `src/utils.rs` after an existing public function near the bottom of the module — just before the `#[cfg(test)]` block at line 734 is a natural home. Add a section comment (`// --- tolerant_i64 ---`) if the file uses section markers for other helper groups.

Do NOT add any `use` or `pub use` re-exports outside the function definitions — `serde_json::Value` is already imported at line 10.

### Task 3. Rewrite `.claude/rules/rust-patterns.md` Counter section

**Files:** `.claude/rules/rust-patterns.md`

**What to build:**

Replace lines 78-86 (the "Counter and State Field Type Tolerance" section body) with the text from the Approach/Rule rewrite sub-section above. Keep the section heading. Do not touch any other section. This task must commit in the same git commit as tasks 1 and 2 — docs-with-behavior rule forbids splitting.

**Verification after edit:** grep `.claude/rules/rust-patterns.md` for `phase_transition.rs` — must return zero hits in the Counter section. Grep for `tolerant_i64_opt` and `tolerant_i64` — must return hits in the rewritten section.

### Task 4. Migrate `src/phase_transition.rs`

**Files:** `src/phase_transition.rs`

**What to build:**

1. Delete `fn tolerant_i64` at lines 14-19 (including the doc comment at lines 9-13).
2. Add `tolerant_i64` to the existing `use crate::utils::{elapsed_since, format_time, now};` line at line 7, producing `use crate::utils::{elapsed_since, format_time, now, tolerant_i64};` (or alphabetized).
3. Call sites at lines 46 and 132 stay unchanged — same function name, same signature.

**TDD notes:** no new tests. Existing integration tests (`phase_enter`, `append_cumulative`) exercise the behavior. `bin/flow ci` is the gate.

### Task 5. Migrate `src/check_freshness.rs`

**Files:** `src/check_freshness.rs`

**What to build:**

1. Delete `fn read_retries_value` at lines 181-193 (including its doc comment at lines 181-183).
2. Import `tolerant_i64` from utils — extend the existing `use crate::utils::...` line or add one if missing.
3. Rewire call at line 160: `cell.set(read_retries_value(state));` → `cell.set(tolerant_i64(&state["freshness_retries"]));`
4. Rewire call at line 174: `let next = read_retries_value(state) + 1;` → `let next = tolerant_i64(&state["freshness_retries"]) + 1;`
5. Update the doc comment at line 670 from `// Counter type tolerance tests: the fallback chain in read_retries_value ...` to describe the same test intent without the file-specific helper name, e.g. `// Counter type tolerance tests: tolerant_i64 (from utils) accepts int, float, and string representations because state files can outlive the code that writes them.`

**TDD notes:** existing tests `test_retry_value_as_float`, `test_retry_value_as_string`, `test_retry_value_as_unparseable_string_defaults_to_zero` at lines 674-714 exercise the full fallback chain and must pass unchanged. They are the regression gate for this task.

**Index safety note:** the `state["freshness_retries"]` access is guarded by `if !(state.is_object() || state.is_null()) { return; }` earlier in each closure, so `IndexMut` is safe here — matches the pattern used for `state["phases"][phase]["cumulative_seconds"]` in `phase_transition.rs`.

### Task 6. Migrate `src/hooks/post_compact.rs`

**Files:** `src/hooks/post_compact.rs`

**What to build:**

1. Import `tolerant_i64` from utils — add `tolerant_i64` to the existing `use crate::utils::...` line or add one if missing.
2. Replace the inline chain at lines 40-47:

   ```rust
   let count = state
       .get("compact_count")
       .and_then(|v| {
           v.as_i64()
               .or_else(|| v.as_f64().map(|f| f as i64))
               .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
       })
       .unwrap_or(0);
   ```

   with:

   ```rust
   let count = state.get("compact_count").map(tolerant_i64).unwrap_or(0);
   ```

3. Keep the comment at lines 36-39 describing tolerance semantics — it's forward-facing and accurate. Do not delete.

**TDD notes:** `bin/flow ci` is the gate. Existing post-compact hook tests cover the increment behavior.

### Task 7. Migrate `src/format_pr_timings.rs`

**Files:** `src/format_pr_timings.rs`

**What to build:**

1. Import `tolerant_i64` — add to the existing `use crate::utils::format_time;` line, producing `use crate::utils::{format_time, tolerant_i64};`.
2. Replace lines 39-42:

   ```rust
   let seconds = phase
       .and_then(|p| p.get("cumulative_seconds"))
       .and_then(|v| v.as_i64().or_else(|| v.as_f64().map(|f| f as i64)))
       .unwrap_or(0);
   ```

   with:

   ```rust
   let seconds = phase
       .and_then(|p| p.get("cumulative_seconds"))
       .map(tolerant_i64)
       .unwrap_or(0);
   ```

**TDD notes:** existing tests `test_all_complete`, `test_partial_state`, `test_started_only`, `test_uses_format_time` at lines 168-263 exercise the value round-trip and must pass unchanged. Optionally add one new test `test_cumulative_seconds_as_string` that writes `json!("945")` into a phase's `cumulative_seconds` and asserts the table contains the expected formatted time — this locks the new tolerance behavior that was silently missing before.

### Task 8. Migrate `src/tui_data.rs`

**Files:** `src/tui_data.rs`

**What to build:**

1. Import `tolerant_i64_opt` — extend the existing `use crate::utils::{...};` line at lines 14-17 with `tolerant_i64_opt`.
2. Delete the historical-provenance comment at line 756: `// int(data["five_hour_pct"]) — handle null via TypeError parity`. (Violates `.claude/rules/comment-quality.md` — origin story referencing a prior Python port.)
3. Replace the block at lines 757-768:

   ```rust
   if let Some(v) = data.get("five_hour_pct") {
       if let Some(n) = v.as_i64().or_else(|| v.as_f64().map(|f| f as i64)) {
           rl_5h = Some(n);
       }
   }
   if let Some(v) = data.get("seven_day_pct") {
       if let Some(n) = v.as_i64().or_else(|| v.as_f64().map(|f| f as i64)) {
           rl_7d = Some(n);
       }
   }
   ```

   with:

   ```rust
   rl_5h = data.get("five_hour_pct").and_then(tolerant_i64_opt);
   rl_7d = data.get("seven_day_pct").and_then(tolerant_i64_opt);
   ```

**TDD notes:** Add one new test in `tui_data.rs`'s test module (if one exists — verify first) that constructs a `rate-limits.json`-shaped `Value` with a string-typed `five_hour_pct` and asserts the resulting `AccountMetrics` is not marked stale. If the file has no existing test module for this code path, skip the test (adding a whole test scaffold is out of scope for this task; the `tolerant_i64_opt` unit tests in task 1 lock the helper behavior).

### Task 9. Verify `bin/flow ci` green and scope sweep

**Files:** none (validation only)

**What to build:**

1. Run `bin/flow ci` and confirm it passes green.
2. Grep `src/` for the inline pattern substrings that the refactor was meant to eliminate:
   - `as_i64\(\)\.or_else\(\|\| v\.as_f64` — must return zero hits.
   - `fn read_retries_value` — must return zero hits.
   - `fn tolerant_i64` (private form, not `pub fn`) — must return zero hits.
3. Grep `.claude/rules/rust-patterns.md` for `phase_transition.rs` — must return zero hits in the Counter section.
4. Grep `src/` for `tolerant_i64` — every hit must be a `use` import, a call, a test, or the definition in `utils.rs`.

**TDD notes:** this task is the final safety net. If any grep returns unexpected hits, fix before closing the task.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Extract shared tolerant_i64 helper and replace inline callsites (issue #1016)

```xml
<dag goal="Extract shared tolerant_i64 helper and replace inline callsites" mode="full">
  <plan>
    <node id="1" name="Canonical Helper Inspection" type="research"
          depends="[]" parallel_with="[]">
      <objective>Read phase_transition.rs tolerant_i64 to capture exact signature, doc, visibility, and behavior</objective>
    </node>
    <node id="2" name="Callsite A — tui_data.rs" type="research"
          depends="[1]" parallel_with="3,4">
      <objective>Read lines ~758 and ~764 of src/tui_data.rs to capture current closures and the value expressions they wrap</objective>
    </node>
    <node id="3" name="Callsite B — format_pr_timings.rs" type="research"
          depends="[1]" parallel_with="2,4">
      <objective>Read line ~41 of src/format_pr_timings.rs to capture the current closure and value expression</objective>
    </node>
    <node id="4" name="Home Module Survey" type="research"
          depends="[1]" parallel_with="2,3">
      <objective>Read src/utils.rs to confirm it is the right home (module visibility, existing helpers, imports)</objective>
    </node>
    <node id="5" name="Consumer Discovery" type="analysis"
          depends="[1]" parallel_with="6,7">
      <objective>Grep the entire src/ tree for `.as_i64().or_else` and related patterns to ensure we find every inline form — not just the three the issue names</objective>
    </node>
    <node id="6" name="Test Coverage Audit" type="analysis"
          depends="[1]" parallel_with="5,7">
      <objective>Locate existing tests for tolerant_i64 in phase_transition.rs (if any) and identify test file for the new shared helper</objective>
    </node>
    <node id="7" name="Rule Reference Audit" type="analysis"
          depends="[1]" parallel_with="5,6">
      <objective>Read .claude/rules/rust-patterns.md "Counter and State Field Type Tolerance" section to capture the current wording about where the helper lives</objective>
    </node>
    <node id="8" name="Approach Synthesis" type="synthesis"
          depends="[2,3,4,5,6,7]" parallel_with="[]">
      <objective>Merge findings into a single implementation plan: new home, signature, test strategy, callsite rewrites, rule update, atomic grouping for CI safety</objective>
    </node>
    <node id="9" name="Risk and TDD Validation" type="validation"
          depends="[8]" parallel_with="[]">
      <objective>Check the plan for CI intermediate states, import chain correctness, test-before-impl ordering, and docs-with-behavior atomic commit grouping</objective>
    </node>
  </plan>
</dag>
```

## Node 1: Canonical Helper Inspection

**Quality: 10/10**

Read `src/phase_transition.rs:14-19`:

```rust
/// Read a JSON value as i64, tolerating int, float, and string representations.
///
/// State files can outlive the code that writes them. This function accepts
/// all three representations so counter fields survive round-trips through
/// external editors or legacy writers that store numbers as strings or floats.
fn tolerant_i64(v: &Value) -> i64 {
    v.as_i64()
        .or_else(|| v.as_f64().map(|f| f as i64))
        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
        .unwrap_or(0)
}
```

- Currently **private** (`fn`, not `pub fn`).
- Used at `phase_transition.rs:46` (`visit_count = tolerant_i64(...) + 1`) and `phase_transition.rs:132` (`existing = tolerant_i64(...)`).

**Key finding:** Helper is `fn`, takes `&Value`, returns `i64`, uses `unwrap_or(0)`. Must become `pub fn` in new home.

## Node 2: Callsite A — tui_data.rs

**Quality: 9/10**

Read `src/tui_data.rs:750-778`. This callsite reads rate-limit percentages (`five_hour_pct`, `seven_day_pct`) from `~/.claude/rate-limits.json`, not state-file counters:

```rust
if let Some(v) = data.get("five_hour_pct") {
    if let Some(n) = v.as_i64().or_else(|| v.as_f64().map(|f| f as i64)) {
        rl_5h = Some(n);
    }
}
```

**Key finding:** Current inline form returns `Option<i64>`, not `i64`. The callsite distinguishes "field missing / unparseable" (stays `None`, marks data stale) from "present" (`Some(n)`). The canonical `tolerant_i64 -> i64` with `unwrap_or(0)` **changes the contract** here because it conflates missing with 0.

## Node 3: Callsite B — format_pr_timings.rs

**Quality: 10/10**

Read `src/format_pr_timings.rs:31-51`:

```rust
let seconds = phase
    .and_then(|p| p.get("cumulative_seconds"))
    .and_then(|v| v.as_i64().or_else(|| v.as_f64().map(|f| f as i64)))
    .unwrap_or(0);
```

**Key finding:** Genuine state-file `cumulative_seconds` counter read. Exact fit for the refactor. Uses `.unwrap_or(0)` semantic → matches the `tolerant_i64` (i64-returning) contract perfectly.

## Merge Nodes 2 + 3

- `format_pr_timings.rs:39-42` — genuine counter, needs the `unwrap_or(0)` flavor.
- `tui_data.rs:757-768` — rate-limit percentages, needs the `Option<i64>` flavor.
- **Implication:** A single `tolerant_i64 -> i64` helper is NOT sufficient. Need two API shapes: `tolerant_i64_opt -> Option<i64>` (primary) and `tolerant_i64 -> i64` (thin `unwrap_or(0)` wrapper).

## Node 4: Home Module Survey

**Quality: 10/10**

Read `src/utils.rs:1-80, 720-759`.

- Already imports `serde_json::Value` at line 10.
- Existing `#[cfg(test)] mod tests` block at line 734 (uses `use super::*`).
- Already imported by `phase_transition.rs` (`use crate::utils::{elapsed_since, format_time, now};`).

**Key finding:** Perfect home. Just add `pub fn tolerant_i64_opt` + `pub fn tolerant_i64` alongside existing helpers, and new tests in the existing test module.

## Node 5: Consumer Discovery

**Quality: 10/10**

Grep for `as_i64\(\)\.or_else`:

- `src/format_pr_timings.rs:41`
- `src/tui_data.rs:758, 764`

Grep for `as_str\(\)\.and_then\(\|s\| s\.parse`:

- `src/check_freshness.rs:190`  ← **scope expansion**
- `src/phase_transition.rs:17` (the helper itself)
- `src/hooks/post_compact.rs:45`  ← **scope expansion**

**Two additional callsites the issue did not enumerate:**

1. `src/check_freshness.rs:184-193` — local `fn read_retries_value(state: &Value) -> i64` helper. Duplicate of `tolerant_i64` under a different name. Has both int/float/string fallback. Called at lines 160 and 174. Existing tests (`test_retry_value_as_{float,string,unparseable}`) at lines 674-714 exercise the fallback.

2. `src/hooks/post_compact.rs:40-48` — inlines the three-variant form directly for `compact_count` counter.

**Key finding:** Scope per `.claude/rules/docs-with-behavior.md` Scope Enumeration: "every matching file is in-scope regardless of what the issue body names." Total callsites: 5 callsite groups.

## Node 6: Test Coverage Audit

**Quality: 10/10**

Grep for `tolerant_i64`:

- No existing direct unit tests.
- Integration tests in `check_freshness.rs` (lines 674-714) exercise the fallback chain end-to-end.
- Rule references: `.claude/rules/rust-patterns.md:83` (specific: names `phase_transition.rs`) and `.claude/rules/state-files.md:43` (generic).

**Key finding:** Need to add direct unit tests for both `tolerant_i64_opt` and `tolerant_i64` in `utils::tests` (11 new tests covering int/float/string/bool/null/unparseable input). Integration tests in `check_freshness.rs` stay as regression coverage.

## Node 7: Rule Reference Audit

**Quality: 10/10**

Read `.claude/rules/rust-patterns.md:78-87`:

```markdown
State files can outlive the code that writes them. Accept int, float,
and string representations when reading counters:
`.as_i64().or_else(|| v.as_f64().map(|f| f as i64)).or_else(|| v.as_str().and_then(|s| s.parse().ok()))`.

`phase_transition.rs` defines `tolerant_i64()` as a named helper
encapsulating this pattern for `visit_count` and `cumulative_seconds`.
When other modules need the same tolerance, extract a shared helper
or reference this implementation.
```

**Key finding:** Current rule text is prescriptive ("extract a shared helper"). After refactor, rule must point at `utils::tolerant_i64{,_opt}` as canonical home and drop the "extract" language.

`.claude/rules/state-files.md:43` is generic ("Use `tolerant_i64()` for counter fields") — no file location named, no change needed.

## Node 8: Approach Synthesis

**Quality: 10/10**

**API design (two functions):**

```rust
/// Read a JSON value as i64, tolerating int, float, and string representations.
/// Returns None when the value cannot be interpreted as a number.
pub fn tolerant_i64_opt(v: &Value) -> Option<i64> {
    v.as_i64()
        .or_else(|| v.as_f64().map(|f| f as i64))
        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
}

/// Read a JSON value as i64 with 0 as the default.
///
/// Thin wrapper over tolerant_i64_opt for counter fields where a missing
/// or unparseable value should mean zero rather than "data not available".
pub fn tolerant_i64(v: &Value) -> i64 {
    tolerant_i64_opt(v).unwrap_or(0)
}
```

**Home:** `src/utils.rs`.

**Scope expanded from 3 callsites (issue) to 5 callsite groups:**

1. `phase_transition.rs` — remove private helper, import from utils (2 callsites, no logic change)
2. `check_freshness.rs` — remove private `read_retries_value`, rewire 2 callers, update stale doc comment at line 670
3. `hooks/post_compact.rs` — replace inline form at line 40-48
4. `format_pr_timings.rs` — replace inline form at line 39-42 via `.map(tolerant_i64)`
5. `tui_data.rs` — replace inline forms at 757-768 via `.and_then(tolerant_i64_opt)`; remove stale "TypeError parity" comment at line 756 (comment-quality rule violation — historical-provenance)

**Rule doc updates (docs-with-behavior atomic):** `.claude/rules/rust-patterns.md` Counter section rewritten to point at `utils::tolerant_i64{,_opt}`.

**Atomic grouping:** Single commit for (helper + tests + rule update). Callsite migrations in separate commits.

## Node 9: Risk and TDD Validation

**Quality: 10/10**

1. **CI intermediate states** — Helper added first as `pub fn`, no callers break. Each migration commit green. Private fns deleted only after all internal callers rewired.
2. **Import chain** — `utils.rs` has no dependency on migrated modules. `phase_transition.rs` already `use crate::utils::{...}`. No cycles.
3. **TDD ordering** — Unit tests written in the same commit as the new helper (11 tests). Integration tests in `check_freshness.rs` act as regression coverage.
4. **docs-with-behavior atomicity** — Rule rewrite and helper definition must land together in a single atomic commit.
5. **Contract change at tui_data.rs** — New `tolerant_i64_opt` accepts string-numeric where old form did not. **Must verify**: does `~/.claude/rate-limits.json` ever produce string values? (Written by Claude Code itself, not by this repo.) Direction is *more permissive* — safer for a tolerance helper. Flag in plan Risks.
6. **Stale comment in tui_data.rs:756** (`// int(data["five_hour_pct"]) — handle null via TypeError parity`) — historical-provenance, violates `.claude/rules/comment-quality.md`. Since the file is in the PR diff, code-review-scope rule makes it in-scope to clean up.
7. **Risk Verification Enforcement** — Risk #5 has explicit verification task.

---

## Synthesis Block

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

**Goal.** Extract `tolerant_i64` into a shared home (`src/utils.rs`) and replace all inline two- and three-variant forms, rewiring the `.claude/rules/rust-patterns.md` Counter section to point at the new canonical location.

**API (two functions):** `tolerant_i64_opt -> Option<i64>` (primary) and `tolerant_i64 -> i64` (thin wrapper using `unwrap_or(0)`).

**Call graph of changes:**

```
Node A: utils.rs                 ──┐
  + tolerant_i64_opt               │
  + tolerant_i64                   ├─► atomic commit with rule update
  + 11 new unit tests              │   (docs-with-behavior)
  .claude/rules/rust-patterns.md ──┘

Node B: phase_transition.rs   ── remove private fn, add to use line
Node C: check_freshness.rs    ── remove read_retries_value, rewire 2 callers, update test doc comment
Node D: hooks/post_compact.rs ── replace inline form
Node E: format_pr_timings.rs  ── replace inline form
Node F: tui_data.rs           ── replace inline forms + remove stale Python-parity comment
```

Node A is the only prerequisite. B–F are independent and can commit in any order after A.

**vs. Vanilla Claude (what linear reasoning would have missed):**

- **Scope expansion from 3 to 5 callsites** — linear would have trusted the issue body's list and left `check_freshness.rs` + `hooks/post_compact.rs` as silent duplicates, perpetuating the drift the issue is trying to eliminate.
- **Two-API design** — linear would have extracted the single `tolerant_i64 -> i64` form and either broken the `tui_data.rs` rate-limit contract (conflating missing with zero) or skipped those callsites and left inline forms.
- **Docs-with-behavior atomic commit** — linear would have planned the rule rewrite as a separate "cleanup" task and shipped an intermediate state where the rule points at a helper that doesn't exist yet.
- **Comment-quality sweep in tui_data.rs** — linear would have rewired the callsite and left the historical-provenance comment in place, a code-review finding waiting to happen.

Confidence: 97% | Nodes: 9 | Parallel branches: 2 (after Node 1: {2,3,4} and {5,6,7})

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 4m |
| Plan | 9m |
| Code | 28m |
| Code Review | 16m |
| Learn | 8m |
| Complete | <1m |
| **Total** | **1h 6m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/extract-shared-toleranti64.json</summary>

```json
{
  "schema_version": 1,
  "branch": "extract-shared-toleranti64",
  "repo": "benkruger/flow",
  "pr_number": 1017,
  "pr_url": "https://github.com/benkruger/flow/pull/1017",
  "started_at": "2026-04-11T00:30:33-07:00",
  "current_phase": "flow-complete",
  "framework": "rust",
  "files": {
    "plan": ".flow-states/extract-shared-toleranti64-plan.md",
    "dag": ".flow-states/extract-shared-toleranti64-dag.md",
    "log": ".flow-states/extract-shared-toleranti64.log",
    "state": ".flow-states/extract-shared-toleranti64.json"
  },
  "session_tty": "/dev/ttys006",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #1016",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-11T00:30:33-07:00",
      "completed_at": "2026-04-11T00:34:55-07:00",
      "session_started_at": null,
      "cumulative_seconds": 262,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-11T00:35:05-07:00",
      "completed_at": "2026-04-11T00:44:15-07:00",
      "session_started_at": null,
      "cumulative_seconds": 550,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-11T00:45:11-07:00",
      "completed_at": "2026-04-11T01:13:27-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1696,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-11T01:13:38-07:00",
      "completed_at": "2026-04-11T01:29:42-07:00",
      "session_started_at": null,
      "cumulative_seconds": 964,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-11T01:29:53-07:00",
      "completed_at": "2026-04-11T01:38:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 507,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-11T01:38:33-07:00",
      "completed_at": "2026-04-11T01:38:52-07:00",
      "session_started_at": null,
      "cumulative_seconds": 19,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-11T00:35:05-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-11T00:45:11-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-11T01:13:38-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-11T01:29:53-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-11T01:38:33-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 9,
  "code_task": 9,
  "code_task_name": "Verify ci green and scope sweep",
  "diff_stats": {
    "files_changed": 7,
    "insertions": 152,
    "deletions": 67,
    "captured_at": "2026-04-11T01:13:27-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "findings": [
    {
      "finding": "tui_data.rs rate-limit reader now accepts string-numeric values, potentially suppressing warnings",
      "reason": "The deleted Python-parity comment was itself incorrect — Python int() accepts numeric strings, so the new behavior is closer to the Python original, not a new attack surface. Trust boundary on ~/.claude/rate-limits.json is unchanged.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:24:40-07:00"
    },
    {
      "finding": "tolerant_i64_opt returns Some(0) for NaN floats",
      "reason": "Not reachable in practice — serde_json::Number::from_f64 rejects non-finite floats, and JSON syntax has no NaN literal. No code in the repo constructs Value::Number(NaN) programmatically.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:24:46-07:00"
    },
    {
      "finding": "tolerant_i64_opt returns Some(i64::MAX) for Infinity floats",
      "reason": "Not reachable in practice — same as NaN finding: serde_json::Number rejects non-finite floats and JSON has no Infinity literal.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:24:52-07:00"
    },
    {
      "finding": "state-files.md rule should mention tolerant_i64_opt",
      "reason": "state-files.md is specifically about counter fields in state files and the non-Option variant is the correct recommendation for that scope. Expanding the rule to cover _opt would be scope creep outside the rule's purpose.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:25:08-07:00"
    },
    {
      "finding": "Callsites choosing tolerant_i64 vs tolerant_i64_opt need clarifying comments",
      "reason": "The function doc comments already explain when to use each variant. Variable types at each callsite (Option-wrapped i64 vs bare i64) make the choice self-evident. Adding redundant callsite comments would be noise.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:25:19-07:00"
    },
    {
      "finding": "utils.rs:1481 test comment said IndexMut but the test uses shared Index access",
      "reason": "The expression state[missing_key] as a read-only borrow goes through the Index trait not IndexMut. Fixed the comment to say Index and referenced Value::Null correctly.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:26:34-07:00"
    },
    {
      "finding": "Integer overflow in counter-increment callsites when state contains values at or near i64::MAX",
      "reason": "Pre-existing in phase_transition.rs visit_count/cumulative_seconds, check_freshness.rs freshness_retries, and post_compact.rs compact_count. Files are all in the PR diff per code-review-scope rule. Replaced raw + 1 and + elapsed with saturating_add to prevent panic in debug builds and silent wraparound in release builds.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:26:41-07:00"
    },
    {
      "finding": "utils.rs test section marker did not match the file convention",
      "reason": "Test section used // --- tolerant_i64_opt() / tolerant_i64() --- which uses a slash separator where the rest of the file uses single-function or single-topic markers. Standardized to // --- tolerant_i64 --- to match the impl section and the rest of the file.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:26:48-07:00"
    },
    {
      "finding": "Plan phase should add counter-overflow audit task for numeric helper refactors",
      "reason": "The counter-overflow gap was correctly detected and fixed by Code Review agents. Moving correctness analysis from Code Review to Plan would slow every plan phase speculatively without clear benefit. The existing two-tier process worked as designed.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T01:33:14-07:00"
    },
    {
      "finding": "Atomic task grouping creates friction with the code_task increment-by-1 constraint",
      "reason": "CLAUDE.md already explicitly documents this behavior (code_task can only be incremented by 1 per call even when multiple tasks are committed atomically). The friction is by design and already captured in project documentation.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T01:33:19-07:00"
    },
    {
      "finding": "No rule documented the test module section marker convention",
      "reason": "Code Review caught a marker deviation that was only discoverable by reading the file. Added a Test Module Section Markers section to rust-patterns.md documenting the single-topic marker pattern and how to match existing conventions.",
      "outcome": "rule_written",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T01:34:49-07:00",
      "path": ".claude/rules/rust-patterns.md"
    },
    {
      "finding": "No rule required saturating_add on counter reads from tolerant_i64",
      "reason": "Code Review caught an overflow vulnerability that required saturating_add at 4 callsites. Added a Saturating Arithmetic on Counter Reads section to rust-patterns.md so future refactors involving counter reads default to saturating semantics without waiting for Code Review to catch the pattern.",
      "outcome": "rule_written",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T01:34:55-07:00",
      "path": ".claude/rules/rust-patterns.md"
    },
    {
      "finding": "init_state caches framework from .flow.json without re-verifying project markers",
      "reason": "State file inherits a stale framework value and nothing re-checks it. Causes mid-flow CI failures requiring manual set-timestamp surgery to recover.",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T01:38:01-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1019"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "issues_filed": [
    {
      "label": "Flow",
      "title": "init_state caches framework from .flow.json without re-verifying project markers",
      "url": "https://github.com/benkruger/flow/issues/1019",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T01:37:54-07:00"
    }
  ],
  "complete_steps_total": 6,
  "complete_step": 6,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/extract-shared-toleranti64.log</summary>

```text
2026-04-11T00:30:32-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-11T00:30:32-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-11T00:30:33-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-11T00:30:33-07:00 [Phase 1] create .flow-states/extract-shared-toleranti64.json (exit 0)
2026-04-11T00:30:33-07:00 [Phase 1] freeze .flow-states/extract-shared-toleranti64-phases.json (exit 0)
2026-04-11T00:30:33-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-11T00:30:34-07:00 [Phase 1] start-init — label-issues (labeled: [1016], failed: [])
2026-04-11T00:30:40-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-11T00:34:32-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-11T00:34:33-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-11T00:34:41-07:00 [Phase 1] start-workspace — worktree .worktrees/extract-shared-toleranti64 (ok)
2026-04-11T00:34:46-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-11T00:34:46-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-11T00:34:46-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-11T00:34:55-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-11T00:34:55-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-11T00:37:44-07:00 [Phase 2] Step 2 — decompose node 4: utils.rs survey (in progress)
2026-04-11T00:44:15-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-11T00:45:11-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-11T00:45:40-07:00 [Phase 3] Task 1 — TDD write failing tests (in progress)
2026-04-11T00:54:08-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-11T00:54:11-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-11T00:57:18-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-11T00:57:22-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-11T01:01:03-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-11T01:01:07-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-11T01:05:01-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-11T01:05:05-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-11T01:08:34-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-11T01:08:37-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-11T01:11:56-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-11T01:12:00-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-11T01:13:27-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-11T01:13:38-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-11T01:29:23-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-11T01:29:27-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-11T01:29:42-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-11T01:29:53-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-11T01:37:04-07:00 [Phase 5] finalize-commit — ci (ok)
2026-04-11T01:37:08-07:00 [Phase 5] finalize-commit — done ("ok")
2026-04-11T01:38:20-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-11T01:38:52-07:00 [Phase 6] complete-finalize — starting
2026-04-11T01:38:52-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-11T01:38:52-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Flow | init_state caches framework from .flow.json without re-verifying project markers | Learn | #1019 |

<!-- end:Issues Filed -->