### PR TITLE
Flaky Thunderingherdzerodelay

### DIFF
--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -391,7 +391,7 @@ fn thundering_herd_zero_delay() {
         let remaining = join_deadline.saturating_duration_since(Instant::now());
         assert!(
             !remaining.is_zero(),
-            "Thundering herd test exceeded 30s deadline"
+            "Thundering herd test exceeded 90s deadline"
         );
         handle.join().expect("Worker thread panicked");
     }

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -214,7 +214,7 @@ fn start_lock_serialization() {
                         "--acquire",
                         "--wait",
                         "--timeout",
-                        "30",
+                        "90",
                         "--interval",
                         "1",
                         "--feature",
@@ -298,9 +298,10 @@ fn start_lock_serialization() {
 #[test]
 fn thundering_herd_zero_delay() {
     // 3 threads start simultaneously (barrier). All acquire lock, no overlaps.
-    // Uses 3 workers (not 5) with 100ms hold time (not 300ms) to keep wall time
-    // under 5 seconds. The lock polling interval is 1 second (integer-only),
-    // so fewer workers and shorter holds reduce total wait time.
+    // Uses 3 workers with 100ms hold time to keep wall time under 5 seconds
+    // normally. The 90-second timeout and join deadline provide generous
+    // headroom for CI environments under heavy parallel test load, where
+    // thread scheduling delays can stretch sleep durations significantly.
     let tmp = tempfile::tempdir().expect("Failed to create tempdir");
     let repo = tmp.path().to_path_buf();
     init_git_repo(&repo);
@@ -327,7 +328,7 @@ fn thundering_herd_zero_delay() {
                         "--acquire",
                         "--wait",
                         "--timeout",
-                        "30",
+                        "90",
                         "--interval",
                         "1",
                         "--feature",
@@ -384,8 +385,8 @@ fn thundering_herd_zero_delay() {
         })
         .collect();
 
-    // Join with a reasonable timeout check
-    let join_deadline = Instant::now() + Duration::from_secs(30);
+    // Join with a generous deadline to tolerate CI load spikes
+    let join_deadline = Instant::now() + Duration::from_secs(90);
     for handle in handles {
         let remaining = join_deadline.saturating_duration_since(Instant::now());
         assert!(


### PR DESCRIPTION
## What

fix flaky thundering herd zero delay test #1014.

Closes #1014

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/flaky-thunderingherdzerodelay-plan.md` |
| Log | `.flow-states/flaky-thunderingherdzerodelay.log` |
| State | `.flow-states/flaky-thunderingherdzerodelay.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: Fix Flaky thundering_herd_zero_delay Test

## Context

Issue #1014 reports that `tests/concurrency.rs::thundering_herd_zero_delay` intermittently fails with workers receiving `"timeout"` instead of `"acquired"` when racing to acquire a lock. The failure was observed during Phase 6: Complete of PR #1006 — passed on retry with no code changes (1 of 2 attempts failed).

## Exploration

| File | Role |
|------|------|
| `tests/concurrency.rs:298-417` | The flaky test — 3 workers racing for a lock with 100ms hold, 1s poll, 30s timeout, 30s join deadline |
| `tests/concurrency.rs:188-296` | `start_lock_serialization` — similar pattern with 300ms hold, 30s timeout, same 30s join deadline |
| `src/commands/start_lock.rs:148-188` | `acquire_with_wait` — the retry loop that uses `Instant::now()` + timeout comparison with `thread::sleep` intervals |

**Root cause:** The 30-second timeout in `--timeout 30` is too tight for a test running under heavy parallel load. The lock mechanism uses `thread::sleep(Duration::from_secs(1))` for polling. Under heavy CPU contention from concurrent cargo tests:

- The 100ms lock-hold sleep can stretch to seconds
- The 1-second poll sleep can stretch to seconds
- Each retry iteration (sleep + acquire attempt) compounds these delays
- After ~10-15 bloated iterations, the 30-second wall-clock timeout expires before all 3 workers have cycled through

The happy path completes in ~3 seconds. The timeout is purely a safety valve — increasing it has zero effect on normal execution time.

The join deadline (also 30 seconds) has the same vulnerability: it's checked before each `handle.join()`, and if earlier joins consumed most of the budget, the remaining check fails even though the workers would complete shortly.

## Risks

- **False pass risk:** increasing timeouts could mask a real deadlock. Mitigated: the test still asserts no-overlap timing invariants, and the join deadline provides an upper bound. A real deadlock would hit the extended timeout and fail.
- **Test wall time:** extending from 30s to 90s timeout does NOT change typical execution time (~3s). The timeout only fires on failure paths.

## Approach

Increase the timeout from 30s to 90s in both tests (`thundering_herd_zero_delay` and `start_lock_serialization`). Also increase the join deadline from 30s to 90s to match. This gives 3x headroom for scheduling jitter under load while keeping the same functional assertions.

Both tests use the same pattern, so fixing only one would leave the other vulnerable to the same flake.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Increase timeouts in both tests | implement | — |

## Tasks

### Task 1: Increase lock acquisition timeout and join deadline

**Files to modify:** `tests/concurrency.rs`

In `thundering_herd_zero_delay` (line 298):
- Change `--timeout 30` to `--timeout 90` (line 329)
- Change `Duration::from_secs(30)` join deadline to `Duration::from_secs(90)` (line 388)
- Update the test comment to note the generous timeout rationale

In `start_lock_serialization` (line 188):
- Change `--timeout 30` to `--timeout 90` (line 218)
- No join deadline to update (this test uses plain `handle.join()` without a deadline)

**TDD notes:** Run `bin/flow test -- thundering_herd` and `bin/flow test -- start_lock_serialization` to verify both pass. The change is a timeout increase, so the test itself is the validation — it should pass consistently.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 1m |
| Plan | 2m |
| Code | 5m |
| Code Review | 9m |
| Learn | 2m |
| Complete | <1m |
| **Total** | **20m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/flaky-thunderingherdzerodelay.json</summary>

```json
{
  "schema_version": 1,
  "branch": "flaky-thunderingherdzerodelay",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1043,
  "pr_url": "https://github.com/benkruger/flow/pull/1043",
  "started_at": "2026-04-12T09:26:47-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/flaky-thunderingherdzerodelay-plan.md",
    "dag": null,
    "log": ".flow-states/flaky-thunderingherdzerodelay.log",
    "state": ".flow-states/flaky-thunderingherdzerodelay.json"
  },
  "session_tty": "/dev/ttys007",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "fix flaky thundering herd zero delay test #1014",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-12T09:26:47-07:00",
      "completed_at": "2026-04-12T09:28:45-07:00",
      "session_started_at": null,
      "cumulative_seconds": 118,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-12T09:28:55-07:00",
      "completed_at": "2026-04-12T09:31:07-07:00",
      "session_started_at": null,
      "cumulative_seconds": 132,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-12T09:31:32-07:00",
      "completed_at": "2026-04-12T09:36:37-07:00",
      "session_started_at": null,
      "cumulative_seconds": 305,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-12T09:36:46-07:00",
      "completed_at": "2026-04-12T09:45:57-07:00",
      "session_started_at": null,
      "cumulative_seconds": 551,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-12T09:46:06-07:00",
      "completed_at": "2026-04-12T09:48:09-07:00",
      "session_started_at": null,
      "cumulative_seconds": 123,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-12T09:48:28-07:00",
      "completed_at": "2026-04-12T09:48:48-07:00",
      "session_started_at": null,
      "cumulative_seconds": 20,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-12T09:28:55-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-12T09:31:32-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-12T09:36:46-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-12T09:46:06-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-12T09:48:28-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 1,
  "code_task_name": "Increase lock acquisition timeout and join deadline",
  "code_task": 1,
  "diff_stats": {
    "files_changed": 1,
    "insertions": 8,
    "deletions": 7,
    "captured_at": "2026-04-12T09:36:37-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "findings": [
    {
      "finding": "Pre-mortem: lock timeout equals join deadline diagnostic race",
      "reason": "Join deadline starts after thread spawn so fires after worker timeouts - theoretical race does not manifest",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T09:43:09-07:00"
    },
    {
      "finding": "Pre-mortem: workers panic on timeout instead of clean diagnostic",
      "reason": "Panic on timeout is correct test behavior - a timeout IS a test failure and the panic message includes worker ID and status",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T09:43:16-07:00"
    },
    {
      "finding": "Pre-mortem: tripling timeout masks lock corruption signal",
      "reason": "Lock corruption is detected by the no-overlap timing assertion, not by the timeout - timeout only affects acquisition wait time",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T09:43:20-07:00"
    },
    {
      "finding": "Stale 30s in assertion message at line 394 - says 30s deadline but actual deadline is 90s",
      "reason": "All 4 agents converged on this finding - assertion message was not updated when deadline was tripled",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T09:43:43-07:00"
    },
    {
      "finding": "Learn-analyst: all 5 findings either confirmed compliance or were too session-specific to generalize",
      "reason": "No process gaps, no rule violations, no missing rules identified",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-12T09:47:35-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/flaky-thunderingherdzerodelay.log</summary>

```text
2026-04-12T09:26:47-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-12T09:26:47-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-12T09:26:47-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-12T09:26:47-07:00 [Phase 1] create .flow-states/flaky-thunderingherdzerodelay.json (exit 0)
2026-04-12T09:26:47-07:00 [Phase 1] freeze .flow-states/flaky-thunderingherdzerodelay-phases.json (exit 0)
2026-04-12T09:26:47-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-12T09:26:48-07:00 [Phase 1] start-init — label-issues (labeled: [1014], failed: [])
2026-04-12T09:26:54-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-12T09:28:24-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-12T09:28:24-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-12T09:28:31-07:00 [Phase 1] start-workspace — worktree .worktrees/flaky-thunderingherdzerodelay (ok)
2026-04-12T09:28:35-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-12T09:28:35-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-12T09:28:35-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-12T09:28:45-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-12T09:28:45-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-12T09:30:14-07:00 [Phase 2] Step 2 — DAG skip, single-file fix (ok)
2026-04-12T09:31:07-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-12T09:31:32-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-12T09:36:22-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-12T09:36:26-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-12T09:36:37-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-12T09:36:46-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-12T09:45:42-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-12T09:45:45-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-12T09:45:57-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-12T09:46:06-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-12T09:48:09-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-12T09:48:48-07:00 [Phase 6] complete-finalize — starting
2026-04-12T09:48:48-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-12T09:48:48-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>