### PR TITLE
Dogfood Supersession Rule Wire

### DIFF
--- a/agents/adversarial.md
+++ b/agents/adversarial.md
@@ -80,12 +80,6 @@ survive instead of zero output.
 your approach. Write harder tests targeting deeper edge cases. Overwrite
 the temp file and re-run. Maximum 3 rounds total.
 
-**Clean up.** Delete the temp test file before returning:
-
-```bash
-rm <temp_test_file>
-```
-
 ## Output Format
 
 For each finding (failing test), produce a structured block:
@@ -132,14 +126,13 @@ cases that the trace or verify step refutes.
 ## Rules
 
 - Only use the Write tool to write to `<temp_test_file>` — no other path
-- Only use Bash for `<test_command>`, `rm`, `git log`, `git show`, and `git diff`
+- Only use Bash for `<test_command>`, `git log`, `git show`, and `git diff`
 - Never use `cd <path> && git` — use `git -C <path>` if needed
 - Never use piped commands (|) — use separate Bash calls
 - Never use cat, head, tail, grep, rg, find, or ls via Bash
 - Never search or read outside the project directory
 - Do not speculate about intent — reason only from code evidence
 - Do not suggest fixes — only identify gaps via failing tests
-- Always delete the temp test file before returning
 
 ## Return Format
 

--- a/docs/phases/phase-4-code-review.md
+++ b/docs/phases/phase-4-code-review.md
@@ -63,6 +63,10 @@ For each finding from all agents, classify as:
 - **Real + out-of-scope** — file as Tech Debt or Documentation Drift issue
 - **False positive** — discard with rationale
 
+The supersession test from `.claude/rules/supersession.md` runs before
+the in-scope/out-of-scope decision — code the PR has made permanently
+redundant is routed to in-scope deletion regardless of file location.
+
 ### Step 4 — Fix
 
 Fix all real in-scope findings, run `bin/flow ci`, commit once.

--- a/docs/skills/flow-code-review.md
+++ b/docs/skills/flow-code-review.md
@@ -50,7 +50,10 @@ independently).
 Classify each finding: real in-scope (fix), real out-of-scope (file
 issue), or false positive (discard). Each triage decision is recorded
 via `bin/flow add-finding` with the outcome and reasoning. Shows triage
-summary table.
+summary table. For each real finding, the supersession test from
+`.claude/rules/supersession.md` runs before the diff-boundary test —
+code the PR has made permanently redundant is in-scope for deletion
+regardless of file location.
 
 ### Step 4 — Fix
 

--- a/skills/flow-code-review/SKILL.md
+++ b/skills/flow-code-review/SKILL.md
@@ -310,12 +310,7 @@ Prefix the prompt with:
 
 Wait for all agents to return.
 
-If the adversarial agent was launched, verify the temp test file was
-deleted. If it still exists, delete it:
-
-```bash
-rm <temp_test_file>
-```
+The Phase 6 complete/abort cleanup (`src/cleanup.rs::try_delete_adversarial_test_files`) deletes the adversarial test file by prefix match, so no mid-phase cleanup is needed here.
 
 Record step completion:
 
@@ -333,6 +328,30 @@ pass `--auto` as well. Do not output anything else after this invocation.
 
 Triage findings from each agent in order: reviewer, pre-mortem,
 adversarial, documentation. For each finding, classify it:
+
+### Supersession check
+
+The supersession test catches code that the current PR makes permanently
+redundant — code that would leave the PR's behavior unchanged if deleted.
+Running it before the diff-boundary test lets the triage route such code
+to Step 4 for deletion regardless of file location. Without this check,
+dead-on-merge code slips through as "out-of-scope" and becomes tech debt
+that every future reader must re-classify.
+
+Before applying the diff-boundary test, run the supersession test from
+`.claude/rules/supersession.md`. For every finding classified as real,
+ask: **"Would deleting the code this finding describes leave the PR's
+behavior unchanged?"**
+
+If yes, the finding is in-scope for deletion regardless of which file
+the code lives in — route it to Step 4 for deletion. Do not file an
+issue. Do not apply the diff-boundary test.
+
+If no, proceed with the diff-boundary test below.
+
+The supersession test overrides the diff-boundary test. A file that is
+not in the PR diff can still be in-scope if its contents are dead code
+the PR created.
 
 **Real + in-scope** — a credible issue supported by evidence. Apply the
 diff-boundary test: if the finding is in a file that appears in

--- a/skills/flow-code-review/SKILL.md
+++ b/skills/flow-code-review/SKILL.md
@@ -349,6 +349,11 @@ issue. Do not apply the diff-boundary test.
 
 If no, proceed with the diff-boundary test below.
 
+If uncertain whether the code is superseded, treat as "no" and proceed
+with the diff-boundary test. The safe default is the conservative path —
+filing an issue for code that turns out to be dead is recoverable;
+deleting code that turns out to be live is not.
+
 The supersession test overrides the diff-boundary test. A file that is
 not in the PR diff can still be in-scope if its contents are dead code
 the PR created.

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2889,6 +2889,17 @@ fn code_review_step_3_has_triage() {
 }
 
 #[test]
+fn code_review_has_supersession_check() {
+    let c = common::read_skill("flow-code-review");
+    let lower = c.to_lowercase();
+    assert!(
+        lower.contains("supersession"),
+        "flow-code-review/SKILL.md Step 3 Triage must include a supersession check \
+         per .claude/rules/supersession.md (Code Review Phase section)"
+    );
+}
+
+#[test]
 fn code_review_step_2_launches_four_agents() {
     let c = common::read_skill("flow-code-review");
     assert!(

--- a/tests/tombstones.rs
+++ b/tests/tombstones.rs
@@ -243,3 +243,36 @@ fn test_no_has_redirect_function() {
          which tracks bash quote state."
     );
 }
+
+/// Tombstone: mid-phase `rm <temp_test_file>` in flow-code-review SKILL.md
+/// removed in PR #1040. Must not return.
+#[test]
+fn test_code_review_no_mid_phase_adversarial_rm() {
+    let path = common::repo_root()
+        .join("skills")
+        .join("flow-code-review")
+        .join("SKILL.md");
+    let content = fs::read_to_string(&path).expect("flow-code-review SKILL.md must exist");
+    assert!(
+        !content.contains("rm <temp_test_file>"),
+        "Mid-phase `rm <temp_test_file>` block was deleted in PR #1040 and must not return. \
+         Phase 6 cleanup (src/cleanup.rs::try_delete_adversarial_test_files) is the \
+         authoritative cleanup — mid-phase rm targets an extensionless path that never \
+         exists and silently no-ops."
+    );
+}
+
+/// Tombstone: mid-phase `rm <temp_test_file>` in adversarial.md Round 2
+/// removed in PR #1040. Must not return.
+#[test]
+fn test_adversarial_agent_no_mid_phase_rm() {
+    let path = common::repo_root().join("agents").join("adversarial.md");
+    let content = fs::read_to_string(&path).expect("agents/adversarial.md must exist");
+    assert!(
+        !content.contains("rm <temp_test_file>"),
+        "Mid-phase `rm <temp_test_file>` block in Round 2 was deleted in PR #1040 and must \
+         not return. Phase 6 cleanup (src/cleanup.rs::try_delete_adversarial_test_files) is \
+         the authoritative cleanup — the agent's mid-phase rm targets an extensionless path \
+         that never exists and silently no-ops."
+    );
+}

--- a/tests/tombstones.rs
+++ b/tests/tombstones.rs
@@ -200,52 +200,7 @@ fn test_no_backward_facing_comments_in_rust_source() {
     );
 }
 
-// --- validate-pretool quote-aware scanner removal tombstones (PR #1035) ---
-//
-// PR #1035 replaced two byte-level scanners in
-// src/hooks/validate_pretool.rs with a single quote-aware state
-// machine (scan_unquoted) plus two predicates (compound_op_predicate,
-// redirect_predicate). The old functions were quote-unaware and
-// produced false positives whenever operator characters appeared
-// inside quoted arguments. These source-content tombstones assert the
-// old function names do not reappear in the source file — a merge
-// conflict that reintroduces them alongside the new scanner would
-// silently revert the fix.
-
-/// Tombstone: has_unescaped_semicolon removed in PR #1035. Must not return.
-#[test]
-fn test_no_has_unescaped_semicolon_function() {
-    let path = common::repo_root()
-        .join("src")
-        .join("hooks")
-        .join("validate_pretool.rs");
-    let content = fs::read_to_string(&path).expect("validate_pretool.rs must exist");
-    assert!(
-        !content.contains("fn has_unescaped_semicolon"),
-        "fn has_unescaped_semicolon was deleted in PR #1035 and must not return. \
-         Semicolon detection now goes through compound_op_predicate + scan_unquoted \
-         which tracks bash quote state."
-    );
-}
-
-/// Tombstone: has_redirect removed in PR #1035. Must not return.
-#[test]
-fn test_no_has_redirect_function() {
-    let path = common::repo_root()
-        .join("src")
-        .join("hooks")
-        .join("validate_pretool.rs");
-    let content = fs::read_to_string(&path).expect("validate_pretool.rs must exist");
-    assert!(
-        !content.contains("fn has_redirect"),
-        "fn has_redirect was deleted in PR #1035 and must not return. \
-         Redirection detection now goes through redirect_predicate + scan_unquoted \
-         which tracks bash quote state."
-    );
-}
-
-/// Tombstone: mid-phase `rm <temp_test_file>` in flow-code-review SKILL.md
-/// removed in PR #1040. Must not return.
+/// Tombstone: mid-phase rm in flow-code-review SKILL.md removed in PR #1040. Must not return.
 #[test]
 fn test_code_review_no_mid_phase_adversarial_rm() {
     let path = common::repo_root()
@@ -262,8 +217,7 @@ fn test_code_review_no_mid_phase_adversarial_rm() {
     );
 }
 
-/// Tombstone: mid-phase `rm <temp_test_file>` in adversarial.md Round 2
-/// removed in PR #1040. Must not return.
+/// Tombstone: mid-phase rm in adversarial.md removed in PR #1040. Must not return.
 #[test]
 fn test_adversarial_agent_no_mid_phase_rm() {
     let path = common::repo_root().join("agents").join("adversarial.md");


### PR DESCRIPTION
## What

work on issue #1037.

Closes #1037

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/dogfood-supersession-rule-wire-plan.md` |
| DAG | `.flow-states/dogfood-supersession-rule-wire-dag.md` |
| Log | `.flow-states/dogfood-supersession-rule-wire.log` |
| State | `.flow-states/dogfood-supersession-rule-wire.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/b969d4b0-125f-45cf-aac0-28c0c5056a1e.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Implementation Plan — Dogfood Supersession Rule Wire

## Context

Main branch commit `b34f923a` added `.claude/rules/supersession.md`, a new rule that says: when a PR introduces code that makes other code elsewhere in the repo permanently redundant, the redundant code must be deleted in the same PR. The rule runs in two phases — Plan (enumerate superseded code during Exploration) and Code Review (run the supersession test on every real finding before the diff-boundary test).

Issue #1037 is the follow-up to dogfood that rule. PR #1036 added the Phase 6 `try_delete_adversarial_test_files` cleanup step in `src/cleanup.rs`, which made the mid-phase `rm <temp_test_file>` blocks in `skills/flow-code-review/SKILL.md` Step 2 and `agents/adversarial.md` Round 2 unreachable-in-effect. They are exactly the "authoritative replacement" shape the supersession rule catches and should have been deleted in #1036.

This PR:

1. Wires a Supersession check sub-section into the Code Review Step 3 Triage flow so future PRs catch this class of gap during Code Review.
2. Deletes the dead mid-phase `rm` blocks that PR #1036 superseded (in both the skill and the agent).
3. Updates the adversarial agent's Rules section to drop `rm` from the Bash allow list and remove the "Always delete the temp test file before returning" instruction.
4. Adds a contract test `code_review_has_supersession_check` and tombstone tests for the removed `rm` patterns.
5. Sweeps 7 orphan `.flow-states/*-adversarial_test.*` files left over from flows that ran before PR #1036 merged.
6. Syncs `docs/skills/flow-code-review.md` and `docs/phases/phase-4-code-review.md` with the Step 3 addition.

## Exploration

### Affected files

| File | Change type | Why |
|------|-------------|-----|
| `skills/flow-code-review/SKILL.md` | Add sub-section + delete dead rm block | Add `### Supersession check` before diff-boundary test in Step 3; delete `rm <temp_test_file>` block in Step 2 (lines 313-318); replace with one-sentence pointer to Phase 6 cleanup |
| `agents/adversarial.md` | Delete lines + narrow Rules list | Delete `**Clean up.**` paragraph + bash block at lines 83-87; remove `rm` from Bash allow-list at line 135; delete line 142 `Always delete the temp test file before returning` |
| `tests/skill_contracts.rs` | Add contract test | New `code_review_has_supersession_check` after `code_review_step_3_has_triage` at line 2883 |
| `tests/tombstones.rs` | Add tombstone tests | Assert SKILL.md does not contain `rm <temp_test_file>` and adversarial.md does not contain `rm <temp_test_file>`; both reference PR #1040 |
| `docs/skills/flow-code-review.md` | Sync Step 3 description | Add single sentence noting supersession test runs before diff-boundary test |
| `docs/phases/phase-4-code-review.md` | Sync Step 3 description | Same one-sentence addition |
| `.flow-states/*-adversarial_test.*` (7 files) | One-shot deletion | Orphans already made dead by Phase 6 cleanup — gitignored, no diff impact |

### Orphan file inventory (gitignored, not in PR diff)

- `.flow-states/add---label-and---milestone-adversarial_test.rs`
- `.flow-states/add-findings-ledger-to-complete-adversarial_test.rs`
- `.flow-states/missing-use-case-tests-state-adversarial_test.rs`
- `.flow-states/tech-debt-extract-duplicated-adversarial_test.rs`
- `.flow-states/more-backward-facing-comments-adversarial_test.rs`
- `.flow-states/marketing-site-maintenance-adversarial_test.rs`
- `.flow-states/flow-code-review-adversarial-adversarial_test.rs` (the one cited in the issue)

### Patterns discovered

- **Authoritative cleanup is confirmed.** `src/cleanup.rs::try_delete_adversarial_test_files` (lines 141-199) uses a prefix glob `{branch}-adversarial_test.` with extension-agnostic deletion, handles partial failures, and is called unconditionally at line 356-359 inside `cleanup::steps()`. The call-site comment (line 354) states "Covers both complete (pr_number=None) and abort (pr_number=Some) paths since they share this function." Phase 6 cleanup invariant holds for both `/flow:flow-complete` and `/flow:flow-abort`.
- **Rule layer already wired.** `.claude/rules/code-review-scope.md` already says "Before applying the diff-boundary test, run the supersession test from `.claude/rules/supersession.md`." The gap is only in the skill layer — Step 3's prose routes real findings through the diff-boundary test directly without mentioning the supersession test.
- **Contract test naming convention.** `tests/skill_contracts.rs` uses `code_review_<assertion>` with `common::read_skill("flow-code-review")` + `assert!(c.contains(...))`. Peers at lines 2883 (`code_review_step_3_has_triage`), 2892, 2906, 2915 confirm the pattern.
- **Tombstone convention.** `tests/tombstones.rs` uses source-content assertions via `fs::read_to_string` and `!content.contains(...)` with `/// Tombstone: <what> removed in PR #<N>. Must not return.` doc comments. Pattern at lines 215-245 (`test_no_has_unescaped_semicolon_function`, `test_no_has_redirect_function`).
- **Placeholder is still load-bearing.** The `<temp_test_file>` placeholder is still used in SKILL.md Step 1 (definition at lines 183-186) and in adversarial.md (as the Write target path). The contract test `code_review_adversarial_uses_temp_test_file_placeholder` at `tests/skill_contracts.rs:2933` asserts the placeholder appears in SKILL.md. Tombstone assertions must target the full `rm <temp_test_file>` pattern, not the placeholder alone.
- **Docs are high-level summaries.** `docs/skills/flow-code-review.md` lines 48-53 and `docs/phases/phase-4-code-review.md` lines 58-64 describe Step 3 Triage in outcome-category terms (real+in-scope, real+out-of-scope, false positive) without mentioning the diff-boundary test. A minimal one-sentence sync is sufficient.

## Risks

1. **Contract test atomicity.** The new `code_review_has_supersession_check` test asserts "supersession" appears in SKILL.md. Committing the test before Task 5 (adding the Step 3 sub-section) breaks CI in the intermediate state. The test task and the SKILL.md edit must land in the **same commit**. (Tracked by the atomicity grouping in Task 13.)

2. **Tombstone atomicity.** The tombstone tests assert `rm <temp_test_file>` is absent from SKILL.md and adversarial.md. Committing the tombstones before Tasks 6 and 7 (the deletions) breaks CI. The tombstone tasks and the deletion tasks must land in the **same commit**. (Tracked by the atomicity grouping in Task 13.)

3. **Tombstone precision — must verify the match string targets only the bash command.** The placeholder `<temp_test_file>` itself is still load-bearing in SKILL.md Step 1 (definition `<temp_test_file>` = `.flow-states/<branch>-adversarial_test`) and in adversarial.md (the Write tool target). The contract test `code_review_adversarial_uses_temp_test_file_placeholder` at `tests/skill_contracts.rs:2933` asserts the placeholder appears. The new tombstone must assert on the exact string `rm <temp_test_file>` (the bash command form), NOT on `<temp_test_file>` alone, or the tombstone will break the peer test. **Must verify** in Task 4 that the tombstone assertion matches only the `rm `-prefixed form by spot-checking the string.

4. **Rules-section edit scope in `agents/adversarial.md`.** Narrowing the Bash allow list at line 135 and removing the single bullet at line 142 must use targeted Edit operations (not replace_all). Each edit must be line-precise to avoid touching adjacent Rules entries (the allow-list entry sits between `Only use the Write tool to write...` and `Never use cd <path> && git...`; the "Always delete" entry sits between `Do not suggest fixes...` and the `## Return Format` heading).

5. **Purpose preamble required for new sub-section.** Per `.claude/rules/skill-authoring.md` Purpose Preamble for Behavioral Sections, the new `### Supersession check` sub-section must open with 2-3 sentences explaining why the check exists, what problem it solves, and what fails without it. The draft in the DAG file includes a 3-sentence preamble; apply it verbatim in Task 5.

6. **Docs drift — both `docs/skills/flow-code-review.md` and `docs/phases/phase-4-code-review.md` describe Step 3 Triage.** Per `.claude/rules/docs-with-behavior.md`, changed skill steps require doc updates in the same commit. Both files currently describe triage outcome categories without mentioning the diff-boundary test. Task 10 adds a single sentence noting the supersession test runs before the diff-boundary test. This is a minimal sync — docs are high-level summaries, not reference documentation.

7. **Orphan scope expansion — issue cites 1 file, sweep finds 7.** Per `.claude/rules/scope-expansion.md`, expand when all three conditions hold: (a) inert — yes, filesystem-only deletions; (b) single guard covers the class forward — yes, `try_delete_adversarial_test_files` in `src/cleanup.rs` catches all future occurrences via prefix glob; (c) splitting re-does work — marginal (`rm` is cheap). Conditions (a) and (b) strongly hold; expand. The 7 files are gitignored and will not appear in the PR diff — Task 12 runs them after commit as a filesystem-only sweep.

8. **Pre-existing rule reference to issue #1037 is forward-facing and must stay intact.** The `.claude/rules/skill-authoring.md` "Placeholder Resolution Must Match Runtime Paths" section references issue #1037 as the motivating cautionary example. This reference is forward-facing (explains WHY the rule exists) and must NOT be deleted. No task touches this file, so the risk is purely about scope discipline — do not broaden the PR to include rule file edits.

9. **Must verify Phase 6 cleanup invariant.** The supersession claim assumes `try_delete_adversarial_test_files` runs for every flow. **Verified during Task 1 exploration:** the function is called unconditionally from `cleanup::steps()` at `src/cleanup.rs:356-359`, inside a helper shared by both flow-complete and flow-abort (line 354 comment: "Covers both complete (pr_number=None) and abort (pr_number=Some) paths since they share this function"). The invariant holds.

10. **Guard universality is NOT at risk.** The supersession check added in Task 5 is a triage-prose addition to one SKILL.md file — not a process-level guard applied to a code family. The Guard Universality rule in `.claude/rules/rust-patterns.md` does not apply. No scope enumeration required.

## Approach

Execute all changes as a single atomic commit that simultaneously adds the supersession check, deletes the superseded code, adds the contract test and tombstones, and syncs the docs. The orphan filesystem sweep runs out-of-commit after the PR content lands.

Rationale for atomic commit:

- **Contract test atomicity** — the new `code_review_has_supersession_check` test would fail without the SKILL.md edit.
- **Tombstone atomicity** — the tombstone tests would fail without the deletions.
- **Docs-with-behavior** — `.claude/rules/docs-with-behavior.md` requires behavior changes and their docs to land in the same commit.
- **Supersession dogfooding** — the rule itself says "the current session already has the context to recognize and delete the code. A future session must rediscover it." A single commit is strictly cheaper than splitting.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Verify Phase 6 cleanup invariant (already done during Plan exploration) | validation | — |
| 2. Check docs for Step 3 Triage descriptions (already done during Plan exploration) | validation | — |
| 3. Write `code_review_has_supersession_check` contract test | test | 1 |
| 4. Write tombstone tests for removed `rm <temp_test_file>` patterns (precision: assert on `rm <temp_test_file>`, not placeholder alone) | test | 1 |
| 5. Add `### Supersession check` sub-section with purpose preamble to SKILL.md Step 3 | implement | 3 |
| 6. Delete `rm <temp_test_file>` block in SKILL.md Step 2; replace with one-sentence pointer to `src/cleanup.rs::try_delete_adversarial_test_files` | implement | 4 |
| 7. Delete `**Clean up.**` paragraph + bash block in `agents/adversarial.md` lines 83-87 | implement | 4 |
| 8. Narrow `agents/adversarial.md` Rules Bash allow-list at line 135 (remove `rm`) | implement | 4 |
| 9. Delete `Always delete the temp test file before returning` at `agents/adversarial.md` line 142 | implement | 4 |
| 10. Sync `docs/skills/flow-code-review.md` and `docs/phases/phase-4-code-review.md` Step 3 descriptions | docs | 2, 5 |
| 11. Run `bin/flow ci` to confirm all tests green | validation | 3, 4, 5, 6, 7, 8, 9, 10 |
| 12. Delete 7 orphan `.flow-states/*-adversarial_test.*` files (filesystem only, gitignored) | cleanup | 11 |
| 13. Atomic commit of tasks 3-10 via `/flow:flow-commit` | commit | 11 |

**Atomicity group:** Tasks 3, 4, 5, 6, 7, 8, 9, 10 land in the same commit (Task 13). Tasks 1, 2, 11, 12, 13 are not code tasks (they are validations, CI run, and commit) — they do not consume `code_tasks_total` slots for implementation progress tracking.

**Implementation task count (`code_tasks_total`):** 8 (tasks 3 through 10).

## Tasks

### Task 1 — Verify Phase 6 cleanup invariant (done during exploration)

**Status:** verified during Plan phase exploration. `try_delete_adversarial_test_files` is called unconditionally at `src/cleanup.rs:356-359` inside `cleanup::steps()`, which is shared by both `/flow:flow-complete` and `/flow:flow-abort`. The Phase 6 authoritative cleanup claim holds.

No action required in Code phase.

### Task 2 — Check docs for Step 3 Triage descriptions (done during exploration)

**Status:** verified during Plan phase exploration. Both `docs/skills/flow-code-review.md` (lines 48-53) and `docs/phases/phase-4-code-review.md` (lines 58-64) describe Step 3 Triage in outcome-category terms. Neither mentions the diff-boundary test or supersession. A minimal one-sentence sync is needed in each file (Task 10).

No code action required; Task 10 is the follow-through.

### Task 3 — Add contract test `code_review_has_supersession_check`

**Files:** `tests/skill_contracts.rs`

**Location:** Insert after `code_review_step_3_has_triage` at line 2883 so the `code_review_step_3_*` group stays contiguous.

**TDD notes:** The test must fail before Task 5 adds the supersession sub-section to SKILL.md, and pass after. Case-insensitive `.to_lowercase().contains("supersession")` allows minor wording drift without breaking the test.

**Assertion shape:**

```rust
#[test]
fn code_review_has_supersession_check() {
    let c = common::read_skill("flow-code-review");
    let lower = c.to_lowercase();
    assert!(
        lower.contains("supersession"),
        "flow-code-review/SKILL.md Step 3 Triage must include a supersession check \
         per .claude/rules/supersession.md (Code Review Phase section)"
    );
}
```

### Task 4 — Add tombstone tests for removed mid-phase `rm` blocks

**Files:** `tests/tombstones.rs`

**Location:** After the existing `test_no_has_redirect_function` tombstone at line 233-245 — keep the source-content tombstone group contiguous.

**TDD notes:** Two tests, both following the `tests/tombstones.rs` source-content assertion pattern. Each test reads the target file via `fs::read_to_string` and asserts the string `"rm <temp_test_file>"` is absent. **Precision:** the assertion targets `rm <temp_test_file>` (the bash command form), NOT `<temp_test_file>` alone — the placeholder is still load-bearing in SKILL.md Step 1 (definition) and adversarial.md (Write target), and the peer contract test `code_review_adversarial_uses_temp_test_file_placeholder` at `tests/skill_contracts.rs:2933` asserts the placeholder appears. Targeting the `rm`-prefixed form preserves that peer test.

Both tests must fail before Tasks 6 and 7 (the deletions), and pass after.

**Test 1:**

```rust
/// Tombstone: mid-phase `rm <temp_test_file>` in flow-code-review SKILL.md
/// removed in PR #1040. Must not return.
#[test]
fn test_code_review_no_mid_phase_adversarial_rm() {
    let path = common::repo_root()
        .join("skills")
        .join("flow-code-review")
        .join("SKILL.md");
    let content = fs::read_to_string(&path).expect("flow-code-review SKILL.md must exist");
    assert!(
        !content.contains("rm <temp_test_file>"),
        "Mid-phase `rm <temp_test_file>` block was deleted in PR #1040 and must not return. \
         Phase 6 cleanup (src/cleanup.rs::try_delete_adversarial_test_files) is the \
         authoritative cleanup — mid-phase rm targets an extensionless path that never \
         exists and silently no-ops."
    );
}
```

**Test 2:**

```rust
/// Tombstone: mid-phase `rm <temp_test_file>` in adversarial.md Round 2
/// removed in PR #1040. Must not return.
#[test]
fn test_adversarial_agent_no_mid_phase_rm() {
    let path = common::repo_root()
        .join("agents")
        .join("adversarial.md");
    let content = fs::read_to_string(&path).expect("agents/adversarial.md must exist");
    assert!(
        !content.contains("rm <temp_test_file>"),
        "Mid-phase `rm <temp_test_file>` block in Round 2 was deleted in PR #1040 and must \
         not return. Phase 6 cleanup (src/cleanup.rs::try_delete_adversarial_test_files) is \
         the authoritative cleanup — the agent's mid-phase rm targets an extensionless path \
         that never exists and silently no-ops."
    );
}
```

### Task 5 — Add Supersession check sub-section to SKILL.md Step 3

**Files:** `skills/flow-code-review/SKILL.md`

**Location:** Between the Step 3 introductory sentence ("Triage findings from each agent in order: reviewer, pre-mortem, adversarial, documentation. For each finding, classify it:") and the existing `**Real + in-scope**` paragraph — around line 336. Insert as a new `### Supersession check` sub-section.

**Content (apply verbatim):**

```markdown
### Supersession check

The supersession test catches code that the current PR makes permanently
redundant — code that would leave the PR's behavior unchanged if deleted.
Running it before the diff-boundary test lets the triage route such code
to Step 4 for deletion regardless of file location. Without this check,
dead-on-merge code slips through as "out-of-scope" and becomes tech debt
that every future reader must re-classify.

Before applying the diff-boundary test, run the supersession test from
`.claude/rules/supersession.md`. For every finding classified as real,
ask: **"Would deleting the code this finding describes leave the PR's
behavior unchanged?"**

If yes, the finding is in-scope for deletion regardless of which file
the code lives in — route it to Step 4 for deletion. Do not file an
issue. Do not apply the diff-boundary test.

If no, proceed with the diff-boundary test below.

The supersession test overrides the diff-boundary test. A file that is
not in the PR diff can still be in-scope if its contents are dead code
the PR created.
```

**Design notes:**

- The 3-sentence preamble satisfies `.claude/rules/skill-authoring.md` Purpose Preamble for Behavioral Sections.
- The routing language mirrors `.claude/rules/supersession.md` Code Review Phase section verbatim in intent.
- The explicit "overrides" statement prevents the reader from accidentally applying both tests in sequence.

### Task 6 — Delete dead `rm <temp_test_file>` block in SKILL.md Step 2

**Files:** `skills/flow-code-review/SKILL.md`

**Location:** Lines 313-318 — the `If the adversarial agent was launched, verify the temp test file was deleted. If it still exists, delete it:` paragraph and the following bash block containing `rm <temp_test_file>`.

**Replacement:** One sentence pointing to Phase 6 cleanup:

```markdown
The Phase 6 complete/abort cleanup (`src/cleanup.rs::try_delete_adversarial_test_files`) deletes the adversarial test file by prefix match, so no mid-phase cleanup is needed here.
```

**Rationale:** The Phase 6 cleanup is authoritative — it runs a prefix glob over `{branch}-adversarial_test.*` and handles whatever extension the agent chose. The mid-phase `rm` targeted the extensionless placeholder and silently no-oped. The replacement sentence tells a future reader where the real cleanup happens so the absence of mid-phase `rm` is explained.

### Task 7 — Delete dead `**Clean up.**` block in adversarial.md Round 2

**Files:** `agents/adversarial.md`

**Location:** Lines 83-87 — the `**Clean up.** Delete the temp test file before returning:` paragraph and the following bash block containing `rm <temp_test_file>`.

**Replacement:** None. The Round 2 flow transitions directly from "Overwrite the temp file and re-run. Maximum 3 rounds total." (line 81) to the `## Output Format` heading. The agent's Workflow section ends without a cleanup step; Phase 6 cleanup is authoritative.

### Task 8 — Narrow adversarial.md Rules Bash allow-list

**Files:** `agents/adversarial.md`

**Location:** Line 135.

**Current:**

```text
- Only use Bash for `<test_command>`, `rm`, `git log`, `git show`, and `git diff`
```

**New:**

```text
- Only use Bash for `<test_command>`, `git log`, `git show`, and `git diff`
```

**Targeted Edit** — no `replace_all`. The `rm` entry was the only permitted-but-unused Bash command after Tasks 6 and 7 remove all `rm` consumers from the agent workflow.

### Task 9 — Delete `Always delete the temp test file before returning` Rules line

**Files:** `agents/adversarial.md`

**Location:** Line 142 — the single bullet `- Always delete the temp test file before returning`.

**Replacement:** None. Delete the bullet outright. The surrounding Rules entries stay unchanged.

**Targeted Edit** — no `replace_all`.

### Task 10 — Sync docs with Step 3 addition

**Files:**

- `docs/skills/flow-code-review.md` (lines 48-53, the Step 3 — Triage section)
- `docs/phases/phase-4-code-review.md` (lines 58-64, the Step 3 — Triage section)

**TDD notes:** Both docs describe Step 3 Triage in outcome-category terms without mentioning the diff-boundary test. Add a single sentence to each file noting that the supersession test runs before the diff-boundary test. Keep the existing outcome-category prose unchanged.

**Proposed sentence to add to `docs/skills/flow-code-review.md` Step 3:**

Append to the existing Step 3 paragraph (after "Shows triage summary table."):

```text
For each real finding, the supersession test from `.claude/rules/supersession.md` runs before the diff-boundary test — code the PR has made permanently redundant is in-scope for deletion regardless of file location.
```

**Proposed sentence to add to `docs/phases/phase-4-code-review.md` Step 3:**

Append to the existing classification list (after "False positive — discard with rationale"):

```text
The supersession test from `.claude/rules/supersession.md` runs before the in-scope/out-of-scope decision — code the PR has made permanently redundant is routed to in-scope deletion regardless of file location.
```

### Task 11 — Run `bin/flow ci` to confirm green

**Command:** `${CLAUDE_PLUGIN_ROOT}/bin/flow ci`

**Must be green before commit.** All tombstone tests, the new contract test, and all existing tests must pass. If CI fails:

- Tombstone precision issue → narrow the tombstone match string per Risk 3
- Contract test ordering issue → verify Task 5 landed before Task 3 runs (both in same commit, so this is about commit contents not commit order)
- Docs sync issue → verify Task 10 edits are in the staged tree

### Task 12 — Delete 7 orphan `.flow-states/*-adversarial_test.*` files

**Files (all under `.flow-states/` at project root, gitignored, outside worktree):**

- `.flow-states/add---label-and---milestone-adversarial_test.rs`
- `.flow-states/add-findings-ledger-to-complete-adversarial_test.rs`
- `.flow-states/missing-use-case-tests-state-adversarial_test.rs`
- `.flow-states/tech-debt-extract-duplicated-adversarial_test.rs`
- `.flow-states/more-backward-facing-comments-adversarial_test.rs`
- `.flow-states/marketing-site-maintenance-adversarial_test.rs`
- `.flow-states/flow-code-review-adversarial-adversarial_test.rs`

**Command:** Single `rm` via Bash tool listing all 7 absolute paths.

**Rationale:** Filesystem-only, no diff impact. Runs AFTER the commit lands so the PR body doesn't mention filesystem state that isn't in the diff.

**Scope expansion justification:** Per `.claude/rules/scope-expansion.md`, all three conditions hold: (a) inert (filesystem-only deletions), (b) `try_delete_adversarial_test_files` is the forward-looking guard, (c) splitting would force a future session to re-do the sweep. Expand.

### Task 13 — Atomic commit of tasks 3-10 via `/flow:flow-commit`

**Command:** Invoke `/flow:flow-commit` after Task 11 CI is green.

**Commit scope:** All changes from tasks 3, 4, 5, 6, 7, 8, 9, 10 in a single commit. Task 11 is CI (pre-commit gate). Task 12 (orphan sweep) runs AFTER the commit.

**Atomicity rationale:** Tasks 3 and 4 (tests) reference code that tasks 5, 6, 7 produce/delete. Committing tests without their referenced code breaks CI in the intermediate commit.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Dogfood the supersession rule on issue #1037

```xml
<dag goal="Dogfood the supersession rule on issue #1037 — 5 work items" mode="full">
  <plan>
    <node id="1" name="Read existing structure" type="research" depends="[]" parallel_with="[]">
      <objective>Read skills/flow-code-review/SKILL.md (Step 2 and Step 3), agents/adversarial.md (Round 2 and Rules), tests/skill_contracts.rs, .claude/rules/supersession.md to ground all planning decisions in actual file state.</objective>
    </node>
    <node id="2" name="Verify dead-code claims" type="validation" depends="[1]" parallel_with="3">
      <objective>Confirm the Phase 6 src/cleanup.rs::try_delete_adversarial_test_files step is authoritative and makes the mid-phase rm blocks unreachable-in-effect. Confirm the orphan file .flow-states/flow-code-review-adversarial-adversarial_test.rs still exists on disk.</objective>
    </node>
    <node id="3" name="Design supersession check prose" type="creative" depends="[1]" parallel_with="2">
      <objective>Draft the "### Supersession check" sub-section for SKILL.md Step 3 that runs before the diff-boundary test. Mirror the rule's Code Review Phase language verbatim so the skill and rule agree.</objective>
    </node>
    <node id="4" name="Design contract test" type="design" depends="[1]" parallel_with="[]">
      <objective>Define test_code_review_has_supersession_check: reads skill content via common::read_skill, asserts case-insensitive "supersession" is present. Pattern-match existing tests in tests/skill_contracts.rs.</objective>
    </node>
    <node id="5" name="Agent allow list narrowing" type="analysis" depends="[1]" parallel_with="[]">
      <objective>Identify the specific Bash allow-list line in agents/adversarial.md that grants rm. Determine whether removing it leaves any legitimate rm consumer inside the agent.</objective>
    </node>
    <node id="6" name="Dependency ordering" type="analysis" depends="[2,3,4,5]" parallel_with="[]">
      <objective>Sequence the 5 work items with TDD discipline (test before implementation) and supersession atomicity (deletions and their superseder land together). Produce the task table + DAG.</objective>
    </node>
    <node id="7" name="Risk audit" type="validation" depends="[6]" parallel_with="[]">
      <objective>Enumerate risks: contract test atomicity with supersession-check addition, tombstone gap for removed rm lines, scope of Rules-section edit in agents/adversarial.md, CLAUDE.md and docs/skills/flow-code-review.md drift from Step 3 restructuring.</objective>
    </node>
    <node id="8" name="Synthesis" type="synthesis" depends="[6,7]" parallel_with="[]">
      <objective>Produce the final plan: Context, Exploration, Risks, Approach, Dependency Graph, Tasks. Ready for Plan phase to write to .flow-states/&lt;branch&gt;-plan.md.</objective>
    </node>
  </plan>
</dag>
```

**Validation:**
- No cycles ✓
- All deps exist ✓
- Nodes 2/3 parallel (both depend only on 1) ✓
- Node 8 terminal synthesis ✓
- 8 nodes — standard size for 5 concrete work items ✓

---

## PHASE 1: EXECUTE

▶ **NODE 1: Read existing structure** (depends on: [])

Read `skills/flow-code-review/SKILL.md` in full. Key findings:

- Step 2 (Launch agents) lines 313-318: `If the adversarial agent was launched, verify the temp test file was deleted. If it still exists, delete it:` followed by `rm <temp_test_file>` bash block.
- Step 3 (Triage) lines 332-362: structures real/out-of-scope/false-positive classification with the diff-boundary test inline at lines 337-341 (`**Real + in-scope** — ... Apply the diff-boundary test: if the finding is in a file that appears in git diff origin/main...HEAD, it is in-scope — fix it.`).
- Step 1 defines `<temp_test_file>` = `.flow-states/<branch>-adversarial_test` (without extension) at lines 183-186.

Read `.claude/rules/supersession.md`. The Code Review Phase section says: "When triaging findings from agents, apply the supersession test BEFORE the diff-boundary test. For every real finding, ask: 'Would deleting the code this finding describes leave the PR's behavior unchanged?' If yes → the finding is in-scope for deletion regardless of which file the code lives in."

Read `.claude/rules/code-review-scope.md`. Already references supersession: "Before applying the diff-boundary test, run the supersession test from `.claude/rules/supersession.md`. If a finding describes code the PR has made redundant, it is in-scope for deletion regardless of file location and the diff-boundary test does not apply." So the rule layer is wired — the skill layer just needs to surface it inline.

Quality: 9/10 — SKILL.md fully read, rule alignment confirmed.

Key finding: The skill's Step 3 currently has the diff-boundary test as the ONLY routing logic for real findings. Rule layer already references supersession, but the Step 3 prose doesn't mention it. A future session reading only the skill would never know to apply the supersession test.

---

▶ **PARALLEL BRANCH A — NODE 2: Verify dead-code claims**

Read `agents/adversarial.md` in full. Key findings:

- Lines 83-87: `**Clean up.** Delete the temp test file before returning:` followed by `rm <temp_test_file>` bash block. Dead code — the placeholder resolves to `.flow-states/<branch>-adversarial_test` (no extension), but the agent wrote `.flow-states/<branch>-adversarial_test.<ext>`. The `rm` silently no-ops.
- Line 135: `- Only use Bash for <test_command>, rm, git log, git show, and git diff` — the Rules section still grants `rm` permission.
- Line 142: `- Always delete the temp test file before returning` — the Rules section enforces the dead behavior.

Read `src/cleanup.rs` lines 115-199 (the `try_delete_adversarial_test_files` function). Confirmed:

- Runs unconditionally during Phase 6 cleanup (Complete and Abort paths)
- Uses a prefix glob `{branch}-adversarial_test.` — matches whatever extension the agent chose
- Handles partial failures, non-file entries, and missing directories
- The function doc comment describes it as the authoritative cleanup path

Verify orphan file existence. The cited orphan `.flow-states/flow-code-review-adversarial-adversarial_test.rs` exists in the main repo's `.flow-states/` directory (not the worktree — `.flow-states/` is a shared path outside worktrees). A full glob scan of `.flow-states/*adversarial_test*` reveals **7 orphan files**, not just 1:

- `.flow-states/add---label-and---milestone-adversarial_test.rs`
- `.flow-states/add-findings-ledger-to-complete-adversarial_test.rs`
- `.flow-states/missing-use-case-tests-state-adversarial_test.rs`
- `.flow-states/tech-debt-extract-duplicated-adversarial_test.rs`
- `.flow-states/more-backward-facing-comments-adversarial_test.rs`
- `.flow-states/marketing-site-maintenance-adversarial_test.rs`
- `.flow-states/flow-code-review-adversarial-adversarial_test.rs` (the one cited)

All 7 are gitignored (verified via `git check-ignore`), so they won't appear in the PR diff. This is a scope-expansion decision point: issue cites 1, sweep finds 7.

Quality: 9/10 — dead-code claim confirmed by reading authoritative cleanup source. Orphan scope expanded from 1 to 7.

Key finding: The mid-phase `rm <temp_test_file>` blocks in BOTH SKILL.md Step 2 and adversarial.md Round 2 are made permanently unreachable-in-effect by `src/cleanup.rs::try_delete_adversarial_test_files`. This is exactly the "authoritative replacement" supersession shape.

---

▶ **PARALLEL BRANCH B — NODE 3: Design supersession check prose**

Proposed prose for SKILL.md Step 3 (new `### Supersession check` sub-section inserted BEFORE the existing real/in-scope triage logic):

```markdown
### Supersession check

The supersession test catches code that the current PR makes permanently
redundant — code that would leave the PR's behavior unchanged if deleted.
Running it before the diff-boundary test lets the triage route such code
to Step 4 for deletion regardless of file location. Without this check,
dead-on-merge code slips through as "out-of-scope" and becomes tech debt
that every future reader must re-classify.

Before applying the diff-boundary test, run the supersession test from
`.claude/rules/supersession.md`. For every finding classified as real,
ask: **"Would deleting the code this finding describes leave the PR's
behavior unchanged?"**

If yes, the finding is in-scope for deletion regardless of which file
the code lives in — route it to Step 4 for deletion. Do not file an
issue. Do not apply the diff-boundary test.

If no, proceed with the diff-boundary test below.

The supersession test overrides the diff-boundary test. A file that is
not in the PR diff can still be in-scope if its contents are dead code
the PR created.
```

Design choices:

- **Purpose preamble** per `.claude/rules/skill-authoring.md` Purpose Preamble for Behavioral Sections: 3 sentences explaining why the check exists, what problem it solves, and what fails without it.
- **Mirror rule language** so a future session comparing the skill against `.claude/rules/supersession.md` finds consistent prose.
- **Explicit override statement** so the reader cannot accidentally apply both tests in sequence.

Quality: 9/10 — aligned with rule, carries preamble, uses imperative voice.

---

▶ **NODE 4: Design contract test**

Read `tests/skill_contracts.rs` for the `code_review_*` naming pattern. Confirmed pattern at lines 2883, 2892, 2906, 2915 — all use `common::read_skill("flow-code-review")` + `assert!(c.contains(...))` shape.

Proposed contract test:

```rust
#[test]
fn code_review_has_supersession_check() {
    let c = common::read_skill("flow-code-review");
    let lower = c.to_lowercase();
    assert!(
        lower.contains("supersession"),
        "flow-code-review/SKILL.md Step 3 Triage must include a supersession check \
         per .claude/rules/supersession.md (Code Review Phase section)"
    );
}
```

Location: after `code_review_step_3_has_triage` at line 2883, keeping the code_review_step_3_* group together.

Quality: 9/10 — matches existing pattern, case-insensitive match so minor wording drift doesn't break the test, diagnostic message cites the rule.

---

▶ **NODE 5: Agent allow list narrowing**

The adversarial.md Rules line currently reads:

```text
- Only use Bash for <test_command>, rm, git log, git show, and git diff
```

After removing `rm`, the agent has no legitimate remaining `rm` consumer — the Phase 6 `try_delete_adversarial_test_files` runs in Rust, not the agent's Bash. The narrowed line:

```text
- Only use Bash for <test_command>, git log, git show, and git diff
```

Also delete line 142 (`- Always delete the temp test file before returning`) and the entire `**Clean up.**` paragraph + bash block at lines 83-87.

Verification: no other part of adversarial.md invokes `rm` via bash. Only the `## Clean up` section uses it, and that section is being deleted.

Quality: 9/10 — targeted edit, no side effects on other rules.

---

▶ **NODE 6: Dependency ordering**

Atomicity constraint analysis:

- **Contract test atomicity (TDD tension).** The new `code_review_has_supersession_check` test is a positive-existence test that would FAIL without the Step 3 addition. Per `.claude/rules/skill-authoring.md` Contract Test Atomicity in Plan Dependencies rule, **the test task and the SKILL.md Step 3 edit must land in the same commit**.
- **Tombstone atomicity for removed `rm` blocks.** Two deletion sites contain a named behavioral pattern (mid-phase adversarial test `rm`). Tombstone tests assert the `rm <temp_test_file>` pattern is absent — they FAIL before the deletion. They must land in the same commit as the deletions.
- **Orphan deletion independence.** The 7 orphan files are gitignored and live in `.flow-states/`. Deleting them is a filesystem-only action, not a PR artifact. Can happen out of commit.

Task sequencing (TDD + supersession atomicity):

1. Verify Phase 6 cleanup runs unconditionally (validation, no deps)
2. Check docs for Step 3 Triage drift (validation, no deps)
3. Write `code_review_has_supersession_check` contract test (test, depends on 1)
4. Write tombstone tests for removed `rm` blocks (test, depends on 1)
5. Add Supersession check sub-section to SKILL.md Step 3 (impl, depends on 3)
6. Delete dead `rm` block in SKILL.md Step 2 (impl, depends on 4)
7. Delete `## Clean up` block in adversarial.md (impl, depends on 4)
8. Narrow adversarial.md Rules Bash allow-list (impl, depends on 4)
9. Delete `Always delete the temp test file` Rules line (impl, depends on 4)
10. Sync docs if drift found (docs, depends on 2, 5)
11. Run `bin/flow ci` (validation, depends on 3-10)
12. Delete 7 orphan `.flow-states` files (cleanup, depends on 11)
13. Atomic commit of tasks 3-10 (commit, depends on 11)

Quality: 9/10.

---

▶ **NODE 7: Risk audit**

1. **Contract test atomicity.** Task 3 asserts "supersession" appears in SKILL.md. Committing the test before Task 5 breaks CI in the intermediate state. Group them in Task 13 (single commit).
2. **Tombstone atomicity.** Tasks 4, 6, 7 must also land together. The tombstone assertion and the deletion must be in the same commit or CI fails either before or after.
3. **Tombstone precision on `<temp_test_file>` placeholder.** The placeholder `<temp_test_file>` itself is still load-bearing in SKILL.md Step 1 (definition) and in adversarial.md (Write target). A contract test at line 2933 (`code_review_adversarial_uses_temp_test_file_placeholder`) already asserts the placeholder appears. The new tombstone must assert `rm <temp_test_file>` (the bash `rm` command with the placeholder) is absent — NOT the placeholder alone — or it will break the peer contract test.
4. **Rules-section scope in adversarial.md.** Narrowing the Bash allow list and removing line 142 must use targeted Edit (not replace_all) to avoid touching unrelated rules. The edit must be line-level precise.
5. **Purpose preamble required.** Per `.claude/rules/skill-authoring.md` Purpose Preamble for Behavioral Sections, the new `### Supersession check` sub-section must open with 2-3 sentences explaining why the step exists. Node 3's draft includes a 3-sentence preamble. Verify it survives Code Review.
6. **Docs drift in `docs/skills/flow-code-review.md` and `docs/phases/phase-4-code-review.md`.** Per `.claude/rules/docs-with-behavior.md`, changed skill steps require doc updates in the same commit. **Must verify** these two files describe Step 3 Triage and, if so, update them to reflect the supersession check. Task 2 is the verification; Task 10 is the sync (conditional).
7. **Orphan scope expansion from 1 to 7 files.** Per `.claude/rules/scope-expansion.md`, expand when all three conditions hold: (a) inert — yes (filesystem-only); (b) single guard covers the class forward — yes (`try_delete_adversarial_test_files`); (c) splitting re-does work — marginal (`rm` is cheap). Conditions (a) and (b) strongly hold; expand.
8. **Pre-existing rule reference to issue #1037 must stay.** The `.claude/rules/skill-authoring.md` Placeholder Resolution Must Match Runtime Paths section cites issue #1037 as the motivating example. This reference is forward-facing — it explains WHY the rule exists — and must NOT be deleted.
9. **Must verify Phase 6 cleanup runs on both Complete and Abort paths.** Task 1 explicitly verifies the invariant by reading `src/cleanup.rs` call sites in `flow-complete` and `flow-abort` skills.
10. **`.claude/rules/code-review-scope.md` already references supersession.** The rule file's "How to Apply" section already says "Before applying the diff-boundary test, run the supersession test from `.claude/rules/supersession.md`." This is evidence the design is already agreed-upon at the rule layer; only the skill layer needs the surface.

Quality: 9/10.

---

▶ **NODE 8: Synthesis**

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

## Context

Main branch commit `b34f923a` added `.claude/rules/supersession.md`, a new rule that says: when a PR introduces code that makes other code elsewhere in the repo permanently redundant, the redundant code must be deleted in the same PR. The rule runs in two phases — Plan (enumerate superseded code) and Code Review (run a supersession test before the diff-boundary test).

Issue #1037 is the follow-up to dogfood that rule. PR #1036 added the Phase 6 `try_delete_adversarial_test_files` cleanup step in `src/cleanup.rs`, which made the mid-phase `rm <temp_test_file>` blocks in `skills/flow-code-review/SKILL.md` Step 2 and `agents/adversarial.md` Round 2 unreachable-in-effect. They are exactly the "authoritative replacement" shape the supersession rule catches and should have been deleted in #1036.

This PR:

1. Wires a Supersession check sub-section into the Code Review Step 3 Triage flow so future PRs catch this class of gap during Code Review.
2. Deletes the dead mid-phase `rm` blocks that PR #1036 superseded.
3. Updates the adversarial agent's Rules section to drop `rm` from the Bash allow list and remove the "Always delete the temp test file before returning" instruction.
4. Adds a contract test `code_review_has_supersession_check` that mechanically guards against silent removal of the supersession check.
5. Sweeps 7 orphan `.flow-states/*-adversarial_test.*` files left over from flows that ran before PR #1036 merged.

## Exploration

### Affected files

| File | Change type | Why |
|------|-------------|-----|
| `skills/flow-code-review/SKILL.md` | Add sub-section + delete dead rm block | Add `### Supersession check` before diff-boundary test in Step 3; delete lines 313-318 `rm <temp_test_file>` block in Step 2 |
| `agents/adversarial.md` | Delete lines + narrow Rules list | Delete `## Clean up` bash block at lines 83-87; remove `rm` from allow-list at line 135; remove line 142 "Always delete the temp test file before returning" |
| `tests/skill_contracts.rs` | Add contract test | New `code_review_has_supersession_check` alongside peers (e.g. `code_review_step_3_has_triage` at line 2883) |
| `tests/tombstones.rs` | Add tombstone tests | Assert neither SKILL.md nor adversarial.md contains the dead `rm <temp_test_file>` pattern |
| `.flow-states/*-adversarial_test.*` (7 files) | One-shot deletion | Orphans from pre-#1036 flows; already made dead by Phase 6 cleanup |
| `docs/skills/flow-code-review.md` | Verify + sync if drift | Step 3 Triage description may need to mention supersession check |
| `docs/phases/phase-4-code-review.md` | Verify + sync if drift | Same reason |

### Orphan file inventory (gitignored, not in PR diff)

- `.flow-states/add---label-and---milestone-adversarial_test.rs`
- `.flow-states/add-findings-ledger-to-complete-adversarial_test.rs`
- `.flow-states/missing-use-case-tests-state-adversarial_test.rs`
- `.flow-states/tech-debt-extract-duplicated-adversarial_test.rs`
- `.flow-states/more-backward-facing-comments-adversarial_test.rs`
- `.flow-states/marketing-site-maintenance-adversarial_test.rs`
- `.flow-states/flow-code-review-adversarial-adversarial_test.rs` (the one cited in the issue)

### Patterns discovered

- `src/cleanup.rs::try_delete_adversarial_test_files` is the authoritative cleanup (lines 141-199). It uses prefix glob + extension-agnostic deletion, handles partial failures, and runs at Phase 6 Complete/Abort unconditionally.
- `.claude/rules/code-review-scope.md` already references the supersession test ("Before applying the diff-boundary test, run the supersession test from `.claude/rules/supersession.md`"), so the rule layer is wired. The skill layer just needs to surface the check inline.
- `tests/skill_contracts.rs` contract-test naming pattern: `code_review_<assertion>` using `common::read_skill("flow-code-review")` + `assert!(c.contains(...))`.

## Risks

1. **Contract test atomicity.** The new `code_review_has_supersession_check` test asserts "supersession" appears in the skill. Committing the test before adding the supersession check breaks CI in the intermediate state. The test task and the SKILL.md Step 3 edit must land in the **same commit**.
2. **Tombstone atomicity.** The tombstone tests assert the `rm <temp_test_file>` pattern is absent from SKILL.md and adversarial.md. Committing the tests before the deletions breaks CI. The tombstone tasks and the deletion tasks must land in the **same commit**.
3. **Tombstone precision on `<temp_test_file>` placeholder.** The placeholder `<temp_test_file>` itself is still load-bearing in SKILL.md Step 1 (definition) and adversarial.md (Write target). The contract test `code_review_adversarial_uses_temp_test_file_placeholder` at `tests/skill_contracts.rs:2933` asserts the placeholder appears. The new tombstone must assert `rm <temp_test_file>` (the bash command) is absent — NOT the placeholder alone — or it breaks the peer test. **Must verify the tombstone pattern matches only the bash `rm` command, not the placeholder definition.**
4. **Rules-section edit scope in `agents/adversarial.md`.** Narrowing the Bash allow list and removing the "Always delete" Rules line must use targeted Edit operations (not replace_all). Each edit must be line-precise to avoid touching other Rules entries.
5. **Purpose preamble required for new sub-section.** Per `.claude/rules/skill-authoring.md` Purpose Preamble for Behavioral Sections, the new `### Supersession check` sub-section must open with 2-3 sentences explaining why the step exists. The draft in Node 3 includes a 3-sentence preamble; verify it survives Code Review.
6. **Docs drift in `docs/skills/flow-code-review.md` and `docs/phases/phase-4-code-review.md`.** Per `.claude/rules/docs-with-behavior.md`, changed skill steps require doc updates in the same commit. **Must verify** these two files describe Step 3 Triage and, if so, update them to reflect the supersession check. Task 2 is the verification; Task 10 is the sync.
7. **Orphan scope expansion from 1 to 7 files.** Per `.claude/rules/scope-expansion.md`, expand when all three conditions hold: (a) inert — yes (filesystem-only); (b) single guard covers the class forward — yes (`try_delete_adversarial_test_files`); (c) splitting re-does work — marginal (`rm` is cheap). Conditions (a) and (b) strongly hold; expand.
8. **Pre-existing `.claude/rules/skill-authoring.md` reference to issue #1037 is forward-facing.** The rule file references #1037 as a cautionary example (the "Placeholder Resolution Must Match Runtime Paths" section). This reference explains WHY the rule exists and must NOT be deleted.
9. **Must verify Phase 6 cleanup invariant.** The supersession claim assumes `try_delete_adversarial_test_files` runs for every flow. Task 1 verifies both `/flow:flow-complete` and `/flow:flow-abort` call it unconditionally so no flow leaks.

## Approach

Single atomic commit that:

- Adds the `### Supersession check` sub-section with purpose preamble to SKILL.md Step 3 (before the existing real/in-scope/out-of-scope logic)
- Deletes the dead `rm <temp_test_file>` block from SKILL.md Step 2 (lines 313-318) and replaces with a one-sentence pointer to Phase 6 cleanup
- Deletes the dead `## Clean up` bash block from adversarial.md (lines 83-87)
- Narrows adversarial.md Rules Bash allow-list by removing `rm`
- Removes the `Always delete the temp test file before returning` Rules line
- Adds `code_review_has_supersession_check` contract test
- Adds tombstone tests for the removed `rm <temp_test_file>` patterns in both files
- Updates `docs/skills/flow-code-review.md` and `docs/phases/phase-4-code-review.md` if they describe Step 3 Triage
- Deletes 7 orphan `.flow-states/*-adversarial_test.*` files (filesystem only — gitignored, not in commit)

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Verify `/flow:flow-complete` and `/flow:flow-abort` both call `try_delete_adversarial_test_files` unconditionally | validation | — |
| 2. Check `docs/skills/flow-code-review.md` and `docs/phases/phase-4-code-review.md` for Step 3 Triage descriptions | validation | — |
| 3. Write `code_review_has_supersession_check` contract test in `tests/skill_contracts.rs` | test | 1 |
| 4. Write tombstone tests asserting SKILL.md and adversarial.md do not contain the mid-phase `rm <temp_test_file>` pattern (in `tests/tombstones.rs`, reference PR #1040) | test | 1 |
| 5. Add `### Supersession check` sub-section with preamble to SKILL.md Step 3 (before real/in-scope triage) | implement | 3 |
| 6. Delete `rm <temp_test_file>` block (SKILL.md Step 2 lines 313-318); replace with one-sentence pointer to `src/cleanup.rs::try_delete_adversarial_test_files` | implement | 4 |
| 7. Delete `## Clean up` paragraph + bash block in adversarial.md (lines 83-87) | implement | 4 |
| 8. Narrow adversarial.md Rules Bash allow-list (remove `rm`) | implement | 4 |
| 9. Delete `Always delete the temp test file before returning` Rules line in adversarial.md | implement | 4 |
| 10. Sync `docs/skills/flow-code-review.md` and `docs/phases/phase-4-code-review.md` with the Step 3 addition (only if Task 2 found drift) | docs | 2, 5 |
| 11. Run `bin/flow ci` to confirm all tests green | validation | 3, 4, 5, 6, 7, 8, 9, 10 |
| 12. Delete 7 orphan `.flow-states/*-adversarial_test.*` files (filesystem only — gitignored, not in PR diff) | cleanup | 11 |
| 13. Atomic commit of tasks 3-10 via `/flow:flow-commit` | commit | 11 |

**Atomicity group:** Tasks 3, 4, 5, 6, 7, 8, 9, 10 must land in the **same commit** (Task 13). Task 3 asserts "supersession" appears in SKILL.md — would fail without Task 5. Task 4 asserts the `rm <temp_test_file>` pattern is absent — would fail without Tasks 6 and 7. Task 10 is the docs-with-behavior rule.

**Out of commit:** Task 12 is a filesystem-only cleanup of gitignored files — no diff impact, runs after commit succeeds.

## Tasks

1. **Verify Phase 6 cleanup invariant**
   - Files: `skills/flow-complete/SKILL.md`, `skills/flow-abort/SKILL.md`, `src/cleanup.rs`
   - TDD notes: Confirm both flow-complete and flow-abort invoke cleanup unconditionally so the Phase 6 authoritative replacement claim holds.

2. **Check docs for Step 3 Triage descriptions**
   - Files: `docs/skills/flow-code-review.md`, `docs/phases/phase-4-code-review.md`
   - TDD notes: Grep for "Triage" and "diff boundary" in both files. If Step 3 behavior is described, sync in Task 10.

3. **Add contract test `code_review_has_supersession_check`**
   - Files: `tests/skill_contracts.rs`
   - Location: After `code_review_step_3_has_triage` at line 2883
   - TDD notes: Asserts `common::read_skill("flow-code-review").to_lowercase().contains("supersession")`. Must fail before Task 5, pass after.

4. **Add tombstone tests for removed mid-phase `rm` blocks**
   - Files: `tests/tombstones.rs`
   - TDD notes: Two tests:
     - `code_review_no_mid_phase_adversarial_rm` — asserts SKILL.md does not contain `rm <temp_test_file>` (the bash command, not the placeholder definition). Comment: `// Tombstone: removed in PR #1040. Must not return.`
     - `adversarial_agent_no_mid_phase_rm` — asserts `agents/adversarial.md` does not contain `rm <temp_test_file>`. Same comment.
   - Tombstone format: follow `Tombstone:.*?PR #(\d+)` pattern from `.claude/rules/tombstone-tests.md`.
   - **Precision check:** assert on the full pattern `rm <temp_test_file>` (with leading `rm `), not on `<temp_test_file>` alone. The placeholder is still used in SKILL.md Step 1 and adversarial.md Write target.
   - Must fail before Tasks 6 and 7, pass after.

5. **Add Supersession check sub-section to SKILL.md Step 3**
   - Files: `skills/flow-code-review/SKILL.md`
   - Location: Between the Step 3 heading prose and the existing real/in-scope paragraph (before line 337 `**Real + in-scope**`)
   - Content: Purpose preamble (3 sentences explaining why) + the supersession test question + routing logic + note that it overrides diff-boundary test. Mirror `.claude/rules/supersession.md` Code Review Phase section.

6. **Delete dead `rm <temp_test_file>` block in SKILL.md Step 2**
   - Files: `skills/flow-code-review/SKILL.md`
   - Location: Lines 313-318 (the `If the adversarial agent was launched, verify...` paragraph + bash block)
   - Replacement: One-sentence note — "The Phase 6 complete/abort cleanup (`src/cleanup.rs::try_delete_adversarial_test_files`) deletes the adversarial test file by prefix match, so no mid-phase cleanup is needed here."

7. **Delete dead `## Clean up` block in adversarial.md Round 2**
   - Files: `agents/adversarial.md`
   - Location: Lines 83-87 (the `**Clean up.**` paragraph + bash block with `rm <temp_test_file>`)
   - Replacement: None. The Round 2 flow goes directly from "Overwrite the temp file and re-run" to the Output Format section. Phase 6 cleanup is authoritative.

8. **Narrow adversarial.md Rules Bash allow-list**
   - Files: `agents/adversarial.md`
   - Location: Line 135 `- Only use Bash for <test_command>, rm, git log, git show, and git diff`
   - New: `- Only use Bash for <test_command>, git log, git show, and git diff`
   - Targeted Edit — no replace_all.

9. **Delete `Always delete the temp test file before returning` Rules line**
   - Files: `agents/adversarial.md`
   - Location: Line 142
   - Targeted Edit — delete the single bullet.

10. **Sync docs if drift found**
    - Files: `docs/skills/flow-code-review.md`, `docs/phases/phase-4-code-review.md` (conditional on Task 2)
    - TDD notes: Update Step 3 Triage description to mention the supersession check.

11. **Run `bin/flow ci` to confirm green**
    - Command: `${CLAUDE_PLUGIN_ROOT}/bin/flow ci`
    - Must be green before commit.

12. **Delete 7 orphan `.flow-states/*-adversarial_test.*` files**
    - Files (via Bash `rm`):
      - `.flow-states/add---label-and---milestone-adversarial_test.rs`
      - `.flow-states/add-findings-ledger-to-complete-adversarial_test.rs`
      - `.flow-states/missing-use-case-tests-state-adversarial_test.rs`
      - `.flow-states/tech-debt-extract-duplicated-adversarial_test.rs`
      - `.flow-states/more-backward-facing-comments-adversarial_test.rs`
      - `.flow-states/marketing-site-maintenance-adversarial_test.rs`
      - `.flow-states/flow-code-review-adversarial-adversarial_test.rs`
    - Filesystem only — gitignored, no diff impact. Run after commit succeeds.

13. **Atomic commit of tasks 3-10 via `/flow:flow-commit`**
    - All tasks land in one commit to satisfy contract test atomicity and tombstone atomicity.

Confidence: 92% | Nodes: 8 | Parallel branches: 2 (Nodes 2 and 3)

**vs. Vanilla Claude (what linear reasoning would have missed):**

- **Tombstone atomicity** — linear reasoning would add the tombstone test AFTER the deletion, breaking CI in the intermediate state. The DAG surfaces the atomicity constraint before task ordering.
- **Scope expansion from 1 to 7 orphan files** — linear reasoning would follow the issue body verbatim and delete only the one cited file, leaving 6 orphans. The DAG surfaces the sweep as a decision point and applies the scope-expansion rule.
- **Purpose preamble requirement** — linear reasoning would write the supersession check section without the preamble, missing the `skill-authoring.md` rule. The DAG explicitly audits skill-authoring rules for new sub-sections.
- **Docs drift verification** — linear reasoning would only update the skill and miss `docs/skills/flow-code-review.md` and `docs/phases/phase-4-code-review.md`. The DAG lists them as conditional Task 10.
- **Tombstone precision** — linear reasoning would write a tombstone asserting `<temp_test_file>` is absent and break the unrelated `code_review_adversarial_uses_temp_test_file_placeholder` contract test. The DAG surfaces the precision requirement (`rm ` + placeholder, not placeholder alone).
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 11m |
| Code | 8m |
| Code Review | 13h 48m |
| Learn | 4m |
| Complete | 1m |
| **Total** | **14h 15m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/dogfood-supersession-rule-wire.json</summary>

```json
{
  "schema_version": 1,
  "branch": "dogfood-supersession-rule-wire",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1040,
  "pr_url": "https://github.com/benkruger/flow/pull/1040",
  "started_at": "2026-04-11T17:32:40-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/dogfood-supersession-rule-wire-plan.md",
    "dag": ".flow-states/dogfood-supersession-rule-wire-dag.md",
    "log": ".flow-states/dogfood-supersession-rule-wire.log",
    "state": ".flow-states/dogfood-supersession-rule-wire.json"
  },
  "session_tty": "/dev/ttys002",
  "session_id": "b969d4b0-125f-45cf-aac0-28c0c5056a1e",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/b969d4b0-125f-45cf-aac0-28c0c5056a1e.jsonl",
  "notes": [],
  "prompt": "work on issue #1037",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-11T17:32:40-07:00",
      "completed_at": "2026-04-11T17:33:08-07:00",
      "session_started_at": null,
      "cumulative_seconds": 28,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-11T17:33:18-07:00",
      "completed_at": "2026-04-11T17:45:14-07:00",
      "session_started_at": null,
      "cumulative_seconds": 716,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-11T17:46:20-07:00",
      "completed_at": "2026-04-11T17:55:00-07:00",
      "session_started_at": null,
      "cumulative_seconds": 520,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-11T17:55:12-07:00",
      "completed_at": "2026-04-12T07:43:17-07:00",
      "session_started_at": null,
      "cumulative_seconds": 49685,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-12T07:43:31-07:00",
      "completed_at": "2026-04-12T07:48:14-07:00",
      "session_started_at": null,
      "cumulative_seconds": 283,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-12T07:48:46-07:00",
      "completed_at": "2026-04-12T07:50:33-07:00",
      "session_started_at": null,
      "cumulative_seconds": 107,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-11T17:33:18-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-11T17:46:20-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-11T17:55:12-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-12T07:43:31-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-12T07:48:46-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 8,
  "code_task_name": "Sync docs with Step 3 supersession addition",
  "code_task": 8,
  "diff_stats": {
    "files_changed": 6,
    "insertions": 78,
    "deletions": 15,
    "captured_at": "2026-04-11T17:55:00-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "findings": [
    {
      "finding": "Pre-mortem: SKILL.md Step 2 inline reference to try_delete_adversarial_test_files will drift on rename",
      "reason": "Forward-facing per comment-quality.md — describes current mechanism, not historical state. Speculative future drift is not a current defect.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T07:33:02-07:00"
    },
    {
      "finding": "Adversarial: SKILL.md supersession section lacks shape names from the rule",
      "reason": "By design — the skill references the rule file by path for shape definitions. Duplicating names creates two maintenance locations. The skill is a routing instruction, the rule is the reference.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T07:33:23-07:00"
    },
    {
      "finding": "Plan skill + Plan docs missing supersession wire-up",
      "reason": "Supersession rule documents a two-phase story. PR #1040 wires Code Review only. Plan skill has no supersession references. Gap predates this PR.",
      "outcome": "filed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T07:35:27-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1041"
    },
    {
      "finding": "Tombstone doc comments split Tombstone: from PR #1040 across two lines — invisible to tombstone-audit regex",
      "reason": "Rust regex crate . does not match newlines. Both tombstone headers had Tombstone: on line 1 and PR #1040 on line 2. Collapsed to single lines matching existing convention.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T07:37:13-07:00"
    },
    {
      "finding": "Supersession check missing tiebreaker for uncertain cases",
      "reason": "skill-authoring.md Safe Defaults for Subjective Classification requires explicit tiebreaker. Added: if uncertain treat as no, proceed with diff-boundary test.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T07:37:37-07:00"
    },
    {
      "finding": "Learn-analyst: Tombstone deletion bypassed formal audit workflow",
      "reason": "False premise — tombstone-audit WAS run in Code Review Step 1 and returned PR #1035 as stale. Step 4 mechanically removed per the skill instructions. The learn-analyst inferred manual deletion from the diff alone without visibility into the audit run.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-12T07:46:52-07:00"
    }
  ],
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "Wire supersession enumeration into Plan phase skill and docs",
      "url": "https://github.com/benkruger/flow/issues/1041",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T07:35:11-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/dogfood-supersession-rule-wire.log</summary>

```text
2026-04-11T17:32:40-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-11T17:32:40-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-11T17:32:40-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-11T17:32:40-07:00 [Phase 1] create .flow-states/dogfood-supersession-rule-wire.json (exit 0)
2026-04-11T17:32:40-07:00 [Phase 1] freeze .flow-states/dogfood-supersession-rule-wire-phases.json (exit 0)
2026-04-11T17:32:40-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-11T17:32:42-07:00 [Phase 1] start-init — label-issues (labeled: [1037], failed: [])
2026-04-11T17:32:48-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-11T17:32:48-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-11T17:32:49-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-11T17:32:56-07:00 [Phase 1] start-workspace — worktree .worktrees/dogfood-supersession-rule-wire (ok)
2026-04-11T17:33:00-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-11T17:33:00-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-11T17:33:00-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-11T17:33:08-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-11T17:33:08-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-11T17:37:45-07:00 [stop-continue] first stop, conditional continue: pending=decompose
2026-04-11T17:45:14-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-11T17:46:20-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-11T17:46:35-07:00 [Phase 3] Step 0 — phase-enter (exit 0)
2026-04-11T17:54:34-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-11T17:54:38-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-11T17:55:00-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-11T17:55:12-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-12T07:42:35-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-12T07:42:38-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-12T07:43:17-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-12T07:43:31-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-12T07:48:14-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-12T07:50:33-07:00 [Phase 6] complete-finalize — starting
2026-04-12T07:50:33-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-12T07:50:33-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | Wire supersession enumeration into Plan phase skill and docs | Code Review | #1041 |

<!-- end:Issues Filed -->