### PR TITLE
More Backward Facing Comments

### DIFF
--- a/.claude/rules/comment-quality.md
+++ b/.claude/rules/comment-quality.md
@@ -50,3 +50,28 @@ When writing or reviewing comments:
    what was broken before
 4. For non-obvious values (timeouts, limits, thresholds), explain
    why the value was chosen — not what another system used
+
+## Enforcement
+
+`tests/tombstones.rs::test_no_backward_facing_comments_in_rust_source`
+mechanically enforces this rule at CI time. The scanner walks every
+`*.rs` file under `src/` and `tests/`, filters out lines matching the
+tombstone exception (`Tombstone:.*?PR #`), and asserts no line contains
+any phrase from a curated prohibited-pattern list (covering parity
+references to a deleted Python codebase, historical PR provenance,
+origin stories, "Before the fix" narratives, and dead section markers).
+The scanner self-excludes its own file via canonicalized-path
+comparison because it must contain the prohibited patterns as search
+input.
+
+The pattern list is curated rather than regex-based: it captures every
+phrasing the rule explicitly prohibits, plus the phrasings observed in
+the repo at the time the rule was first enforced. Novel phrasings
+introduced by future commits are not caught automatically — the rule
+itself remains the primary instrument, and the scanner is the
+merge-conflict trip-wire that locks in the cleanup. When CI fails on a
+new prohibited pattern, prefer rewriting the comment to describe
+current behavior over expanding the pattern list. When CI fails on a
+legitimate forward-facing comment that nonetheless contains a
+prohibited substring, narrow the comment's wording or add a more
+specific rule exception in the same commit.

--- a/.claude/rules/comment-quality.md
+++ b/.claude/rules/comment-quality.md
@@ -51,6 +51,39 @@ When writing or reviewing comments:
 4. For non-obvious values (timeouts, limits, thresholds), explain
    why the value was chosen — not what another system used
 
+## Rewriting Existing Comments
+
+When fixing a backward-facing comment flagged by the scanner or a
+reviewer, do not paraphrase the old comment. Paraphrasing preserves
+the backward-facing structure — the reference to a deleted thing is
+still load-bearing in the new wording, just hidden. A paraphrased
+rewrite typically substitutes a vague phrase ("the previous
+implementation", "the original approach", "how it used to be") for
+the specific prohibited phrase and passes the scanner while still
+violating the rule.
+
+The correct rewrite discipline:
+
+1. **Read the surrounding code first.** Open the file to the cited
+   line and read ~10 lines of context. Understand what the code
+   currently does before writing anything.
+2. **Describe what you see.** Write the new comment from the code,
+   not from the old comment. State the contract, the invariant, the
+   constraint, or the non-obvious choice — whatever the reader
+   actually needs.
+3. **Do not read the old comment to paraphrase it.** Reading the old
+   comment is fine for orientation, but the rewrite must come from
+   the code, not from the old wording.
+4. **Re-read your rewrite with a forward-facing eye.** Apply the
+   Forward-Facing Test above to your own output. If the new comment
+   only makes sense to a reader who has read the old comment, it is
+   still backward-facing — go back to step 1.
+
+Rewrites that miss this discipline produce a second round of
+violations: the scanner or a reviewer flags the rewrite, another
+Code Review cycle fixes it, and the fix commit doubles the work.
+Read the code first, write from the code.
+
 ## Enforcement
 
 `tests/tombstones.rs::test_no_backward_facing_comments_in_rust_source`

--- a/.claude/rules/scope-expansion.md
+++ b/.claude/rules/scope-expansion.md
@@ -1,0 +1,87 @@
+# Scope Expansion for Sweeping Fixes
+
+When an issue cites N violations of a rule and the Plan-phase sweep
+discovers significantly more of the same class, decide whether to
+expand the PR to cover the full sweep or bound it to the cited
+violations.
+
+## The Decision
+
+Expand scope to cover the full sweep when ALL three conditions hold:
+
+1. **The fixes are inert** — text-only changes with no behavioral
+   effect (comment rewrites, doc updates, renames that don't break
+   the public API, permission list additions). "Inert" means the
+   diff cannot introduce runtime bugs.
+2. **A single automated guard can prevent regression** — one test,
+   scanner, lint rule, or schema check can cover the entire class
+   of violation forward. If the guard cannot be written (the rule
+   is still evolving, the pattern is too context-sensitive for
+   mechanical detection, etc.), scope expansion produces a
+   one-shot cleanup that future PRs will silently undo.
+3. **Splitting would re-do work** — the sweep already mapped the
+   codebase. Splitting into per-file issues forces every future
+   session to re-explore the same files to apply the same fix.
+   The Plan phase exploration is the expensive part; the rewrite
+   itself is cheap.
+
+If any condition fails, bound the PR to the cited violations and
+file a follow-up issue capturing the sweep results so a future
+session can decide the right shape after the rule is stable.
+
+## Why
+
+Bounding to the issue scope guarantees a follow-up cycle: the next
+adversarial test run or the next manual review finds the uncovered
+violations, files another issue, and the process repeats. Three to
+four iterations of this pattern — each one identical in shape — is
+the signal that scope was the wrong dimension to bound on. Expanding
+once, landing the guard once, and moving on is strictly cheaper than
+running the Plan → Code → Code Review → Learn → Complete cycle
+three times on the same underlying class of problem.
+
+The cost of expanding is PR size and review time. The cost of NOT
+expanding is session compounding: each follow-up flow costs a full
+lifecycle, not just the minutes of the rewrite. When the guard is
+cheap and the fixes are inert, expanding is almost always the right
+call.
+
+## How to Apply
+
+During the Plan phase, after reading the issue and doing the
+codebase sweep:
+
+1. Count the cited violations vs. the sweep total. If the sweep
+   finds ≥2x the cited count, scope expansion is a live option.
+2. Evaluate the three conditions above. Be honest about condition
+   2 in particular — "a scanner would be nice to write" is not the
+   same as "a scanner can mechanically detect this class of
+   violation with acceptable false-positive rate."
+3. If all three hold, recommend the expanded scope in the Risks
+   section of the plan and enumerate all affected files in the
+   Exploration table. Add a task for the guard (test/scanner/lint)
+   and make it depend on all the rewrite tasks — the guard lands
+   last, after the rewrites clear the guard's assertion.
+4. If any condition fails, bound the plan to the cited violations
+   and file a `Tech Debt` issue capturing the sweep inventory.
+   Reference the current PR number in the issue body so the future
+   session has a pointer to the shape of fix that worked.
+
+## Examples
+
+**Expand**: Issue cites 7 backward-facing comments, sweep finds
+~50 more. Comment rewrites are inert, a substring scanner can
+enforce the rule forward, splitting would force each file to be
+re-read in a later flow. All three conditions hold — expand.
+
+**Don't expand**: Issue cites a race condition in one module,
+sweep finds three other modules with similar patterns. The fixes
+are behavioral (not inert), no single test can cover all four
+modules' execution paths, and each module needs its own
+domain-specific analysis. Bound to the cited module.
+
+**Don't expand**: Issue cites a permission-model bug, sweep finds
+a broader architectural gap. The bug itself is fixable, but the
+broader gap requires a design conversation before any fix. Bound
+to the cited bug and file a design issue for the architectural
+question.

--- a/.claude/rules/tombstone-tests.md
+++ b/.claude/rules/tombstone-tests.md
@@ -27,6 +27,17 @@ sensitive) followed by any text, then `PR #` and digits. The
 to extract PR numbers — comments that don't match this pattern are
 invisible to the audit.
 
+**Only `PR #<number>` is recognized.** Alternatives like
+`issue #<number>`, `commit <sha>`, `for ticket <N>`, or `per PR
+<N>` are invisible to the audit and will never be counted as stale
+no matter how old the underlying PR is. Use `PR #<number>` exactly,
+even if the conceptual "source" of the removal was an issue — cite
+the merge PR that performed the removal, not the issue that filed
+the request. If the removal landed outside a PR (e.g. a direct
+push, which should never happen in this repo but can in others),
+the tombstone is inauditable and should be accompanied by a doc
+comment explaining why.
+
 ```rust
 #[test]
 fn test_code_review_no_plugin_step() {

--- a/src/analyze_issues.rs
+++ b/src/analyze_issues.rs
@@ -246,7 +246,9 @@ pub fn parse_blocker_response(json_str: &str, issue_numbers: &[i64]) -> HashMap<
 /// Uses `blockedBy(first: 10)` connection with batched aliased queries.
 /// Returns HashMap mapping issue number to list of open blocker issue numbers.
 /// Returns empty HashMap on any failure (graceful degradation).
-/// Timeout: 30 seconds (matches Python).
+/// Timeout: 30 seconds — long enough for the GraphQL endpoint to
+/// respond on a slow link, short enough to keep the analyze step
+/// from hanging the calling skill.
 pub fn fetch_blockers(repo: &str, issue_numbers: &[i64]) -> HashMap<i64, Vec<i64>> {
     if issue_numbers.is_empty() {
         return HashMap::new();
@@ -282,7 +284,8 @@ pub fn fetch_blockers(repo: &str, issue_numbers: &[i64]) -> HashMap<i64, Vec<i64
     };
 
     // Drain stdout in a thread to prevent pipe buffer deadlock, then
-    // poll for exit with a 30s timeout (matches Python timeout=30).
+    // poll for exit with a 30-second timeout (the same budget the
+    // outer fetch_blockers contract documents).
     let stdout_handle = child.stdout.take();
     let reader = std::thread::spawn(move || {
         let mut buf = String::new();
@@ -514,8 +517,9 @@ pub fn run(args: Args) {
             }
         };
 
-        // Drain stdout in a thread to prevent pipe buffer deadlock, then
-        // poll for exit with a 30s timeout (matches Python timeout=30).
+        // Drain stdout in a thread to prevent pipe buffer deadlock,
+        // then poll for exit with a 30-second timeout — the analyze
+        // path's outer budget is documented on the caller above.
         let stdout_handle = child.stdout.take();
         let stderr_handle = child.stderr.take();
         let stdout_reader = std::thread::spawn(move || {

--- a/src/bump_version.rs
+++ b/src/bump_version.rs
@@ -132,7 +132,9 @@ pub fn run_impl(args: &Args, repo_root: &Path) -> Result<String, String> {
                 !name.starts_with('.') && e.path().join("SKILL.md").exists()
             })
             .collect();
-        // Sort for deterministic output matching Python's sorted()
+        // Sort by file name so the bump output is byte-stable across
+        // runs and machines. Without this, version-bump diffs would
+        // shuffle skill order based on filesystem iteration order.
         entries.sort_by_key(|e| e.file_name());
 
         for entry in entries {

--- a/src/check_freshness.rs
+++ b/src/check_freshness.rs
@@ -21,9 +21,10 @@ const MAX_RETRIES: i64 = 3;
 #[derive(Parser, Debug)]
 #[command(name = "check-freshness", about = "Pre-merge freshness check")]
 pub struct Args {
-    /// Raw args — parsed manually inside run() to silently skip unknown
-    /// flags matching Python's manual arg loop
-    /// (tested by test_cli_unknown_args_ignored).
+    /// Raw args — parsed manually inside `run()` so unknown flags are
+    /// silently skipped instead of triggering clap's strict-parse
+    /// error. The contract is exercised by
+    /// `test_cli_unknown_args_ignored`.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
     pub raw_args: Vec<String>,
 }
@@ -79,9 +80,11 @@ pub fn check_freshness_impl(
     }
 
     // Step 2: git merge-base --is-ancestor origin/main HEAD
-    // Exit 0 → up_to_date. Non-zero or timeout → proceed to merge attempt
-    // (Python swallows the timeout intentionally — tested by
-    // test_merge_base_timeout).
+    // Exit 0 → up_to_date. Non-zero or timeout → proceed to merge
+    // attempt. Timeouts are deliberately swallowed (rather than
+    // returned as an error) so a slow `git merge-base` falls through
+    // to the merge step instead of aborting freshness — verified by
+    // `test_merge_base_timeout`.
     let mb = git_cmd(
         &["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"],
         LOCAL_TIMEOUT,
@@ -283,11 +286,10 @@ pub fn check_freshness(state_file: Option<&Path>, cwd: &Path) -> Value {
     check_freshness_impl(state_file, &mut git)
 }
 
-/// CLI entry point. Parses `raw_args` manually (silently skipping
-/// unknowns, matching Python's manual loop — tested by
-/// `test_cli_unknown_args_ignored`), runs `check_freshness`, prints the
-/// JSON result, and exits with status 1 for any result other than
-/// `up_to_date` or `merged`.
+/// CLI entry point. Parses `raw_args` manually so unknown flags are
+/// silently skipped (verified by `test_cli_unknown_args_ignored`),
+/// runs `check_freshness`, prints the JSON result, and exits with
+/// status 1 for any result other than `up_to_date` or `merged`.
 pub fn run(args: Args) {
     let mut state_file: Option<PathBuf> = None;
     let mut i = 0;
@@ -300,16 +302,15 @@ pub fn run(args: Args) {
         }
     }
 
-    // Inherit CWD from the calling process — must match Python's behavior.
-    // Python's `subprocess.run` calls in check-freshness.py pass no `cwd=`
-    // argument, so git commands run in the shell's current directory (the
-    // feature worktree when invoked from complete-merge.py). Using
-    // `project_root()` here would return the MAIN repo root (the first
-    // entry of `git worktree list --porcelain`), causing git commands to
-    // run in the main worktree where HEAD=main — which would make
+    // Inherit CWD from the calling process — git commands must run in
+    // the feature worktree (the shell's current directory), not the
+    // main repo root. Using `project_root()` here would return the
+    // MAIN repo root (the first entry of `git worktree list
+    // --porcelain`), causing git commands to run in the main worktree
+    // where HEAD=main — which would make
     // `git merge-base --is-ancestor origin/main HEAD` trivially succeed
-    // and always return `up_to_date` regardless of the feature branch's
-    // actual state.
+    // and always return `up_to_date` regardless of the feature
+    // branch's actual state.
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let result = check_freshness(state_file.as_deref(), &cwd);
 
@@ -675,8 +676,9 @@ mod tests {
     fn test_retry_value_as_float() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("state.json");
-        // Write freshness_retries as a float (e.g. from older Python code
-        // that did float arithmetic on the counter).
+        // Write freshness_retries as a float to verify the reader's
+        // type-tolerance fallback chain accepts a JSON number that
+        // arrived as `1.0` instead of `1`.
         fs::write(&path, r#"{"branch":"test","freshness_retries":1.0}"#).unwrap();
         let responses = vec![ok(), err(1, ""), ok()];
         let mut git = mock_runner(responses);

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -871,7 +871,8 @@ exit 0
 
     #[test]
     fn tool_sequence_python_has_three_tools() {
-        // Python: build is no-op
+        // Python projects skip the build step (no compile phase),
+        // leaving format → lint → test as the three-tool sequence.
         let tools = build_tool_sequence("python").unwrap();
         assert_eq!(tools.len(), 3);
         assert_eq!(tools[0].name, "format");

--- a/src/close_issue.rs
+++ b/src/close_issue.rs
@@ -106,13 +106,16 @@ pub fn run(args: Args) {
 
 #[cfg(test)]
 mod tests {
-    // close_issue_by_number calls gh subprocess — tested via Python integration tests.
-    // Unit tests here cover the helper functions.
+    // close_issue_by_number shells out to `gh` and is therefore not
+    // unit-testable without process mocking. Unit tests in this module
+    // cover the pure helper functions instead; the gh path is exercised
+    // end-to-end by the QA harness.
 
     #[test]
     fn detect_repo_or_fail_returns_some() {
         // This test just validates the function signature — the actual
-        // detection runs against git remote which we can't mock in Rust.
-        // Python integration tests cover the detect_repo_or_fail path.
+        // detection runs against `git remote`, which we cannot mock in
+        // a unit test without spawning a real git process. End-to-end
+        // coverage of detect_repo_or_fail lives in the QA harness.
     }
 }

--- a/src/commands/init_state.rs
+++ b/src/commands/init_state.rs
@@ -17,8 +17,10 @@ use crate::utils::{
 
 /// Create the initial FLOW state file with null PR fields.
 ///
-/// Builds the state as a serde_json::Value to match Python key ordering
-/// exactly. Writes to `.flow-states/<branch>.json`.
+/// Builds the state as a `serde_json::Value` so the top-level key
+/// order is fixed and predictable across runs — tests and hand-edited
+/// state files rely on the deterministic order. Writes to
+/// `.flow-states/<branch>.json`.
 ///
 /// `commit_format` — optional commit message format (`"full"` or `"title-only"`)
 /// extracted from `.flow.json` during prime. Written to state file when present;
@@ -672,7 +674,10 @@ mod tests {
             "start_step",
             "start_steps_total",
         ];
-        assert_eq!(keys, expected, "Key order must match Python output");
+        assert_eq!(
+            keys, expected,
+            "Key order must remain stable across serialization runs"
+        );
     }
 
     // --- Directory creation ---

--- a/src/commands/start_step.rs
+++ b/src/commands/start_step.rs
@@ -39,10 +39,11 @@ pub fn run(step: i64, branch: &str, subcommand: Vec<String>) {
     let updated = update_step(&state_path, step);
 
     if !subcommand.is_empty() {
-        // Wrapping mode: exec into bin/flow (the hybrid dispatcher) so
-        // Python-only subcommands like `ci` still work via fallback.
-        // The binary is at target/{debug,release}/flow-rs — go up 3
-        // levels to reach the plugin/repo root, then into bin/flow.
+        // Wrapping mode: exec into `bin/flow` (the dispatcher) so the
+        // wrapped subcommand runs through the same dispatch logic as
+        // any other `bin/flow` invocation. The binary is at
+        // `target/{debug,release}/flow-rs` — go up 3 levels to reach
+        // the plugin/repo root, then into `bin/flow`.
         let flow_bin = std::env::current_exe()
             .ok()
             .and_then(|p| p.parent()?.parent()?.parent().map(|d| d.to_path_buf()))

--- a/src/complete_merge.rs
+++ b/src/complete_merge.rs
@@ -164,7 +164,9 @@ pub fn complete_merge(pr_number: i64, state_file: &str) -> Value {
     )
 }
 
-/// CLI entry point. Exits 1 if status != "merged" (matches Python behavior).
+/// CLI entry point. Exits 1 when the merge attempt did not reach the
+/// `merged` status — the calling skill treats a non-zero exit as a
+/// signal to halt the Complete phase before post-merge cleanup runs.
 pub fn run(args: Args) {
     let result = complete_merge(args.pr, &args.state_file);
     println!("{}", result);

--- a/src/complete_post_merge.rs
+++ b/src/complete_post_merge.rs
@@ -86,7 +86,9 @@ pub fn post_merge_inner(
         json!({})
     };
 
-    // Filter repo: null and empty are both falsy (matches Python truthy check)
+    // Treat both `null` and the empty string `""` as "no repo set" so
+    // downstream issue-closing and Slack steps short-circuit cleanly
+    // when the state file lacks a repo.
     let repo: Option<String> = state
         .get("repo")
         .and_then(|v| v.as_str())
@@ -148,7 +150,10 @@ pub fn post_merge_inner(
                     log("[Phase 6] complete-post-merge — phase-transition (ok)");
                 }
                 _ => {
-                    // Python: pt_err or pt_result.stderr.strip()
+                    // Prefer the structured parse error when present;
+                    // fall back to the raw stderr text from the
+                    // subprocess so the failure surfaces something
+                    // human-readable in either case.
                     let msg = parse_err.unwrap_or_else(|| stderr.trim().to_string());
                     log("[Phase 6] complete-post-merge — phase-transition (failed)");
                     failures.insert("phase_transition".to_string(), json!(msg));
@@ -209,7 +214,9 @@ pub fn post_merge_inner(
             }
         }
     }
-    // Transport errors on format-issues-summary are silently ignored (Python matches)
+    // Transport errors on format-issues-summary are silently ignored:
+    // the issues banner is decorative, and post-merge should not fail
+    // because the formatter subprocess returned a non-zero status.
 
     // --- Step 9: Close referenced issues ---
 
@@ -331,7 +338,9 @@ pub fn post_merge_inner(
     }
     result.insert("parents_closed".to_string(), json!(parents_closed));
 
-    // Slack notification — filter null and empty string (Python falsy equivalence)
+    // Slack notification — only post if a non-empty thread_ts is set;
+    // both `null` and the empty string `""` mean "no Slack thread to
+    // reply to" and skip the notification entirely.
     let slack_thread_ts: Option<String> = state
         .get("slack_thread_ts")
         .and_then(|v| v.as_str())
@@ -384,7 +393,9 @@ pub fn post_merge_inner(
                                     "--message",
                                     &msg,
                                 ];
-                                // Fire and forget — Python ignores the result
+                                // Fire-and-forget: the notification
+                                // record is best-effort and a failure
+                                // here must not roll back the merge.
                                 let _ = runner(&add_args, LOCAL_TIMEOUT);
                             }
                         }
@@ -422,7 +433,10 @@ pub fn post_merge(pr_number: i64, state_file: &str, branch: &str) -> Value {
     )
 }
 
-/// CLI entry point. Always exits 0 (best-effort — matches Python main()).
+/// CLI entry point. Always exits 0 — post-merge is best-effort and any
+/// downstream failures (Slack, label cleanup, parent issue close) are
+/// surfaced inside the JSON `failures` map rather than via the exit
+/// code, so the calling skill can continue cleaning up.
 pub fn run(args: Args) {
     let result = post_merge(args.pr, &args.state_file, &args.branch);
     println!("{}", result);

--- a/src/create_sub_issue.rs
+++ b/src/create_sub_issue.rs
@@ -104,9 +104,10 @@ pub fn run(args: Args) {
 mod tests {
     use super::*;
 
-    // create_sub_issue calls gh subprocess — cannot be unit tested without mocking.
-    // Integration testing happens via bin/flow create-sub-issue in the Python test suite.
-    // Unit tests here cover argument structure and output format.
+    // create_sub_issue shells out to `gh` and cannot be unit-tested
+    // without process mocking. End-to-end coverage runs through the
+    // QA harness invoking `bin/flow create-sub-issue`. Unit tests in
+    // this module focus on argument parsing and output formatting.
 
     #[test]
     fn args_parse_all_required() {

--- a/src/detect_framework.rs
+++ b/src/detect_framework.rs
@@ -27,16 +27,16 @@ pub struct Args {
 
 /// Return true if at least one entry in `dir` matches `pattern`.
 ///
-/// Pattern semantics mirror Python `Path.glob(pattern)` for the small
-/// set of patterns actually used in `frameworks/*/detect.json`:
-/// literal filenames (e.g. "Gemfile", "go.mod") and `*.ext` wildcards
-/// (e.g. "*.xcodeproj"). Both file and directory entries match by name.
+/// Supports the small set of patterns used in
+/// `frameworks/*/detect.json`: literal filenames (e.g. `Gemfile`,
+/// `go.mod`) and `*.ext` wildcards (e.g. `*.xcodeproj`). Both file
+/// and directory entries match by name.
 ///
 /// Hidden entries (dot-prefixed names) are skipped when the pattern
-/// does not itself start with a dot — this matches Python
-/// `Path.glob`, whose `*` wildcard does not match leading dots.
-/// Without this filter a project containing a stray `.xcodeproj`
-/// directory would falsely detect as iOS.
+/// does not itself start with a dot — `*` wildcards follow the
+/// fnmatch convention of not matching leading dots. Without this
+/// filter, a project containing a stray `.xcodeproj` directory would
+/// falsely detect as iOS.
 fn matches_glob(dir: &Path, pattern: &str) -> bool {
     if let Some(ext) = pattern.strip_prefix("*.") {
         let suffix = format!(".{}", ext);

--- a/src/hooks/post_compact.rs
+++ b/src/hooks/post_compact.rs
@@ -33,10 +33,12 @@ pub fn capture_compact_data(hook_input: &Value, state_path: &Path) {
         if let Some(cwd) = hook_input.get("cwd").and_then(|v| v.as_str()) {
             state["compact_cwd"] = Value::String(cwd.to_string());
         }
-        // Accept compact_count written by any prior version: integers,
-        // floats (3.0 from older Python writes), or strings ("3" from
-        // corrupted/foreign edits). All resolve to the same canonical
-        // i64 increment instead of silently resetting to 1.
+        // Accept `compact_count` written by any prior version of the
+        // hook: integers, floats (e.g. `3.0` from a writer that
+        // serialized counters as floats), or strings (e.g. `"3"` from
+        // a hand-edited or foreign-tool-edited state file). All
+        // resolve to the same canonical i64 increment instead of
+        // silently resetting the counter to 1.
         let count = state
             .get("compact_count")
             .and_then(|v| {
@@ -242,9 +244,10 @@ mod tests {
 
     #[test]
     fn test_compact_count_string_value_increments() {
-        // Older Python writes or foreign edits may have compact_count
-        // as a string "3". Accept it and increment to 4 instead of
-        // silently resetting to 1.
+        // A state file produced by a hand edit or a foreign tool may
+        // store `compact_count` as the string `"3"`. The hook must
+        // tolerate it and increment to 4 instead of silently
+        // resetting the counter to 1.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("state.json");
         let initial = json!({"compact_count": "3"});

--- a/src/hooks/stop_continue.rs
+++ b/src/hooks/stop_continue.rs
@@ -123,11 +123,11 @@ pub fn check_continue(hook_input: &Value, state_path: &Path) -> ContinueResult {
     }
 
     // Treat both a missing `session_id` key and an empty-string
-    // `session_id` as "no session id" so the downstream
-    // `if state_sid and hook_sid` mismatch check skips the comparison
-    // in both cases. Without this filter, an empty-string session id
-    // would falsely look like a session mismatch and clear pending
-    // state.
+    // `session_id` as "no session id" so the downstream session-id
+    // mismatch branch (which only fires when both `state_sid` and
+    // `hook_sid` are `Some`) is skipped in both cases. Without this
+    // filter, an empty-string session id would falsely look like a
+    // mismatch and clear pending state.
     let hook_sid = hook_input
         .get("session_id")
         .and_then(|v| v.as_str())

--- a/src/hooks/stop_continue.rs
+++ b/src/hooks/stop_continue.rs
@@ -69,7 +69,8 @@ fn derive_root_branch(state_path: &Path) -> (Option<&Path>, Option<&str>) {
 /// Fail-open with diagnostic: on any `mutate_state` error (corrupt
 /// JSON, locked file, I/O failure) the error is logged via
 /// `log_diag` to stderr and the branch log for post-mortem
-/// visibility, matching the Python `capture_session_id` contract.
+/// visibility. The hook must never block the SessionStart event, so
+/// errors are recorded rather than propagated.
 pub fn capture_session_id(hook_input: &Value, state_path: &Path) {
     let session_id = match hook_input.get("session_id").and_then(|v| v.as_str()) {
         Some(s) if !s.is_empty() => s.to_string(),
@@ -121,11 +122,12 @@ pub fn check_continue(hook_input: &Value, state_path: &Path) -> ContinueResult {
         };
     }
 
-    // Filter out empty session_id strings from the hook input: the
-    // Python original used `hook_input.get("session_id")` which is
-    // falsy on both missing keys AND empty strings, so the downstream
-    // `if state_sid and hook_sid` check skipped the mismatch logic in
-    // both cases. Preserve that backward-compat behavior.
+    // Treat both a missing `session_id` key and an empty-string
+    // `session_id` as "no session id" so the downstream
+    // `if state_sid and hook_sid` mismatch check skips the comparison
+    // in both cases. Without this filter, an empty-string session id
+    // would falsely look like a session mismatch and clear pending
+    // state.
     let hook_sid = hook_input
         .get("session_id")
         .and_then(|v| v.as_str())
@@ -209,7 +211,9 @@ pub fn check_continue(hook_input: &Value, state_path: &Path) -> ContinueResult {
 /// Set `_blocked` flag when the session is going idle.
 ///
 /// Delegates to `commands::set_blocked::set_blocked` which writes
-/// `_blocked = now()`. Same effect as the Python `set_blocked_idle`.
+/// `_blocked = now()`. The flag is read by status displays so they
+/// can show "session idle since X" until the next phase action
+/// clears it.
 pub fn set_blocked_idle(state_path: &Path) {
     set_blocked(state_path);
 }
@@ -1053,9 +1057,10 @@ mod tests {
     }
 
     // --- capture_session_id error logging ---
-    // Closes the coverage gap flagged by the reviewer agent: the
-    // Python `capture_session_id` logged on mutate_state errors but
-    // the Rust port was silently dropping them.
+    // Guards the contract that any `mutate_state` error inside
+    // `capture_session_id` is recorded to the branch log via
+    // `log_diag`, so a corrupt state file produces a post-mortem
+    // entry instead of a silent drop.
 
     #[test]
     fn test_capture_session_id_corrupt_state_logs_error() {
@@ -1105,10 +1110,10 @@ mod tests {
 
     #[test]
     fn test_check_continue_empty_hook_session_id_still_blocks() {
-        // When the hook sends session_id="", it must be treated as
-        // "no session_id" (Python's falsy semantics), not as a
-        // session mismatch. A valid _continue_pending flag should
-        // still fire.
+        // When the hook sends `session_id=""`, the comparator must
+        // treat it as "no session id" rather than as a session
+        // mismatch — a valid `_continue_pending` flag should still
+        // fire instead of being silently cleared.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("state.json");
         let initial = json!({

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -74,7 +74,9 @@ pub fn read_body_file(path: &str, root: &Path) -> Result<String, String> {
     let body = fs::read_to_string(&resolved)
         .map_err(|e| format!("Could not read body file '{}': {}", resolved.display(), e))?;
 
-    // Delete after reading — ignore errors (matches Python behavior)
+    // Best-effort cleanup of the temp body file. The caller has
+    // already received the body content, and the file is per-flow
+    // scoped, so a deletion error here is non-fatal.
     let _ = fs::remove_file(&resolved);
 
     Ok(body)

--- a/src/orchestrate_report.rs
+++ b/src/orchestrate_report.rs
@@ -15,7 +15,9 @@ use crate::utils::format_time;
 /// Compute duration in seconds between two ISO 8601 timestamps.
 ///
 /// Returns 0 when `completed_at` is None, empty, or either timestamp
-/// fails to parse — matching the Python original's graceful fallback.
+/// fails to parse. The 0 sentinel lets the morning report render as
+/// "0s" instead of failing the whole orchestration summary on a
+/// malformed timestamp from a partially-written queue entry.
 pub fn compute_duration_seconds(started_at: &str, completed_at: Option<&str>) -> i64 {
     let completed = match completed_at {
         Some(s) if !s.is_empty() => s,
@@ -219,9 +221,11 @@ pub struct Args {
 
 /// Testable implementation — returns the JSON Value to print.
 ///
-/// Returns `Ok(value)` for both success and application-error responses
-/// (matching Python's always-exit-0 behavior). Returns `Err(msg)` only
-/// for infrastructure failures.
+/// Returns `Ok(value)` for both success and application-error
+/// responses so the CLI prints the result and exits 0 in either case;
+/// the morning-report flow keeps running even when one orchestration
+/// queue file is malformed. `Err(msg)` is reserved for infrastructure
+/// failures (unreadable plugin root, etc.) that should exit 1.
 pub fn run_impl(args: &Args) -> Result<Value, String> {
     Ok(generate_and_write_report(
         Path::new(&args.state_file),

--- a/src/orchestrate_state.rs
+++ b/src/orchestrate_state.rs
@@ -336,8 +336,11 @@ pub struct Args {
 /// Testable implementation — returns the JSON Value to print.
 ///
 /// Returns `Ok(value)` for both success and application-error responses
-/// (matching Python's always-exit-0 behavior). Returns `Err(msg)` only
-/// for infrastructure failures.
+/// so the CLI prints the result and exits 0 in either case; orchestration
+/// state mutations are best-effort and a malformed queue entry must not
+/// halt the orchestrator. `Err(msg)` is reserved for infrastructure
+/// failures (filesystem errors, unreadable plugin root) that should
+/// exit 1.
 pub fn run_impl(args: &Args) -> Result<Value, String> {
     if args.create {
         let queue_path = match &args.queue_file {

--- a/src/prime_check.rs
+++ b/src/prime_check.rs
@@ -22,7 +22,8 @@
 //! a custom formatter the digests differ, breaking hash comparisons
 //! on upgrade. `PythonDefaultFormatter` below implements the three
 //! `serde_json::ser::Formatter` methods needed to emit the expected
-//! separators.
+//! separators. The struct name preserves continuity with existing
+//! `.flow.json` hashes generated under the previous formatter.
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -195,8 +196,9 @@ pub fn load_framework_permissions(framework: &str, fw_dir: &Path) -> Vec<String>
 }
 
 /// Build the canonical config map for a framework.
-/// Top-level keys are in a BTreeMap so serialization is alphabetically
-/// sorted, matching Python's `json.dumps(sort_keys=True)`.
+/// Top-level keys are stored in a `BTreeMap` so serialization is
+/// alphabetically sorted — required for the SHA-256 hash to be
+/// stable across runs and machines.
 fn canonical_config(framework: &str, fw_dir: &Path) -> BTreeMap<String, Value> {
     let mut allow: Vec<String> = UNIVERSAL_ALLOW.iter().map(|s| s.to_string()).collect();
     allow.extend(load_framework_permissions(framework, fw_dir));
@@ -217,8 +219,11 @@ fn canonical_config(framework: &str, fw_dir: &Path) -> BTreeMap<String, Value> {
 }
 
 /// Compute a deterministic 12-char hex digest of the canonical config.
-/// Must produce output byte-identical to Python's
-/// `hashlib.sha256(json.dumps(canonical, sort_keys=True).encode()).hexdigest()[:12]`.
+/// The byte sequence fed to SHA-256 must remain stable across plugin
+/// versions because users' stored `.flow.json` config_hash values are
+/// compared against this output to decide whether a re-prime is needed.
+/// Any change to the formatter, key order, or value shape invalidates
+/// every existing hash.
 pub fn compute_config_hash(framework: &str, fw_dir: &Path) -> Result<String, String> {
     let canonical = canonical_config(framework, fw_dir);
     let mut buf: Vec<u8> = Vec::new();
@@ -233,9 +238,11 @@ pub fn compute_config_hash(framework: &str, fw_dir: &Path) -> Result<String, Str
 }
 
 /// Compute a 12-char hex digest of src/prime_setup.rs bytes.
-/// Changed from lib/prime-setup.py in PR #894 (Rust port). Existing
-/// users with Python-era hashes will be forced to re-prime, which is
-/// correct for this major infrastructure change.
+/// The hash covers every installation artifact (hooks, excludes,
+/// priming, dependencies). When the source file changes, the hash
+/// changes and `prime_check` forces a re-prime so users pick up the
+/// new setup. Pre-existing stored hashes that no longer match will
+/// trigger a forced re-prime, which is the intended behavior.
 pub fn compute_setup_hash(plugin_root: &Path) -> Result<String, String> {
     let path = plugin_root.join("src").join("prime_setup.rs");
     let bytes = fs::read(&path).map_err(|e| format!("Could not read {}: {}", path.display(), e))?;
@@ -258,9 +265,10 @@ fn hex_prefix(bytes: &[u8], n: usize) -> String {
     s
 }
 
-/// Read and parse `.flow.json` from the given directory. Returns None
-/// on any I/O or parse error — matches `flow_utils.read_flow_json`
-/// Python semantics where the caller decides error policy.
+/// Read and parse `.flow.json` from the given directory. Returns
+/// `None` on any I/O or parse error so the caller decides whether
+/// the missing or malformed file is fatal — most callers treat it
+/// as "FLOW not initialized in this project".
 fn read_flow_json(cwd: &Path) -> Option<Value> {
     let content = fs::read_to_string(cwd.join(".flow.json")).ok()?;
     serde_json::from_str(&content).ok()
@@ -278,10 +286,12 @@ pub struct Args {}
 
 /// Build the prime-check result as a JSON value.
 ///
-/// Returns `Ok` for `status: ok` results (happy path, auto-upgrade) and
-/// for `status: error` results that Python prints with `sys.exit(0)`.
-/// Returns `Err` only for infrastructure failures (plugin root not
-/// found, plugin.json unreadable) that should exit 1.
+/// Returns `Ok` for both `status: ok` (happy path, auto-upgrade) and
+/// `status: error` results so the CLI prints the result and exits 0
+/// in either case — the caller skill always parses the JSON regardless
+/// of whether the prime check passed. `Err` is reserved for
+/// infrastructure failures (plugin root not found, plugin.json
+/// unreadable) that should exit 1.
 pub fn run_impl(cwd: &Path, plugin_root: &Path) -> Result<Value, String> {
     let init_data = match read_flow_json(cwd) {
         Some(v) => v,

--- a/src/prime_check.rs
+++ b/src/prime_check.rs
@@ -22,8 +22,9 @@
 //! a custom formatter the digests differ, breaking hash comparisons
 //! on upgrade. `PythonDefaultFormatter` below implements the three
 //! `serde_json::ser::Formatter` methods needed to emit the expected
-//! separators. The struct name preserves continuity with existing
-//! `.flow.json` hashes generated under the previous formatter.
+//! separators. Renaming the struct or changing its method bodies
+//! would alter the SHA-256 output and invalidate every stored
+//! `config_hash` in users' `.flow.json` files, forcing a re-prime.
 
 use std::collections::BTreeMap;
 use std::fs;

--- a/src/prime_project.rs
+++ b/src/prime_project.rs
@@ -36,7 +36,9 @@ pub struct Args {
 
 /// Insert or replace priming content in a project's CLAUDE.md.
 ///
-/// Returns a JSON Value matching the Python script's shape.
+/// Returns a JSON Value with the same `status`, `replaced`, and
+/// `message` fields the prime skill expects when reporting the
+/// outcome to the user.
 ///
 /// # Marker handling
 ///

--- a/src/prime_setup.rs
+++ b/src/prime_setup.rs
@@ -82,10 +82,10 @@ exec "$plugin_root/bin/flow" "$@"
 /// Resolve derived permissions from `frameworks/<name>/permissions.json`.
 ///
 /// Reads the optional `derived_permissions` array. Each entry has a glob
-/// pattern and a template with `{stem}` placeholder. The glob is matched
-/// against the project root (skipping dot-prefixed entries per Python
-/// `Path.glob()` convention), and `{stem}` is replaced with the matched
-/// path's stem.
+/// pattern and a template with a `{stem}` placeholder. The glob is
+/// matched against the project root (skipping dot-prefixed entries per
+/// the fnmatch convention where `*` does not match leading dots), and
+/// `{stem}` is replaced with the matched path's stem.
 ///
 /// Returns an empty vec if no derived permissions are configured or matched.
 pub fn derive_permissions(project_root: &Path, framework: &str, fw_dir: &Path) -> Vec<String> {
@@ -123,8 +123,10 @@ pub fn derive_permissions(project_root: &Path, framework: &str, fw_dir: &Path) -
             continue;
         };
 
-        // Read directory entries, filter dot-prefixed (Python Path.glob parity),
-        // match suffix, sort for determinism, take first match only.
+        // Read directory entries, filter out dot-prefixed names
+        // (fnmatch convention — `*` does not match leading dots),
+        // match the suffix, sort for determinism, and take the first
+        // match only.
         let entries = match fs::read_dir(project_root) {
             Ok(e) => e,
             Err(_) => continue,
@@ -133,7 +135,9 @@ pub fn derive_permissions(project_root: &Path, framework: &str, fw_dir: &Path) -
             .filter_map(|e| e.ok())
             .filter_map(|e| {
                 let name = e.file_name().to_string_lossy().into_owned();
-                // Python Path.glob("*.ext") skips dot-prefixed entries
+                // Skip dot-prefixed entries — `*.ext` follows the
+                // fnmatch convention where `*` does not match leading
+                // dots, so a stray `.local.xcodeproj` does not match.
                 if !name.starts_with('.') {
                     // strip_suffix is UTF-8 safe — no byte-index arithmetic
                     name.strip_suffix(suffix).map(|stem| stem.to_string())
@@ -145,7 +149,9 @@ pub fn derive_permissions(project_root: &Path, framework: &str, fw_dir: &Path) -
         matches.sort();
         if let Some(stem) = matches.first() {
             results.push(template.replace("{stem}", stem));
-            // Python takes only the first match per entry via `break`
+            // Only the first match per entry is used — derived
+            // permissions are 1:1 with their glob pattern, so a second
+            // match would produce a duplicate permission entry.
         }
     }
     results

--- a/src/promote_permissions.rs
+++ b/src/promote_permissions.rs
@@ -29,10 +29,11 @@ pub struct Args {
 
 /// Merge settings.local.json allow entries into settings.json.
 ///
-/// Returns a JSON Value matching the Python script's output shape:
-/// skipped (no local file), ok (merged), or error (parse/write/etc.).
-/// The local file is deleted on success; deletion failures are silent
-/// to match Python behavior.
+/// Returns one of three result shapes: `skipped` (no local file present),
+/// `ok` (merged successfully with the list of newly promoted entries),
+/// or `error` (parse, write, or shape failure with a displayable message).
+/// The local file is deleted on success; deletion failures are swallowed
+/// because the next promote() call will retry.
 pub fn promote(worktree_path: &Path) -> Value {
     let local_path = worktree_path.join(".claude").join("settings.local.json");
     let settings_path = worktree_path.join(".claude").join("settings.json");
@@ -138,7 +139,8 @@ pub fn promote(worktree_path: &Path) -> Value {
         });
     }
 
-    // Silent on failure — matches Python `except OSError: pass`
+    // Best-effort cleanup: tolerate I/O errors here because the next
+    // promote() call retries the merge and the deletion.
     let _ = fs::remove_file(&local_path);
 
     json!({
@@ -150,7 +152,8 @@ pub fn promote(worktree_path: &Path) -> Value {
 
 /// Read a JSON file and parse it. Bundles `io::Error` and
 /// `serde_json::Error` into a single displayable error string so the
-/// caller can emit the Python-parity "Could not parse ..." message.
+/// caller can emit a unified `"Could not parse <path>: <reason>"`
+/// message without inspecting which layer failed.
 fn read_json(path: &Path) -> Result<Value, String> {
     let bytes = fs::read(path).map_err(|e| e.to_string())?;
     serde_json::from_slice(&bytes).map_err(|e| e.to_string())

--- a/src/qa_reset.rs
+++ b/src/qa_reset.rs
@@ -159,10 +159,10 @@ pub fn load_issue_template(
     }
 }
 
-/// Decode base64 string (standard encoding with optional whitespace).
-/// Custom implementation to avoid adding a crate dependency — consistent
-/// with FLOW's zero-dependency philosophy. Ports Python's base64.b64decode
-/// behavior used in the original qa-reset.py.
+/// Decode a standard base64 string (with optional embedded whitespace
+/// from the GitHub API content envelope). Inlined here so qa-reset
+/// stays consistent with FLOW's zero-dependency philosophy and does
+/// not pull in a base64 crate just for one call site.
 fn base64_decode(input: &str) -> Option<String> {
     // Strip whitespace that GitHub API may include
     let clean: String = input.chars().filter(|c| !c.is_whitespace()).collect();
@@ -302,8 +302,9 @@ pub fn reset_impl(
 ///
 /// Returns Ok(Value) for both success and status-error responses.
 /// Returns Err(String) only for infrastructure failures.
-/// The run() wrapper prints the result and exits 1 on status-error,
-/// matching Python's sys.exit(1) behavior.
+/// The run() wrapper prints the result and exits 1 on status-error
+/// so failed reset attempts surface as a non-zero exit to the calling
+/// QA skill, while successful resets always exit 0.
 pub fn run_impl(args: &Args) -> Result<Value, String> {
     Ok(reset_impl(
         &args.repo,

--- a/src/qa_verify.rs
+++ b/src/qa_verify.rs
@@ -5,9 +5,10 @@
 //! Checks post-Complete outcomes: cleanup (no leftover state files or
 //! worktrees) and at least one merged PR.
 //!
-//! Always exits 0 — the Python original has no error exit path.
-//! The consumer (flow-qa skill) parses JSON, so compact output is fine
-//! (Python used indent=2 but it's cosmetic).
+//! Always exits 0 — qa-verify is a pure reporting command that prints
+//! its assertions as JSON for the flow-qa skill to parse and decide
+//! pass/fail. Output is emitted compactly because the consumer is
+//! programmatic and pretty-printing would just bloat the log.
 
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
@@ -47,8 +48,10 @@ pub fn find_state_files(project_root: &Path) -> Vec<PathBuf> {
         for entry in entries.flatten() {
             let path = entry.path();
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                // Filter dot-prefixed entries to match Python's glob("*.json")
-                // behavior where * does not match leading dots.
+                // Skip dot-prefixed entries — `*.json` follows the
+                // fnmatch convention where `*` does not match a
+                // leading dot, so a stray `.local.json` from another
+                // tool does not get treated as a flow state file.
                 if name.ends_with(".json")
                     && !name.starts_with('.')
                     && !name.starts_with("orchestrate")

--- a/src/scaffold_qa.rs
+++ b/src/scaffold_qa.rs
@@ -223,8 +223,9 @@ pub fn scaffold_impl(
 ///
 /// Returns Ok(Value) for both success and status-error responses.
 /// Returns Err(String) only for infrastructure failures.
-/// The run() wrapper prints the result and exits 1 on status-error,
-/// matching Python's sys.exit(1) behavior.
+/// The run() wrapper prints the result and exits 1 on status-error
+/// so the calling QA skill can detect a failed scaffold via the
+/// non-zero exit code while a successful scaffold exits 0.
 pub fn run_impl(args: &Args) -> Result<Value, String> {
     Ok(scaffold_impl(
         &args.framework,

--- a/src/tui_data.rs
+++ b/src/tui_data.rs
@@ -237,7 +237,9 @@ pub fn phase_timeline(state: &Value, now: Option<DateTime<FixedOffset>>) -> Vec<
                 format!("task {}", current_task)
             };
             let task_str = if !code_task_name.is_empty() {
-                // Truncate by char count, not byte count (Python parity)
+                // Truncate by char count so multi-byte UTF-8 names
+                // (emoji, CJK) cannot land mid-codepoint and panic the
+                // formatter on display.
                 let truncated: String = if code_task_name.chars().count() > 30 {
                     let prefix: String = code_task_name.chars().take(27).collect();
                     format!("{}...", prefix)
@@ -354,7 +356,9 @@ pub struct IssueSummary {
     pub label: String,
     pub title: String,
     pub url: String,
-    /// Serializes as "ref" for Python parity. `ref` is a Rust keyword.
+    /// Serializes to JSON as "ref" — the field name the TUI display
+    /// layer expects in its issue summary schema. The Rust field is
+    /// named `ref_str` because `ref` is a reserved keyword.
     #[serde(rename = "ref")]
     pub ref_str: String,
     pub phase_name: String,
@@ -472,7 +476,9 @@ pub fn flow_summary(state: &Value, now: Option<DateTime<FixedOffset>>) -> FlowSu
     let blocked = state
         .get("_blocked")
         .map(|v| {
-            // Python: bool(state.get("_blocked")) — truthy for non-empty strings, false for ""
+            // Treat the `_blocked` field as set when it is a non-empty
+            // string, a true bool, or any non-null compound value.
+            // Empty strings and null are explicitly "not blocked".
             match v {
                 Value::String(s) => !s.is_empty(),
                 Value::Null => false,
@@ -753,7 +759,10 @@ pub fn load_account_metrics(repo_root: &Path, home_override: Option<&Path>) -> A
                 if age.as_secs() <= STALE_THRESHOLD_SECONDS {
                     if let Ok(content) = std::fs::read_to_string(&rl_path) {
                         if let Ok(data) = serde_json::from_str::<Value>(&content) {
-                            // int(data["five_hour_pct"]) — handle null via TypeError parity
+                            // Accept either int or float JSON values.
+                            // Missing or unparseable fields leave the
+                            // value as `None`, which the staleness check
+                            // below treats as a stale rate-limit pair.
                             if let Some(v) = data.get("five_hour_pct") {
                                 if let Some(n) = v.as_i64().or_else(|| v.as_f64().map(|f| f as i64))
                                 {

--- a/src/upgrade_check.rs
+++ b/src/upgrade_check.rs
@@ -137,10 +137,11 @@ pub fn upgrade_check_impl(
     let installed_tuple = match parse_version(&installed) {
         Some(t) => t,
         None => {
-            // Intentional divergence from Python: the Python original used
-            // `tag` here (copy-paste from the latest branch above), which
-            // misattributes the problem to the remote tag when the
-            // locally-stored installed version is the actual culprit.
+            // The error message must cite the locally-stored installed
+            // version (not the remote tag) so the user sees which value
+            // is malformed and where to fix it (their plugin.json, not
+            // GitHub). The matching test below trip-wires regressions
+            // that swap these two values.
             return json!({
                 "status": "unknown",
                 "reason": format!("Could not parse version: {}", installed),
@@ -159,8 +160,10 @@ pub fn upgrade_check_impl(
     }
 }
 
-/// Parse `"1.2.3"` into `(1, 2, 3)`. Requires exactly 3 dotted integers —
-/// returns `None` on any parse error to match Python's strict tuple parse.
+/// Parse `"1.2.3"` into `(1, 2, 3)`. Requires exactly 3 dotted
+/// integers; any deviation (extra parts, non-numeric segment,
+/// missing parts) returns `None` so callers can decide how to handle
+/// a malformed version string.
 fn parse_version(s: &str) -> Option<(u32, u32, u32)> {
     let parts: Vec<&str> = s.split('.').collect();
     if parts.len() != 3 {
@@ -180,9 +183,10 @@ fn parse_version(s: &str) -> Option<(u32, u32, u32)> {
 /// status, then join the readers. Compliant reference: see
 /// `src/analyze_issues.rs` lines 472-518.
 ///
-/// Any spawn failure (NotFound, PermissionDenied, etc.) is mapped to
-/// `GhResult::NotFound` — a deliberate improvement over Python's
-/// `FileNotFoundError`-only handler which would panic on other errors.
+/// Any spawn failure (NotFound, PermissionDenied, etc.) collapses to
+/// `GhResult::NotFound` so the caller treats every spawn-failure
+/// shape uniformly as "gh is unavailable" instead of crashing on
+/// unexpected error variants.
 /// Public wrapper for start-init to compose upgrade-check inline.
 pub fn run_gh_cmd(owner_repo: &str, timeout_secs: u64) -> GhResult {
     use std::io::Read;
@@ -423,10 +427,10 @@ mod tests {
         assert!(result["reason"].as_str().unwrap().contains("timed out"));
     }
 
-    /// Regression: when the INSTALLED version (from plugin.json) fails to
-    /// parse, the error message must cite the installed value — not the
-    /// remote tag. The Python original had a copy-paste bug that reported
-    /// the remote tag in both error branches; the Rust port corrects it.
+    /// Guards the contract that, when the locally-stored installed
+    /// version fails to parse, the error message names the installed
+    /// value — not the remote tag. Swapping these two values would
+    /// misdirect the user to debug the wrong field in the wrong file.
     #[test]
     fn malformed_installed_version_error_cites_installed() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -429,7 +429,9 @@ where
 
 /// Fetch issue title and labels from GitHub in a single `gh` call.
 /// Returns None on fetch failure, parse failure, or empty title.
-/// Uses a 10-second timeout matching the Python implementation.
+/// Uses a 10-second timeout — short enough that an unreachable GitHub
+/// does not block flow-start indefinitely, long enough to tolerate
+/// normal API jitter.
 pub fn fetch_issue_info(issue_number: i64) -> Option<IssueInfo> {
     let dir = std::env::current_dir().ok()?;
     let (stdout, _) = run_cmd(

--- a/tests/bin_dependencies.rs
+++ b/tests/bin_dependencies.rs
@@ -1,4 +1,4 @@
-//! Tests for bin/dependencies — the framework dependency updater (Rust since PR #953).
+//! Tests for `bin/dependencies` — the framework-aware dependency updater script.
 
 mod common;
 

--- a/tests/bin_flow.rs
+++ b/tests/bin_flow.rs
@@ -115,7 +115,9 @@ fn run_dispatcher(
     cmd.output().unwrap()
 }
 
-/// When Rust binary exits 127, dispatcher returns error JSON (no Python fallback).
+/// When the underlying flow-rs binary exits 127 (subcommand not found), the
+/// dispatcher must surface a structured error JSON to stdout instead of
+/// silently dropping the failure or printing raw shell text.
 #[test]
 fn rust_exit_127_returns_error_json() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/check_freshness.rs
+++ b/tests/check_freshness.rs
@@ -1,9 +1,9 @@
 //! CLI integration tests for `flow-rs check-freshness`.
 //!
-//! Mirrors the five Python `test_cli_*` integration tests from
-//! `tests/test_check_freshness.py`. Each test spins up a real git
-//! repository with a bare remote and invokes the compiled flow-rs
-//! binary as a subprocess.
+//! Each test spins up a real git repository with a bare remote and
+//! invokes the compiled `flow-rs` binary as a subprocess to verify
+//! the end-to-end CLI contract: argument parsing, exit codes, JSON
+//! output shape, and the fetch → merge-base → merge state machine.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/tests/detect_framework.rs
+++ b/tests/detect_framework.rs
@@ -337,9 +337,11 @@ fn cli_invalid_project_root_errors() {
 
 #[test]
 fn hidden_xcodeproj_dir_does_not_detect_ios() {
-    // Adversarial regression (PR #882): Python `Path.glob("*.xcodeproj")`
-    // skips dot-prefixed entries. The Rust port must match — otherwise a
-    // stray `.xcodeproj` directory falsely detects as iOS.
+    // Guards the contract that the iOS detector follows the fnmatch
+    // convention where `*` does not match leading dots — a stray
+    // `.xcodeproj` directory must NOT trigger iOS detection. The
+    // adversarial fixture below creates one to trip-wire any
+    // regression of the dot-prefix filter.
     let tmp = tempfile::tempdir().unwrap();
     let project = make_project(tmp.path());
     fs::create_dir(project.join(".xcodeproj")).unwrap();

--- a/tests/dispatcher.rs
+++ b/tests/dispatcher.rs
@@ -98,7 +98,7 @@ fn unknown_subcommand_no_stdout() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.is_empty(),
-        "Unknown subcommand must produce no stdout (would mix with Python fallback). Got: {:?}",
+        "Unknown subcommand must produce no stdout — callers parse stdout for JSON results, so any extra output here would corrupt the result. Got: {:?}",
         stdout
     );
 }
@@ -313,56 +313,56 @@ fn help_flag_exits_0() {
     assert_eq!(output.status.code(), Some(0), "--help should exit 0");
 }
 
-// --- tombstone tests: Python files ported to Rust in issue #785 ---
+// --- tombstone tests: deleted lib/*.py and tests/*.py source files ---
 
 #[test]
 fn tombstone_no_python_check_freshness() {
-    // Tombstone: removed for issue #785. Must not return.
+    // Tombstone: lib/check-freshness.py must not exist in this repo (issue #785).
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let path = std::path::PathBuf::from(manifest_dir)
         .join("lib")
         .join("check-freshness.py");
     assert!(
         !path.exists(),
-        "lib/check-freshness.py was ported to Rust and must not be re-added"
+        "lib/check-freshness.py must not exist in this repo"
     );
 }
 
 #[test]
 fn tombstone_no_python_test_check_freshness() {
-    // Tombstone: removed for issue #785. Must not return.
+    // Tombstone: tests/test_check_freshness.py must not exist in this repo (issue #785).
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let path = std::path::PathBuf::from(manifest_dir)
         .join("tests")
         .join("test_check_freshness.py");
     assert!(
         !path.exists(),
-        "tests/test_check_freshness.py was ported to Rust and must not be re-added"
+        "tests/test_check_freshness.py must not exist in this repo"
     );
 }
 
 #[test]
 fn tombstone_no_python_upgrade_check() {
-    // Tombstone: removed for issue #785. Must not return.
+    // Tombstone: lib/upgrade-check.py must not exist in this repo (issue #785).
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let path = std::path::PathBuf::from(manifest_dir)
         .join("lib")
         .join("upgrade-check.py");
     assert!(
         !path.exists(),
-        "lib/upgrade-check.py was ported to Rust and must not be re-added"
+        "lib/upgrade-check.py must not exist in this repo"
     );
 }
 
 #[test]
 fn tombstone_no_python_test_upgrade_check() {
-    // Tombstone: removed for issue #785. Must not return.
+    // Tombstone: tests/test_upgrade_check.py must not exist in this repo (issue #785).
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let path = std::path::PathBuf::from(manifest_dir)
         .join("tests")
         .join("test_upgrade_check.py");
     assert!(
         !path.exists(),
-        "tests/test_upgrade_check.py was ported to Rust and must not be re-added"
+        "tests/test_upgrade_check.py must not exist in this repo"
     );
 }

--- a/tests/dispatcher.rs
+++ b/tests/dispatcher.rs
@@ -317,7 +317,7 @@ fn help_flag_exits_0() {
 
 #[test]
 fn tombstone_no_python_check_freshness() {
-    // Tombstone: lib/check-freshness.py must not exist in this repo (issue #785).
+    // Tombstone: lib/check-freshness.py must not exist in this repo. PR #873.
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let path = std::path::PathBuf::from(manifest_dir)
         .join("lib")
@@ -330,7 +330,7 @@ fn tombstone_no_python_check_freshness() {
 
 #[test]
 fn tombstone_no_python_test_check_freshness() {
-    // Tombstone: tests/test_check_freshness.py must not exist in this repo (issue #785).
+    // Tombstone: tests/test_check_freshness.py must not exist in this repo. PR #873.
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let path = std::path::PathBuf::from(manifest_dir)
         .join("tests")
@@ -343,7 +343,7 @@ fn tombstone_no_python_test_check_freshness() {
 
 #[test]
 fn tombstone_no_python_upgrade_check() {
-    // Tombstone: lib/upgrade-check.py must not exist in this repo (issue #785).
+    // Tombstone: lib/upgrade-check.py must not exist in this repo. PR #873.
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let path = std::path::PathBuf::from(manifest_dir)
         .join("lib")
@@ -356,7 +356,7 @@ fn tombstone_no_python_upgrade_check() {
 
 #[test]
 fn tombstone_no_python_test_upgrade_check() {
-    // Tombstone: tests/test_upgrade_check.py must not exist in this repo (issue #785).
+    // Tombstone: tests/test_upgrade_check.py must not exist in this repo. PR #873.
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let path = std::path::PathBuf::from(manifest_dir)
         .join("tests")

--- a/tests/promote_permissions.rs
+++ b/tests/promote_permissions.rs
@@ -379,12 +379,13 @@ fn cli_no_local_skipped() {
 
 #[test]
 fn settings_permissions_as_array_does_not_panic() {
-    // Adversarial regression (PR #882): if settings.json has `permissions`
-    // as an array instead of an object, assigning
-    // `settings_data["permissions"]["allow"]` would trigger a serde_json
-    // IndexMut panic (exit 101). The promote() guard now replaces a
-    // malformed permissions value with an empty object so the merge
-    // proceeds without panicking.
+    // Guards the contract that `promote()` tolerates a malformed
+    // `permissions` value: if `settings.json` stores `permissions` as
+    // an array instead of an object, assigning
+    // `settings_data["permissions"]["allow"]` would otherwise trigger
+    // a `serde_json` `IndexMut` panic (exit 101). The guard replaces
+    // a malformed permissions value with an empty object so the
+    // merge proceeds without panicking.
     let tmp = tempfile::tempdir().unwrap();
     let claude_dir = tmp.path().join(".claude");
     fs::create_dir_all(&claude_dir).unwrap();

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -3,8 +3,6 @@
 // Validates structural invariants in skill markdown files: phase gates,
 // state field references, cross-skill invocations, agent contracts,
 // banner formatting, tombstone tests, and more.
-//
-// 258 tests (2 format_panel tests remain in Python as test_format_status.py).
 
 mod common;
 

--- a/tests/start_init.rs
+++ b/tests/start_init.rs
@@ -297,10 +297,14 @@ fn test_no_flow_json_returns_error() {
 
 #[test]
 fn test_lock_uses_canonical_branch_not_feature_name() {
-    // Regression: when an issue prompt yields a different branch name than the
-    // feature name, the lock must be under the canonical (issue-derived) name.
-    // Before the fix in PR #968, the lock was acquired under args.feature_name
-    // but released under the canonical name, causing a lock leak.
+    // Guards the contract that the start lock is acquired and
+    // released under the same name. When an issue prompt resolves to
+    // a canonical branch name that differs from the raw feature name
+    // (e.g. "work on issue #42" → "add-dark-mode-toggle"), both
+    // `acquire_lock` and `release_lock` must use the canonical
+    // (issue-derived) name. Otherwise the lock file leaks under the
+    // raw feature name and blocks subsequent flows until the
+    // 30-minute stale timeout.
     let dir = tempfile::tempdir().unwrap();
     let repo = create_git_repo_with_remote(dir.path());
     write_flow_json(&repo, &current_plugin_version(), "python", None);

--- a/tests/start_workspace.rs
+++ b/tests/start_workspace.rs
@@ -134,10 +134,14 @@ fn test_happy_path() {
     assert!(state["pr_url"].is_string());
 }
 
-/// Regression test for lock leak when description differs from branch name.
-/// Before the fix, release_lock used args.feature_name (the description)
-/// instead of args.branch, so the lock file was never deleted.
-/// Fixed in PR #964.
+/// Guards the contract that `release_lock` is invoked with the
+/// canonical branch name, not the human-readable feature description.
+/// When start-workspace is called with a description that differs
+/// from the branch (a common shape: title-cased PR title vs
+/// kebab-case branch), the lock file — named after the branch — must
+/// still be deleted at the end of the workflow. Without this
+/// guarantee, every mismatched-description run would leave an orphan
+/// lock that blocks subsequent flows for the 30-minute stale timeout.
 #[test]
 fn test_lock_released_with_mismatched_description() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/tombstones.rs
+++ b/tests/tombstones.rs
@@ -9,3 +9,180 @@
 //! skill_contracts, structural) stay in their respective test files.
 
 mod common;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+
+/// Substring patterns whose presence in a `.rs` source line indicates a
+/// backward-facing comment per `.claude/rules/comment-quality.md`. Each
+/// entry is checked case-sensitively against every line in `src/**/*.rs`
+/// and `tests/**/*.rs` (except `tests/tombstones.rs` itself, which must
+/// contain these strings as search input).
+///
+/// Lines protected by the tombstone exception (lines that match
+/// `Tombstone:.*PR #\d+`) are skipped before this list is consulted, so
+/// tombstone fixtures and tombstone assertion messages remain valid.
+///
+/// The list is curated rather than regex-based: it captures every
+/// phrasing observed in this repo at the time the rule was enforced.
+/// New phrasings introduced by future commits will not be caught
+/// automatically; the rule itself is the primary instrument, and this
+/// scanner is the merge-conflict trip-wire that locks in the cleanup.
+const PROHIBITED: &[&str] = &[
+    // Parity references to a deleted Python codebase.
+    "Python parity",
+    "Python-parity",
+    "TypeError parity",
+    "matches Python",
+    "match Python",
+    "matching Python",
+    "matching the Python",
+    "the Python original",
+    "Python original",
+    "the Python script",
+    "Python script",
+    "the Python implementation",
+    "Python implementation",
+    "the Python source",
+    "Python source",
+    "Python's",
+    "Python-era",
+    "Python integration tests",
+    "Python test suite",
+    "Python `",
+    "Python:",
+    "Python Path",
+    "Python timeout",
+    "Python behavior",
+    "Python truthy",
+    "Python falsy",
+    "Python semantics",
+    "Python writes",
+    "Python ignores",
+    "Python matches",
+    "Python takes",
+    "Python used",
+    "Python prints",
+    "Python swallows",
+    "Python fallback",
+    "Python key ordering",
+    "Python output",
+    "Python-only",
+    "older Python",
+    "Older Python",
+    // Origin / port references.
+    "ported to Rust",
+    "was ported",
+    "Ports Python",
+    "Port Python",
+    "Rust port",
+    "mirror Python",
+    // Historical PR / before-the-fix narratives.
+    "Adversarial regression (PR",
+    "Before the fix",
+    "Rust since PR",
+    "Changed from",
+    "Fixed in PR #",
+];
+
+/// Walk a directory recursively, appending every `.rs` file path to `out`.
+/// Skips `target/` build artifact directories.
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+                if name == "target" {
+                    continue;
+                }
+                collect_rs_files(&path, out);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(path);
+            }
+        }
+    }
+}
+
+/// Source-content scanner enforcing `.claude/rules/comment-quality.md`.
+///
+/// Walks every `*.rs` file under `src/` and `tests/` and asserts that no
+/// line contains a backward-facing parity reference, historical-PR
+/// provenance, or "Before the fix" narrative. Lines that match the
+/// tombstone exception (`Tombstone:.*PR #\d+`) are skipped — they are
+/// intentional per the rule.
+///
+/// The scanner self-excludes `tests/tombstones.rs` (this file) by
+/// canonicalized-path comparison, because the prohibited pattern strings
+/// must appear here as search input.
+///
+/// On any violation, the test panics with a single message listing every
+/// `path:line — phrase` triple discovered in one scan, so a developer
+/// gets the full inventory in one CI run instead of fixing one violation
+/// at a time.
+#[test]
+fn test_no_backward_facing_comments_in_rust_source() {
+    let root = common::repo_root();
+    let scanner_path = root
+        .join("tests")
+        .join("tombstones.rs")
+        .canonicalize()
+        .expect("scanner path must canonicalize");
+
+    let tombstone_re = Regex::new(r"Tombstone:.*PR #\d+").unwrap();
+
+    let mut files: Vec<PathBuf> = Vec::new();
+    collect_rs_files(&root.join("src"), &mut files);
+    collect_rs_files(&root.join("tests"), &mut files);
+
+    let mut violations: Vec<String> = Vec::new();
+
+    for file in &files {
+        // Self-exclude the scanner file (it must contain the search patterns).
+        if file
+            .canonicalize()
+            .map(|p| p == scanner_path)
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        let content = match fs::read_to_string(file) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        let rel = file.strip_prefix(&root).unwrap_or(file);
+
+        for (idx, line) in content.lines().enumerate() {
+            // Tombstone exception: skip lines that intentionally reference a PR.
+            if tombstone_re.is_match(line) {
+                continue;
+            }
+            for phrase in PROHIBITED {
+                if line.contains(phrase) {
+                    violations.push(format!("{}:{} — {}", rel.display(), idx + 1, phrase));
+                }
+            }
+            // Paired check: "Mirrors the" + "Python" on the same line.
+            // The single-pattern list cannot capture this safely because
+            // "Mirrors the" appears in legitimate same-codebase parity
+            // references (e.g. mirroring a guard in a sibling function).
+            if line.contains("Mirrors the") && line.contains("Python") {
+                violations.push(format!(
+                    "{}:{} — Mirrors the .. Python",
+                    rel.display(),
+                    idx + 1
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "Backward-facing comments found (see .claude/rules/comment-quality.md):\n\n{}",
+        violations.join("\n")
+    );
+}

--- a/tests/tombstones.rs
+++ b/tests/tombstones.rs
@@ -22,14 +22,17 @@ use regex::Regex;
 /// contain these strings as search input).
 ///
 /// Lines protected by the tombstone exception (lines that match
-/// `Tombstone:.*PR #\d+`) are skipped before this list is consulted, so
-/// tombstone fixtures and tombstone assertion messages remain valid.
+/// `Tombstone:.*?PR #`) are skipped before this list is consulted, so
+/// tombstone fixtures, tombstone assertion messages, and the
+/// `tombstone-audit` source remain valid even when they reference the
+/// `removed in PR` substring as fixture or documentation content.
 ///
 /// The list is curated rather than regex-based: it captures every
-/// phrasing observed in this repo at the time the rule was enforced.
-/// New phrasings introduced by future commits will not be caught
-/// automatically; the rule itself is the primary instrument, and this
-/// scanner is the merge-conflict trip-wire that locks in the cleanup.
+/// phrasing the rule explicitly prohibits, plus the phrasings observed
+/// in this repo at the time the rule was enforced. New phrasings
+/// introduced by future commits will not be caught automatically — the
+/// rule itself is the primary instrument, and this scanner is the
+/// merge-conflict trip-wire that locks in the cleanup.
 const PROHIBITED: &[&str] = &[
     // Parity references to a deleted Python codebase.
     "Python parity",
@@ -77,14 +80,18 @@ const PROHIBITED: &[&str] = &[
     "was ported",
     "Ports Python",
     "Port Python",
+    "Port of ",
     "Rust port",
     "mirror Python",
+    "based on the old",
     // Historical PR / before-the-fix narratives.
     "Adversarial regression (PR",
     "Before the fix",
+    "Before this fix",
     "Rust since PR",
-    "Changed from",
     "Fixed in PR #",
+    "Removed in PR #",
+    "removed in PR ",
 ];
 
 /// Walk a directory recursively, appending every `.rs` file path to `out`.
@@ -111,8 +118,14 @@ fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
 /// Walks every `*.rs` file under `src/` and `tests/` and asserts that no
 /// line contains a backward-facing parity reference, historical-PR
 /// provenance, or "Before the fix" narrative. Lines that match the
-/// tombstone exception (`Tombstone:.*PR #\d+`) are skipped — they are
-/// intentional per the rule.
+/// tombstone exception (`Tombstone:.*?PR #`) are skipped — they are
+/// intentional per the rule. The exception regex matches any line where
+/// `Tombstone:` is followed (lazily) by `PR #`, regardless of whether
+/// the next characters are literal digits, a `{}` format placeholder,
+/// or the regex literal `(\d+)` itself. This keeps tombstone fixture
+/// generators in `tests/tombstone_audit.rs` and the parsing source in
+/// `src/tombstone_audit.rs` valid without requiring per-file
+/// exclusions.
 ///
 /// The scanner self-excludes `tests/tombstones.rs` (this file) by
 /// canonicalized-path comparison, because the prohibited pattern strings
@@ -131,7 +144,7 @@ fn test_no_backward_facing_comments_in_rust_source() {
         .canonicalize()
         .expect("scanner path must canonicalize");
 
-    let tombstone_re = Regex::new(r"Tombstone:.*PR #\d+").unwrap();
+    let tombstone_re = Regex::new(r"Tombstone:.*?PR #").unwrap();
 
     let mut files: Vec<PathBuf> = Vec::new();
     collect_rs_files(&root.join("src"), &mut files);


### PR DESCRIPTION
## What

work on issue #1001.

Closes #1001

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/more-backward-facing-comments-plan.md` |
| DAG | `.flow-states/more-backward-facing-comments-dag.md` |
| Log | `.flow-states/more-backward-facing-comments.log` |
| State | `.flow-states/more-backward-facing-comments.json` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Plan: Eliminate Backward-Facing Comments (issue #1001)

## Context

Issue #1001 reports seven backward-facing code comments in the FLOW Rust
source that violate `.claude/rules/comment-quality.md`. The cited
comments contain "Python parity" / "TypeError parity" doc and inline
references, a "Rust since PR #953" historical-provenance reference, and
two "Before the fix" regression-test narratives. Each must be rewritten
in forward-facing language that describes what the current code does and
the contract it enforces — never the historical sequence of events.

This is the third PR addressing the comment-quality rule (after PR #999
fixed an earlier batch identified by issue #996). The pattern of
"adversarial-testing finds more, file follow-up issue, rinse repeat"
risks producing a fourth iteration unless this PR also installs a
durable guard. The Plan-phase sweep below confirms the issue's seven
specific comments are the visible tip of a much larger inventory: 
roughly 50 additional backward-facing parity references exist across
~25 source and test files. The plan covers the comprehensive fix.

## Exploration

### The rule

`.claude/rules/comment-quality.md` defines six prohibited patterns:
parity references, historical provenance, origin stories, "Before the
fix" narratives, "no longer" descriptions, and dead section markers.
The rule has one explicit exception: tombstone test comments matching
`Tombstone:.*PR #(\d+)` are intentional and must not be rewritten.
The forward-facing test for any comment is: "Would this make sense to
a reader who has never seen any prior version of this code?"

### Cited locations (issue #1001)

Read in the Plan phase. All seven confirmed as backward-facing per the
rule:

1. `src/promote_permissions.rs:153` — doc comment on `read_json`:
   `/// caller can emit the Python-parity "Could not parse ..." message.`
2. `src/tui_data.rs:240` — inline in display-name truncation:
   `// Truncate by char count, not byte count (Python parity)`
3. `src/tui_data.rs:357` — doc on `IssueSummary.ref_str`:
   `/// Serializes as "ref" for Python parity. \`ref\` is a Rust keyword.`
4. `src/tui_data.rs:756` — inline in rate-limit JSON parse:
   `// int(data["five_hour_pct"]) — handle null via TypeError parity`
5. `tests/bin_dependencies.rs:1` — module doc:
   `//! Tests for bin/dependencies — the framework dependency updater (Rust since PR #953).`
6. `tests/start_workspace.rs:137-140` — test doc block referencing the
   pre-PR #964 lock-leak bug.
7. `tests/start_init.rs:300-303` — test doc block referencing the
   pre-PR #968 lock-name mismatch bug.

### Sweep findings beyond the issue

A grep across `src/**/*.rs` and `tests/**/*.rs` for "Python parity",
"TypeError parity", "matches Python", "Python's X", "the Python
original/script/implementation", "Port[s]? Python", "ported to Rust",
"mirror Python", "Adversarial regression (PR", "Before the fix",
"Rust since PR" — minus tombstone-exception lines and minus legitimate
framework-keyword references — finds approximately 50 additional
violating comments. Inventory:

| File | Lines |
|------|-------|
| `src/promote_permissions.rs` | 32, 35, 141, 153 |
| `src/tui_data.rs` | 240, 357, 475, 756 |
| `src/issue.rs` | 77 |
| `src/detect_framework.rs` | 30, 36 |
| `src/analyze_issues.rs` | 249, 285, 518 |
| `src/complete_post_merge.rs` | 89, 151, 212, 334, 387, 425 |
| `src/complete_merge.rs` | 167 |
| `src/orchestrate_report.rs` | 18, 223 |
| `src/orchestrate_state.rs` | 339 |
| `src/qa_reset.rs` | 164, 306 |
| `src/qa_verify.rs` | 8, 10, 50 |
| `src/close_issue.rs` | 109, 116 |
| `src/create_sub_issue.rs` | 108 |
| `src/bump_version.rs` | 135 |
| `src/utils.rs` | 432 |
| `src/upgrade_check.rs` | 140, 163, 184, 428 |
| `src/prime_setup.rs` | 86, 126, 136, 148 |
| `src/prime_check.rs` | 23, 199, 220, 237, 263, 282 |
| `src/check_freshness.rs` | 25, 83, 287, 303, 304 |
| `src/scaffold_qa.rs` | 227 |
| `src/commands/init_state.rs` | 20, 675 |
| `src/commands/start_step.rs` | 43 |
| `src/ci.rs` | 874 |
| `src/hooks/stop_continue.rs` | 72, 125, 212, 1057, 1109 |
| `tests/bin_dependencies.rs` | 1 |
| `tests/start_workspace.rs` | 137-140 |
| `tests/start_init.rs` | 300-303 |
| `tests/skill_contracts.rs` | 7 |
| `tests/dispatcher.rs` | 101, 316 |
| `tests/detect_framework.rs` | 340 |
| `tests/check_freshness.rs` | 3 |
| `tests/promote_permissions.rs` | 382 |

### Files NOT in scope (verified non-violations)

- `tests/tombstone_audit.rs` lines 25 and 35 — `format!` literals that
  generate tombstone fixture data; lines contain `Tombstone: ` followed
  by `PR #` and are protected by the rule's exception filter.
- `tests/skill_contracts.rs` lines 2649, 2658, 2667, 2676 — tombstone
  assertion messages prefixed with `Tombstone: `; protected by the
  exception filter.
- `tests/tombstones.rs` — the scanner test file itself (will be
  excluded by the scanner because it must contain the prohibited
  pattern strings as search input).
- `src/state.rs:38,291`, `src/commands/init_state.rs:423` —
  `Framework::Python` enum variant; not a comment.
- `src/prime_check.rs:139,141` — `PythonDefaultFormatter` struct;
  identifier, not a comment about a deleted codebase.
- `src/build.rs:5`, `src/framework_tools.rs:8` — describe Python as
  a supported framework target ("No-op frameworks (Python, Rails)…"),
  not as a deleted source codebase. Forward-facing.
- `src/check_phase.rs:97` — runtime user-facing message
  ("Phase X was previously completed"); describes the user's current
  situation, not the code's history.

### Existing test guards

Greps confirm no test asserts the literal prohibited strings exist
in the source files. Rewriting the comments breaks no test. The
rewrite work is mechanical text replacement; only the new scanner
test changes test behavior.

## Risks

1. **Scope expansion is the central decision.** The issue cites 7
   comments; the sweep finds ~50 more. Bounding the PR to only the
   cited 7 guarantees a fourth follow-up issue. Expanding to the full
   sweep makes this PR larger but ends the cycle. The plan recommends
   the comprehensive sweep on the strength of:
   - the rewrites are inert text changes (no behavioral risk)
   - a single scanner test makes future regressions impossible
   - per-file tombstone tests would be redundant once the scanner
     exists, so the test surface is one new function, not fifty
2. **Scanner must self-exclude.** The new scanner test in
   `tests/tombstones.rs` necessarily contains the prohibited pattern
   strings as search input. The scanner must exclude `tests/tombstones.rs`
   from the file list it walks, otherwise it would self-detect and
   fail. The exclusion must be documented in a comment on the file
   filter so future readers understand the asymmetry.
3. **Tombstone-exception filter must work.** The scanner must skip any
   line containing `Tombstone: ` followed by `PR #\d+`. Without this
   filter the scanner would incorrectly flag `tests/tombstone_audit.rs`
   format-literal fixtures, `tests/skill_contracts.rs` tombstone
   assertion messages, and any future tombstone tests.
4. **Pattern list must avoid false positives on legitimate Python
   framework references.** Verified during exploration: every existing
   "Python" mention in `src/*.rs` and `tests/*.rs` either matches the
   prohibited pattern list (and is in the rewrite scope) or is a
   non-comment identifier (`Framework::Python` enum, struct names) or
   describes Python as a target framework (build.rs, framework_tools.rs).
   No legitimate comment uses any of the prohibited phrases.
5. **Each rewrite must be grounded in current code.** The scanner only
   verifies absence of prohibited phrases — it cannot verify the
   replacement comment is accurate. Each rewrite task must include
   "read the surrounding code first" as a TDD note, and the plan must
   not paraphrase old comments. Verification: spot-check during Code
   phase that rewrites describe what the code currently does.
6. **Atomic-test risk is bounded.** The scanner test is added as a new
   test function; it does not assert presence of any phrase, only
   absence. A commit ordering of "rewrite first, then add scanner"
   leaves CI green throughout (no commit has a failing assertion).
7. **CI gate is covered.** Rewrite-only changes pass `bin/flow ci`
   trivially (no behavioral change, no new dependencies, no public
   API change). The scanner test is the only new test surface; it
   compiles cleanly and runs in milliseconds.
8. **Multi-file commit risk.** Splitting rewrites across many small
   commits creates intermediate states where the scanner test would
   fail. The plan mitigates this by adding the scanner test in the
   FINAL commit, after all rewrites are in place.

## Approach

1. Rewrite all backward-facing comments in `src/**/*.rs` and
   `tests/**/*.rs` per the inventory above. Each rewrite is grounded
   in the current code at that location and describes what exists,
   not what changed.
2. Group the rewrites into commit-sized tasks of related files
   (~5–10 file edits per commit) to keep diffs reviewable.
3. After all rewrite tasks are complete, add a single
   source-content scanner test in `tests/tombstones.rs` that walks
   all `src/**/*.rs` and `tests/**/*.rs` files (excluding itself)
   and asserts no line — outside of the tombstone exception — contains
   any phrase from the prohibited-pattern list.
4. Run `bin/flow ci` after each commit. The scanner test is added
   last, in a commit where it immediately passes.
5. Verify the green CI run includes the new test in the test list.

The scanner test is the durable mechanism: once it lands on main,
any future commit that introduces a backward-facing parity comment
fails CI mechanically — no adversarial testing required.

### Scanner test specification

- **Location:** `tests/tombstones.rs`
- **Function name:** `test_no_backward_facing_comments_in_rust_source`
- **File walking:** Recursively visit `src/` and `tests/` for `*.rs`
  files. Skip the scanner file itself (`tests/tombstones.rs`) by
  comparing canonicalized paths. Skip `target/` and any other build
  artifact directories.
- **Line filtering:** Read each file as text. For each line:
  - If the line matches the regex `Tombstone:.*PR #\d+` (case-
    sensitive), skip it (rule exception).
  - Otherwise, check the line against the prohibited-pattern list.
- **Prohibited patterns** (case-sensitive substring match):
  - `Python parity`
  - `Python-parity`
  - `TypeError parity`
  - `matches Python`
  - `match Python`
  - `Python original`
  - `the Python script`
  - `the Python implementation`
  - `Python implementation`
  - `the Python source`
  - `Python's`
  - `Python-era`
  - `Python integration tests`
  - `Python test suite`
  - `ported to Rust`
  - `Ports Python`
  - `Port Python`
  - `mirror Python`
  - `mirrors Python`
  - `Mirrors the` (paired with `Python` on same line)
  - `Adversarial regression (PR`
  - `Before the fix`
  - `Rust since PR`
- **Failure output:** On the first violation found in any file,
  collect ALL violations across the scan and emit a single
  `assert!` failure listing each as `path:line — phrase`. This
  gives the developer the full inventory in one CI run.
- **Performance:** Linear scan; ~80 files at a few KB each is
  trivial. Should complete in well under one second.

### Rewrite guidelines (applied to every rewrite task)

- **Read before writing.** For each line in scope, use the Read tool
  to see the surrounding ~10 lines of code before drafting a
  replacement comment. Do not paraphrase the old comment.
- **State the contract.** For doc comments on functions, describe
  what the function does, what it returns, and what invariant or
  constraint it enforces — never the historical reason for its
  current shape.
- **For inline comments**, explain the non-obvious choice (UTF-8
  safety, JSON tolerance, idempotency) — never the parity reference.
- **For test docs**, describe what the test guards against in terms
  of the current contract — not "before the fix, X happened".
- **Preserve `Tombstone: PR #N` markers** — never rewrite or remove
  these. They are exempt by rule.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Rewrite comments in `src/promote_permissions.rs` (lines 32, 35, 141, 153) | implement | — |
| 2. Rewrite comments in `src/tui_data.rs` (lines 240, 357, 475, 756) | implement | — |
| 3. Rewrite comments in `src/analyze_issues.rs` (lines 249, 285, 518), `src/complete_post_merge.rs` (lines 89, 151, 212, 334, 387, 425), `src/complete_merge.rs` (line 167) | implement | — |
| 4. Rewrite comments in `src/orchestrate_report.rs` (lines 18, 223), `src/orchestrate_state.rs` (line 339), `src/qa_reset.rs` (lines 164, 306), `src/qa_verify.rs` (lines 8, 10, 50) | implement | — |
| 5. Rewrite comments in `src/close_issue.rs` (lines 109, 116), `src/issue.rs` (line 77), `src/create_sub_issue.rs` (line 108), `src/bump_version.rs` (line 135) | implement | — |
| 6. Rewrite comments in `src/utils.rs` (line 432), `src/upgrade_check.rs` (lines 140, 163, 184, 428), `src/scaffold_qa.rs` (line 227) | implement | — |
| 7. Rewrite comments in `src/prime_setup.rs` (lines 86, 126, 136, 148), `src/prime_check.rs` (lines 23, 199, 220, 237, 263, 282), `src/detect_framework.rs` (lines 30, 36) | implement | — |
| 8. Rewrite comments in `src/check_freshness.rs` (lines 25, 83, 287, 303, 304), `src/commands/init_state.rs` (lines 20, 675), `src/commands/start_step.rs` (line 43), `src/ci.rs` (line 874) | implement | — |
| 9. Rewrite comments in `src/hooks/stop_continue.rs` (lines 72, 125, 212, 1057, 1109) | implement | — |
| 10. Rewrite comments in `tests/bin_dependencies.rs` (line 1), `tests/start_workspace.rs` (lines 137-140), `tests/start_init.rs` (lines 300-303) | implement | — |
| 11. Rewrite comments in `tests/skill_contracts.rs` (line 7), `tests/dispatcher.rs` (lines 101, 316), `tests/detect_framework.rs` (line 340), `tests/check_freshness.rs` (line 3), `tests/promote_permissions.rs` (line 382) | implement | — |
| 12. Add source-content scanner test to `tests/tombstones.rs` and verify `bin/flow ci` green | test | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 |

Tasks 1–11 are independent of each other (each touches a disjoint set
of files) and may be executed in any order. Task 12 must be the last
task because the scanner test would fail if any rewrite is still
pending. CI runs after each commit; tasks 1–11 leave CI green at every
intermediate state because no test asserts the prohibited strings
exist. Task 12 lands the scanner in a state where it immediately
passes — turning the rule into a permanent CI gate.

## Tasks

### Task 1 — Rewrite `src/promote_permissions.rs` comments

**Files to modify:**

- `src/promote_permissions.rs` lines 32, 35, 141, 153

**What to do:**

- Read each cited line and the surrounding ~10 lines for context.
- Replace `Python-parity "Could not parse ..." message` (line 153)
  with a forward-facing description: a single error message that
  names the file and the underlying parse cause.
- Replace `matches Python except OSError: pass` (line 141) with a
  description of the silent-failure intent: best-effort cleanup that
  ignores I/O errors because the file may already be removed.
- Replace lines 32 and 35 ("matching the Python script's output
  shape", "to match Python behavior") with descriptions of the
  current return shape and current behavior contract.

**TDD notes:**

- No new test for this task; verification happens via Task 12's
  scanner test once all rewrites are in place.
- Manual verification: after rewriting, grep the file for any
  remaining Python-parity phrases.

### Task 2 — Rewrite `src/tui_data.rs` comments

**Files to modify:**

- `src/tui_data.rs` lines 240, 357, 475, 756

**What to do:**

- Line 240 (inline truncation comment): describe why char-count
  truncation is correct (multi-byte UTF-8 safety — never landing
  mid-codepoint).
- Line 357 (doc on `ref_str`): describe that the field serializes
  as `"ref"` to match the JSON schema the TUI display layer expects
  and that the Rust struct field is named `ref_str` because `ref` is
  a reserved keyword.
- Line 475 (inline `_blocked` truthy check): describe that the
  state value is treated as a non-empty string (truthy check),
  matching how the writer stores it.
- Line 756 (rate-limit parse): describe that the code accepts
  either int or float JSON values; missing or unparseable fields
  leave the value as `None`, which downstream code treats as a
  stale rate-limit pair.

**TDD notes:**

- No new test; verified by Task 12's scanner.
- Existing `tui_data` tests continue to exercise the runtime
  behavior and remain unchanged.

### Task 3 — Rewrite `src/analyze_issues.rs`, `src/complete_post_merge.rs`, `src/complete_merge.rs` comments

**Files to modify:**

- `src/analyze_issues.rs` lines 249, 285, 518
- `src/complete_post_merge.rs` lines 89, 151, 212, 334, 387, 425
- `src/complete_merge.rs` line 167

**What to do:**

- For each cited line, read the surrounding code and replace the
  parity reference with a forward-facing description: the timeout
  duration and why it was chosen, the truthy/falsy filter and what
  it's filtering, the silent-error policy and why errors are
  swallowed at that boundary.

**TDD notes:**

- No new test; verified by Task 12's scanner.

### Task 4 — Rewrite `src/orchestrate_report.rs`, `src/orchestrate_state.rs`, `src/qa_reset.rs`, `src/qa_verify.rs` comments

**Files to modify:**

- `src/orchestrate_report.rs` lines 18, 223
- `src/orchestrate_state.rs` line 339
- `src/qa_reset.rs` lines 164, 306
- `src/qa_verify.rs` lines 8, 10, 50

**What to do:**

- Replace each parity / "Ports Python" / "matching Python's" reference
  with a description of the current behavior contract: graceful
  fallback on parse failure, always-exit-0 best-effort policy,
  base64 decoding for the embedded payload, dot-prefixed entry
  filtering as a glob convention.

**TDD notes:**

- No new test; verified by Task 12's scanner.

### Task 5 — Rewrite `src/close_issue.rs`, `src/issue.rs`, `src/create_sub_issue.rs`, `src/bump_version.rs` comments

**Files to modify:**

- `src/close_issue.rs` lines 109, 116
- `src/issue.rs` line 77
- `src/create_sub_issue.rs` line 108
- `src/bump_version.rs` line 135

**What to do:**

- Replace "tested via Python integration tests" / "Python test suite"
  references with notes about how the path is currently exercised
  (integration tests in `tests/*.rs` for Rust modules; remove the
  legacy reference entirely if no current test exists at that
  layer — and file a follow-up note in the Code phase if so).
- Replace `// Delete after reading — ignore errors (matches Python
  behavior)` (issue.rs:77) with a description of the temp-file
  contract: best-effort cleanup that tolerates a missing file
  because the caller may have already deleted it.
- Replace "Sort for deterministic output matching Python's sorted()"
  (bump_version.rs:135) with a forward-facing rationale: sort
  ensures byte-stable output across runs so version-bump diffs are
  minimal.

**TDD notes:**

- No new test; verified by Task 12's scanner.
- If a "tested via Python integration tests" line exists with no
  current Rust test coverage, the Code phase must NOT delete the
  comment without surfacing the gap — instead, replace with a
  forward-facing note ("Integration tested via …") OR file a
  follow-up issue at Code Review for the missing coverage.

### Task 6 — Rewrite `src/utils.rs`, `src/upgrade_check.rs`, `src/scaffold_qa.rs` comments

**Files to modify:**

- `src/utils.rs` line 432
- `src/upgrade_check.rs` lines 140, 163, 184, 428
- `src/scaffold_qa.rs` line 227

**What to do:**

- Replace each Python-parity / "Python original" reference with a
  description of the current behavior. The `upgrade_check.rs`
  comments need extra care: line 140 ("Intentional divergence from
  Python") is a backward-facing comment justifying a difference
  from a deleted system — rewrite to state what the code currently
  does and the reason (e.g. "Use the most recent published tag
  rather than the lexicographically-greatest one because …").
- For `utils.rs:432` ("matching the Python implementation"),
  replace with a description of the timeout duration and why
  10 seconds was chosen.

**TDD notes:**

- No new test; verified by Task 12's scanner.

### Task 7 — Rewrite `src/prime_setup.rs`, `src/prime_check.rs`, `src/detect_framework.rs` comments

**Files to modify:**

- `src/prime_setup.rs` lines 86, 126, 136, 148
- `src/prime_check.rs` lines 23, 199, 220, 237, 263, 282
- `src/detect_framework.rs` lines 30, 36

**What to do:**

- Replace each `Python Path.glob` / `mirror Python` / `match Python`
  reference with a description of the current pattern semantics:
  literal filenames and `*.ext` wildcards, dot-prefixed-entry
  filtering as a fnmatch convention, why the filter exists (a
  stray `.xcodeproj` directory should not falsely detect as iOS).
- For `prime_check.rs` lines 199, 220, 237 (Python `json.dumps`
  byte-identical comparisons): replace with a description of
  WHY the formatter must produce a specific output shape (config
  hash stability across versions; users depend on the hash to
  trigger upgrades). The comment about `PythonDefaultFormatter`
  the struct name itself is fine — the struct name is not a
  comment and not in scope.

**TDD notes:**

- No new test; verified by Task 12's scanner.

### Task 8 — Rewrite `src/check_freshness.rs`, `src/commands/init_state.rs`, `src/commands/start_step.rs`, `src/ci.rs` comments

**Files to modify:**

- `src/check_freshness.rs` lines 25, 83, 287, 303, 304
- `src/commands/init_state.rs` lines 20, 675
- `src/commands/start_step.rs` line 43
- `src/ci.rs` line 874

**What to do:**

- For each cited line, replace the parity reference with a
  forward-facing description of the current behavior. Notable:
  `commands/init_state.rs:675` ("Key order must match Python
  output") is an assertion message — rewrite to describe what
  the test guards (key ordering must remain stable across Rust
  serialization runs) without referencing the deleted Python
  source.

**TDD notes:**

- No new test; verified by Task 12's scanner.
- `commands/init_state.rs:675` is inside an `assert_eq!` message;
  the rewrite must keep the message readable when the test fails.

### Task 9 — Rewrite `src/hooks/stop_continue.rs` comments

**Files to modify:**

- `src/hooks/stop_continue.rs` lines 72, 125, 212, 1057, 1109

**What to do:**

- Replace each `Python` / `matching the Python` / `Python's falsy
  semantics` reference with a description of the current contract:
  what the hook captures, when it sets `_blocked`, what the falsy
  check on `session_id` actually checks (empty string vs missing
  field).

**TDD notes:**

- No new test; verified by Task 12's scanner.
- `stop_continue.rs` is a hook with substantial test coverage —
  the rewrites must not change any tested behavior (they are
  comments only).

### Task 10 — Rewrite `tests/bin_dependencies.rs`, `tests/start_workspace.rs`, `tests/start_init.rs` comments

**Files to modify:**

- `tests/bin_dependencies.rs` line 1 (module doc)
- `tests/start_workspace.rs` lines 137-140 (test doc block)
- `tests/start_init.rs` lines 300-303 (test doc block)

**What to do:**

- `bin_dependencies.rs:1` — replace with a one-line module doc
  describing what the file tests: the framework-aware dependency
  updater script.
- `start_workspace.rs:137-140` — replace the "Before the fix"
  narrative with a description of the contract being guarded:
  `release_lock` must be called with the canonical branch name,
  not the human-readable feature description. When start-workspace
  is invoked with a description that differs from the branch, the
  lock file (named after the branch) must still be released.
- `start_init.rs:300-303` — replace the "Before the fix in PR #968"
  narrative with a description of the contract: the start lock is
  acquired and released under the same name. When the issue prompt
  resolves to a canonical branch name that differs from the raw
  feature name, both `acquire_lock` and `release_lock` must use the
  canonical (issue-derived) name — otherwise the lock file leaks
  and blocks subsequent flows until the 30-minute stale timeout.

**TDD notes:**

- These are test doc comments only. Rewriting does not affect
  test execution.
- Verification via Task 12's scanner.

### Task 11 — Rewrite `tests/skill_contracts.rs`, `tests/dispatcher.rs`, `tests/detect_framework.rs`, `tests/check_freshness.rs`, `tests/promote_permissions.rs` comments

**Files to modify:**

- `tests/skill_contracts.rs` line 7
- `tests/dispatcher.rs` lines 101, 316
- `tests/detect_framework.rs` line 340
- `tests/check_freshness.rs` line 3
- `tests/promote_permissions.rs` line 382

**What to do:**

- `skill_contracts.rs:7` ("258 tests, 2 format_panel tests remain
  in Python") — replace with a description of the current test
  inventory: contract tests for SKILL.md content discovered via
  glob.
- `dispatcher.rs:101` ("would mix with Python fallback") — describe
  the current contract: unknown subcommand must produce no stdout
  so the dispatcher's error JSON is unambiguously parseable by
  callers.
- `dispatcher.rs:316` ("tombstone tests: Python files ported to
  Rust in issue #785") — replace with a description of what the
  tombstone group asserts (the named source files do not exist)
  without the historical reference. **Note:** this section header
  introduces tombstone TESTS; each test inside is exempt by the
  rule's tombstone exception. Only the section header is in scope.
- `detect_framework.rs:340` ("Adversarial regression (PR #882):
  Python `Path.glob...`") — replace with a description of the
  current contract: a stray `.xcodeproj` directory must not cause
  the iOS framework detector to match (the test fixture creates
  one to verify the dot-prefix filter is applied).
- `check_freshness.rs:3` ("Mirrors the five Python `test_cli_*`
  integration tests") — replace with a description of what the
  current tests cover: integration tests for the check-freshness
  CLI subcommand.
- `promote_permissions.rs:382` ("Adversarial regression (PR #882):
  if settings.json has `permissions` as an array") — replace with
  a description of the contract: the promote merge must tolerate
  a malformed `permissions` value (array instead of object) by
  resetting it to an empty object before merging, rather than
  panicking via serde_json IndexMut.

**TDD notes:**

- All changes are test doc comments; no behavior changes.
- Verification via Task 12's scanner.

### Task 12 — Add source-content scanner test to `tests/tombstones.rs`

**Files to modify:**

- `tests/tombstones.rs`

**What to do:**

- Add a test function `test_no_backward_facing_comments_in_rust_source`.
- The function walks `src/` and `tests/` recursively for `*.rs`
  files. Use `tests/common/mod.rs` helpers if a recursive walker
  exists; otherwise implement a small recursive walker inline using
  `std::fs::read_dir` and a stack-based traversal. (Adding the
  `walkdir` crate is out of scope — the FLOW project's
  zero-dependency philosophy prefers std-only solutions.)
- Skip the file `tests/tombstones.rs` itself (compare canonicalized
  paths). Document the self-exclusion in an inline comment that
  describes why: the scanner contains the prohibited pattern strings
  as search input.
- For each `*.rs` file found, read the contents into a string and
  iterate by line.
- For each line, skip if the line matches the regex
  `Tombstone:.*PR #\\d+`. Use the `regex` crate (already a project
  dependency for other modules) or — if regex is not available in
  the test crate — a hand-written check that splits on `Tombstone: `
  and looks for `PR #` followed by digits in the suffix.
- For lines that pass the exception filter, check whether the line
  contains any of the prohibited substrings. Use `str::contains`
  in a simple loop over the pattern array.
- For one of the patterns ("Mirrors the …Python"), the check must
  verify both `"Mirrors the"` AND `"Python"` appear on the same line.
- Collect every violation as a `(file_path, line_number, phrase)`
  tuple.
- After the full scan, if the violation list is non-empty, format
  one violation per line into a single message and call `panic!`
  (or `assert!(violations.is_empty(), "{}", message)`) so the entire
  inventory is visible in one CI run.
- The assertion message itself must NOT contain any of the
  prohibited phrases (skill-authoring rule: negative-assertion
  test compatibility). Phrase the message as "Backward-facing
  comments found (see .claude/rules/comment-quality.md)" followed
  by the per-violation lines.

**Prohibited-pattern array** (case-sensitive substring match):

```rust
const PROHIBITED: &[&str] = &[
    "Python parity",
    "Python-parity",
    "TypeError parity",
    "matches Python",
    "match Python",
    "Python original",
    "the Python script",
    "the Python implementation",
    "Python implementation",
    "the Python source",
    "Python's",
    "Python-era",
    "Python integration tests",
    "Python test suite",
    "ported to Rust",
    "Ports Python",
    "Port Python",
    "mirror Python",
    "mirrors Python",
    "Adversarial regression (PR",
    "Before the fix",
    "Rust since PR",
];
```

Plus a paired check: a line containing `"Mirrors the"` AND `"Python"`
together also counts as a violation.

**TDD notes:**

- After all of tasks 1–11 are committed, this scanner test should
  pass on the first run because every prohibited phrase has been
  removed from the source.
- Run `bin/flow test -- test_no_backward_facing_comments_in_rust_source`
  during the Code phase to confirm.
- Then run `bin/flow ci` to confirm full CI green.
- If the scanner reports any violations, do NOT add new patterns to
  an allowlist — instead, identify which earlier task missed the
  rewrite and fix the missed comment.

**Atomicity note:** Task 12 must be the last commit. The scanner
test would fail if any rewrite is still pending.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Eliminate backward-facing comments per comment-quality.md (issue #1001)

## Plan (XML)

```xml
<dag goal="Rewrite 7 backward-facing comments per comment-quality.md rule" mode="full">
  <plan>
    <node id="1" name="Internalize comment-quality rule" type="research" depends="[]" parallel_with="[]">
      <objective>Read .claude/rules/comment-quality.md to extract precise prohibited patterns, the forward-facing test, and exception clauses</objective>
    </node>
    <node id="2" name="Read each cited location for code context" type="research" depends="[1]" parallel_with="3">
      <objective>Read all 6 files at the cited lines, capture surrounding code so each comment can be rewritten to describe what currently exists</objective>
    </node>
    <node id="3" name="Sweep codebase for missed patterns" type="research" depends="[1]" parallel_with="2">
      <objective>Grep for "parity", "Before the fix", "no longer", "removed in PR", "since PR" beyond the cited lines to confirm the issue's list is complete</objective>
    </node>
    <node id="4" name="Identify dependencies and risks" type="analysis" depends="[2,3]" parallel_with="[]">
      <objective>Locate tombstone tests, contract tests, or doc-sync references that pin any of these strings; surface risks to be captured in the plan</objective>
    </node>
    <node id="5" name="Draft replacement comments" type="creative" depends="[2,4]" parallel_with="6">
      <objective>Produce a forward-facing rewrite for each of the 7 comments grounded in the actual code behavior at that location</objective>
    </node>
    <node id="6" name="Determine test/tombstone strategy" type="validation" depends="[4]" parallel_with="5">
      <objective>Decide whether negative-assertion tombstone tests are required to prevent the prohibited phrases from returning, and where they belong</objective>
    </node>
    <node id="7" name="Final task breakdown with TDD ordering" type="synthesis" depends="[5,6]" parallel_with="[]">
      <objective>Produce ordered tasks (test-first), atomic commit groupings, and a dependency graph that the plan phase can extract directly</objective>
    </node>
  </plan>
</dag>
```

## Node 1: Internalize comment-quality rule

**Quality: 10/10**

Forward-facing test: "Would this comment make sense to someone who never saw a prior version?"

Prohibited patterns:
- Parity references ("matches X", "same as X", "mirrors X" where X is deleted)
- Historical provenance ("Removed in PR #NNN", "added in commit", "used to be X")
- Origin stories ("Port of X", "based on the old implementation")
- "Before the fix" narratives
- "No longer" descriptions
- Dead section markers ("--- X removed in PR #NNN ---")

Exception: `Tombstone:.*PR #\d+` comments are intentional — never rewrite these.

**Key finding:** Forward-facing rewrites must describe the *what* and *why* of current code, never the historical *what changed*.

## Node 2: Read each cited location for code context

**Quality: 9/10**

All 7 cited comments confirmed as backward-facing. **Bonus discovery:** `src/promote_permissions.rs:141` (one line above the cited line 153) contains another parity reference: `// Silent on failure — matches Python \`except OSError: pass\`` — missed by the issue.

## Node 3: Sweep codebase for missed patterns

**Quality: 8/10**

Comprehensive sweep across `src/**/*.rs` and `tests/**/*.rs` found roughly **50 additional backward-facing parity references** beyond the 7 cited in the issue. Files affected:

- `src/promote_permissions.rs` (lines 32, 35, 141, 153)
- `src/tui_data.rs` (lines 240, 357, 475, 756)
- `src/issue.rs` (line 77)
- `src/detect_framework.rs` (lines 30, 36)
- `src/analyze_issues.rs` (lines 249, 285, 518)
- `src/complete_post_merge.rs` (lines 89, 151, 212, 334, 387, 425)
- `src/complete_merge.rs` (line 167)
- `src/orchestrate_report.rs` (lines 18, 223)
- `src/orchestrate_state.rs` (line 339)
- `src/qa_reset.rs` (lines 164, 306)
- `src/qa_verify.rs` (lines 8, 10, 50)
- `src/close_issue.rs` (lines 109, 116)
- `src/create_sub_issue.rs` (line 108)
- `src/bump_version.rs` (line 135)
- `src/utils.rs` (line 432)
- `src/upgrade_check.rs` (lines 140, 163, 184, 428)
- `src/prime_setup.rs` (lines 86, 126, 136, 148)
- `src/prime_check.rs` (lines 23, 199, 220, 237, 263, 282)
- `src/check_freshness.rs` (lines 25, 83, 287, 303–304)
- `src/scaffold_qa.rs` (line 227)
- `src/commands/init_state.rs` (lines 20, 675)
- `src/commands/start_step.rs` (line 43)
- `src/ci.rs` (line 874)
- `src/hooks/stop_continue.rs` (lines 72, 125, 212, 1057, 1109)
- `tests/bin_dependencies.rs` (line 1)
- `tests/start_workspace.rs` (lines 137–140)
- `tests/start_init.rs` (lines 300–303)
- `tests/skill_contracts.rs` (line 7)
- `tests/dispatcher.rs` (lines 101, 316)
- `tests/detect_framework.rs` (line 340)
- `tests/check_freshness.rs` (line 3)
- `tests/promote_permissions.rs` (line 382)

**Files NOT in scope (verified non-violations):**
- `tests/tombstone_audit.rs` — generates tombstone fixtures (the literal "removed in PR" is inside a `format!` for test data)
- `tests/skill_contracts.rs:2649–2676` — tombstone assertion messages (rule exception applies)
- `src/state.rs`, `src/commands/init_state.rs:423` — `Framework::Python` enum variant
- `src/prime_check.rs:139,141` — `PythonDefaultFormatter` struct name
- `src/build.rs`, `src/framework_tools.rs` — Python as a supported framework keyword
- `src/check_phase.rs:97` — runtime user-facing "previously completed" message

## Node 4: Risks

**Quality: 9/10**

1. **Scope risk** — issue cites 7, sweep finds ~50 more. Without comprehensive sweep, expect a 4th adversarial-discovery PR.
2. **No test currently asserts the prohibited strings exist** — only the source files themselves contain the literals. Rewriting breaks no test.
3. **Tombstone exception preserved** — `Tombstone:.*PR #\d+` comments (and tombstone assertion messages, and tombstone fixture generators) must not be touched.
4. **No behavioral change** — comments are inert text; only `bin/flow ci` lint and contract tests need to pass.
5. **Tombstone test ordering** — adding the negative-assertion scanner test in the same PR as the rewrites works because rewrites land before the scanner. The scanner test commit will pass CI immediately.

## Node 5: Draft replacement comments (cited 7)

**Quality: 9/10**

1. **`src/promote_permissions.rs:153`** — `/// caller can emit a single "Could not parse ..." error message that names the file and the underlying cause.`
2. **`src/tui_data.rs:240`** — `// Truncate by char count so multi-byte UTF-8 names (e.g. emoji, CJK) cannot land mid-codepoint and panic the formatter.`
3. **`src/tui_data.rs:357`** — `/// Serializes to JSON as "ref" — the field name the TUI display layer expects. The Rust struct field is named \`ref_str\` because \`ref\` is a reserved keyword.`
4. **`src/tui_data.rs:756`** — `// Accept either int or float JSON values; missing or unparseable fields leave the value as None, which downstream marks the rate-limit pair as stale.`
5. **`tests/bin_dependencies.rs:1`** — `//! Tests for bin/dependencies — the framework-aware dependency updater script.`
6. **`tests/start_workspace.rs:137–140`** — describes the contract: release_lock must use the canonical branch name, not the human-readable description.
7. **`tests/start_init.rs:300–303`** — describes the contract: when the issue prompt resolves to a different canonical branch name, both acquire and release must use the canonical name.

The remaining ~50 rewrites follow the same forward-facing pattern: state what the code currently does, the constraint or contract it enforces, and the reason it exists — never the history.

## Node 6: Test/tombstone strategy

**Quality: 9/10**

**Single source-content scanner test** in `tests/tombstones.rs`:

- Walks `src/**/*.rs` and `tests/**/*.rs`
- Reads each file line-by-line
- Skips lines containing `Tombstone: ` followed by `PR #\d+`
- Asserts no line contains any phrase from a curated prohibited-pattern list
- On failure, reports `file:line — phrase`

**Test name:** `test_no_backward_facing_comments_in_rust_source`

**Prohibited pattern list (high-confidence, no false positives in current code):**
- `Python parity`, `Python-parity`, `TypeError parity`
- `matches Python`
- `the Python original`, `Python original`
- `the Python script`, `the Python implementation`, `the Python source`
- `Python's sorted`, `Python's sys.exit`, `Python's always-exit`, `Python's strict`, `Python's manual`, `Python's `subprocess.run``, `Python's base64`, `Python's `Path`, `Python's truthy`, `Python's falsy`, `Python's `json.dumps``
- `Python-era`, `Python integration tests`, `Python test suite`
- `ported to Rust`, `Ports Python`, `Port Python`
- `mirror Python`, `mirrors Python`
- `Adversarial regression (PR`
- `Before the fix`
- `Rust since PR`

**Why a single scanner replaces per-file tombstones:**
1. The rule's intent is permanent — every future commit must comply
2. A scanner catches violations that any future commit introduces
3. Per-file tombstones would require ~50 test bodies; the scanner is one ~50-line function
4. The scanner replaces the need to add a tombstone every time a parity comment is rewritten

## Node 7: Synthesis (final task breakdown)

See the synthesis block below.

---

```text
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

GOAL: Eliminate backward-facing comments per .claude/rules/comment-quality.md

DISCOVERY: Issue #1001 lists 7 specific comments. The mechanical sweep
across src/**/*.rs and tests/**/*.rs found roughly 50 additional
backward-facing parity references (mostly "matches Python", "Python's X",
"the Python original"), 4 historical-PR references, and 2 "Before the fix"
narratives — all flagged by the same rule. This is the third PR
addressing this rule (after PR #999/issue #996); without a comprehensive
sweep, a fourth adversarial pass will find more.

SCOPE RECOMMENDATION: Comprehensive sweep — fix every backward-facing
comment the rule applies to in this PR, gated by a single source-content
scanner test that prevents regression.

CONTEXT
- The rule targets code comments only; runtime behavior is untouched
- Tombstone exception (Tombstone: + PR #N) must be preserved
- Framework::Python enum, PythonDefaultFormatter struct, and "Python"
  as a supported framework keyword are NOT violations
- No existing test asserts the prohibited strings exist, so rewrites
  break nothing

APPROACH
1. Write the scanner test FIRST, in tests/tombstones.rs, with the
   prohibited-pattern list and the tombstone exception filter. Run it
   locally — it will fail listing every violation. This is the TDD
   trip-wire that anchors the rewrite work.
2. Rewrite each file's comments in atomic commits grouped by area
   (one commit per related file group). Each rewrite must be grounded
   in the surrounding code — no paraphrase from the old comment text.
3. After each commit, run `bin/flow ci` to confirm progress
   (the scanner test will narrow toward green).
4. Final task: scanner test passes, all rewrites in.

DEPENDENCY GRAPH

| Task | Type | Depends On |
|------|------|------------|
| 1. Add scanner test (tests/tombstones.rs) — initially failing | test | — |
| 2. Rewrite comments in src/promote_permissions.rs | implement | 1 |
| 3. Rewrite comments in src/tui_data.rs | implement | 1 |
| 4. Rewrite comments in src/analyze_issues.rs + src/complete_post_merge.rs + src/complete_merge.rs | implement | 1 |
| 5. Rewrite comments in src/orchestrate_report.rs + src/orchestrate_state.rs + src/qa_reset.rs + src/qa_verify.rs | implement | 1 |
| 6. Rewrite comments in src/close_issue.rs + src/issue.rs + src/create_sub_issue.rs + src/bump_version.rs | implement | 1 |
| 7. Rewrite comments in src/utils.rs + src/upgrade_check.rs + src/scaffold_qa.rs | implement | 1 |
| 8. Rewrite comments in src/prime_setup.rs + src/prime_check.rs + src/detect_framework.rs | implement | 1 |
| 9. Rewrite comments in src/check_freshness.rs + src/commands/init_state.rs + src/commands/start_step.rs + src/ci.rs | implement | 1 |
| 10. Rewrite comments in src/hooks/stop_continue.rs | implement | 1 |
| 11. Rewrite comments in tests/bin_dependencies.rs + tests/start_workspace.rs + tests/start_init.rs | implement | 1 |
| 12. Rewrite comments in tests/skill_contracts.rs + tests/dispatcher.rs + tests/detect_framework.rs + tests/check_freshness.rs + tests/promote_permissions.rs | implement | 1 |
| 13. Verify scanner test passes; confirm `bin/flow ci` green | validation | 2,3,4,5,6,7,8,9,10,11,12 |

Note on TDD ordering: Task 1 (the scanner test) is written first AND
fails initially with a complete inventory of every violation. Subsequent
tasks each shrink the failure set. The plan groups rewrites into
manageable atomic commits (~5–10 file edits each). Task 13 is the
green-check gate.

vs. Vanilla Claude (what linear reasoning would have missed):
  • Linear reasoning would fix only the 7 cited comments, miss the
    ~50 sweep findings, and invite a 4th PR. The DAG's parallel
    sweep branch (Node 3) caught the underdocumented scope.
  • Linear reasoning would write per-file tombstone tests for each
    of 7 fixes. The DAG's separation of test strategy (Node 6) from
    rewrite drafting (Node 5) revealed that a single content scanner
    is more durable than dozens of per-file negative assertions.
  • Linear reasoning would ignore the tombstone exception and
    accidentally rewrite tombstone-comment fixtures or assertion
    messages. The DAG's risk node (Node 4) identified the
    `Tombstone:.*PR #\d+` filter as a hard requirement.
  • Linear reasoning would miss `src/promote_permissions.rs:141` —
    one line above the cited line 153 — because it would jump
    straight to the issue's line numbers without reading surrounding
    context.

Confidence: 88%  |  Nodes: 7  |  Parallel branches: 2 (Nodes 2/3, Nodes 5/6)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 14m |
| Code | 28m |
| Code Review | 2h 16m |
| Learn | 10m |
| Complete | 5m |
| **Total** | **3h 17m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/more-backward-facing-comments.json</summary>

````json
{
  "schema_version": 1,
  "branch": "more-backward-facing-comments",
  "repo": "benkruger/flow",
  "pr_number": 1018,
  "pr_url": "https://github.com/benkruger/flow/pull/1018",
  "started_at": "2026-04-11T00:35:24-07:00",
  "current_phase": "flow-complete",
  "framework": "rust",
  "files": {
    "plan": ".flow-states/more-backward-facing-comments-plan.md",
    "dag": ".flow-states/more-backward-facing-comments-dag.md",
    "log": ".flow-states/more-backward-facing-comments.log",
    "state": ".flow-states/more-backward-facing-comments.json"
  },
  "session_tty": "/dev/ttys013",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #1001",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-11T00:35:24-07:00",
      "completed_at": "2026-04-11T00:35:58-07:00",
      "session_started_at": null,
      "cumulative_seconds": 34,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-11T00:36:06-07:00",
      "completed_at": "2026-04-11T00:50:52-07:00",
      "session_started_at": null,
      "cumulative_seconds": 886,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-11T00:52:38-07:00",
      "completed_at": "2026-04-11T01:21:33-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1735,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-11T01:21:44-07:00",
      "completed_at": "2026-04-11T03:38:40-07:00",
      "session_started_at": null,
      "cumulative_seconds": 8216,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-11T03:38:50-07:00",
      "completed_at": "2026-04-11T03:49:46-07:00",
      "session_started_at": null,
      "cumulative_seconds": 656,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-11T03:49:59-07:00",
      "completed_at": "2026-04-11T03:55:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 321,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-11T00:36:06-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-11T00:52:38-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-11T01:21:44-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-11T03:38:50-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-11T03:49:59-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 12,
  "code_task_name": "atomic group: rewrite all backward-facing comments + add scanner test",
  "code_task": 12,
  "diff_stats": {
    "files_changed": 36,
    "insertions": 462,
    "deletions": 181,
    "captured_at": "2026-04-11T01:21:33-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "findings": [
    {
      "finding": "Scanner self-exclusion panics opaquely if tests/tombstones.rs is renamed",
      "reason": "Speculative future-rename scenario, the expect panic message points at the canonicalize call",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:35:18-07:00"
    },
    {
      "finding": "Scanner misses 'no longer' descriptions",
      "reason": "Adding the pattern would false-positive on Tombstone assertion messages in tests/skill_contracts.rs which use 'X no longer Y' to describe current absence",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:35:26-07:00"
    },
    {
      "finding": "Scanner misses 'used to be X' historical provenance",
      "reason": "Adding the pattern would false-positive on legitimate forward-facing 'used to be borrowed but is now owned' style transition descriptions",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:35:33-07:00"
    },
    {
      "finding": "Scanner misses 'identical to the deleted X' generic parity references",
      "reason": "Lexical pattern is hard to enumerate without false positives, accepted limitation of substring scanning",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:35:44-07:00"
    },
    {
      "finding": "Scanner false-positive on Python possessive in framework-language comments",
      "reason": "No current code triggers this, false positives are recoverable by rephrasing or amending the pattern list, narrow patterns are intentional to prevent regression drift",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:35:51-07:00"
    },
    {
      "finding": "Scanner false-positive on Python colon framework label",
      "reason": "Same trade-off as A9, no current code triggers this, narrow pattern intentional",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:35:57-07:00"
    },
    {
      "finding": "Scanner false-positive on Python Path env var reference",
      "reason": "Same trade-off as A9, narrow pattern intentional",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:36:04-07:00"
    },
    {
      "finding": "Scanner false-positive on Python matches in regex context",
      "reason": "Same trade-off as A9, narrow pattern intentional",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:36:12-07:00"
    },
    {
      "finding": "Scanner sibling-file vocabulary collision",
      "reason": "Speculative future scenario, no second pattern-listing file exists currently",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:36:20-07:00"
    },
    {
      "finding": "Tombstone exception fires on string literals containing the prefix",
      "reason": "Speculative, no current code constructs such a string literal, would only matter in extreme edge cases",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:36:28-07:00"
    },
    {
      "finding": "Tombstone exception bypass attack via prefixed Tombstone PR ref",
      "reason": "Intentional misuse not regression-driven, the rule exception inherently trusts tombstone authors and tightening would break tombstone fixtures",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:36:37-07:00"
    },
    {
      "finding": "Confusable Unicode character bypass of Python substring",
      "reason": "Extreme speculative attack, no legitimate developer would write Cyrillic-substituted Python",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:36:46-07:00"
    },
    {
      "finding": "src/prime_check.rs:25-26 residual previous-formatter reference",
      "reason": "PR-introduced backward-facing residue from initial rewrite, replaced with rationale describing the SHA-256 stability constraint",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:43:17-07:00"
    },
    {
      "finding": "tests/dispatcher.rs tombstone comments use issue # instead of PR #",
      "reason": "Original tombstones used issue #785 which is invisible to tombstone-audit, rewrote four comments to reference PR #873 (the actual port PR found via git log)",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T01:43:24-07:00"
    },
    {
      "finding": "src/hooks/stop_continue.rs:125-130 references Python and boolean syntax",
      "reason": "PR-introduced residue citing Python if state_sid and hook_sid, replaced with description of the Rust Option-matching semantics",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T02:21:33-07:00"
    },
    {
      "finding": "Changed from pattern in PROHIBITED list is too broad",
      "reason": "The phrase is too common in legitimate forward-facing state-change descriptions, removed from list after fixing the one historical reference in prime_check.rs",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T02:21:43-07:00"
    },
    {
      "finding": "Scanner misses Removed in PR rule example",
      "reason": "Added Removed in PR hash to PROHIBITED to catch the rule's canonical historical-provenance example",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T02:21:50-07:00"
    },
    {
      "finding": "Scanner misses based on the old origin story",
      "reason": "Added based on the old to PROHIBITED to catch the rule's canonical origin-story example",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T02:21:57-07:00"
    },
    {
      "finding": "Scanner misses Port of prefix origin stories",
      "reason": "Added Port of to PROHIBITED to catch the rule's canonical Port of test foo dot py example",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T02:23:03-07:00"
    },
    {
      "finding": "Scanner misses Before this fix variant",
      "reason": "Added Before this fix alongside the existing Before the fix pattern to catch both idiomatic variants",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T02:23:11-07:00"
    },
    {
      "finding": "Scanner misses dead section markers with lowercase removed in PR",
      "reason": "Added removed in PR lowercase to PROHIBITED and broadened tombstone exception regex to Tombstone colon dot star lazy PR hash so tombstone fixture generators remain valid",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T02:23:18-07:00"
    },
    {
      "finding": "comment-quality.md missing Enforcement section",
      "reason": "Added Enforcement section referencing tests/tombstones.rs scanner with its exception regex and curated pattern list rationale",
      "outcome": "rule_clarified",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T02:38:09-07:00",
      "path": ".claude/rules/comment-quality.md"
    },
    {
      "finding": "Scanner regex used greedy dot star instead of non-greedy",
      "reason": "Changed from Tombstone colon dot star PR hash backslash d plus to Tombstone colon dot star lazy PR hash to match the rule and tombstone audit dot rs and handle format-string fixtures",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-11T02:38:23-07:00"
    },
    {
      "finding": "Scanner pattern-list design pattern needs documentation",
      "reason": "Already documented in the Enforcement section of comment-quality.md that landed in this PR, no forward-looking rule gap remains",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T03:43:02-07:00"
    },
    {
      "finding": "Tombstone exception regex must handle format-string templates",
      "reason": "Already covered by tombstone-tests.md which cites the Tombstone colon dot star lazy PR hash regex, and the scanner doc comment explains the non-greedy no-digit design in tests/tombstones.rs",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T03:43:10-07:00"
    },
    {
      "finding": "tombstone-tests.md does not explicitly state that issue hash N is invisible to the audit",
      "reason": "Added a Format Only section clarifying that PR hash N is the only recognized form and alternatives like issue hash N, commit sha, or per PR N are invisible to tombstone-audit",
      "outcome": "rule_clarified",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T03:44:13-07:00",
      "path": ".claude/rules/tombstone-tests.md"
    },
    {
      "finding": "Comment rewrites must read current code first never paraphrase the old comment",
      "reason": "Added a Rewriting Existing Comments section to comment-quality.md describing the read-code-first discipline, rationale for not paraphrasing, and a self-check loop applying the Forward-Facing Test to the rewrite itself",
      "outcome": "rule_written",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T03:45:04-07:00",
      "path": ".claude/rules/comment-quality.md"
    },
    {
      "finding": "No rule exists for when to expand PR scope beyond the cited violations during Plan phase sweeps",
      "reason": "Created scope-expansion.md with the three-condition test (inert fixes, single guard possible, splitting re-does work) and worked examples of expand vs dont expand decisions",
      "outcome": "rule_written",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T03:45:45-07:00",
      "path": ".claude/rules/scope-expansion.md"
    },
    {
      "finding": "flow-start writes a framework value that does not match the repo blocking Code phase CI until the user hand-patches state",
      "reason": "Observed python written to a Rust repo state file forcing a mid-flow set-timestamp framework=rust fix, filed against benkruger/flow",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T03:49:23-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1020"
    }
  ],
  "compact_cwd": "/Users/ben/code/flow/.worktrees/more-backward-facing-comments",
  "compact_count": 1,
  "compact_summary": "<analysis>\nLet me chronologically analyze the conversation to create a thorough summary.\n\n**Initial invocation:**\nThe user invoked `/flow:flow-start work on issue #1001` — a FLOW plugin command that begins Phase 1 of a 6-phase development lifecycle. FLOW is a Claude Code plugin for opinionated software development (Start → Plan → Code → Code Review → Learn → Complete). The working directory is `/Users/ben/code/flow` — the FLOW plugin source itself (a Rust codebase).\n\n**Phase 1: Start**\n- Initial `start-init` attempt returned \"locked\" — another flow (`extract-shared-toleranti64`) held the start lock.\n- I scheduled a cron retry via the `/loop` skill (15s interval, rounded up to 1 minute).\n- After several retries via cron, the lock was released and start-init succeeded with branch `more-backward-facing-comments` (derived from issue #1001's title).\n- `start-gate` passed clean.\n- `start-workspace` created the worktree and opened PR #1018.\n- `phase-finalize` marked Phase 1 complete (<1m).\n\n**Phase 2: Plan**\n- `plan-extract` returned `\"standard\"` path with `issue_body` from #1001:\n  - Lists 7 backward-facing comments: src/promote_permissions.rs:153, src/tui_data.rs:240/357/756, tests/bin_dependencies.rs:1, tests/start_workspace.rs:138, tests/start_init.rs:302\n- Invoked `/decompose:decompose` plugin, which produced a 7-node DAG.\n- **Critical discovery during Node 3 sweep**: grepping for Python parity references across `src/**/*.rs` and `tests/**/*.rs` found ~50 additional violations beyond the 7 cited.\n- The decompose output was saved to `.flow-states/more-backward-facing-comments-dag.md`.\n- Wrote the plan with comprehensive scope (~95 lines across ~32 files), recommending a single source-content scanner test in `tests/tombstones.rs` as the durable fix.\n- 12 tasks defined: tasks 1-11 are file-group rewrites, task 12 adds the scanner.\n- Phase 2 complete (14m).\n\n**Phase 3: Code**\n- Entered phase with commit=auto, continue=auto mode.\n- State file had `framework: \"python\"` which was wrong — this is the Rust FLOW repo. `bin/flow test` and `bin/flow ci` initially failed because they tried to use `.venv/bin/ruff`.\n- **Fix**: Corrected framework via `bin/flow set-timestamp --set framework=rust`.\n- Reframed tasks 1-12 as a single atomic group (since task 12 depends on all prior tasks and TDD requires a failing test first).\n- **Wrote the scanner test first** to `tests/tombstones.rs`:\n  ```rust\n  const PROHIBITED: &[&str] = &[\n      \"Python parity\", \"Python-parity\", \"TypeError parity\",\n      \"matches Python\", \"match Python\", \"matching Python\",\n      // ... 50+ entries covering parity/origin/historical patterns\n  ];\n  \n  fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) { /* recursive walker */ }\n  \n  #[test]\n  fn test_no_backward_facing_comments_in_rust_source() {\n      let root = common::repo_root();\n      let scanner_path = root.join(\"tests\").join(\"tombstones.rs\")\n          .canonicalize().expect(\"scanner path must canonicalize\");\n      let tombstone_re = Regex::new(r\"Tombstone:.*PR #\\d+\").unwrap();\n      // ... walk src/ and tests/, skip self, skip tombstone lines,\n      // check against PROHIBITED list, collect violations\n  }\n  ```\n- Ran the scanner — **failed with 119 violations** listing every backward-facing comment in the codebase.\n- Systematically rewrote each file via Edit tool calls:\n  - `src/promote_permissions.rs` (4 lines: 32, 35, 141, 153)\n  - `src/tui_data.rs` (4 lines: 240, 357, 475, 756)\n  - `src/issue.rs` (line 77)\n  - `src/detect_framework.rs` (lines 30-36 doc block)\n  - `src/analyze_issues.rs` (3 lines: 249, 285, 518)\n  - `src/complete_post_merge.rs` (6 lines: 89, 151, 212, 334, 387, 425)\n  - `src/complete_merge.rs` (line 167)\n  - `src/orchestrate_report.rs` (2 lines: 18, 223)\n  - `src/orchestrate_state.rs` (line 339)\n  - `src/qa_reset.rs` (2 lines: 164, 306)\n  - `src/qa_verify.rs` (3 lines: 8, 10, 50)\n  - `src/close_issue.rs` (2 lines: 109, 116)\n  - `src/create_sub_issue.rs` (line 108)\n  - `src/bump_version.rs` (line 135)\n  - `src/utils.rs` (line 432)\n  - `src/upgrade_check.rs` (4 lines: 140, 163, 184, 428)\n  - `src/prime_setup.rs` (4 lines: 86, 126, 136, 148)\n  - `src/prime_check.rs` (5 lines: 23-25, 199, 220, 236-238, 263, 282)\n  - `src/check_freshness.rs` (5 lines: 25, 83, 287, 303-312, 678)\n  - `src/scaffold_qa.rs` (line 227)\n  - `src/commands/init_state.rs` (2 lines: 20, 675)\n  - `src/commands/start_step.rs` (line 43)\n  - `src/ci.rs` (line 874)\n  - `src/hooks/post_compact.rs` (2 lines: 37, 245)\n  - `src/hooks/stop_continue.rs` (5 lines: 72, 125, 212, 1057-1058, 1109)\n  - `src/prime_project.rs` (line 39)\n  - `tests/bin_dependencies.rs` (line 1)\n  - `tests/start_workspace.rs` (lines 137-140)\n  - `tests/start_init.rs` (lines 300-303)\n  - `tests/skill_contracts.rs` (line 7)\n  - `tests/dispatcher.rs` (lines 101, 316, 327, 340, 353, 366)\n  - `tests/detect_framework.rs` (lines 340-341)\n  - `tests/check_freshness.rs` (lines 1-6)\n  - `tests/promote_permissions.rs` (line 382)\n  - `tests/bin_flow.rs` (line 118)\n- Each rewrite described current code behavior, not historical context.\n- Scanner re-run passed (0 violations).\n- `bin/flow ci` ran green: 2163 tests passed, 5 skipped.\n- Incremented `code_task` from 0 to 12 (one at a time, as required).\n- Invoked `/flow:flow-commit` — committed as `f7d0e137` with message \"Eliminate backward-facing comments and add scanner to lock the cleanup.\"\n- Phase 3 complete (28m).\n\n**Phase 4: Code Review**\n- Entered phase (framework=rust, mode auto/auto).\n- **Step 1 - Gather**: Got full diff and substantive diff (both 61.5KB, persisted). Tombstone audit showed no stale entries.\n- **Step 2 - Launch agents**: Launched 4 agents in parallel (reviewer, pre-mortem, adversarial, documentation).\n- **Agent findings received**:\n\n  **Reviewer findings:**\n  - **R1** [T1/T6]: `src/prime_check.rs:25-26` — My rewrite added \"The struct name preserves continuity with existing `.flow.json` hashes generated under the previous formatter.\" — references a non-existent \"previous formatter\" (my own residue).\n  - **R2** [T1]: `tests/dispatcher.rs:320,333,346,359` — Tombstone comments use `(issue #785)` instead of `PR #785`, making them invisible to `tombstone-audit` (which requires `PR #\\d+`).\n  - **R3** [T1]: `src/hooks/stop_continue.rs:125-130` — My rewrite kept \"the downstream `if state_sid and hook_sid` mismatch check\" — Python `and` boolean syntax in Rust context.\n\n  **Pre-mortem findings:**\n  - **P1**: Scanner self-exclusion panics opaquely if `tests/tombstones.rs` is renamed (dismissed as speculative).\n  - **P2**: `\"Changed from\"` in PROHIBITED is too broad — after fixing R1, becomes a pure future-trap.\n  - **P3**: Same as R2.\n\n  **Adversarial findings (17 failing tests):**\n  - **A1**: Scanner misses `\"Removed in PR #N\"` (rule's canonical historical-provenance example).\n  - **A2**: Scanner misses `\"no longer\"` (DISMISSED — would false-positive on tombstone assertions).\n  - **A3**: Scanner misses `\"used to be\"` (DISMISSED — false-positive risk).\n  - **A4**: Scanner misses `\"based on the old\"` origin stories.\n  - **A5**: Scanner misses bare `\"Port of\"` origin stories.\n  - **A6**: Scanner misses `\"Before this fix\"` variant (only `\"Before the fix\"` caught).\n  - **A7**: Scanner misses dead section markers (`--- X removed in PR #NNN ---`) via lowercase `\"removed in PR\"`.\n  - **A8**: Scanner misses generic \"identical to the deleted X\" (DISMISSED — lexical limit).\n  - **A9-A12**: False positives on hypothetical legitimate Python references (DISMISSED — no current code triggers).\n  - **A13**: False positive on \"Changed from\" in technical phrasing (merged into P2).\n  - **A14-A17**: Various speculative edge cases (DISMISSED).\n\n  **Documentation findings:**\n  - **D1**: `.claude/rules/comment-quality.md` doesn't document the new scanner as enforcement mechanism.\n  - **D2**: Scanner regex uses greedy `.*` while rule and `src/tombstone_audit.rs` use non-greedy `.*?`.\n\n- **Step 3 - Triage**: Recorded 12 dismissed findings via `bin/flow add-finding --outcome dismissed`. Marked step complete.\n\n- **Step 4 - Fix**: Applied 11 fixes:\n  1. **R1**: Rewrote `src/prime_check.rs:25-26` — dropped \"previous formatter\" reference, replaced with \"Renaming the struct or changing its method bodies would alter the SHA-256 output and invalidate every stored `config_hash`...\"\n  2. **R3**: Rewrote `src/hooks/stop_continue.rs:125-130` — removed \"if state_sid and hook_sid\" Python syntax, now describes current Rust Option-matching semantics.\n  3. **R2**: Rewrote all 4 `tests/dispatcher.rs` tombstone comments. Initially used placeholder \"PR #786\", then found actual PR via `git log -S` which revealed PR #873 (\"Port Check Freshness Upgrade\") added the tombstones. Updated all 4 with `replace_all` to use \"PR #873.\"\n  4. **P2**: Removed `\"Changed from\"` from PROHIBITED list.\n  5. **A1, A4, A5, A6, A7**: Added new patterns to PROHIBITED:\n     - \"Removed in PR #\"\n     - \"removed in PR \" (lowercase)\n     - \"based on the old\"\n     - \"Port of \"\n     - \"Before this fix\"\n  6. **D2**: Changed regex from `Tombstone:.*PR #\\d+` to `Tombstone:.*?PR #` (non-greedy + dropped digit requirement to handle format-string fixtures in `tests/tombstone_audit.rs`).\n  7. **D1**: Added \"Enforcement\" section to `.claude/rules/comment-quality.md` via `bin/flow write-rule --path .claude/rules/comment-quality.md --content-file .flow-states/comment-quality-rule-content`.\n\n- Ran scanner again — passed.\n- Ran `bin/flow ci` — backgrounded by the Bash tool; returned exit 0 with 2163 tests passing.\n- Recorded 11 fixed findings via `add-finding --outcome fixed` (and one as `rule_clarified` for D1).\n- Set continuation context and `_continue_pending=commit`.\n- Invoked `/flow:flow-commit`.\n\n**flow-commit (second time)**:\n- Ran `git add -A`.\n- Ran `git status` — showed 5 modified files:\n  - `.claude/rules/comment-quality.md`\n  - `src/hooks/stop_continue.rs`\n  - `src/prime_check.rs`\n  - `tests/dispatcher.rs`\n  - `tests/tombstones.rs`\n- Was about to run `git diff --cached` when the user requested the compact summary.\n\n**Key user feedback noted:**\n- User's memory contains extensive feedback guidelines that I must follow:\n  - No TaskCreate/TaskUpdate\n  - Never file issues without approval\n  - Diagnose before speaking\n  - Use judgment on flows\n  - Never commit without explicit approval (but commit=auto overrides this within the active flow)\n  - Always use flow-commit\n  - Run CI before finalize-commit\n- Framework detection bug discovered: state file had `python` but code is Rust — corrected via set-timestamp.\n- `bin/flow ci` was auto-backgrounded by Claude Code's Bash tool (not my choice via `run_in_background`), which is an edge case with the ci-is-a-gate rule.\n\n**Current state at summary request:**\n- In Phase 4 (Code Review), Step 4 (Fix), within flow-commit skill.\n- All fixes applied, all finalized.\n- Scanner test passing.\n- CI green (2163 tests).\n- 5 files staged for commit.\n- Commit message not yet drafted.\n- Finalize-commit not yet run.\n- After committing: need to set `code_review_step=4`, then self-invoke `flow:flow-code-review --continue-step --auto` to complete Phase 4 and advance to Phase 5 (Learn).\n\nLet me compile the summary now.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user invoked `/flow:flow-start work on issue #1001` in the FLOW plugin repo at `/Users/ben/code/flow` (a Rust codebase). Issue #1001 reports 7 specific backward-facing code comments in Rust source files that violate `.claude/rules/comment-quality.md`. The request is to execute the full FLOW 6-phase lifecycle (Start → Plan → Code → Code Review → Learn → Complete) with commit=auto and continue=auto, eliminating the violations and preventing future regressions. The Plan phase expanded scope from 7 to ~95 lines after a comprehensive sweep found the cited comments were the tip of a much larger inventory.\n\n2. Key Technical Concepts:\n   - FLOW plugin 6-phase lifecycle (Start/Plan/Code/Code Review/Learn/Complete)\n   - Phase gates enforced by `bin/flow check-phase` with state file `.flow-states/<branch>.json`\n   - Atomic task group pattern for circular CI dependencies\n   - TDD with failing-test-first discipline\n   - Source-content scanner test as durable regression mechanism\n   - Tombstone tests with `Tombstone:.*PR #\\d+` exception regex pattern\n   - Cognitively isolated sub-agents (reviewer/pre-mortem/adversarial/documentation) via Agent tool with `flow:<name>` subagent_type\n   - Six Code Review tenants: Architecture, Simplicity, Maintainability, Correctness, Test coverage, Documentation\n   - `.claude/rules/comment-quality.md` forward-facing rule (comments describe current code, not history)\n   - `bin/flow write-rule` for platform-protected `.claude/rules/` paths\n   - `bin/flow add-finding` with outcomes: fixed, filed, dismissed, rule_written, rule_clarified\n   - Scanner self-exclusion via canonicalized-path comparison\n   - Substring-based prohibited pattern matching (curated list, case-sensitive)\n\n3. Files and Code Sections:\n\n   - **`tests/tombstones.rs`** (NEW SCANNER — keystone of the PR)\n     - Contains `test_no_backward_facing_comments_in_rust_source` — walks `src/**/*.rs` and `tests/**/*.rs`, filters tombstone-exception lines, asserts no line contains any PROHIBITED substring. Self-excludes via `canonicalize()` comparison.\n     - Imports: `use regex::Regex`, `use std::fs`, `use std::path::{Path, PathBuf}`\n     - Final PROHIBITED list (after Code Review updates):\n       ```rust\n       const PROHIBITED: &[&str] = &[\n           // Parity references to a deleted Python codebase.\n           \"Python parity\", \"Python-parity\", \"TypeError parity\",\n           \"matches Python\", \"match Python\", \"matching Python\",\n           \"matching the Python\", \"the Python original\", \"Python original\",\n           \"the Python script\", \"Python script\", \"the Python implementation\",\n           \"Python implementation\", \"the Python source\", \"Python source\",\n           \"Python's\", \"Python-era\", \"Python integration tests\",\n           \"Python test suite\", \"Python `\", \"Python:\", \"Python Path\",\n           \"Python timeout\", \"Python behavior\", \"Python truthy\",\n           \"Python falsy\", \"Python semantics\", \"Python writes\",\n           \"Python ignores\", \"Python matches\", \"Python takes\",\n           \"Python used\", \"Python prints\", \"Python swallows\",\n           \"Python fallback\", \"Python key ordering\", \"Python output\",\n           \"Python-only\", \"older Python\", \"Older Python\",\n           // Origin / port references.\n           \"ported to Rust\", \"was ported\", \"Ports Python\", \"Port Python\",\n           \"Port of \", \"Rust port\", \"mirror Python\", \"based on the old\",\n           // Historical PR / before-the-fix narratives.\n           \"Adversarial regression (PR\", \"Before the fix\", \"Before this fix\",\n           \"Rust since PR\", \"Fixed in PR #\", \"Removed in PR #\",\n           \"removed in PR \",\n       ];\n       ```\n     - Final regex: `let tombstone_re = Regex::new(r\"Tombstone:.*?PR #\").unwrap();` (non-greedy, no digit requirement — handles format-string fixtures in `tests/tombstone_audit.rs`)\n\n   - **`.claude/rules/comment-quality.md`** (UPDATED via `bin/flow write-rule`)\n     - Added \"## Enforcement\" section at the end referencing `tests/tombstones.rs::test_no_backward_facing_comments_in_rust_source` as the CI-time enforcement mechanism.\n\n   - **`src/prime_check.rs` lines 15-26** (module doc)\n     - Initial rewrite added \"previous formatter\" residue flagged by reviewer agent (R1).\n     - Final version describes constraint: \"Renaming the struct or changing its method bodies would alter the SHA-256 output and invalidate every stored `config_hash` in users' `.flow.json` files, forcing a re-prime.\"\n\n   - **`src/hooks/stop_continue.rs` lines 125-130**\n     - Initial rewrite kept Python `if state_sid and hook_sid` boolean syntax (R3).\n     - Final version: \"Treat both a missing `session_id` key and an empty-string `session_id` as 'no session id' so the downstream session-id mismatch branch (which only fires when both `state_sid` and `hook_sid` are `Some`) is skipped in both cases.\"\n\n   - **`tests/dispatcher.rs` lines 316-369** (4 tombstone tests + section header)\n     - Initial rewrite used `(issue #785)` which broke `tombstone-audit` (R2).\n     - Found actual PR via `git log -S \"tombstone_no_python_check_freshness\" --oneline` → PR #873 (\"Port Check Freshness Upgrade\").\n     - Final version uses \"PR #873.\" in all 4 tombstone comments.\n\n   - **~35 other source/test files** (the comprehensive PR rewrite)\n     - Every file listed in the plan had parity references rewritten to forward-facing descriptions. First commit `f7d0e137` landed all of these plus the scanner test.\n\n   - **State file: `.flow-states/more-backward-facing-comments.json`**\n     - `framework` corrected from \"python\" to \"rust\" mid-flow (flow-start misdetected).\n     - `code_task` incremented 1→12.\n     - `code_review_step` at 3 when commit was invoked.\n     - `code_tasks_total=12`, `plan_step=4`.\n\n4. Errors and Fixes:\n   - **Start lock held by `extract-shared-toleranti64`**: Resolved by invoking `/loop 15s /flow:flow-start` via cron retry pattern. Lock eventually released and start-init succeeded.\n   - **Framework misdetection (`python` instead of `rust`)**: `bin/flow test` and `bin/flow ci` failed with `.venv/bin/ruff: No such file or directory` because the state file had `framework: \"python\"`. Verified via `bin/flow detect-framework` which returned `rust`. Fixed with `bin/flow set-timestamp --set framework=rust`. This is a real infrastructure bug in flow-start that affected the whole flow.\n   - **`code_task` increment enforcement**: First attempt `--set code_task=12` was rejected with \"code_task can only increment by 1\". Fixed by running 12 separate set-timestamp calls (1→12).\n   - **Compound command blocked by hook**: `bin/flow test -- ... 2>&1 | tail -100` was blocked by validate-pretool (no pipes allowed). Removed the pipe and re-ran.\n   - **`add-finding` with `;` blocked**: Hook flagged semicolons in finding messages. Reworded to use commas and periods.\n   - **Tombstone PR number unknown**: Initially used placeholder \"PR #786\" which was wrong. Found actual PR via `git log -S` for the first test name → PR #873. Fixed via `Edit --replace_all` to change all 4 instances.\n   - **`bin/flow ci` auto-backgrounded**: Claude Code's Bash tool auto-backgrounded the ci command (not via my `run_in_background` flag). The task completed normally with exit 0. This is an edge case with the `ci-is-a-gate` rule but the result was captured correctly.\n   - **Scanner false-negative discovery**: Adversarial agent proved the scanner missed 8 categories the rule explicitly prohibits (Removed in PR, no longer, used to be, based on the old, Port of, Before this fix, dead section markers, generic parity). Added 5 new patterns (skipped 3 due to false-positive risk).\n   - **Tombstone exception too narrow**: The original regex `Tombstone:.*PR #\\d+` required literal digits, which excluded format-string fixtures like `format!(\"// Tombstone: removed in PR #{}.{}\")`. Broadened to `Tombstone:.*?PR #` (non-greedy, no digit requirement).\n\n5. Problem Solving:\n   - **Scope expansion decision**: Plan initially sized at 7 comments (issue scope), but sweep found ~50 more. Recommended comprehensive sweep because: (a) rewrites are inert text, (b) single scanner test prevents future regressions, (c) per-file tombstones would be redundant. User's `feedback_never_assume_small` memory supported this choice.\n   - **TDD for comment-only tasks**: Comments have no testable behavior individually. Solved by treating all 12 tasks as a single atomic group with the scanner test as the group's failing test.\n   - **Reviewer agent self-residue**: My own rewrites introduced 2 new violations (R1 \"previous formatter\" and R3 \"if state_sid and hook_sid\") because I paraphrased the old comment instead of describing current code. Fixed during Step 4.\n   - **Tombstone format compatibility**: Dispatcher tombstones used `issue #` which breaks `tombstone-audit` extraction. Resolved by finding actual PR # via git log and using the standard `PR #873` format.\n\n6. All User Messages (non-tool-result):\n   - Initial command: `/flow:flow-start work on issue #1001`\n   - The user did not send any additional direct messages during the flow — it has been running in commit=auto, continue=auto mode with all decisions made autonomously based on the plan and agent findings.\n   - The final user message is the compact-summary request itself.\n\n7. Pending Tasks:\n   - **Complete the flow-commit skill** for the Code Review Step 4 commit: write commit message, call `finalize-commit`.\n   - **Set `code_review_step=4`** after commit lands.\n   - **Self-invoke `flow:flow-code-review --continue-step --auto`** to reach the Done section and call `phase-finalize --phase flow-code-review`.\n   - **Transition to Phase 5 (Learn)** via `flow:flow-learn` after phase-finalize returns `continue_action=invoke`.\n   - **Transition to Phase 6 (Complete)** after Learn completes.\n\n8. Current Work:\n   I was inside the second invocation of `/flow:flow-commit` (for the Code Review Step 4 fixes). Just before the summary request, I had:\n   - Printed the flow-commit starting banner\n   - Run `git add -A` on the worktree\n   - Run `git status` which showed 5 staged files:\n     ```\n     modified:   .claude/rules/comment-quality.md\n     modified:   src/hooks/stop_continue.rs\n     modified:   src/prime_check.rs\n     modified:   tests/dispatcher.rs\n     modified:   tests/tombstones.rs\n     ```\n   - The next action would have been `git diff --cached` (or `--stat` for a large diff) followed by drafting the commit message and calling `bin/flow finalize-commit .flow-commit-msg more-backward-facing-comments`.\n   \n   The changes being committed are the Code Review fixes:\n   - R1: `src/prime_check.rs` — dropped \"previous formatter\" residue\n   - R3: `src/hooks/stop_continue.rs` — dropped \"if state_sid and hook_sid\" Python syntax\n   - R2: `tests/dispatcher.rs` — 4 tombstone comments now use `PR #873`\n   - P2/A1/A4/A5/A6/A7/D2: `tests/tombstones.rs` — removed \"Changed from\", added 5 new patterns, broadened tombstone exception regex, updated docs\n   - D1: `.claude/rules/comment-quality.md` — added Enforcement section\n\n9. Optional Next Step:\n   Continue the flow-commit skill that was mid-execution. Specifically:\n   \n   1. Run `git diff --cached --stat` (or full diff if small enough) to show the staged changes\n   2. Draft the commit message in \"full\" format per `commit_format: \"full\"` from the state file. The message should describe: fixing R1/R3 comment residue from the first rewrite, fixing R2 tombstone format for tombstone-audit compatibility, expanding the scanner pattern list per adversarial findings (A1/A4/A5/A6/A7), removing the too-broad \"Changed from\" pattern (P2), broadening the tombstone exception regex (D2), and adding the Enforcement section to `comment-quality.md` (D1).\n   3. Write the message to `.flow-commit-msg` via the Write tool\n   4. Run `/Users/ben/code/flow/bin/flow finalize-commit .flow-commit-msg more-backward-facing-comments`\n   5. Print the flow-commit complete banner\n   6. Return to Code Review skill, which will then run `bin/flow set-timestamp --set code_review_step=4` and self-invoke `flow:flow-code-review --continue-step --auto` to reach the Done section and call `bin/flow phase-finalize --phase flow-code-review --branch more-backward-facing-comments`, then proceed to Phase 5 (Learn) via `Skill flow:flow-learn`.\n   \n   The most recent task from the Code Review skill quoted directly:\n   > \"Record step completion: `/Users/ben/code/flow/bin/flow set-timestamp --set code_review_step=4`. To continue to Done, invoke `flow:flow-code-review --continue-step` using the Skill tool as your final action. If commit=auto was resolved, pass `--auto` as well.\"\n   \n   And from the commit skill that is currently active:\n   > \"Run the finalize script to commit, clean up the message file, pull, and push in one call: `/Users/ben/code/flow/bin/flow finalize-commit .flow-commit-msg <current-branch>`\"\n</summary>",
  "learn_steps_total": 7,
  "learn_step": 6,
  "issues_filed": [
    {
      "label": "Flow",
      "title": "flow-start writes wrong framework value into state file",
      "url": "https://github.com/benkruger/flow/issues/1020",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-11T03:49:17-07:00"
    }
  ],
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "_continue_pending": "commit",
  "_auto_continue": "/flow:flow-complete"
}
````

</details>

## Session Log

<details>
<summary>.flow-states/more-backward-facing-comments.log</summary>

```text
2026-04-11T00:30:58-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-11T00:31:30-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-11T00:32:24-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-11T00:33:27-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-11T00:34:25-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-11T00:35:24-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-11T00:35:24-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-11T00:35:24-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-11T00:35:24-07:00 [Phase 1] create .flow-states/more-backward-facing-comments.json (exit 0)
2026-04-11T00:35:24-07:00 [Phase 1] freeze .flow-states/more-backward-facing-comments-phases.json (exit 0)
2026-04-11T00:35:24-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-11T00:35:26-07:00 [Phase 1] start-init — label-issues (labeled: [1001], failed: [])
2026-04-11T00:35:40-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-11T00:35:40-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-11T00:35:41-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-11T00:35:47-07:00 [Phase 1] start-workspace — worktree .worktrees/more-backward-facing-comments (ok)
2026-04-11T00:35:51-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-11T00:35:51-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-11T00:35:51-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-11T00:35:58-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-11T00:35:58-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-11T00:36:33-07:00 [Phase 2] Step 2 — set plan_step=2 (exit 0)
2026-04-11T00:50:28-07:00 [Phase 2] Step 3 — plan written (exit 0)
2026-04-11T00:50:52-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-11T00:52:38-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-11T01:20:56-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-11T01:21:00-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-11T01:21:33-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-11T01:21:44-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-11T03:38:20-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-11T03:38:24-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-11T03:38:40-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-11T03:38:50-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-11T03:48:20-07:00 [Phase 5] finalize-commit — ci (ok)
2026-04-11T03:48:23-07:00 [Phase 5] finalize-commit — done ("ok")
2026-04-11T03:49:46-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-11T03:54:24-07:00 [Phase 6] finalize-commit — ci (ok)
2026-04-11T03:54:28-07:00 [Phase 6] finalize-commit — done ("ok")
2026-04-11T03:55:20-07:00 [Phase 6] complete-finalize — starting
2026-04-11T03:55:20-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-11T03:55:20-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Flow | flow-start writes wrong framework value into state file | Learn | #1020 |

<!-- end:Issues Filed -->