### PR TITLE
Centralize Flow States Path

### DIFF
--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -1,0 +1,67 @@
+# Autonomous Phase Discipline
+
+When a phase is configured for autonomous execution (`continue: auto`
+in the state file's skills section, typically propagated from the
+`--auto` flag), the session must not introduce user-facing pauses
+that the user did not request.
+
+## The Rule
+
+During any phase with `continue: auto`:
+
+- Never emit `AskUserQuestion` for checkpoints the user did not ask
+  for — "want me to proceed?", "want me to continue?", "should I
+  pause for context?" are all prohibited.
+- Never self-declare a "context check", "budget check", or "session
+  hand-off" mid-phase. The stop-continue hook is the only
+  permissible signal for external help.
+- Never mark state counters (like `code_task`) as complete and then
+  halt without committing the corresponding work. The counter and
+  the commit must advance together.
+- Never unilaterally decide the flow is "too big" and ask whether
+  to continue — autonomy means the user already answered that
+  question when they chose `--auto`.
+
+If Claude feels the urge to pause because of context pressure, a
+long-running task, or uncertainty about scope: commit the in-flight
+work at a natural boundary, then resume on the next task. Pausing
+to ask the user is an interruption; committing and continuing is
+not.
+
+## Why
+
+Autonomous flows are explicitly configured by the user. A
+self-imposed pause defeats the configuration — the user has to
+intervene to say "please continue the thing I already told you to
+continue." Every such intervention costs trust and round-trip
+latency.
+
+The specific failure mode this rule targets: a long Code phase
+(many tasks, many commits) where the session begins to feel
+context pressure and injects a pause to "check in" with the user.
+The user then has to say "you stopped for no reason, keep going."
+This happened during PR #1046 twice in the same Code phase; see
+the state file's `findings[]` for the recorded learnings.
+
+## How to Apply
+
+- At every step boundary in a `continue: auto` phase, the next
+  action is either (a) the next skill instruction or (b) a
+  self-invocation via Skill tool. Never an `AskUserQuestion` that
+  is not already mandated by the skill.
+- If the skill's HARD-GATE says to ask the user, follow the gate.
+  If the skill does not instruct a pause, do not invent one.
+- When the user sends a message mid-phase, answer their message.
+  That is different from pausing — the user initiated the
+  interaction, so the autonomy contract is not violated.
+- If context is genuinely exhausted, commit the current work with
+  a message naming the task, then stop. The stop-continue hook
+  logs the halt for the user to resume from. Do not pause at a
+  point where nothing was committed.
+
+## Scope
+
+This rule applies to every phase that can be autonomous: Start,
+Plan, Code, Code Review, Learn, Complete. The `continue: auto`
+configuration is readable in every phase's `phase-enter`
+response.

--- a/src/add_finding.rs
+++ b/src/add_finding.rs
@@ -3,6 +3,7 @@ use std::process;
 use clap::Parser;
 use serde_json::json;
 
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::lock::mutate_state;
 use crate::output::{json_error, json_ok};
@@ -73,7 +74,7 @@ pub fn run_impl(args: &Args) -> Result<usize, String> {
 
     let branch = resolve_branch(args.branch.as_deref(), &root)
         .ok_or_else(|| "Could not determine current branch".to_string())?;
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
 
     if !state_path.exists() {
         return Err("no_state".to_string());

--- a/src/add_issue.rs
+++ b/src/add_issue.rs
@@ -3,6 +3,7 @@ use std::process;
 use clap::Parser;
 use serde_json::json;
 
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::lock::mutate_state;
 use crate::output::{json_error, json_ok};
@@ -42,7 +43,7 @@ pub fn run(args: Args) {
             process::exit(1);
         }
     };
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
 
     if !state_path.exists() {
         println!(r#"{{"status":"no_state"}}"#);

--- a/src/add_notification.rs
+++ b/src/add_notification.rs
@@ -3,6 +3,7 @@ use std::process;
 use clap::Parser;
 use serde_json::json;
 
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::lock::mutate_state;
 use crate::output::{json_error, json_ok};
@@ -47,7 +48,7 @@ pub fn run(args: Args) {
             process::exit(1);
         }
     };
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
 
     if !state_path.exists() {
         println!(r#"{{"status":"no_state"}}"#);

--- a/src/append_note.rs
+++ b/src/append_note.rs
@@ -4,6 +4,7 @@ use std::process;
 use clap::Parser;
 use serde_json::{json, Value};
 
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::lock::mutate_state;
 use crate::output::{json_error, json_ok};
@@ -35,7 +36,7 @@ pub fn run(args: Args) {
             process::exit(1);
         }
     };
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
 
     if !state_path.exists() {
         println!(r#"{{"status":"no_state"}}"#);

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -34,6 +34,8 @@ use clap::Parser;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
+use crate::flow_paths::FlowPaths;
+
 /// CLI arguments for `bin/flow ci`.
 #[derive(Parser, Debug)]
 #[command(name = "ci", about = "Run CI with dirty-check optimization")]
@@ -126,8 +128,7 @@ pub fn any_tool_is_stub(tools: &[CiTool]) -> bool {
 ///
 /// Also used by [`crate::finalize_commit::run_impl`] to refresh the sentinel after a clean commit.
 pub fn sentinel_path(root: &Path, branch: &str) -> PathBuf {
-    root.join(".flow-states")
-        .join(format!("{}-ci-passed", branch))
+    FlowPaths::new(root, branch).ci_sentinel()
 }
 
 /// Run a git command in `cwd`, returning its stdout as a lossy UTF-8 string.

--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -20,6 +20,7 @@ use clap::Parser;
 use indexmap::IndexMap;
 
 use crate::commands::log::append_log;
+use crate::flow_paths::FlowPaths;
 use crate::output::{json_error, json_ok};
 
 const CMD_TIMEOUT: Duration = Duration::from_secs(30);
@@ -279,23 +280,18 @@ pub fn cleanup(
     );
 
     // Delete state file
-    let flow_states = project_root.join(".flow-states");
+    let paths = FlowPaths::new(project_root, branch);
+    let flow_states = paths.flow_states_dir();
     steps.insert(
         "state_file".to_string(),
-        try_delete_file(&flow_states.join(format!("{}.json", branch))),
+        try_delete_file(&paths.state_file()),
     );
 
     // Delete plan file
-    steps.insert(
-        "plan_file".to_string(),
-        try_delete_file(&flow_states.join(format!("{}-plan.md", branch))),
-    );
+    steps.insert("plan_file".to_string(), try_delete_file(&paths.plan_file()));
 
     // Delete DAG file
-    steps.insert(
-        "dag_file".to_string(),
-        try_delete_file(&flow_states.join(format!("{}-dag.md", branch))),
-    );
+    steps.insert("dag_file".to_string(), try_delete_file(&paths.dag_file()));
 
     // Log cleanup progress before the log file is deleted.
     // Only log if the log file already exists — append_log creates the file
@@ -303,7 +299,7 @@ pub fn cleanup(
     // of "skipped" for test fixtures that intentionally remove the log file.
     // This entry is written mid-cleanup (before file deletions), so it cannot
     // report a total step count — the JSON output has the full step results.
-    let log_path = flow_states.join(format!("{}.log", branch));
+    let log_path = paths.log_file();
     if log_path.exists() {
         let _ = append_log(
             project_root,
@@ -313,39 +309,36 @@ pub fn cleanup(
     }
 
     // Delete log file
-    steps.insert(
-        "log_file".to_string(),
-        try_delete_file(&flow_states.join(format!("{}.log", branch))),
-    );
+    steps.insert("log_file".to_string(), try_delete_file(&paths.log_file()));
 
     // Delete frozen phases file
     steps.insert(
         "frozen_phases".to_string(),
-        try_delete_file(&flow_states.join(format!("{}-phases.json", branch))),
+        try_delete_file(&paths.frozen_phases()),
     );
 
     // Delete CI sentinel
     steps.insert(
         "ci_sentinel".to_string(),
-        try_delete_file(&flow_states.join(format!("{}-ci-passed", branch))),
+        try_delete_file(&paths.ci_sentinel()),
     );
 
     // Delete timings file
     steps.insert(
         "timings_file".to_string(),
-        try_delete_file(&flow_states.join(format!("{}-timings.md", branch))),
+        try_delete_file(&paths.timings_file()),
     );
 
     // Delete closed issues file
     steps.insert(
         "closed_issues_file".to_string(),
-        try_delete_file(&flow_states.join(format!("{}-closed-issues.json", branch))),
+        try_delete_file(&paths.closed_issues()),
     );
 
     // Delete issues file
     steps.insert(
         "issues_file".to_string(),
-        try_delete_file(&flow_states.join(format!("{}-issues.md", branch))),
+        try_delete_file(&paths.issues_file()),
     );
 
     // Delete adversarial test file(s) produced by the Phase 4 adversarial

--- a/src/commands/clear_blocked.rs
+++ b/src/commands/clear_blocked.rs
@@ -1,6 +1,7 @@
 use std::io::Read;
 use std::path::Path;
 
+use crate::flow_paths::FlowPaths;
 use crate::git::{current_branch, project_root};
 use crate::lock::mutate_state;
 
@@ -28,7 +29,7 @@ pub fn run() {
     };
 
     let root = project_root();
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
 
     clear_blocked(&state_path);
 }

--- a/src/commands/init_state.rs
+++ b/src/commands/init_state.rs
@@ -5,6 +5,7 @@ use indexmap::IndexMap;
 use serde_json::{json, Value};
 
 use crate::commands::log::append_log;
+use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 use crate::label_issues::LABEL;
 use crate::output::{json_error, json_ok};
@@ -96,9 +97,10 @@ pub fn create_state(
         state.insert("start_steps_total".into(), json!(total));
     }
 
-    let state_dir = project_root.join(".flow-states");
+    let paths = FlowPaths::new(project_root, branch);
+    let state_dir = paths.flow_states_dir();
     fs::create_dir_all(&state_dir).map_err(|e| format!("Cannot create .flow-states: {}", e))?;
-    let state_path = state_dir.join(format!("{}.json", branch));
+    let state_path = paths.state_file();
     let output = serde_json::to_string_pretty(&Value::Object(state))
         .map_err(|e| format!("JSON serialize error: {}", e))?;
     fs::write(&state_path, output).map_err(|e| format!("Cannot write state file: {}", e))?;

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -5,6 +5,7 @@ use std::process;
 
 use fs2::FileExt;
 
+use crate::flow_paths::FlowPaths;
 use crate::git;
 use crate::utils;
 
@@ -13,9 +14,9 @@ use crate::utils;
 /// Creates the `.flow-states/` directory if it does not exist.
 /// Acquires an exclusive file lock before writing.
 pub fn append_log(root: &Path, branch: &str, message: &str) -> Result<(), std::io::Error> {
-    let log_dir = root.join(".flow-states");
-    fs::create_dir_all(&log_dir)?;
-    let log_path = log_dir.join(format!("{}.log", branch));
+    let paths = FlowPaths::new(root, branch);
+    fs::create_dir_all(paths.flow_states_dir())?;
+    let log_path = paths.log_file();
     let timestamp = utils::now();
 
     let file = OpenOptions::new()

--- a/src/commands/set_blocked.rs
+++ b/src/commands/set_blocked.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use serde_json::Value;
 
+use crate::flow_paths::FlowPaths;
 use crate::git::{current_branch, project_root};
 use crate::lock::mutate_state;
 use crate::utils::now;
@@ -35,7 +36,7 @@ pub fn run() {
     };
 
     let root = project_root();
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
 
     set_blocked(&state_path);
 }

--- a/src/commands/set_timestamp.rs
+++ b/src/commands/set_timestamp.rs
@@ -2,6 +2,7 @@ use std::process;
 
 use serde_json::{json, Value};
 
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::lock::mutate_state;
 use crate::output::{json_error, json_ok};
@@ -174,7 +175,7 @@ pub fn run(set_args: Vec<String>, branch_override: Option<String>) {
         }
     };
 
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
 
     if !state_path.exists() {
         json_error(

--- a/src/commands/start_lock.rs
+++ b/src/commands/start_lock.rs
@@ -11,6 +11,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Value};
 
+use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 use crate::output::json_error;
 
@@ -28,7 +29,10 @@ fn mtime_secs(path: &Path) -> Option<f64> {
 /// Create the queue directory if needed, return its path.
 pub fn queue_path(root: &Path) -> PathBuf {
     let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
-    let state_dir = root.join(".flow-states");
+    // Use FlowPaths to locate `.flow-states/`; the queue lives
+    // under it but is shared across every branch on this machine,
+    // so the branch name is an unused placeholder here.
+    let state_dir = FlowPaths::new(&root, "").flow_states_dir();
     let _ = fs::create_dir_all(&state_dir);
     let queue_dir = state_dir.join(QUEUE_DIRNAME);
     let _ = fs::create_dir_all(&queue_dir);

--- a/src/commands/start_lock.rs
+++ b/src/commands/start_lock.rs
@@ -293,7 +293,12 @@ mod tests {
         let root = dir.path().canonicalize().unwrap();
         let qp = queue_path(&root);
         assert!(qp.is_dir());
-        assert_eq!(qp, root.join(".flow-states").join(QUEUE_DIRNAME));
+        assert_eq!(
+            qp,
+            FlowPaths::new(&root, "")
+                .flow_states_dir()
+                .join(QUEUE_DIRNAME)
+        );
     }
 
     #[test]

--- a/src/commands/start_step.rs
+++ b/src/commands/start_step.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use serde_json::json;
 
+use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 use crate::lock::mutate_state;
 use crate::output::json_ok;
@@ -34,7 +35,7 @@ pub fn update_step(state_path: &Path, step: i64) -> bool {
 /// execs into a subcommand via bin/flow.
 pub fn run(step: i64, branch: &str, subcommand: Vec<String>) {
     let root = project_root();
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, branch).state_file();
 
     let updated = update_step(&state_path, step);
 

--- a/src/complete_fast.rs
+++ b/src/complete_fast.rs
@@ -27,6 +27,7 @@ use crate::complete_preflight::{
     check_learn_phase, check_pr_status, merge_main, resolve_mode, run_cmd_with_timeout, CmdResult,
     COMPLETE_STEPS_TOTAL, NETWORK_TIMEOUT,
 };
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::lock::mutate_state;
 use crate::phase_transition::phase_enter;
@@ -48,7 +49,7 @@ pub struct Args {
 
 /// Read and parse a state file, returning (state_value, state_path).
 fn read_state(root: &Path, branch: &str) -> Result<(Value, PathBuf), String> {
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(root, branch).state_file();
     if !state_path.exists() {
         return Err(format!(
             "No state file found for branch '{}'. Run /flow:flow-start first.",

--- a/src/complete_finalize.rs
+++ b/src/complete_finalize.rs
@@ -19,6 +19,7 @@ use serde_json::{json, Value};
 use crate::cleanup;
 use crate::commands::log::append_log;
 use crate::complete_post_merge;
+use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 
 #[derive(Parser, Debug)]
@@ -146,7 +147,10 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     // Matches the guard pattern in complete_post_merge.rs to avoid
     // creating the directory in test fixtures that deliberately omit it.
     let log = |msg: &str| {
-        if root.join(".flow-states").is_dir() {
+        if FlowPaths::new(&root, &args.branch)
+            .flow_states_dir()
+            .is_dir()
+        {
             let _ = append_log(&root, &args.branch, msg);
         }
     };

--- a/src/complete_post_merge.rs
+++ b/src/complete_post_merge.rs
@@ -13,6 +13,7 @@ use serde_json::{json, Map, Value};
 
 use crate::commands::log::append_log;
 use crate::complete_preflight::{run_cmd_with_timeout, CmdResult, LOCAL_TIMEOUT, NETWORK_TIMEOUT};
+use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 use crate::lock::mutate_state;
 use crate::utils::bin_flow_path;
@@ -57,8 +58,9 @@ pub fn post_merge_inner(
     // Best-effort logging — only log when .flow-states/ already exists.
     // append_log creates the directory if missing, which would break test
     // fixtures that deliberately omit it.
+    let paths = FlowPaths::new(root, branch);
     let log = |msg: &str| {
-        if root.join(".flow-states").is_dir() {
+        if paths.flow_states_dir().is_dir() {
             let _ = append_log(root, branch, msg);
         }
     };
@@ -190,9 +192,7 @@ pub fn post_merge_inner(
     }
 
     // Format issues summary
-    let issues_output_path = root
-        .join(".flow-states")
-        .join(format!("{}-issues.md", branch));
+    let issues_output_path = paths.issues_file();
     let issues_output = issues_output_path.to_string_lossy().to_string();
     let iss_args = [
         bin_flow,
@@ -238,9 +238,7 @@ pub fn post_merge_inner(
 
     // Write closed-issues file if non-empty
     if !closed_issues.is_empty() {
-        let closed_path = root
-            .join(".flow-states")
-            .join(format!("{}-closed-issues.json", branch));
+        let closed_path = paths.closed_issues();
         let closed_json =
             serde_json::to_string(&closed_issues).unwrap_or_else(|_| "[]".to_string());
         if let Err(e) = std::fs::write(&closed_path, closed_json) {
@@ -251,9 +249,7 @@ pub fn post_merge_inner(
     // --- Step 10: Parallel post-merge operations ---
 
     // Format complete summary
-    let closed_file_path_buf = root
-        .join(".flow-states")
-        .join(format!("{}-closed-issues.json", branch));
+    let closed_file_path_buf = paths.closed_issues();
     let closed_file_path = closed_file_path_buf.to_string_lossy().to_string();
     let mut sum_args: Vec<&str> = vec![
         bin_flow,

--- a/src/complete_preflight.rs
+++ b/src/complete_preflight.rs
@@ -21,6 +21,7 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 use serde_json::{json, Value};
 
+use crate::flow_paths::FlowPaths;
 use crate::git::{current_branch, project_root};
 use crate::lock::mutate_state;
 use crate::utils::{bin_flow_path, derive_worktree, parse_conflict_files};
@@ -329,7 +330,7 @@ pub fn preflight_inner(
     };
 
     // Read state file
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(root, &branch).state_file();
     let mut state: Option<Value> = None;
     let mut inferred = false;
 

--- a/src/cwd_scope.rs
+++ b/src/cwd_scope.rs
@@ -32,6 +32,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::flow_paths::FlowPaths;
+
 /// Enforce that `cwd` is inside (or equal to) the expected subdirectory
 /// of the worktree for the current branch's flow.
 ///
@@ -63,9 +65,7 @@ pub fn enforce(cwd: &Path, project_root: &Path) -> Result<(), String> {
         None => return Ok(()),
     };
 
-    let state_path = project_root
-        .join(".flow-states")
-        .join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(project_root, &branch).state_file();
     if !state_path.exists() {
         return Ok(());
     }

--- a/src/finalize_commit.rs
+++ b/src/finalize_commit.rs
@@ -23,6 +23,7 @@ use serde_json::{json, Value};
 
 use crate::commands::log::append_log;
 use crate::complete_preflight::{LOCAL_TIMEOUT, NETWORK_TIMEOUT};
+use crate::flow_paths::FlowPaths;
 use crate::lock::mutate_state;
 use crate::output::json_error;
 use crate::phase_config::phase_number;
@@ -238,9 +239,7 @@ pub fn run_impl(
 
     // Derive phase number from state file's current_phase for log prefixes.
     let pn = {
-        let state_path = root
-            .join(".flow-states")
-            .join(format!("{}.json", args.branch));
+        let state_path = FlowPaths::new(root, &args.branch).state_file();
         std::fs::read_to_string(&state_path)
             .ok()
             .and_then(|c| serde_json::from_str::<Value>(&c).ok())
@@ -305,9 +304,7 @@ pub fn run_impl(
     // does not force-advance the parent phase after a failed commit.
     // Conflict is NOT cleared — the commit skill retries after resolving.
     if result["status"] == "error" {
-        let state_path = root
-            .join(".flow-states")
-            .join(format!("{}.json", args.branch));
+        let state_path = FlowPaths::new(root, &args.branch).state_file();
         if state_path.exists() {
             let _ = mutate_state(&state_path, |state| {
                 if !(state.is_object() || state.is_null()) {

--- a/src/flow_paths.rs
+++ b/src/flow_paths.rs
@@ -1,0 +1,277 @@
+//! Centralized construction for branch-scoped `.flow-states/*` paths.
+//!
+//! Every branch-scoped file under `.flow-states/` is addressed through a
+//! single `FlowPaths` instance constructed from the project root and the
+//! active branch name. Callers stay agnostic to the filename suffixes, so
+//! the on-disk layout can change by editing this module alone.
+//!
+//! The struct also exposes `flow_states_dir()` for consumers that need
+//! the parent directory (e.g. flow-discovery globs) and `branch()` for
+//! code that still needs the branch name after constructing paths.
+
+use std::path::{Path, PathBuf};
+
+/// Branch-scoped `.flow-states/*` path builder.
+#[derive(Debug, Clone)]
+pub struct FlowPaths {
+    flow_states_dir: PathBuf,
+    branch: String,
+}
+
+impl FlowPaths {
+    /// Construct a new `FlowPaths` rooted at `<project_root>/.flow-states`
+    /// for the given branch.
+    pub fn new(project_root: impl AsRef<Path>, branch: impl Into<String>) -> Self {
+        Self {
+            flow_states_dir: project_root.as_ref().join(".flow-states"),
+            branch: branch.into(),
+        }
+    }
+
+    /// The branch this instance is scoped to.
+    pub fn branch(&self) -> &str {
+        &self.branch
+    }
+
+    /// The `.flow-states/` directory at the project root. Use this for
+    /// cross-branch discovery (e.g. globbing `*.json`) — prefer the
+    /// named file accessors for branch-scoped reads and writes.
+    pub fn flow_states_dir(&self) -> PathBuf {
+        self.flow_states_dir.clone()
+    }
+
+    /// `<.flow-states>/<branch>.json` — authoritative state file.
+    pub fn state_file(&self) -> PathBuf {
+        self.flow_states_dir.join(format!("{}.json", self.branch))
+    }
+
+    /// `<.flow-states>/<branch>.log` — session log appended by skills
+    /// and Rust modules via `append_log`.
+    pub fn log_file(&self) -> PathBuf {
+        self.flow_states_dir.join(format!("{}.log", self.branch))
+    }
+
+    /// `<.flow-states>/<branch>-plan.md` — Plan phase output.
+    pub fn plan_file(&self) -> PathBuf {
+        self.flow_states_dir
+            .join(format!("{}-plan.md", self.branch))
+    }
+
+    /// `<.flow-states>/<branch>-dag.md` — DAG decomposition output.
+    pub fn dag_file(&self) -> PathBuf {
+        self.flow_states_dir.join(format!("{}-dag.md", self.branch))
+    }
+
+    /// `<.flow-states>/<branch>-phases.json` — frozen phase config
+    /// captured at flow-start time.
+    pub fn frozen_phases(&self) -> PathBuf {
+        self.flow_states_dir
+            .join(format!("{}-phases.json", self.branch))
+    }
+
+    /// `<.flow-states>/<branch>-ci-passed` — CI sentinel; presence
+    /// means the last `bin/flow ci` invocation passed for the current
+    /// working tree.
+    pub fn ci_sentinel(&self) -> PathBuf {
+        self.flow_states_dir
+            .join(format!("{}-ci-passed", self.branch))
+    }
+
+    /// `<.flow-states>/<branch>-timings.md` — phase timing report.
+    pub fn timings_file(&self) -> PathBuf {
+        self.flow_states_dir
+            .join(format!("{}-timings.md", self.branch))
+    }
+
+    /// `<.flow-states>/<branch>-closed-issues.json` — issues closed
+    /// during the flow, persisted for the post-merge close step.
+    pub fn closed_issues(&self) -> PathBuf {
+        self.flow_states_dir
+            .join(format!("{}-closed-issues.json", self.branch))
+    }
+
+    /// `<.flow-states>/<branch>-issues.md` — issues summary rendered
+    /// for PR body inclusion.
+    pub fn issues_file(&self) -> PathBuf {
+        self.flow_states_dir
+            .join(format!("{}-issues.md", self.branch))
+    }
+
+    /// `<.flow-states>/<branch>-rule-content.md` — scratch file for
+    /// rule-file edits routed through `bin/flow write-rule`.
+    pub fn rule_content(&self) -> PathBuf {
+        self.flow_states_dir
+            .join(format!("{}-rule-content.md", self.branch))
+    }
+
+    /// `<.flow-states>/<branch>-start-prompt` — verbatim start prompt
+    /// captured by `/flow:flow-start` for downstream phases.
+    pub fn start_prompt(&self) -> PathBuf {
+        self.flow_states_dir
+            .join(format!("{}-start-prompt", self.branch))
+    }
+
+    /// Bare prefix `<branch>-adversarial_test.` used to glob Phase 4
+    /// adversarial test files. The agent chooses the extension at
+    /// runtime so callers filter `fs::read_dir` entries by this
+    /// prefix rather than addressing a fixed filename.
+    pub fn adversarial_test_prefix(&self) -> String {
+        format!("{}-adversarial_test.", self.branch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // --- FlowPaths ---
+
+    fn paths() -> FlowPaths {
+        FlowPaths::new("/tmp/project", "my-feature")
+    }
+
+    #[test]
+    fn branch_returns_configured_branch() {
+        assert_eq!(paths().branch(), "my-feature");
+    }
+
+    #[test]
+    fn flow_states_dir_is_project_root_dot_flow_states() {
+        assert_eq!(
+            paths().flow_states_dir(),
+            PathBuf::from("/tmp/project/.flow-states")
+        );
+    }
+
+    #[test]
+    fn state_file_has_json_suffix() {
+        assert_eq!(
+            paths().state_file(),
+            PathBuf::from("/tmp/project/.flow-states/my-feature.json")
+        );
+    }
+
+    #[test]
+    fn log_file_has_log_suffix() {
+        assert_eq!(
+            paths().log_file(),
+            PathBuf::from("/tmp/project/.flow-states/my-feature.log")
+        );
+    }
+
+    #[test]
+    fn plan_file_has_plan_md_suffix() {
+        assert_eq!(
+            paths().plan_file(),
+            PathBuf::from("/tmp/project/.flow-states/my-feature-plan.md")
+        );
+    }
+
+    #[test]
+    fn dag_file_has_dag_md_suffix() {
+        assert_eq!(
+            paths().dag_file(),
+            PathBuf::from("/tmp/project/.flow-states/my-feature-dag.md")
+        );
+    }
+
+    #[test]
+    fn frozen_phases_has_phases_json_suffix() {
+        assert_eq!(
+            paths().frozen_phases(),
+            PathBuf::from("/tmp/project/.flow-states/my-feature-phases.json")
+        );
+    }
+
+    #[test]
+    fn ci_sentinel_has_ci_passed_suffix() {
+        assert_eq!(
+            paths().ci_sentinel(),
+            PathBuf::from("/tmp/project/.flow-states/my-feature-ci-passed")
+        );
+    }
+
+    #[test]
+    fn timings_file_has_timings_md_suffix() {
+        assert_eq!(
+            paths().timings_file(),
+            PathBuf::from("/tmp/project/.flow-states/my-feature-timings.md")
+        );
+    }
+
+    #[test]
+    fn closed_issues_has_closed_issues_json_suffix() {
+        assert_eq!(
+            paths().closed_issues(),
+            PathBuf::from("/tmp/project/.flow-states/my-feature-closed-issues.json")
+        );
+    }
+
+    #[test]
+    fn issues_file_has_issues_md_suffix() {
+        assert_eq!(
+            paths().issues_file(),
+            PathBuf::from("/tmp/project/.flow-states/my-feature-issues.md")
+        );
+    }
+
+    #[test]
+    fn rule_content_has_rule_content_md_suffix() {
+        assert_eq!(
+            paths().rule_content(),
+            PathBuf::from("/tmp/project/.flow-states/my-feature-rule-content.md")
+        );
+    }
+
+    #[test]
+    fn start_prompt_has_start_prompt_suffix() {
+        assert_eq!(
+            paths().start_prompt(),
+            PathBuf::from("/tmp/project/.flow-states/my-feature-start-prompt")
+        );
+    }
+
+    #[test]
+    fn adversarial_test_prefix_ends_in_dot() {
+        assert_eq!(
+            paths().adversarial_test_prefix(),
+            "my-feature-adversarial_test."
+        );
+    }
+
+    #[test]
+    fn accepts_pathbuf_and_path_for_project_root() {
+        let p1 = FlowPaths::new(PathBuf::from("/p"), "b");
+        let p2 = FlowPaths::new(Path::new("/p"), "b");
+        assert_eq!(p1.state_file(), p2.state_file());
+    }
+
+    #[test]
+    fn accepts_owned_and_borrowed_branch() {
+        let b = String::from("branch-x");
+        let p1 = FlowPaths::new("/p", b.clone());
+        let p2 = FlowPaths::new("/p", b.as_str());
+        assert_eq!(p1.state_file(), p2.state_file());
+    }
+
+    #[test]
+    fn clone_preserves_fields() {
+        let original = paths();
+        let cloned = original.clone();
+        assert_eq!(original.state_file(), cloned.state_file());
+        assert_eq!(original.branch(), cloned.branch());
+    }
+
+    #[test]
+    fn branch_with_slashes_is_preserved_literally() {
+        // Branch names with slashes (e.g. "user/fix") would produce
+        // subdirectory-shaped filenames. FlowPaths passes the branch
+        // through unchanged; sanitization belongs upstream.
+        let p = FlowPaths::new("/p", "user/fix");
+        assert_eq!(
+            p.state_file(),
+            PathBuf::from("/p/.flow-states/user/fix.json")
+        );
+    }
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,6 +2,8 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::flow_paths::FlowPaths;
+
 /// Find the main git repository root.
 ///
 /// Uses `git worktree list --porcelain` to find the root, which works
@@ -118,11 +120,9 @@ fn resolve_branch_impl(
         return Some(b.to_string());
     }
 
-    let state_dir = root.join(".flow-states");
-
     // Exact match — current branch has a state file
     if let Some(ref b) = branch {
-        if state_dir.join(format!("{}.json", b)).exists() {
+        if FlowPaths::new(root, b).state_file().exists() {
             return Some(b.clone());
         }
     }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -9,6 +9,8 @@ use serde_json::Value;
 use std::env;
 use std::path::{Path, PathBuf};
 
+use crate::flow_paths::FlowPaths;
+
 /// Marker directory name for FLOW worktrees.
 const WORKTREE_MARKER: &str = ".worktrees/";
 
@@ -107,7 +109,7 @@ pub fn is_flow_active(branch: &str, root: &Path) -> bool {
     if branch.is_empty() || branch.contains('/') || branch.contains('\\') {
         return false;
     }
-    let state_file = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_file = FlowPaths::new(root, branch).state_file();
     state_file.is_file()
 }
 

--- a/src/hooks/post_compact.rs
+++ b/src/hooks/post_compact.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use serde_json::Value;
 
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::lock::mutate_state;
 use crate::utils::tolerant_i64;
@@ -63,7 +64,7 @@ pub fn run() {
         None => return,
     };
 
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
 
     if !state_path.exists() {
         return;

--- a/src/hooks/stop_continue.rs
+++ b/src/hooks/stop_continue.rs
@@ -18,6 +18,7 @@ use serde_json::{json, Value};
 
 use crate::commands::clear_blocked::clear_blocked;
 use crate::commands::set_blocked::set_blocked;
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::github::detect_repo;
 use crate::lock::mutate_state;
@@ -35,7 +36,7 @@ pub struct ContinueResult {
 fn log_diag(root: Option<&Path>, branch: Option<&str>, message: &str) {
     eprintln!("[FLOW stop-continue] {}", message);
     if let (Some(root), Some(branch)) = (root, branch) {
-        let log_path = root.join(".flow-states").join(format!("{}.log", branch));
+        let log_path = FlowPaths::new(root, branch).log_file();
         if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(&log_path) {
             let _ = writeln!(f, "{} [stop-continue] {}", now(), message);
         }
@@ -556,7 +557,7 @@ pub fn run() {
         Some(b) => b,
         None => return,
     };
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
 
     // First stop handler: on the first Stop event (no _stop_instructed),
     // handles both pending continuations (with conditional user-awareness)

--- a/src/hooks/stop_failure.rs
+++ b/src/hooks/stop_failure.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use serde_json::{json, Value};
 
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::lock::mutate_state;
 use crate::utils::now;
@@ -64,7 +65,7 @@ pub fn run() {
         None => return,
     };
 
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
 
     if !state_path.exists() {
         return;

--- a/src/hooks/validate_ask_user.rs
+++ b/src/hooks/validate_ask_user.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use serde_json::{json, Value};
 
 use super::read_hook_input;
+use crate::flow_paths::FlowPaths;
 use crate::git::{current_branch, project_root};
 use crate::lock::mutate_state;
 use crate::utils::now;
@@ -84,9 +85,7 @@ pub fn run() {
         None => std::process::exit(0),
     };
 
-    let state_path = project_root()
-        .join(".flow-states")
-        .join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(project_root(), &branch).state_file();
 
     let (_allowed, _message, hook_response) = validate(Some(&state_path));
     if let Some(response) = hook_response {

--- a/src/hooks/validate_claude_paths.rs
+++ b/src/hooks/validate_claude_paths.rs
@@ -9,6 +9,7 @@
 use std::path::Path;
 
 use super::{detect_branch_from_cwd, is_flow_active, read_hook_input, resolve_main_root};
+use crate::flow_paths::FlowPaths;
 
 /// Check if a file path targets a protected .claude/ location.
 ///
@@ -77,7 +78,7 @@ fn find_project_root() -> Option<std::path::PathBuf> {
     let cwd = std::env::current_dir().ok()?;
     let mut current = cwd.as_path().to_path_buf();
     loop {
-        if current.join(".flow-states").is_dir() {
+        if FlowPaths::new(&current, "").flow_states_dir().is_dir() {
             return Some(current);
         }
         if !current.pop() {

--- a/src/hooks/validate_worktree_paths.rs
+++ b/src/hooks/validate_worktree_paths.rs
@@ -6,9 +6,12 @@
 //! Exit 0 — allow (path is fine or not in a worktree)
 //! Exit 2 — block (path targets main repo instead of worktree)
 
+use std::path::Path;
+
 use serde_json::Value;
 
 use super::read_hook_input;
+use crate::flow_paths::FlowPaths;
 
 const WORKTREE_MARKER: &str = ".worktrees/";
 
@@ -53,7 +56,8 @@ pub fn validate(file_path: &str, cwd: &str) -> (bool, String) {
     }
 
     // .flow-states/ is the shared state directory at the main repo — always fine
-    let flow_states_prefix = format!("{}/.flow-states/", project_root);
+    let flow_states_dir = FlowPaths::new(Path::new(project_root), "").flow_states_dir();
+    let flow_states_prefix = format!("{}/", flow_states_dir.to_string_lossy());
     if file_path.starts_with(&flow_states_prefix) {
         return (true, String::new());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod cwd_scope;
 pub mod error;
 pub mod extract_release_notes;
 pub mod finalize_commit;
+pub mod flow_paths;
 pub mod format_check;
 pub mod format_complete_summary;
 pub mod format_issues_summary;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use flow_rs::create_milestone;
 use flow_rs::create_sub_issue;
 use flow_rs::extract_release_notes;
 use flow_rs::finalize_commit;
+use flow_rs::flow_paths::FlowPaths;
 use flow_rs::format_check;
 use flow_rs::format_complete_summary;
 use flow_rs::format_issues_summary;
@@ -702,7 +703,8 @@ fn run_check_phase(phase: &str, branch_override: Option<&str>) {
         }
     };
 
-    let state_file = root.join(".flow-states").join(format!("{}.json", branch));
+    let paths = FlowPaths::new(&root, &branch);
+    let state_file = paths.state_file();
     if !state_file.exists() {
         println!(
             "BLOCKED: No FLOW feature in progress on branch \"{}\".",
@@ -729,9 +731,7 @@ fn run_check_phase(phase: &str, branch_override: Option<&str>) {
     };
 
     // Load frozen phase config if available
-    let frozen_path = root
-        .join(".flow-states")
-        .join(format!("{}-phases.json", branch));
+    let frozen_path = paths.frozen_phases();
     let frozen_config = if frozen_path.exists() {
         load_phase_config(&frozen_path).ok()
     } else {
@@ -797,7 +797,8 @@ fn run_phase_transition(
             process::exit(1);
         }
     };
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let paths = FlowPaths::new(&root, &branch);
+    let state_path = paths.state_file();
 
     if !state_path.exists() {
         json_error(
@@ -831,9 +832,7 @@ fn run_phase_transition(
     }
 
     // Load frozen phase config if available
-    let frozen_path = root
-        .join(".flow-states")
-        .join(format!("{}-phases.json", branch));
+    let frozen_path = paths.frozen_phases();
     let frozen_config = if frozen_path.exists() {
         load_phase_config(&frozen_path).ok()
     } else {
@@ -929,9 +928,7 @@ fn run_format_status(branch_override: Option<&str>) {
     let (_state_path, state, matched_branch) = &results[0];
 
     // Load frozen phase config if available
-    let frozen_path = root
-        .join(".flow-states")
-        .join(format!("{}-phases.json", matched_branch));
+    let frozen_path = FlowPaths::new(&root, matched_branch).frozen_phases();
     let phase_config = if frozen_path.exists() {
         load_phase_config(&frozen_path).ok()
     } else {

--- a/src/phase_config.rs
+++ b/src/phase_config.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use indexmap::IndexMap;
 use serde_json::Value;
 
+use crate::flow_paths::FlowPaths;
 use crate::state::{Phase, PhaseState, PhaseStatus, SkillConfig};
 
 /// Phase configuration loaded from flow-phases.json.
@@ -151,10 +152,9 @@ pub fn freeze_phases(
     project_root: &Path,
     branch: &str,
 ) -> std::io::Result<()> {
-    let dest_dir = project_root.join(".flow-states");
-    std::fs::create_dir_all(&dest_dir)?;
-    let dest = dest_dir.join(format!("{}-phases.json", branch));
-    std::fs::copy(phases_json_path, dest)?;
+    let paths = FlowPaths::new(project_root, branch);
+    std::fs::create_dir_all(paths.flow_states_dir())?;
+    std::fs::copy(phases_json_path, paths.frozen_phases())?;
     Ok(())
 }
 
@@ -216,10 +216,11 @@ pub fn build_initial_phases(current_time: &str) -> IndexMap<Phase, PhaseState> {
 /// Empty list = nothing found. Single item = unambiguous match.
 /// Multiple items = caller must disambiguate.
 pub fn find_state_files(root: &Path, branch: &str) -> Vec<(PathBuf, Value, String)> {
-    let state_dir = root.join(".flow-states");
+    let paths = FlowPaths::new(root, branch);
+    let state_dir = paths.flow_states_dir();
 
     // Exact match
-    let exact_path = state_dir.join(format!("{}.json", branch));
+    let exact_path = paths.state_file();
     if exact_path.exists() {
         if let Ok(content) = std::fs::read_to_string(&exact_path) {
             if let Ok(state) = serde_json::from_str::<Value>(&content) {

--- a/src/phase_enter.rs
+++ b/src/phase_enter.rs
@@ -11,6 +11,7 @@ use clap::Parser;
 use serde_json::{json, Value};
 
 use crate::commands::log::append_log;
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::lock::mutate_state;
 use crate::output::json_error;
@@ -60,7 +61,7 @@ fn resolve_state(args: &Args) -> Result<(PathBuf, String, PathBuf), Value> {
         }
     };
 
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
     if !state_path.exists() {
         return Err(json!({
             "status": "error",

--- a/src/phase_finalize.rs
+++ b/src/phase_finalize.rs
@@ -10,6 +10,7 @@ use clap::Parser;
 use serde_json::{json, Value};
 
 use crate::commands::log::append_log;
+use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 use crate::lock::mutate_state;
 use crate::notify_slack;
@@ -48,7 +49,8 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     let root = project_root();
     let branch = &args.branch;
     let phase_num = phase_config::phase_number(&args.phase);
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let paths = FlowPaths::new(&root, branch);
+    let state_path = paths.state_file();
 
     // Drift guard: phase transitions must happen from inside the
     // subdirectory the flow was started in. Running phase-finalize
@@ -68,9 +70,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     }
 
     // Load frozen phase config if available
-    let frozen_path = root
-        .join(".flow-states")
-        .join(format!("{}-phases.json", branch));
+    let frozen_path = paths.frozen_phases();
     let frozen_config = if frozen_path.exists() {
         phase_config::load_phase_config(&frozen_path).ok()
     } else {

--- a/src/plan_check.rs
+++ b/src/plan_check.rs
@@ -22,6 +22,7 @@ use std::path::{Path, PathBuf};
 use clap::Parser;
 use serde_json::{json, Value};
 
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::output::json_error;
 use crate::scope_enumeration::{scan, Violation};
@@ -176,7 +177,7 @@ fn resolve_plan_file_from_state(
         }
     };
 
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(root, &branch).state_file();
     if !state_path.exists() {
         return Ok(Err(json!({
             "status": "error",

--- a/src/plan_extract.rs
+++ b/src/plan_extract.rs
@@ -567,8 +567,15 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         "# Pre-Decomposed Analysis: {}\n\n{}",
         feature_desc, issue_body
     );
-    let dag_rel = format!(".flow-states/{}-dag.md", branch);
     let dag_abs = FlowPaths::new(&root, &branch).dag_file();
+    // Derive the relative path from the absolute path so the value
+    // stored in state stays in sync with the on-disk location. If
+    // `FlowPaths::dag_file()` ever changes its suffix, the state
+    // file's `files.dag` entry follows automatically.
+    let dag_rel = dag_abs
+        .strip_prefix(&root)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| dag_abs.to_string_lossy().into_owned());
     std::fs::write(&dag_abs, &dag_content)
         .map_err(|e| format!("Failed to write DAG file: {}", e))?;
 
@@ -609,8 +616,13 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     let promoted = promote_headings(&plan_section);
 
     // Write plan file
-    let plan_rel = format!(".flow-states/{}-plan.md", branch);
     let plan_abs = FlowPaths::new(&root, &branch).plan_file();
+    // Derive the relative path from the absolute path so the value
+    // stored in state stays in sync with the on-disk location.
+    let plan_rel = plan_abs
+        .strip_prefix(&root)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| plan_abs.to_string_lossy().into_owned());
     std::fs::write(&plan_abs, &promoted)
         .map_err(|e| format!("Failed to write plan file: {}", e))?;
 

--- a/src/plan_extract.rs
+++ b/src/plan_extract.rs
@@ -22,6 +22,7 @@ use serde_json::{json, Value};
 use std::process::Command;
 
 use crate::commands::log::append_log;
+use crate::flow_paths::FlowPaths;
 use crate::git::{project_root, resolve_branch};
 use crate::lock::mutate_state;
 use crate::output::json_error;
@@ -72,7 +73,7 @@ fn resolve_state(args: &Args) -> Result<(PathBuf, String, PathBuf), Value> {
         }
     };
 
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, &branch).state_file();
     if !state_path.exists() {
         return Err(json!({
             "status": "error",
@@ -109,9 +110,7 @@ fn load_frozen_config(
     Option<Vec<String>>,
     Option<indexmap::IndexMap<String, String>>,
 ) {
-    let frozen_path = root
-        .join(".flow-states")
-        .join(format!("{}-phases.json", branch));
+    let frozen_path = FlowPaths::new(root, branch).frozen_phases();
     let frozen_config = if frozen_path.exists() {
         load_phase_config(&frozen_path).ok()
     } else {
@@ -569,7 +568,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         feature_desc, issue_body
     );
     let dag_rel = format!(".flow-states/{}-dag.md", branch);
-    let dag_abs = root.join(&dag_rel);
+    let dag_abs = FlowPaths::new(&root, &branch).dag_file();
     std::fs::write(&dag_abs, &dag_content)
         .map_err(|e| format!("Failed to write DAG file: {}", e))?;
 
@@ -611,7 +610,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
 
     // Write plan file
     let plan_rel = format!(".flow-states/{}-plan.md", branch);
-    let plan_abs = root.join(&plan_rel);
+    let plan_abs = FlowPaths::new(&root, &branch).plan_file();
     std::fs::write(&plan_abs, &promoted)
         .map_err(|e| format!("Failed to write plan file: {}", e))?;
 

--- a/src/qa_verify.rs
+++ b/src/qa_verify.rs
@@ -13,6 +13,8 @@
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 
+use crate::flow_paths::FlowPaths;
+
 use clap::Parser;
 use serde_json::{json, Value};
 
@@ -34,7 +36,7 @@ pub struct Args {
 /// Find all .flow-states/*.json files, excluding non-state files
 /// (orchestrate* and *-phases.json).
 pub fn find_state_files(project_root: &Path) -> Vec<PathBuf> {
-    let state_dir = project_root.join(".flow-states");
+    let state_dir = FlowPaths::new(project_root, "").flow_states_dir();
     if !state_dir.is_dir() {
         return Vec::new();
     }

--- a/src/render_pr_body.rs
+++ b/src/render_pr_body.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use clap::Parser;
 use serde_json::json;
 
+use crate::flow_paths::FlowPaths;
 use crate::format_issues_summary::format_issues_summary;
 use crate::format_pr_timings::format_timings_table;
 use crate::git::{current_branch, project_root};
@@ -245,7 +246,7 @@ pub fn run(args: Args) {
     } else {
         let root = project_root();
         let branch = current_branch().unwrap_or_default();
-        root.join(".flow-states").join(format!("{}.json", branch))
+        FlowPaths::new(&root, &branch).state_file()
     };
 
     if !state_path.exists() {

--- a/src/start_finalize.rs
+++ b/src/start_finalize.rs
@@ -11,6 +11,7 @@ use serde_json::{json, Value};
 
 use crate::commands::log::append_log;
 use crate::commands::start_step::update_step;
+use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 use crate::lock::mutate_state;
 use crate::notify_slack;
@@ -41,7 +42,8 @@ pub struct Args {
 pub fn run_impl(args: &Args) -> Result<Value, String> {
     let root = project_root();
     let branch = &args.branch;
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let paths = FlowPaths::new(&root, branch);
+    let state_path = paths.state_file();
 
     if !state_path.exists() {
         return Ok(json!({
@@ -54,9 +56,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     update_step(&state_path, 5);
 
     // Load frozen phase config if available
-    let frozen_path = root
-        .join(".flow-states")
-        .join(format!("{}-phases.json", branch));
+    let frozen_path = paths.frozen_phases();
     let frozen_config = if frozen_path.exists() {
         phase_config::load_phase_config(&frozen_path).ok()
     } else {

--- a/src/start_gate.rs
+++ b/src/start_gate.rs
@@ -17,6 +17,7 @@ use serde_json::{json, Value};
 use crate::ci;
 use crate::commands::log::append_log;
 use crate::commands::start_step::update_step;
+use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 use crate::output::json_error;
 use crate::update_deps::run_update_deps;
@@ -38,7 +39,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     let branch = &args.branch;
 
     // Update TUI step counter
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, branch).state_file();
     update_step(&state_path, 2);
 
     // Step 1: git pull origin main

--- a/src/start_init.rs
+++ b/src/start_init.rs
@@ -19,6 +19,7 @@ use serde_json::{json, Value};
 use crate::commands::log::append_log;
 use crate::commands::start_lock::{acquire, queue_path, release};
 use crate::commands::start_step::update_step;
+use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 use crate::label_issues::{label_issues, LABEL};
 use crate::output::json_error;
@@ -50,7 +51,10 @@ pub struct Args {
 pub fn run_impl(args: &Args) -> Result<Value, String> {
     let root = project_root();
     let queue_dir = queue_path(&root);
-    let state_dir = root.join(".flow-states");
+    // Construct FlowPaths with a placeholder branch solely to reach
+    // flow_states_dir() — the directory is shared across every branch
+    // on this machine.
+    let state_dir = FlowPaths::new(&root, "").flow_states_dir();
     let _ = fs::create_dir_all(&state_dir);
 
     let plug_root = plugin_root()

--- a/src/start_workspace.rs
+++ b/src/start_workspace.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use crate::commands::log::append_log;
 use crate::commands::start_lock::{queue_path, release};
 use crate::commands::start_step::update_step;
+use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 use crate::github::detect_repo;
 use crate::lock::mutate_state;
@@ -156,7 +157,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     let feature_title = derive_feature(branch);
 
     // Update TUI step counter
-    let state_path = root.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = FlowPaths::new(&root, branch).state_file();
     update_step(&state_path, 3);
 
     let queue_dir = queue_path(&root);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -22,6 +22,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 use ratatui::Terminal;
 
+use crate::flow_paths::FlowPaths;
 use crate::tui_data::{self, AccountMetrics, FlowSummary, OrchestrationSummary};
 
 /// Auto-refresh interval.
@@ -946,10 +947,7 @@ impl TuiApp {
         );
 
         // Read log file
-        let log_path = self
-            .root
-            .join(".flow-states")
-            .join(format!("{}.log", flow.branch));
+        let log_path = FlowPaths::new(&self.root, &flow.branch).log_file();
         let log_content = std::fs::read_to_string(&log_path).ok();
         let entries = tui_data::parse_log_entries(
             log_content.as_deref().unwrap_or(""),

--- a/src/tui_data.rs
+++ b/src/tui_data.rs
@@ -10,6 +10,7 @@ use chrono::{DateTime, FixedOffset};
 use serde::Serialize;
 use serde_json::Value;
 
+use crate::flow_paths::FlowPaths;
 use crate::phase_config::{self, PHASE_ORDER};
 use crate::utils::{
     derive_feature, derive_worktree, elapsed_since, extract_issue_numbers, format_time,
@@ -529,7 +530,7 @@ pub fn flow_summary(state: &Value, now: Option<DateTime<FixedOffset>>) -> FlowSu
 /// then by feature name (alphabetical) as a tiebreaker.
 /// Skips corrupt JSON and non-state files (e.g., *-phases.json).
 pub fn load_all_flows(root: &Path) -> Vec<FlowSummary> {
-    let state_dir = root.join(".flow-states");
+    let state_dir = FlowPaths::new(root, "").flow_states_dir();
     if !state_dir.is_dir() {
         return vec![];
     }
@@ -573,7 +574,7 @@ pub fn load_all_flows(root: &Path) -> Vec<FlowSummary> {
 /// Returns None if the file does not exist, is corrupt, or the state
 /// directory does not exist.
 pub fn load_orchestration(root: &Path) -> Option<Value> {
-    let state_dir = root.join(".flow-states");
+    let state_dir = FlowPaths::new(root, "").flow_states_dir();
     if !state_dir.is_dir() {
         return None;
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+use crate::flow_paths::FlowPaths;
+
 // --- SetupError + run_cmd ---
 
 /// Error type for start-phase subprocess operations (start-workspace, auto-close-parent).
@@ -461,7 +463,7 @@ pub fn check_duplicate_issue(
     if issue_numbers.is_empty() {
         return None;
     }
-    let state_dir = project_root.join(".flow-states");
+    let state_dir = FlowPaths::new(project_root, "").flow_states_dir();
     if !state_dir.is_dir() {
         return None;
     }

--- a/tests/adversarial_agent_block.rs
+++ b/tests/adversarial_agent_block.rs
@@ -3,10 +3,14 @@
 //! These tests target edge cases in the new Agent tool blocking logic
 //! that blocks general-purpose sub-agents during active FLOW phases.
 
+mod common;
+
 use std::fs;
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
+
+use common::flow_states_dir;
 
 use serde_json::{json, Value};
 
@@ -54,7 +58,7 @@ fn setup_flow_active_repo(dir: &Path, branch_name: &str, state: &Value) {
     .unwrap();
 
     // Create state file matching the branch name
-    let state_dir = dir.join(".flow-states");
+    let state_dir = flow_states_dir(dir);
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(
         state_dir.join(format!("{}.json", branch_name)),

--- a/tests/check_phase.rs
+++ b/tests/check_phase.rs
@@ -1,5 +1,9 @@
+mod common;
+
 use std::fs;
 use std::process::Command;
+
+use common::flow_states_dir;
 
 fn make_state(current_phase: &str, phase_statuses: &[(&str, &str)]) -> String {
     let order = [
@@ -48,7 +52,7 @@ fn make_state(current_phase: &str, phase_statuses: &[(&str, &str)]) -> String {
 }
 
 fn setup_state(dir: &std::path::Path, branch: &str, state_json: &str) {
-    let state_dir = dir.join(".flow-states");
+    let state_dir = flow_states_dir(dir);
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(state_dir.join(format!("{}.json", branch)), state_json).unwrap();
 }
@@ -215,10 +219,7 @@ fn frozen_phases_file_is_loaded() {
     // Copy flow-phases.json as frozen phases
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let source = std::path::PathBuf::from(manifest_dir).join("flow-phases.json");
-    let dest = dir
-        .path()
-        .join(".flow-states")
-        .join("test-feature-phases.json");
+    let dest = flow_states_dir(dir.path()).join("test-feature-phases.json");
     fs::copy(source, dest).unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_flow-rs"))

--- a/tests/clear_blocked.rs
+++ b/tests/clear_blocked.rs
@@ -1,8 +1,11 @@
 //! Integration tests for `flow-rs clear-blocked` command.
 
+mod common;
+
 use std::fs;
 use std::process::{Command, Stdio};
 
+use common::flow_states_dir;
 use serde_json::{json, Value};
 
 fn flow_rs() -> Command {
@@ -11,7 +14,7 @@ fn flow_rs() -> Command {
 
 fn setup_git_and_state(dir: &std::path::Path, branch: &str, state: &Value) {
     let _ = Command::new("git").args(["init"]).current_dir(dir).output();
-    let state_dir = dir.join(".flow-states");
+    let state_dir = flow_states_dir(dir);
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(
         state_dir.join(format!("{}.json", branch)),
@@ -61,7 +64,8 @@ fn test_hook_clears_blocked_exits_zero() {
     assert_eq!(output.status.code().unwrap(), 0);
     assert!(output.stdout.is_empty());
 
-    let content = fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap();
+    let content =
+        fs::read_to_string(flow_states_dir(dir.path()).join("test-feature.json")).unwrap();
     let on_disk: Value = serde_json::from_str(&content).unwrap();
     assert!(on_disk.get("_blocked").is_none());
 }
@@ -106,7 +110,8 @@ fn test_hook_preserves_other_fields() {
     let output = run_clear_blocked(dir.path(), "test-feature", b"{}");
     assert_eq!(output.status.code().unwrap(), 0);
 
-    let content = fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap();
+    let content =
+        fs::read_to_string(flow_states_dir(dir.path()).join("test-feature.json")).unwrap();
     let on_disk: Value = serde_json::from_str(&content).unwrap();
     assert!(on_disk.get("_blocked").is_none());
     assert_eq!(on_disk["session_id"], "existing-session");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -67,6 +67,15 @@ pub fn flow_paths_with_dir(project_root: &Path, branch: &str) -> FlowPaths {
     fp
 }
 
+/// Returns the `.flow-states/` directory under `project_root` without
+/// creating it. Equivalent to `FlowPaths::new(project_root, "").flow_states_dir()`
+/// but shorter at callsites — test fixtures use this in place of the
+/// old `dir.path().join(".flow-states")` literal so the directory
+/// name stays owned by `FlowPaths`.
+pub fn flow_states_dir(project_root: &Path) -> std::path::PathBuf {
+    FlowPaths::new(project_root, "").flow_states_dir()
+}
+
 // --- File reading helpers ---
 
 /// Reads and returns the content of `skills/{name}/SKILL.md`.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -49,24 +49,6 @@ pub fn agents_dir() -> PathBuf {
 
 // --- FlowPaths test fixtures ---
 
-/// Construct a `FlowPaths` for a test fixture project root and branch.
-/// Tests that write branch-scoped files under `.flow-states/` should
-/// route every path through this instance rather than assembling the
-/// suffixes inline — the layout is owned by `FlowPaths`.
-pub fn flow_paths(project_root: &Path, branch: &str) -> FlowPaths {
-    FlowPaths::new(project_root, branch)
-}
-
-/// Construct a `FlowPaths` and eagerly create the `.flow-states/`
-/// directory. Use this variant in tests whose first operation is a
-/// write (state file, log, plan, etc.) so the parent directory is
-/// guaranteed to exist.
-pub fn flow_paths_with_dir(project_root: &Path, branch: &str) -> FlowPaths {
-    let fp = FlowPaths::new(project_root, branch);
-    fs::create_dir_all(fp.flow_states_dir()).expect("create .flow-states/");
-    fp
-}
-
 /// Returns the `.flow-states/` directory under `project_root` without
 /// creating it. Equivalent to `FlowPaths::new(project_root, "").flow_states_dir()`
 /// but shorter at callsites — test fixtures use this in place of the

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,6 +12,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+use flow_rs::flow_paths::FlowPaths;
 use serde_json::{json, Value};
 
 // --- Path helpers ---
@@ -44,6 +45,26 @@ pub fn bin_dir() -> PathBuf {
 /// Returns the agents/ directory path.
 pub fn agents_dir() -> PathBuf {
     repo_root().join("agents")
+}
+
+// --- FlowPaths test fixtures ---
+
+/// Construct a `FlowPaths` for a test fixture project root and branch.
+/// Tests that write branch-scoped files under `.flow-states/` should
+/// route every path through this instance rather than assembling the
+/// suffixes inline — the layout is owned by `FlowPaths`.
+pub fn flow_paths(project_root: &Path, branch: &str) -> FlowPaths {
+    FlowPaths::new(project_root, branch)
+}
+
+/// Construct a `FlowPaths` and eagerly create the `.flow-states/`
+/// directory. Use this variant in tests whose first operation is a
+/// write (state file, log, plan, etc.) so the parent directory is
+/// guaranteed to exist.
+pub fn flow_paths_with_dir(project_root: &Path, branch: &str) -> FlowPaths {
+    let fp = FlowPaths::new(project_root, branch);
+    fs::create_dir_all(fp.flow_states_dir()).expect("create .flow-states/");
+    fp
 }
 
 // --- File reading helpers ---

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use common::flow_states_dir;
 use flow_rs::lock::mutate_state;
 use fs2::FileExt;
 use serde_json::{self, json, Value};
@@ -126,7 +127,7 @@ fn log_append_under_contention() {
     let tmp = tempfile::tempdir().expect("Failed to create tempdir");
     let repo = tmp.path().to_path_buf();
     init_git_repo(&repo);
-    fs::create_dir_all(repo.join(".flow-states")).expect("Failed to create .flow-states");
+    fs::create_dir_all(flow_states_dir(&repo)).expect("Failed to create .flow-states");
 
     let repo = Arc::new(repo);
     let barrier = Arc::new(Barrier::new(20));
@@ -156,7 +157,7 @@ fn log_append_under_contention() {
         handle.join().expect("Worker thread panicked");
     }
 
-    let log_file = repo.join(".flow-states").join("test-branch.log");
+    let log_file = flow_states_dir(&repo).join("test-branch.log");
     assert!(log_file.exists(), "Log file was not created");
 
     let content = fs::read_to_string(&log_file).expect("Failed to read log file");
@@ -192,7 +193,7 @@ fn start_lock_serialization() {
     let tmp = tempfile::tempdir().expect("Failed to create tempdir");
     let repo = tmp.path().to_path_buf();
     init_git_repo(&repo);
-    fs::create_dir_all(repo.join(".flow-states")).expect("Failed to create .flow-states");
+    fs::create_dir_all(flow_states_dir(&repo)).expect("Failed to create .flow-states");
 
     let repo = Arc::new(repo);
     let timings: Arc<Mutex<Vec<Timing>>> = Arc::new(Mutex::new(Vec::new()));
@@ -305,7 +306,7 @@ fn thundering_herd_zero_delay() {
     let tmp = tempfile::tempdir().expect("Failed to create tempdir");
     let repo = tmp.path().to_path_buf();
     init_git_repo(&repo);
-    fs::create_dir_all(repo.join(".flow-states")).expect("Failed to create .flow-states");
+    fs::create_dir_all(flow_states_dir(&repo)).expect("Failed to create .flow-states");
 
     let repo = Arc::new(repo);
     let timings: Arc<Mutex<Vec<Timing>>> = Arc::new(Mutex::new(Vec::new()));
@@ -422,7 +423,7 @@ fn parallel_state_file_creation() {
     //5 threads each write a state file for a different branch.
     //All must succeed with correct content.
     let tmp = tempfile::tempdir().expect("Failed to create tempdir");
-    let state_dir = tmp.path().join(".flow-states");
+    let state_dir = flow_states_dir(tmp.path());
     fs::create_dir_all(&state_dir).expect("Failed to create .flow-states");
 
     let state_dir = Arc::new(state_dir);
@@ -480,7 +481,7 @@ fn cleanup_isolation() {
     let tmp = tempfile::tempdir().expect("Failed to create tempdir");
     let repo = tmp.path().to_path_buf();
     init_git_repo(&repo);
-    let state_dir = repo.join(".flow-states");
+    let state_dir = flow_states_dir(&repo);
     fs::create_dir_all(&state_dir).expect("Failed to create .flow-states");
 
     let state_a = state_dir.join("branch-a.json");

--- a/tests/dispatcher.rs
+++ b/tests/dispatcher.rs
@@ -1,4 +1,8 @@
+mod common;
+
 use std::process::Command;
+
+use common::flow_states_dir;
 
 // --- generate-id ---
 
@@ -33,7 +37,7 @@ fn generate_id_stdout_is_8_char_hex() {
 #[test]
 fn log_exits_0_and_writes_file() {
     let dir = tempfile::tempdir().unwrap();
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     std::fs::create_dir(&state_dir).unwrap();
 
     // Initialize a git repo so project_root() works
@@ -166,7 +170,7 @@ fn format_status_valid_state_exits_0() {
         .trim()
         .to_string();
 
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     std::fs::create_dir(&state_dir).unwrap();
     let state = serde_json::json!({
         "branch": branch,
@@ -232,7 +236,7 @@ fn format_status_branch_flag() {
         .output()
         .unwrap();
 
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     std::fs::create_dir(&state_dir).unwrap();
     let state = serde_json::json!({
         "branch": "other-feature",
@@ -292,7 +296,7 @@ fn format_status_corrupt_json_exits_1() {
         .trim()
         .to_string();
 
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     std::fs::create_dir(&state_dir).unwrap();
     std::fs::write(state_dir.join(format!("{}.json", branch)), "{bad json").unwrap();
 

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -8,10 +8,14 @@
 //! and `src/hooks/stop_continue.rs` were tested only via in-process unit tests
 //! that bypassed the clap wiring, stdin reading, and branch resolution layers.
 
+mod common;
+
 use std::fs;
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
+
+use common::flow_states_dir;
 
 use serde_json::{json, Value};
 
@@ -35,7 +39,7 @@ fn flow_rs() -> Command {
 /// resolution deterministic (same pattern as `tests/clear_blocked.rs`).
 fn setup_git_and_state(dir: &Path, branch: &str, state: &Value) {
     let _ = Command::new("git").args(["init"]).current_dir(dir).output();
-    let state_dir = dir.join(".flow-states");
+    let state_dir = flow_states_dir(dir);
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(
         state_dir.join(format!("{}.json", branch)),
@@ -53,7 +57,7 @@ fn setup_git_and_state(dir: &Path, branch: &str, state: &Value) {
 /// risk that a branch-name typo in the path diverges from the
 /// `setup_git_and_state` call.
 fn read_state(dir: &Path, branch: &str) -> Value {
-    let path = dir.join(format!(".flow-states/{}.json", branch));
+    let path = flow_states_dir(dir).join(format!("{}.json", branch));
     serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
 }
 
@@ -468,7 +472,7 @@ fn test_stop_continue_qa_pending_fallback_blocks() {
     // No branch state file — only a qa-pending breadcrumb. The hook's
     // `check_qa_pending` fallback in `run()` should fire and produce block
     // output carrying the QA context.
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(
         state_dir.join("qa-pending.json"),

--- a/tests/hooks_shared.rs
+++ b/tests/hooks_shared.rs
@@ -1,10 +1,13 @@
 //! Tests for shared hook utilities (src/hooks/mod.rs).
 
+mod common;
+
 use std::fs;
 use std::path::Path;
 
 use serde_json::json;
 
+use common::flow_states_dir;
 use flow_rs::hooks;
 
 // === find_settings_and_root_from ===
@@ -113,7 +116,7 @@ fn test_detect_branch_not_in_worktree() {
 #[test]
 fn test_is_flow_active_with_state_file() {
     let dir = tempfile::tempdir().unwrap();
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(state_dir.join("my-feature.json"), "{}").unwrap();
 
@@ -123,7 +126,7 @@ fn test_is_flow_active_with_state_file() {
 #[test]
 fn test_is_flow_active_no_state_file() {
     let dir = tempfile::tempdir().unwrap();
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
 
     assert!(!hooks::is_flow_active("my-feature", dir.path()));
@@ -138,7 +141,7 @@ fn test_is_flow_active_empty_branch() {
 #[test]
 fn test_is_flow_active_rejects_path_separators() {
     let dir = tempfile::tempdir().unwrap();
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
 
     assert!(!hooks::is_flow_active("../etc/passwd", dir.path()));

--- a/tests/init_state.rs
+++ b/tests/init_state.rs
@@ -1,7 +1,10 @@
+mod common;
+
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 
+use common::flow_states_dir;
 use serde_json::{json, Value};
 
 fn flow_rs() -> Command {
@@ -60,7 +63,7 @@ fn parse_stdout(output: &std::process::Output) -> Value {
 }
 
 fn read_state_file(dir: &std::path::Path, branch: &str) -> Value {
-    let path = dir.join(".flow-states").join(format!("{}.json", branch));
+    let path = flow_states_dir(dir).join(format!("{}.json", branch));
     let content = fs::read_to_string(&path).unwrap();
     serde_json::from_str(&content).unwrap()
 }
@@ -233,7 +236,7 @@ fn auto_flag_overrides_skills() {
 fn prompt_from_prompt_file() {
     let dir = tempfile::tempdir().unwrap();
     setup_project(dir.path(), "rails", None);
-    let prompt_path = dir.path().join(".flow-states");
+    let prompt_path = flow_states_dir(dir.path());
     fs::create_dir_all(&prompt_path).unwrap();
     let prompt_file = prompt_path.join("test-prompt-file");
     fs::write(&prompt_file, "fix login timeout with special chars: && | ;").unwrap();
@@ -385,7 +388,7 @@ fn log_file_created() {
     let dir = tempfile::tempdir().unwrap();
     setup_project(dir.path(), "rails", None);
     run_init_state(dir.path(), &["log test"]);
-    let log_path = dir.path().join(".flow-states").join("log-test.log");
+    let log_path = flow_states_dir(dir.path()).join("log-test.log");
     assert!(log_path.exists());
     let log = fs::read_to_string(&log_path).unwrap();
     assert!(log.contains("[Phase 1]"));
@@ -398,10 +401,7 @@ fn frozen_phases_file_created() {
     let dir = tempfile::tempdir().unwrap();
     setup_project(dir.path(), "rails", None);
     run_init_state(dir.path(), &["frozen phases"]);
-    let frozen = dir
-        .path()
-        .join(".flow-states")
-        .join("frozen-phases-phases.json");
+    let frozen = flow_states_dir(dir.path()).join("frozen-phases-phases.json");
     assert!(frozen.exists());
 }
 
@@ -410,10 +410,7 @@ fn frozen_phases_file_matches_source() {
     let dir = tempfile::tempdir().unwrap();
     setup_project(dir.path(), "rails", None);
     run_init_state(dir.path(), &["phases match"]);
-    let frozen = dir
-        .path()
-        .join(".flow-states")
-        .join("phases-match-phases.json");
+    let frozen = flow_states_dir(dir.path()).join("phases-match-phases.json");
     let frozen_data: Value = serde_json::from_str(&fs::read_to_string(&frozen).unwrap()).unwrap();
     let source_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("flow-phases.json");
     let source_data: Value =
@@ -463,7 +460,7 @@ fn fetch_issue_title_failure_returns_error() {
     let dir = tempfile::tempdir().unwrap();
     setup_project(dir.path(), "rails", None);
 
-    let prompt_path = dir.path().join(".flow-states");
+    let prompt_path = flow_states_dir(dir.path());
     fs::create_dir_all(&prompt_path).unwrap();
     let prompt_file = prompt_path.join("test-prompt");
     fs::write(&prompt_file, "work on issue #999").unwrap();
@@ -491,10 +488,7 @@ fn fetch_issue_title_failure_returns_error() {
     assert_eq!(data["step"], "fetch_issue_title");
 
     // No state file should be created
-    let state_path = dir
-        .path()
-        .join(".flow-states")
-        .join("fetch-failure-test.json");
+    let state_path = flow_states_dir(dir.path()).join("fetch-failure-test.json");
     assert!(
         !state_path.exists(),
         "State file should not be created when fetch fails"
@@ -509,7 +503,7 @@ fn duplicate_issue_detected_before_state_creation() {
     setup_project(dir.path(), "rails", None);
 
     // Pre-create an existing state file referencing issue #777
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(
         state_dir.join("existing-flow.json"),
@@ -593,7 +587,7 @@ fn flow_in_progress_label_blocks_start() {
         dir.path(),
         r#"{"title": "Some Issue", "labels": ["Flow In-Progress"]}"#,
     );
-    let prompt_file = write_prompt_file(&dir.path().join(".flow-states"), "work on issue #100");
+    let prompt_file = write_prompt_file(&flow_states_dir(dir.path()), "work on issue #100");
 
     let output = flow_rs()
         .arg("init-state")
@@ -633,7 +627,7 @@ fn flow_in_progress_label_blocks_start() {
     );
 
     // No state file should be created when the guard fires
-    let state_path = dir.path().join(".flow-states").join("some-issue.json");
+    let state_path = flow_states_dir(dir.path()).join("some-issue.json");
     assert!(
         !state_path.exists(),
         "state file must not be created when label guard fires"
@@ -649,7 +643,7 @@ fn flow_in_progress_label_absent_allows_start() {
     setup_project(dir.path(), "rails", None);
 
     let stub_dir = write_gh_stub(dir.path(), r#"{"title": "Some Issue", "labels": []}"#);
-    let prompt_file = write_prompt_file(&dir.path().join(".flow-states"), "work on issue #100");
+    let prompt_file = write_prompt_file(&flow_states_dir(dir.path()), "work on issue #100");
 
     let output = flow_rs()
         .arg("init-state")
@@ -673,7 +667,7 @@ fn flow_in_progress_label_absent_allows_start() {
     assert_eq!(data["status"], "ok");
     assert_eq!(data["branch"], "some-issue");
 
-    let state_path = dir.path().join(".flow-states").join("some-issue.json");
+    let state_path = flow_states_dir(dir.path()).join("some-issue.json");
     assert!(
         state_path.exists(),
         "state file should be created when label is absent"
@@ -693,7 +687,7 @@ fn flow_in_progress_label_case_sensitive_match() {
         dir.path(),
         r#"{"title": "Some Issue", "labels": ["flow in-progress"]}"#,
     );
-    let prompt_file = write_prompt_file(&dir.path().join(".flow-states"), "work on issue #100");
+    let prompt_file = write_prompt_file(&flow_states_dir(dir.path()), "work on issue #100");
 
     let output = flow_rs()
         .arg("init-state")
@@ -728,7 +722,7 @@ fn flow_in_progress_label_with_other_labels() {
         dir.path(),
         r#"{"title": "Multi Label", "labels": ["bug", "Flow In-Progress", "decomposed"]}"#,
     );
-    let prompt_file = write_prompt_file(&dir.path().join(".flow-states"), "work on issue #100");
+    let prompt_file = write_prompt_file(&flow_states_dir(dir.path()), "work on issue #100");
 
     let output = flow_rs()
         .arg("init-state")
@@ -763,7 +757,7 @@ fn flow_in_progress_label_checked_before_duplicate_issue() {
     setup_project(dir.path(), "rails", None);
 
     // Pre-create a local state file targeting the same issue
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(
         state_dir.join("existing-flow.json"),

--- a/tests/phase_enter.rs
+++ b/tests/phase_enter.rs
@@ -3,10 +3,13 @@
 //! phase-enter consolidates: gate check + phase_enter() + step counters +
 //! state data return into a single command parameterized by --phase.
 
+mod common;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+use common::flow_states_dir;
 use serde_json::{json, Value};
 
 // --- Test helpers ---
@@ -58,7 +61,7 @@ fn create_state(
     prev_status: &str,
     skills: Option<Value>,
 ) {
-    let state_dir = repo.join(".flow-states");
+    let state_dir = flow_states_dir(repo);
     fs::create_dir_all(&state_dir).unwrap();
 
     let skills_val = skills.unwrap_or(json!({}));
@@ -202,7 +205,7 @@ fn test_code_phase_happy_path() {
     assert_eq!(data["mode"]["continue"], "manual");
 
     // State should be updated — phase entered
-    let state_path = repo.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = flow_states_dir(&repo).join(format!("{}.json", branch));
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert_eq!(state["phases"]["flow-code"]["status"], "in_progress");
     assert_eq!(state["current_phase"], "flow-code");
@@ -236,7 +239,7 @@ fn test_code_review_phase_happy_path() {
     assert_eq!(data["phase"], "flow-code-review");
 
     // State should have step counters set
-    let state_path = repo.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = flow_states_dir(&repo).join(format!("{}.json", branch));
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert_eq!(state["phases"]["flow-code-review"]["status"], "in_progress");
     assert_eq!(state["code_review_steps_total"], 4);
@@ -267,7 +270,7 @@ fn test_learn_phase_happy_path() {
     assert_eq!(data["phase"], "flow-learn");
 
     // State should have step counters set
-    let state_path = repo.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = flow_states_dir(&repo).join(format!("{}.json", branch));
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert_eq!(state["phases"]["flow-learn"]["status"], "in_progress");
     assert_eq!(state["learn_steps_total"], 7);
@@ -422,7 +425,7 @@ fn test_step_counter_field_names() {
     );
     assert_eq!(parse_output(&output)["status"], "ok");
     let state: Value = serde_json::from_str(
-        &fs::read_to_string(repo.join(".flow-states").join(format!("{}.json", branch))).unwrap(),
+        &fs::read_to_string(flow_states_dir(&repo).join(format!("{}.json", branch))).unwrap(),
     )
     .unwrap();
     assert_eq!(state["code_review_steps_total"], 4);
@@ -466,7 +469,7 @@ fn test_no_steps_total_flag() {
     assert_eq!(parse_output(&output)["status"], "ok");
 
     let state: Value = serde_json::from_str(
-        &fs::read_to_string(repo.join(".flow-states").join(format!("{}.json", branch))).unwrap(),
+        &fs::read_to_string(flow_states_dir(&repo).join(format!("{}.json", branch))).unwrap(),
     )
     .unwrap();
     // No step counter fields should be set

--- a/tests/phase_finalize.rs
+++ b/tests/phase_finalize.rs
@@ -3,10 +3,13 @@
 //! phase-finalize consolidates: phase_complete() + Slack notification +
 //! add-notification into a single command parameterized by --phase.
 
+mod common;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+use common::flow_states_dir;
 use serde_json::{json, Value};
 
 // --- Test helpers ---
@@ -45,7 +48,7 @@ fn create_git_repo(parent: &Path) -> PathBuf {
 
 /// Create a state file with a specified phase in_progress.
 fn create_state(repo: &Path, branch: &str, current_phase: &str, skills_continue: &str) {
-    let state_dir = repo.join(".flow-states");
+    let state_dir = flow_states_dir(repo);
     fs::create_dir_all(&state_dir).unwrap();
 
     let state = json!({
@@ -204,7 +207,7 @@ fn test_learn_with_slack_reply_skipped() {
     assert!(data["continue_action"].is_string());
 
     // State should be updated — phase completed
-    let state_path = repo.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = flow_states_dir(&repo).join(format!("{}.json", branch));
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert_eq!(state["phases"]["flow-learn"]["status"], "complete");
 }
@@ -234,7 +237,7 @@ fn test_start_creates_slack_thread_skipped() {
     assert!(data["formatted_time"].is_string());
 
     // State should show Start complete
-    let state_path = repo.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = flow_states_dir(&repo).join(format!("{}.json", branch));
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert_eq!(state["phases"]["flow-start"]["status"], "complete");
 }
@@ -257,7 +260,7 @@ fn test_no_slack_config() {
     );
 
     // Phase still completes
-    let state_path = repo.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = flow_states_dir(&repo).join(format!("{}.json", branch));
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert_eq!(state["phases"]["flow-code"]["status"], "complete");
 }
@@ -305,7 +308,7 @@ fn test_code_phase() {
     let data = parse_output(&output);
     assert_eq!(data["status"], "ok");
 
-    let state_path = repo.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = flow_states_dir(&repo).join(format!("{}.json", branch));
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert_eq!(state["phases"]["flow-code"]["status"], "complete");
     assert_eq!(state["current_phase"], "flow-code-review");
@@ -322,7 +325,7 @@ fn test_code_review_phase() {
     let data = parse_output(&output);
     assert_eq!(data["status"], "ok");
 
-    let state_path = repo.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = flow_states_dir(&repo).join(format!("{}.json", branch));
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert_eq!(state["phases"]["flow-code-review"]["status"], "complete");
     assert_eq!(state["current_phase"], "flow-learn");

--- a/tests/phase_transition.rs
+++ b/tests/phase_transition.rs
@@ -1,5 +1,9 @@
+mod common;
+
 use std::fs;
 use std::process::Command;
+
+use common::flow_states_dir;
 
 fn make_state(current_phase: &str, phase_statuses: &[(&str, &str)]) -> String {
     let order = [
@@ -53,7 +57,7 @@ fn make_state(current_phase: &str, phase_statuses: &[(&str, &str)]) -> String {
 }
 
 fn setup_state(dir: &std::path::Path, branch: &str, state_json: &str) {
-    let state_dir = dir.join(".flow-states");
+    let state_dir = flow_states_dir(dir);
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(state_dir.join(format!("{}.json", branch)), state_json).unwrap();
 }
@@ -175,7 +179,7 @@ fn error_corrupt_json() {
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(dir.path(), "test-feature");
 
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(state_dir.join("test-feature.json"), "{bad json").unwrap();
 
@@ -213,10 +217,7 @@ fn frozen_phases_file_is_used() {
     // Copy flow-phases.json as frozen
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let source = std::path::PathBuf::from(manifest_dir).join("flow-phases.json");
-    let dest = dir
-        .path()
-        .join(".flow-states")
-        .join("test-feature-phases.json");
+    let dest = flow_states_dir(dir.path()).join("test-feature-phases.json");
     fs::copy(source, dest).unwrap();
 
     // Enter
@@ -260,7 +261,7 @@ fn non_code_phase_no_diff_stats() {
     assert_eq!(code, 0);
 
     // Read state file to verify no diff_stats
-    let state_path = dir.path().join(".flow-states").join("test-feature.json");
+    let state_path = flow_states_dir(dir.path()).join("test-feature.json");
     let content = fs::read_to_string(state_path).unwrap();
     let state: serde_json::Value = serde_json::from_str(&content).unwrap();
     assert!(
@@ -332,7 +333,7 @@ fn code_phase_completion_captures_diff_stats() {
     assert_eq!(json["status"], "ok");
 
     // Read state file to verify diff_stats
-    let state_path = dir.path().join(".flow-states").join("my-feature.json");
+    let state_path = flow_states_dir(dir.path()).join("my-feature.json");
     let content = fs::read_to_string(state_path).unwrap();
     let updated: serde_json::Value = serde_json::from_str(&content).unwrap();
     assert!(
@@ -452,7 +453,7 @@ fn diff_stats_with_merge_commit_in_history() {
     assert_eq!(json["status"], "ok");
 
     // Verify diff_stats parsed correctly with merge in history
-    let state_path = dir.path().join(".flow-states").join("my-feature.json");
+    let state_path = flow_states_dir(dir.path()).join("my-feature.json");
     let content = fs::read_to_string(state_path).unwrap();
     let updated: serde_json::Value = serde_json::from_str(&content).unwrap();
     let stats = &updated["diff_stats"];

--- a/tests/plan_check.rs
+++ b/tests/plan_check.rs
@@ -22,6 +22,8 @@ use std::process::Command;
 
 mod common;
 
+use common::flow_states_dir;
+
 /// Initialize a bare git repo in `dir` with a `main` branch and a dummy
 /// commit. Plan-check only needs the state file, but `project_root()`
 /// requires `.git/` to exist.
@@ -60,7 +62,7 @@ fn setup_git_repo(dir: &std::path::Path, branch: &str) {
 
 /// Write the state file under `.flow-states/<branch>.json`.
 fn write_state(dir: &std::path::Path, branch: &str, plan_rel: Option<&str>) {
-    let state_dir = dir.join(".flow-states");
+    let state_dir = flow_states_dir(dir);
     fs::create_dir_all(&state_dir).unwrap();
     let state = serde_json::json!({
         "branch": branch,

--- a/tests/plan_extract.rs
+++ b/tests/plan_extract.rs
@@ -1,3 +1,6 @@
+mod common;
+
+use common::flow_states_dir;
 use flow_rs::plan_extract::{count_tasks, extract_implementation_plan, promote_headings};
 
 // --- Unit tests for pure functions ---
@@ -209,6 +212,8 @@ mod integration {
     use std::fs;
     use std::process::Command;
 
+    use super::flow_states_dir;
+
     fn setup_git_repo(dir: &std::path::Path, branch: &str) {
         Command::new("git")
             .args(["-c", "init.defaultBranch=main", "init"])
@@ -243,7 +248,7 @@ mod integration {
     }
 
     fn setup_state(dir: &std::path::Path, branch: &str, state_json: &str) {
-        let state_dir = dir.join(".flow-states");
+        let state_dir = flow_states_dir(dir);
         fs::create_dir_all(&state_dir).unwrap();
         fs::write(state_dir.join(format!("{}.json", branch)), state_json).unwrap();
     }
@@ -405,7 +410,7 @@ mod integration {
         let dir = tempfile::tempdir().unwrap();
         setup_git_repo(dir.path(), "test-feature");
 
-        let state_dir = dir.path().join(".flow-states");
+        let state_dir = flow_states_dir(dir.path());
         fs::create_dir_all(&state_dir).unwrap();
         fs::write(state_dir.join("test-feature.json"), "{bad json").unwrap();
 
@@ -528,7 +533,7 @@ mod integration {
 
         // Verify state file was updated: flow-plan should be complete
         let updated_state: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap(),
+            &fs::read_to_string(flow_states_dir(dir.path()).join("test-feature.json")).unwrap(),
         )
         .unwrap();
         assert_eq!(
@@ -569,7 +574,7 @@ mod integration {
 
         // Critical: state file must NOT be corrupted with "complete"
         let updated_state: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap(),
+            &fs::read_to_string(flow_states_dir(dir.path()).join("test-feature.json")).unwrap(),
         )
         .unwrap();
         assert_ne!(
@@ -641,7 +646,7 @@ exit 1
         assert_eq!(json["issue_number"], 99);
 
         // DAG file should have been created
-        let dag_path = dir.path().join(".flow-states/test-feature-dag.md");
+        let dag_path = flow_states_dir(dir.path()).join("test-feature-dag.md");
         assert!(
             dag_path.exists(),
             "DAG file should be created for decomposed issues"
@@ -685,15 +690,15 @@ exit 1
         assert!(json["continue_action"].is_string());
 
         // Verify DAG and plan files created on disk
-        let dag_path = dir.path().join(".flow-states/test-feature-dag.md");
+        let dag_path = flow_states_dir(dir.path()).join("test-feature-dag.md");
         assert!(dag_path.exists(), "DAG file should exist");
 
-        let plan_path = dir.path().join(".flow-states/test-feature-plan.md");
+        let plan_path = flow_states_dir(dir.path()).join("test-feature-plan.md");
         assert!(plan_path.exists(), "Plan file should exist");
 
         // Verify state file shows flow-plan complete
         let updated_state: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap(),
+            &fs::read_to_string(flow_states_dir(dir.path()).join("test-feature.json")).unwrap(),
         )
         .unwrap();
         assert_eq!(
@@ -749,7 +754,7 @@ exit 1
         );
 
         // Plan file MUST exist on disk so the user can edit it in place.
-        let plan_path = dir.path().join(".flow-states/test-feature-plan.md");
+        let plan_path = flow_states_dir(dir.path()).join("test-feature-plan.md");
         assert!(
             plan_path.exists(),
             "plan file must be written to disk even on violation"
@@ -757,7 +762,7 @@ exit 1
 
         // Phase must NOT be marked complete.
         let updated_state: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap(),
+            &fs::read_to_string(flow_states_dir(dir.path()).join("test-feature.json")).unwrap(),
         )
         .unwrap();
         assert_ne!(
@@ -806,7 +811,7 @@ exit 1
 
         // Phase must not be marked complete.
         let updated_state: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap(),
+            &fs::read_to_string(flow_states_dir(dir.path()).join("test-feature.json")).unwrap(),
         )
         .unwrap();
         assert_ne!(
@@ -844,7 +849,7 @@ exit 1
         assert_eq!(json["path"], "resumed");
 
         let updated_state: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap(),
+            &fs::read_to_string(flow_states_dir(dir.path()).join("test-feature.json")).unwrap(),
         )
         .unwrap();
         assert_eq!(

--- a/tests/session_context.rs
+++ b/tests/session_context.rs
@@ -1,6 +1,9 @@
+mod common;
+
 use std::fs;
 use std::process::Command;
 
+use common::flow_states_dir;
 use serde_json::{json, Value};
 
 fn flow_rs() -> Command {
@@ -125,7 +128,7 @@ fn no_state_directory_exits_0_silent() {
 fn empty_state_directory_exits_0_silent() {
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(dir.path());
-    fs::create_dir(dir.path().join(".flow-states")).unwrap();
+    fs::create_dir(flow_states_dir(dir.path())).unwrap();
     let result = run_session_context(dir.path());
     assert_eq!(result.status.code(), Some(0));
     assert_eq!(result.stdout.len(), 0, "No stdout when state dir is empty");
@@ -137,7 +140,7 @@ fn empty_state_directory_exits_0_silent() {
 fn state_files_present_exits_0_no_json() {
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(dir.path());
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir(&state_dir).unwrap();
 
     let state = make_state();
@@ -166,7 +169,7 @@ fn state_files_present_exits_0_no_json() {
 fn on_main_with_state_files_exits_0_no_json() {
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(dir.path());
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir(&state_dir).unwrap();
 
     let state = make_state();
@@ -190,7 +193,7 @@ fn on_main_with_state_files_exits_0_no_json() {
 fn state_files_not_mutated() {
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(dir.path());
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir(&state_dir).unwrap();
 
     let state = make_state();

--- a/tests/session_start.rs
+++ b/tests/session_start.rs
@@ -5,6 +5,8 @@ mod common;
 use std::fs;
 use std::process::Command;
 
+use common::flow_states_dir;
+
 fn run_session_start(cwd: &std::path::Path) -> std::process::Output {
     let script = common::hooks_dir().join("session-start.sh");
     Command::new("bash")
@@ -97,7 +99,7 @@ fn no_state_directory_exits_0_silent() {
 #[test]
 fn empty_state_directory_exits_0_silent() {
     let dir = tempfile::tempdir().unwrap();
-    fs::create_dir_all(dir.path().join(".flow-states")).unwrap();
+    fs::create_dir_all(flow_states_dir(dir.path())).unwrap();
     let output = run_session_start(dir.path());
     assert!(output.status.success());
     assert_eq!(
@@ -133,7 +135,7 @@ fn flow_json_no_state_files_exits_0() {
 fn active_flow_color_sequences_not_in_stdout() {
     let dir = tempfile::tempdir().unwrap();
     init_git_repo(dir.path());
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(
         state_dir.join("color-test.json"),
@@ -161,7 +163,7 @@ fn active_flow_color_sequences_not_in_stdout() {
 fn state_files_present_exits_0_no_json() {
     let dir = tempfile::tempdir().unwrap();
     init_git_repo(dir.path());
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(
         state_dir.join("my-feature.json"),
@@ -184,7 +186,7 @@ fn state_files_present_exits_0_no_json() {
 fn on_main_with_state_files_exits_0_no_json() {
     let dir = tempfile::tempdir().unwrap();
     init_git_repo(dir.path());
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(
         state_dir.join("some-feature.json"),
@@ -206,7 +208,7 @@ fn on_main_with_state_files_exits_0_no_json() {
 fn state_files_not_mutated() {
     let dir = tempfile::tempdir().unwrap();
     init_git_repo(dir.path());
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
 
     let mut state: serde_json::Value =

--- a/tests/set_blocked.rs
+++ b/tests/set_blocked.rs
@@ -1,8 +1,11 @@
 //! Integration tests for `flow-rs set-blocked` command.
 
+mod common;
+
 use std::fs;
 use std::process::{Command, Stdio};
 
+use common::flow_states_dir;
 use regex::Regex;
 use serde_json::{json, Value};
 
@@ -16,7 +19,7 @@ fn iso_pattern() -> Regex {
 
 fn setup_git_and_state(dir: &std::path::Path, branch: &str, state: &Value) {
     let _ = Command::new("git").args(["init"]).current_dir(dir).output();
-    let state_dir = dir.join(".flow-states");
+    let state_dir = flow_states_dir(dir);
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(
         state_dir.join(format!("{}.json", branch)),
@@ -48,7 +51,8 @@ fn test_hook_sets_blocked_exits_zero() {
     assert_eq!(output.status.code().unwrap(), 0);
     assert!(output.stdout.is_empty());
 
-    let content = fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap();
+    let content =
+        fs::read_to_string(flow_states_dir(dir.path()).join("test-feature.json")).unwrap();
     let on_disk: Value = serde_json::from_str(&content).unwrap();
     assert!(on_disk.get("_blocked").is_some());
     assert!(iso_pattern().is_match(on_disk["_blocked"].as_str().unwrap()));

--- a/tests/set_timestamp.rs
+++ b/tests/set_timestamp.rs
@@ -1,8 +1,11 @@
 //! Integration tests for `flow-rs set-timestamp` command.
 
+mod common;
+
 use std::fs;
 use std::process::Command;
 
+use common::flow_states_dir;
 use regex::Regex;
 use serde_json::{json, Value};
 
@@ -35,7 +38,7 @@ fn make_state() -> Value {
 }
 
 fn setup_state(dir: &std::path::Path, branch: &str, state: &Value) -> std::path::PathBuf {
-    let state_dir = dir.join(".flow-states");
+    let state_dir = flow_states_dir(dir);
     fs::create_dir_all(&state_dir).unwrap();
     let path = state_dir.join(format!("{}.json", branch));
     fs::write(&path, serde_json::to_string_pretty(state).unwrap()).unwrap();
@@ -78,7 +81,8 @@ fn test_cli_happy_path() {
     assert_eq!(output["updates"][0]["value"], "approved");
 
     // Verify file was updated
-    let content = fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap();
+    let content =
+        fs::read_to_string(flow_states_dir(dir.path()).join("test-feature.json")).unwrap();
     let on_disk: Value = serde_json::from_str(&content).unwrap();
     assert_eq!(on_disk["design"]["status"], "approved");
 }
@@ -155,7 +159,8 @@ fn test_cli_integer_coercion() {
     assert_eq!(code, 0);
     assert_eq!(output["updates"][0]["value"], 1);
 
-    let content = fs::read_to_string(dir.path().join(".flow-states/test-feature.json")).unwrap();
+    let content =
+        fs::read_to_string(flow_states_dir(dir.path()).join("test-feature.json")).unwrap();
     let on_disk: Value = serde_json::from_str(&content).unwrap();
     assert_eq!(on_disk["code_review_step"], 1);
     assert!(on_disk["code_review_step"].is_i64());
@@ -235,7 +240,7 @@ fn test_cli_error_no_state_file() {
         .output();
 
     // Create .flow-states dir but no state file
-    fs::create_dir_all(dir.path().join(".flow-states")).unwrap();
+    fs::create_dir_all(flow_states_dir(dir.path())).unwrap();
 
     let mut cmd = flow_rs();
     cmd.arg("set-timestamp")
@@ -299,7 +304,7 @@ fn test_cli_error_invalid_format() {
 #[test]
 fn test_cli_error_corrupt_json() {
     let dir = tempfile::tempdir().unwrap();
-    let state_dir = dir.path().join(".flow-states");
+    let state_dir = flow_states_dir(dir.path());
     fs::create_dir_all(&state_dir).unwrap();
     fs::write(state_dir.join("test-feature.json"), "{bad json").unwrap();
 

--- a/tests/start_finalize.rs
+++ b/tests/start_finalize.rs
@@ -11,7 +11,7 @@ use std::process::{Command, Output};
 
 use serde_json::{json, Value};
 
-use common::parse_output;
+use common::{flow_states_dir, parse_output};
 
 // --- Test helpers ---
 
@@ -49,7 +49,7 @@ fn create_git_repo(parent: &Path) -> PathBuf {
 
 /// Create a state file with flow-start in_progress (ready for completion).
 fn create_state_file(repo: &Path, branch: &str, skills_continue: &str) {
-    let state_dir = repo.join(".flow-states");
+    let state_dir = flow_states_dir(repo);
     fs::create_dir_all(&state_dir).unwrap();
     let state = json!({
         "schema_version": 1,
@@ -188,7 +188,7 @@ fn test_happy_path_no_slack() {
     );
 
     // State should be updated
-    let state_path = repo.join(".flow-states").join("finalize-branch.json");
+    let state_path = flow_states_dir(&repo).join("finalize-branch.json");
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert_eq!(state["phases"]["flow-start"]["status"], "complete");
     assert_eq!(state["current_phase"], "flow-plan");

--- a/tests/start_gate.rs
+++ b/tests/start_gate.rs
@@ -12,7 +12,7 @@ use std::process::{Command, Output};
 
 use serde_json::json;
 
-use common::{create_git_repo_with_remote, parse_output};
+use common::{create_git_repo_with_remote, flow_states_dir, parse_output};
 
 // --- Test helpers ---
 
@@ -63,7 +63,7 @@ fn create_bin_deps(repo: &Path, script_body: &str) {
 
 /// Set up a state file so start-gate can find the branch.
 fn create_state_file(repo: &Path, branch: &str) {
-    let state_dir = repo.join(".flow-states");
+    let state_dir = flow_states_dir(repo);
     fs::create_dir_all(&state_dir).unwrap();
     let state = json!({
         "schema_version": 1,

--- a/tests/start_init.rs
+++ b/tests/start_init.rs
@@ -11,8 +11,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use common::{
-    create_gh_stub, create_git_repo_with_remote, current_plugin_version, parse_output,
-    write_flow_json,
+    create_gh_stub, create_git_repo_with_remote, current_plugin_version, flow_states_dir,
+    parse_output, write_flow_json,
 };
 
 // --- Test helpers ---
@@ -73,7 +73,7 @@ fn test_ready_path_happy() {
     assert!(data["branch"].is_string(), "branch field must be present");
 
     // Lock should be acquired (still held — start-workspace releases it)
-    let queue_dir = repo.join(".flow-states").join("start-queue");
+    let queue_dir = flow_states_dir(&repo).join("start-queue");
     assert!(
         queue_dir.join("test-feature").exists(),
         "Lock queue entry must exist after start-init"
@@ -81,7 +81,7 @@ fn test_ready_path_happy() {
 
     // State file should be created by init-state subprocess
     let branch = data["branch"].as_str().unwrap();
-    let state_path = repo.join(".flow-states").join(format!("{}.json", branch));
+    let state_path = flow_states_dir(&repo).join(format!("{}.json", branch));
     assert!(
         state_path.exists(),
         "State file must be created by init-state"
@@ -96,7 +96,7 @@ fn test_locked_path() {
     let stub_dir = create_default_gh_stub(&repo);
 
     // Pre-create a lock entry for another feature
-    let queue_dir = repo.join(".flow-states").join("start-queue");
+    let queue_dir = flow_states_dir(&repo).join("start-queue");
     fs::create_dir_all(&queue_dir).unwrap();
     fs::write(queue_dir.join("other-feature"), "").unwrap();
 
@@ -130,7 +130,7 @@ fn test_prime_check_failed() {
     );
 
     // Lock must be released after prime-check failure
-    let queue_dir = repo.join(".flow-states").join("start-queue");
+    let queue_dir = flow_states_dir(&repo).join("start-queue");
     assert!(
         !queue_dir.join("prime-fail").exists(),
         "Lock must be released on prime-check error"
@@ -156,8 +156,8 @@ fn test_init_state_error() {
     );
 
     // Write a prompt file that references a nonexistent issue
-    let prompt_path = repo.join(".flow-states").join("init-error-start-prompt");
-    fs::create_dir_all(repo.join(".flow-states")).unwrap();
+    let prompt_path = flow_states_dir(&repo).join("init-error-start-prompt");
+    fs::create_dir_all(flow_states_dir(&repo)).unwrap();
     fs::write(&prompt_path, "work on issue #999").unwrap();
 
     let output = run_start_init(
@@ -170,7 +170,7 @@ fn test_init_state_error() {
     assert_eq!(data["status"], "error");
 
     // Issue fetch fails before lock acquisition — no lock was ever acquired
-    let queue_dir = repo.join(".flow-states").join("start-queue");
+    let queue_dir = flow_states_dir(&repo).join("start-queue");
     // No lock under the feature name
     assert!(
         !queue_dir.join("init-error").exists(),
@@ -286,7 +286,7 @@ fn test_no_flow_json_returns_error() {
     );
 
     // Lock must be released (under canonical branch name)
-    let queue_dir = repo.join(".flow-states").join("start-queue");
+    let queue_dir = flow_states_dir(&repo).join("start-queue");
     assert!(
         !queue_dir.join("no-flow-json").exists(),
         "Lock must be released on prime-check error"
@@ -323,8 +323,8 @@ fn test_lock_uses_canonical_branch_not_feature_name() {
     );
 
     // Prompt references issue #42
-    let prompt_path = repo.join(".flow-states").join("regression-start-prompt");
-    fs::create_dir_all(repo.join(".flow-states")).unwrap();
+    let prompt_path = flow_states_dir(&repo).join("regression-start-prompt");
+    fs::create_dir_all(flow_states_dir(&repo)).unwrap();
     fs::write(&prompt_path, "work on issue #42").unwrap();
 
     let output = run_start_init(
@@ -343,7 +343,7 @@ fn test_lock_uses_canonical_branch_not_feature_name() {
     );
 
     // Lock must be under the canonical branch name
-    let queue_dir = repo.join(".flow-states").join("start-queue");
+    let queue_dir = flow_states_dir(&repo).join("start-queue");
     assert!(
         queue_dir.join("add-dark-mode-toggle").exists(),
         "Lock must be under canonical branch name (issue-derived)"

--- a/tests/start_workspace.rs
+++ b/tests/start_workspace.rs
@@ -12,8 +12,8 @@ use std::process::{Command, Output};
 use serde_json::{json, Value};
 
 use common::{
-    create_gh_stub, create_git_repo_with_remote, current_plugin_version, parse_output,
-    write_flow_json,
+    create_gh_stub, create_git_repo_with_remote, current_plugin_version, flow_states_dir,
+    parse_output, write_flow_json,
 };
 
 // --- Test helpers ---
@@ -29,7 +29,7 @@ fn create_default_gh_stub(repo: &Path) -> PathBuf {
 
 /// Set up a pre-existing state file (simulating init-state already ran).
 fn create_state_file(repo: &Path, branch: &str) {
-    let state_dir = repo.join(".flow-states");
+    let state_dir = flow_states_dir(repo);
     fs::create_dir_all(&state_dir).unwrap();
     let state = json!({
         "schema_version": 1,
@@ -64,7 +64,7 @@ fn create_state_file(repo: &Path, branch: &str) {
 
 /// Create a lock queue entry for this feature.
 fn create_lock_entry(repo: &Path, feature: &str) {
-    let queue_dir = repo.join(".flow-states").join("start-queue");
+    let queue_dir = flow_states_dir(repo).join("start-queue");
     fs::create_dir_all(&queue_dir).unwrap();
     fs::write(queue_dir.join(feature), "").unwrap();
 }
@@ -120,14 +120,14 @@ fn test_happy_path() {
     assert!(repo.join(".worktrees").join("test-branch").is_dir());
 
     // Lock should be released (keyed by branch, not by description)
-    let queue_dir = repo.join(".flow-states").join("start-queue");
+    let queue_dir = flow_states_dir(&repo).join("start-queue");
     assert!(
         !queue_dir.join("test-branch").exists(),
         "Lock must be released after start-workspace"
     );
 
     // State file should have PR fields backfilled
-    let state_path = repo.join(".flow-states").join("test-branch.json");
+    let state_path = flow_states_dir(&repo).join("test-branch.json");
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert!(state["pr_number"].is_number());
     assert!(state["pr_url"].is_string());
@@ -168,7 +168,7 @@ fn test_lock_released_with_mismatched_description() {
     assert_eq!(data["status"], "ok");
 
     // Lock must be released under the BRANCH name, not the description
-    let queue_dir = repo.join(".flow-states").join("start-queue");
+    let queue_dir = flow_states_dir(&repo).join("start-queue");
     assert!(
         !queue_dir.join("mismatch-branch").exists(),
         "Lock must be released using branch name, not description"
@@ -207,7 +207,7 @@ fn test_worktree_failure_releases_lock() {
     assert_eq!(data["status"], "error");
 
     // Lock MUST still be released on error
-    let queue_dir = repo.join(".flow-states").join("start-queue");
+    let queue_dir = flow_states_dir(&repo).join("start-queue");
     assert!(
         !queue_dir.join("test-branch").exists(),
         "Lock must be released even on worktree failure"
@@ -230,7 +230,7 @@ fn test_pr_creation_failure_releases_lock() {
     assert_eq!(data["status"], "error");
 
     // Lock must be released
-    let queue_dir = repo.join(".flow-states").join("start-queue");
+    let queue_dir = flow_states_dir(&repo).join("start-queue");
     assert!(
         !queue_dir.join("pr-fail-branch").exists(),
         "Lock must be released even on PR creation failure"
@@ -285,7 +285,7 @@ fn test_state_backfill_preserves_existing_fields() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let state_path = repo.join(".flow-states").join("backfill-branch.json");
+    let state_path = flow_states_dir(&repo).join("backfill-branch.json");
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     // Original fields preserved
     assert_eq!(state["started_at"], "2026-01-01T00:00:00-08:00");
@@ -333,7 +333,7 @@ fn test_worktree_cwd_includes_relative_cwd_suffix() {
     let stub_dir = create_default_gh_stub(&repo);
 
     // Pre-create state file with non-empty relative_cwd
-    let state_dir = repo.join(".flow-states");
+    let state_dir = flow_states_dir(&repo);
     fs::create_dir_all(&state_dir).unwrap();
     let state = json!({
         "schema_version": 1,


### PR DESCRIPTION
## What

Centralize .flow-states path construction with FlowPaths struct #1044.

Closes #1044

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/centralize-flow-states-path-plan.md` |
| DAG | `.flow-states/centralize-flow-states-path-dag.md` |
| Log | `.flow-states/centralize-flow-states-path.log` |
| State | `.flow-states/centralize-flow-states-path.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/23e4f037-b3d7-49af-94cb-94255fb596c8.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

45 Rust modules construct `.flow-states/<branch>-*` paths using inline `format!()` or `.join(".flow-states")` with zero centralization. Introducing a `FlowPaths` struct centralizes all branch-scoped path construction so the upcoming directory-based layout migration becomes a single-point change inside `FlowPaths` internals rather than a 45-file behavioral change.

## Exploration

| File | Role | Path patterns constructed |
|------|------|--------------------------|
| `src/cleanup.rs` | Canonical file type list | All 12 branch-scoped paths: state, log, plan, dag, phases, ci-sentinel, timings, closed-issues, issues, adversarial_test (glob), rule-content, start-prompt |
| `src/commands/init_state.rs` | Creator | state `.json`, `.log`, `-phases.json`, sets `files.log` and `files.state` in state JSON |
| `src/phase_enter.rs` | Core consumer | `root.join(".flow-states").join(format!("{}.json", branch))` |
| `src/phase_finalize.rs` | Core consumer | Same pattern as phase_enter |
| `src/start_init.rs` | Start phase | state file, start-prompt, lock queue paths |
| `src/start_workspace.rs` | Start phase | state file path |
| `src/hooks/mod.rs` | Hook entry | state file existence check |
| `src/hooks/validate_ask_user.rs` | Hook | state file read |
| `src/hooks/validate_claude_paths.rs` | Hook | state file read |
| `src/hooks/validate_worktree_paths.rs` | Hook | state file read |
| `src/hooks/stop_continue.rs` | Hook | state file + log file |
| `src/hooks/stop_failure.rs` | Hook | state file |
| `src/hooks/post_compact.rs` | Hook | state file |
| `src/tui_data.rs` | UI | glob `*.json` in `.flow-states/` for flow discovery |
| `src/tui.rs` | UI | log file path |
| `src/ci.rs` | CI gate | state file, ci-sentinel |
| `src/finalize_commit.rs` | Commit | state file |
| `src/phase_config.rs` | Config | frozen phases path |
| `src/cwd_scope.rs` | Guard | state file |
| `src/git.rs` | Git ops | state file |
| `src/plan_check.rs` | Plan gate | state file |
| `src/plan_extract.rs` | Plan | state file |
| `src/commands/log.rs` | Logging | log file path |
| `src/commands/set_timestamp.rs` | State mutation | state file |
| `src/commands/set_blocked.rs` | State mutation | state file |
| `src/commands/clear_blocked.rs` | State mutation | state file |
| `src/commands/start_step.rs` | State mutation | state file |
| `src/add_issue.rs` | State mutation | state file |
| `src/add_finding.rs` | State mutation | state file |
| `src/add_notification.rs` | State mutation | state file |
| `src/append_note.rs` | State mutation | state file |
| `src/complete_fast.rs` | Complete | state file |
| `src/complete_finalize.rs` | Complete finalize | state file |
| `src/complete_post_merge.rs` | Complete post-merge | state, log, plan, dag, phases, ci-sentinel, timings, closed-issues, issues, adversarial_test |
| `src/complete_preflight.rs` | Complete | state file |
| `src/render_pr_body.rs` | PR body | state file |
| `src/commands/start_lock.rs` | Start lock | lock queue paths in `.flow-states/` |
| `src/orchestrate_state.rs` | Orchestrate | state file (non-branch paths stay inline) |
| `src/orchestrate_report.rs` | Orchestrate | state file (non-branch paths stay inline) |
| `src/qa_reset.rs` | QA | state file |
| `src/qa_verify.rs` | QA | state file |
| `src/utils.rs` | Utility | state file lookup in `check_duplicate_issue()` |
| `src/main.rs` | Dispatcher | state file paths at lines ~705, ~800 |
| `src/start_gate.rs` | Start gate | state file |
| `src/start_finalize.rs` | Start finalize | state file |
| `tests/init_state.rs` | Test | state, log, phases paths |
| `tests/start_init.rs` | Test | state file path |
| `tests/start_workspace.rs` | Test | state file via `create_state_file()` helper |
| `tests/start_finalize.rs` | Test | state file path |
| `tests/session_context.rs` | Test | state file path |
| `tests/roundtrip.rs` | Test | plan, log file paths in state JSON |
| `tests/hooks.rs` | Test | state file via `read_state()` helper |
| `tests/set_blocked.rs` | Test | state file path |
| `tests/start_gate.rs` | Test | state file path |
| `tests/set_timestamp.rs` | Test | state file path |
| `tests/session_start.rs` | Test | state file path |
| `tests/plan_extract.rs` | Test | state file path |
| `tests/plan_check.rs` | Test | state file path |
| `tests/phase_transition.rs` | Test | state file path |
| `tests/phase_finalize.rs` | Test | state file path |
| `tests/phase_enter.rs` | Test | state file path |
| `tests/hooks_shared.rs` | Test | state file path |
| `tests/dispatcher.rs` | Test | state file path |
| `tests/concurrency.rs` | Test | state file path |
| `tests/clear_blocked.rs` | Test | state file path |
| `tests/check_phase.rs` | Test | state file path |
| `tests/adversarial_agent_block.rs` | Test | state file path |

## Risks

- **Scope correction.** The original issue enumerated 43 source modules and 8 test files. Codebase verification during Plan phase found 45 source modules (added `src/complete_finalize.rs`, `src/complete_post_merge.rs`, `src/commands/start_lock.rs`; removed `src/label_issues.rs` which receives path via CLI arg) and 21 test files with inline `.flow-states` path construction.
- **45-file refactor typo risk.** Each module migration is mechanical (replace inline `format!()` with `FlowPaths` method call), but 45 files means 45 opportunities for typos. Mitigation: `bin/flow ci` catches regressions since behavior is unchanged — all paths resolve identically.
- **Non-branch-scoped paths mixed in.** Some modules (orchestrate_state, orchestrate_report, utils) construct both branch-scoped and non-branch-scoped paths. Only branch-scoped paths migrate; non-branch paths stay inline. Mitigation: each module must be read to identify which paths are branch-scoped.
- **`tui_data.rs` glob pattern.** Currently scans `.flow-states/*.json` to discover active flows. The glob stays unchanged in this issue but the `FlowPaths` struct should expose a `flow_states_dir()` accessor so the follow-up issue can change the discovery pattern. Mitigation: note in the struct's doc comment.
- **Test fixture divergence.** If test files are not migrated alongside production code, they construct paths using the old pattern and would silently break if the follow-up issue changes the layout inside `FlowPaths`. Mitigation: migrate tests in the same PR.

## Approach

Introduce `src/flow_paths.rs` with a `FlowPaths` struct that returns the current flat-layout paths. Migrate all 45 modules in batches (core consumers, commands, hooks, UI, others) and all 21 test files. Add a common test helper to `tests/common/mod.rs`. Every path method returns the same value as the current inline construction — zero behavioral change.

The struct exposes:
- `new(project_root, branch)` constructor
- Individual file accessors: `state_file()`, `log_file()`, `plan_file()`, `dag_file()`, `frozen_phases()`, `ci_sentinel()`, `timings_file()`, `closed_issues()`, `issues_file()`, `rule_content()`, `start_prompt()`, `adversarial_test_prefix()`
- Directory accessor: `flow_states_dir()` for callers that need the parent directory
- `branch()` accessor for callers that need the branch name

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Create FlowPaths struct with unit tests | implement + test | — |
| 2. Add FlowPaths test helper to tests/common/mod.rs | implement | 1 |
| 3. Migrate core state file consumers (14 modules) | refactor | 1 |
| 4. Migrate command modules (6 modules) | refactor | 1 |
| 5. Migrate hook modules (7 modules) | refactor | 1 |
| 6. Migrate UI/data modules (2 modules) | refactor | 1 |
| 7. Migrate remaining modules (16 modules) | refactor | 1 |
| 8. Migrate test files (21 files) | refactor | 2 |
| 9. Final CI verification | test | 3, 4, 5, 6, 7, 8 |

## Tasks

### Task 1: Create FlowPaths struct with unit tests

Create `src/flow_paths.rs` with `FlowPaths` struct. Each method returns the current flat-layout path:
- `state_file()` → `<flow_states>/<branch>.json`
- `log_file()` → `<flow_states>/<branch>.log`
- `plan_file()` → `<flow_states>/<branch>-plan.md`
- `dag_file()` → `<flow_states>/<branch>-dag.md`
- `frozen_phases()` → `<flow_states>/<branch>-phases.json`
- `ci_sentinel()` → `<flow_states>/<branch>-ci-passed`
- `timings_file()` → `<flow_states>/<branch>-timings.md`
- `closed_issues()` → `<flow_states>/<branch>-closed-issues.json`
- `issues_file()` → `<flow_states>/<branch>-issues.md`
- `rule_content()` → `<flow_states>/<branch>-rule-content.md`
- `start_prompt()` → `<flow_states>/<branch>-start-prompt`
- `adversarial_test_prefix()` → `<branch>-adversarial_test.`

Add `pub mod flow_paths;` to `src/main.rs` (or `src/lib.rs`).

TDD: Unit tests verify each method returns the expected path for a given project root and branch name.

Files: `src/flow_paths.rs` (new), `src/main.rs` (mod declaration)

### Task 2: Add FlowPaths test helper to tests/common/mod.rs

Add a helper function to `tests/common/mod.rs` that constructs a `FlowPaths` instance for test fixtures, reducing boilerplate across the 21 test files.

Files: `tests/common/mod.rs`

### Task 3: Migrate core state file consumers (14 modules)

Replace inline path construction with `FlowPaths` method calls in: `src/commands/init_state.rs`, `src/add_issue.rs`, `src/add_finding.rs`, `src/add_notification.rs`, `src/append_note.rs`, `src/phase_enter.rs`, `src/phase_finalize.rs`, `src/start_finalize.rs`, `src/start_gate.rs`, `src/start_init.rs`, `src/start_workspace.rs`, `src/plan_check.rs`, `src/plan_extract.rs`, `src/main.rs`.

Each module: construct `FlowPaths::new(root, branch)` once, replace all `root.join(".flow-states").join(format!(...))` calls with the appropriate method.

TDD: `bin/flow ci` passes — behavior is identical.

### Task 4: Migrate command modules (6 modules)

Replace inline path construction in: `src/commands/clear_blocked.rs`, `src/commands/set_blocked.rs`, `src/commands/set_timestamp.rs`, `src/commands/start_step.rs`, `src/commands/start_lock.rs`, `src/commands/log.rs`.

TDD: `bin/flow ci` passes.

### Task 5: Migrate hook modules (7 modules)

Replace inline path construction in: `src/hooks/mod.rs`, `src/hooks/stop_continue.rs`, `src/hooks/stop_failure.rs`, `src/hooks/post_compact.rs`, `src/hooks/validate_ask_user.rs`, `src/hooks/validate_claude_paths.rs`, `src/hooks/validate_worktree_paths.rs`.

TDD: `bin/flow ci` passes.

### Task 6: Migrate UI/data modules (2 modules)

Replace inline path construction in: `src/tui.rs`, `src/tui_data.rs`. Note: `tui_data.rs` glob pattern for flow discovery stays as-is but should use `FlowPaths::flow_states_dir()` for the directory path.

TDD: `bin/flow ci` passes.

### Task 7: Migrate remaining modules (16 modules)

Replace inline path construction in: `src/complete_fast.rs`, `src/complete_finalize.rs`, `src/complete_post_merge.rs`, `src/complete_preflight.rs`, `src/render_pr_body.rs`, `src/finalize_commit.rs`, `src/phase_config.rs`, `src/cwd_scope.rs`, `src/ci.rs`, `src/cleanup.rs`, `src/git.rs`, `src/orchestrate_state.rs`, `src/orchestrate_report.rs`, `src/qa_reset.rs`, `src/qa_verify.rs`, `src/utils.rs`.

Note: `orchestrate_state.rs` and `orchestrate_report.rs` may have non-branch-scoped paths that stay inline.

TDD: `bin/flow ci` passes.

### Task 8: Migrate test files (21 files)

Replace inline path construction in: `tests/init_state.rs`, `tests/start_init.rs`, `tests/start_workspace.rs`, `tests/start_finalize.rs`, `tests/start_gate.rs`, `tests/session_context.rs`, `tests/session_start.rs`, `tests/hooks.rs`, `tests/hooks_shared.rs`, `tests/set_blocked.rs`, `tests/set_timestamp.rs`, `tests/plan_extract.rs`, `tests/plan_check.rs`, `tests/phase_transition.rs`, `tests/phase_finalize.rs`, `tests/phase_enter.rs`, `tests/dispatcher.rs`, `tests/concurrency.rs`, `tests/clear_blocked.rs`, `tests/check_phase.rs`, `tests/adversarial_agent_block.rs`.

Use the common helper from Task 2 where possible.

TDD: All tests pass with identical behavior.

### Task 9: Final CI verification

Run `bin/flow ci` end-to-end. Verify zero test failures, zero behavioral change. Grep for any remaining inline `.flow-states` path construction in `src/*.rs` to confirm complete migration.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: Centralize .flow-states path construction with FlowPaths struct

## Problem

Currently 43 Rust modules construct `.flow-states` paths ad-hoc using inline `format!()` calls like `root.join(".flow-states").join(format!("{}.json", branch))`. There is zero centralization — every module duplicates the path construction pattern independently.

This duplication has two costs:
1. **Layout changes require touching 43 files simultaneously.** The planned directory-based migration requires changing every path construction site in one shot without this refactor.
2. **Path construction bugs are invisible.** A typo in one module's `format!()` string produces a wrong path that only surfaces at runtime in that specific phase.

Evidence from codebase exploration:
- `src/cleanup.rs` constructs 12 distinct file paths inline
- `src/commands/init_state.rs` constructs state, log, and phases paths inline
- `src/phase_enter.rs`, `src/phase_finalize.rs`, `src/start_init.rs` all duplicate the same `root.join(".flow-states").join(format!("{}.json", branch))` pattern
- 7 hook modules each independently construct state file paths
- 8 test files duplicate the same path patterns for fixtures
- No central helper exists anywhere in the codebase

## Acceptance Criteria

- A `FlowPaths` struct exists in `src/flow_paths.rs` with methods for every branch-scoped file type (state, log, plan, dag, frozen_phases, ci_sentinel, timings, closed_issues, issues, rule_content, start_prompt, adversarial_test_prefix)
- All 43 Rust modules use `FlowPaths` methods instead of inline `format!()` for branch-scoped paths
- Non-branch-scoped paths (orchestrate, create-issue, decompose-project) remain inline — they are not branch-scoped
- `bin/flow ci` passes with zero behavioral change — all paths resolve to the same flat-layout locations as before
- Unit tests cover every `FlowPaths` method
- Test files use `FlowPaths` (or a common helper) for fixture path construction

## Implementation Plan

### Context

43 Rust modules construct `.flow-states/<branch>-*` paths using inline `format!()` with zero centralization. Introducing a `FlowPaths` struct centralizes all branch-scoped path construction so the upcoming directory-based layout migration becomes a single-point change inside `FlowPaths` internals rather than a 43-file behavioral change.

### Exploration

| File | Role | Path patterns constructed |
|------|------|--------------------------|
| `src/cleanup.rs` | Canonical file type list | All 12 branch-scoped paths: state, log, plan, dag, phases, ci-sentinel, timings, closed-issues, issues, adversarial_test (glob), rule-content, start-prompt |
| `src/commands/init_state.rs` | Creator | state `.json`, `.log`, `-phases.json`, sets `files.log` and `files.state` in state JSON |
| `src/phase_enter.rs` | Core consumer | `root.join(".flow-states").join(format!("{}.json", branch))` |
| `src/phase_finalize.rs` | Core consumer | Same pattern as phase_enter |
| `src/start_init.rs` | Start phase | state file, start-prompt, lock queue paths |
| `src/start_workspace.rs` | Start phase | state file path |
| `src/hooks/mod.rs` | Hook entry | state file existence check |
| `src/hooks/validate_ask_user.rs` | Hook | state file read |
| `src/hooks/validate_claude_paths.rs` | Hook | state file read |
| `src/hooks/validate_worktree_paths.rs` | Hook | state file read |
| `src/hooks/stop_continue.rs` | Hook | state file + log file |
| `src/hooks/stop_failure.rs` | Hook | state file |
| `src/hooks/post_compact.rs` | Hook | state file |
| `src/tui_data.rs` | UI | glob `*.json` in `.flow-states/` for flow discovery |
| `src/tui.rs` | UI | log file path |
| `src/ci.rs` | CI gate | state file, ci-sentinel |
| `src/finalize_commit.rs` | Commit | state file |
| `src/phase_config.rs` | Config | frozen phases path |
| `src/cwd_scope.rs` | Guard | state file |
| `src/git.rs` | Git ops | state file |
| `src/plan_check.rs` | Plan gate | state file |
| `src/plan_extract.rs` | Plan | state file |
| `src/commands/log.rs` | Logging | log file path |
| `src/commands/set_timestamp.rs` | State mutation | state file |
| `src/commands/set_blocked.rs` | State mutation | state file |
| `src/commands/clear_blocked.rs` | State mutation | state file |
| `src/commands/start_step.rs` | State mutation | state file |
| `src/add_issue.rs` | State mutation | state file |
| `src/add_finding.rs` | State mutation | state file |
| `src/add_notification.rs` | State mutation | state file |
| `src/append_note.rs` | State mutation | state file |
| `src/complete_fast.rs` | Complete | state file |
| `src/complete_preflight.rs` | Complete | state file |
| `src/render_pr_body.rs` | PR body | state file |
| `src/label_issues.rs` | Labels | state file |
| `src/orchestrate_state.rs` | Orchestrate | state file (non-branch paths stay inline) |
| `src/orchestrate_report.rs` | Orchestrate | state file (non-branch paths stay inline) |
| `src/qa_reset.rs` | QA | state file |
| `src/qa_verify.rs` | QA | state file |
| `src/utils.rs` | Utility | state file lookup in `check_duplicate_issue()` |
| `src/main.rs` | Dispatcher | state file paths at lines ~705, ~800 |
| `src/start_gate.rs` | Start gate | state file |
| `src/start_finalize.rs` | Start finalize | state file |
| `tests/init_state.rs` | Test | state, log, phases paths |
| `tests/start_init.rs` | Test | state file path |
| `tests/start_workspace.rs` | Test | state file via `create_state_file()` helper |
| `tests/start_finalize.rs` | Test | state file path |
| `tests/session_context.rs` | Test | state file path |
| `tests/roundtrip.rs` | Test | plan, log file paths in state JSON |
| `tests/hooks.rs` | Test | state file via `read_state()` helper |
| `tests/set_blocked.rs` | Test | state file path |

### Risks

- **43-file refactor typo risk.** Each module migration is mechanical (replace inline `format!()` with `FlowPaths` method call), but 43 files means 43 opportunities for typos. Mitigation: `bin/flow ci` catches regressions since behavior is unchanged — all paths resolve identically.
- **Non-branch-scoped paths mixed in.** Some modules (orchestrate_state, orchestrate_report, utils) construct both branch-scoped and non-branch-scoped paths. Only branch-scoped paths migrate; non-branch paths stay inline. Mitigation: each module must be read to identify which paths are branch-scoped.
- **`tui_data.rs` glob pattern.** Currently scans `.flow-states/*.json` to discover active flows. The glob stays unchanged in this issue but the `FlowPaths` struct should expose a `flow_states_dir()` accessor so the follow-up issue can change the discovery pattern. Mitigation: note in the struct's doc comment.
- **Test fixture divergence.** If test files are not migrated alongside production code, they construct paths using the old pattern and would silently break if the follow-up issue changes the layout inside `FlowPaths`. Mitigation: migrate tests in the same PR.

### Approach

Introduce `src/flow_paths.rs` with a `FlowPaths` struct that returns the current flat-layout paths. Migrate all 43 modules in batches (core consumers, commands, hooks, UI, others) and all 8 test files. Add a common test helper to `tests/common/mod.rs`. Every path method returns the same value as the current inline construction — zero behavioral change.

The struct exposes:
- `new(project_root, branch)` constructor
- Individual file accessors: `state_file()`, `log_file()`, `plan_file()`, `dag_file()`, `frozen_phases()`, `ci_sentinel()`, `timings_file()`, `closed_issues()`, `issues_file()`, `rule_content()`, `start_prompt()`, `adversarial_test_prefix()`
- Directory accessor: `flow_states_dir()` for callers that need the parent directory
- `branch()` accessor for callers that need the branch name

### Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Create FlowPaths struct with unit tests | implement + test | — |
| 2. Add FlowPaths test helper to tests/common/mod.rs | implement | 1 |
| 3. Migrate core state file consumers (14 modules) | refactor | 1 |
| 4. Migrate command modules (5 modules) | refactor | 1 |
| 5. Migrate hook modules (7 modules) | refactor | 1 |
| 6. Migrate UI/data modules (2 modules) | refactor | 1 |
| 7. Migrate remaining modules (15 modules) | refactor | 1 |
| 8. Migrate test files (8 files) | refactor | 2 |
| 9. Final CI verification | test | 3, 4, 5, 6, 7, 8 |

### Tasks

#### Task 1: Create FlowPaths struct with unit tests

Create `src/flow_paths.rs` with `FlowPaths` struct. Each method returns the current flat-layout path:
- `state_file()` → `<flow_states>/<branch>.json`
- `log_file()` → `<flow_states>/<branch>.log`
- `plan_file()` → `<flow_states>/<branch>-plan.md`
- `dag_file()` → `<flow_states>/<branch>-dag.md`
- `frozen_phases()` → `<flow_states>/<branch>-phases.json`
- `ci_sentinel()` → `<flow_states>/<branch>-ci-passed`
- `timings_file()` → `<flow_states>/<branch>-timings.md`
- `closed_issues()` → `<flow_states>/<branch>-closed-issues.json`
- `issues_file()` → `<flow_states>/<branch>-issues.md`
- `rule_content()` → `<flow_states>/<branch>-rule-content.md`
- `start_prompt()` → `<flow_states>/<branch>-start-prompt`
- `adversarial_test_prefix()` → `<branch>-adversarial_test.`

Add `pub mod flow_paths;` to `src/main.rs` (or `src/lib.rs`).

TDD: Unit tests verify each method returns the expected path for a given project root and branch name.

Files: `src/flow_paths.rs` (new), `src/main.rs` (mod declaration)

#### Task 2: Add FlowPaths test helper to tests/common/mod.rs

Add a helper function to `tests/common/mod.rs` that constructs a `FlowPaths` instance for test fixtures, reducing boilerplate across the 8 test files.

Files: `tests/common/mod.rs`

#### Task 3: Migrate core state file consumers (14 modules)

Replace inline path construction with `FlowPaths` method calls in: `src/commands/init_state.rs`, `src/add_issue.rs`, `src/add_finding.rs`, `src/add_notification.rs`, `src/append_note.rs`, `src/phase_enter.rs`, `src/phase_finalize.rs`, `src/start_finalize.rs`, `src/start_gate.rs`, `src/start_init.rs`, `src/start_workspace.rs`, `src/plan_check.rs`, `src/plan_extract.rs`, `src/main.rs`.

Each module: construct `FlowPaths::new(root, branch)` once, replace all `root.join(".flow-states").join(format!(...))` calls with the appropriate method.

TDD: `bin/flow ci` passes — behavior is identical.

#### Task 4: Migrate command modules (5 modules)

Replace inline path construction in: `src/commands/clear_blocked.rs`, `src/commands/set_blocked.rs`, `src/commands/set_timestamp.rs`, `src/commands/start_step.rs`, `src/commands/log.rs`.

TDD: `bin/flow ci` passes.

#### Task 5: Migrate hook modules (7 modules)

Replace inline path construction in: `src/hooks/mod.rs`, `src/hooks/stop_continue.rs`, `src/hooks/stop_failure.rs`, `src/hooks/post_compact.rs`, `src/hooks/validate_ask_user.rs`, `src/hooks/validate_claude_paths.rs`, `src/hooks/validate_worktree_paths.rs`.

TDD: `bin/flow ci` passes.

#### Task 6: Migrate UI/data modules (2 modules)

Replace inline path construction in: `src/tui.rs`, `src/tui_data.rs`. Note: `tui_data.rs` glob pattern for flow discovery stays as-is but should use `FlowPaths::flow_states_dir()` for the directory path.

TDD: `bin/flow ci` passes.

#### Task 7: Migrate remaining modules (15 modules)

Replace inline path construction in: `src/complete_fast.rs`, `src/complete_preflight.rs`, `src/render_pr_body.rs`, `src/finalize_commit.rs`, `src/phase_config.rs`, `src/cwd_scope.rs`, `src/ci.rs`, `src/cleanup.rs`, `src/git.rs`, `src/label_issues.rs`, `src/orchestrate_state.rs`, `src/orchestrate_report.rs`, `src/qa_reset.rs`, `src/qa_verify.rs`, `src/utils.rs`.

Note: `orchestrate_state.rs` and `orchestrate_report.rs` may have non-branch-scoped paths that stay inline.

TDD: `bin/flow ci` passes.

#### Task 8: Migrate test files (8 files)

Replace inline path construction in: `tests/init_state.rs`, `tests/start_init.rs`, `tests/start_workspace.rs`, `tests/start_finalize.rs`, `tests/session_context.rs`, `tests/roundtrip.rs`, `tests/hooks.rs`, `tests/set_blocked.rs`.

Use the common helper from Task 2 where possible.

TDD: All tests pass with identical behavior.

#### Task 9: Final CI verification

Run `bin/flow ci` end-to-end. Verify zero test failures, zero behavioral change. Grep for any remaining inline `.flow-states` path construction in `src/*.rs` to confirm complete migration.

## Files to Investigate

- `src/cleanup.rs` — constructs all 12 branch-scoped file paths, canonical reference for the full file type list
- `src/commands/init_state.rs` — creates initial state, log, and phases files
- `src/phase_enter.rs` — representative core consumer pattern
- `src/hooks/mod.rs` — representative hook consumer pattern
- `src/tui_data.rs` — scans `.flow-states/*.json` for flow discovery (glob pattern stays unchanged but noted for follow-up)
- `tests/common/mod.rs` — no state path helpers currently exist here

## Out of Scope

- Changing the file layout (flat to directory) — that is the follow-up issue
- Migrating non-branch-scoped file paths (orchestrate, create-issue, decompose-project)
- Updating SKILL.md, docs, rules, or CLAUDE.md — no behavioral change means no doc updates
- Adding backward-compatibility resolution logic — that belongs in the follow-up issue

## Context

This refactor is the foundation for the directory-based `.flow-states/<branch>/` migration. By centralizing path construction first as a pure refactor, the subsequent layout change becomes a single-point modification inside `FlowPaths` rather than a 43-file behavioral change. The two-phase approach (centralize, then flip) makes each PR independently reviewable and CI-safe.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | <1m |
| Code | 1h 27m |
| Code Review | 13m |
| Learn | 6m |
| Complete | <1m |
| **Total** | **1h 48m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/centralize-flow-states-path.json</summary>

```json
{
  "schema_version": 1,
  "branch": "centralize-flow-states-path",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1046,
  "pr_url": "https://github.com/benkruger/flow/pull/1046",
  "started_at": "2026-04-12T10:28:00-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/centralize-flow-states-path-plan.md",
    "dag": ".flow-states/centralize-flow-states-path-dag.md",
    "log": ".flow-states/centralize-flow-states-path.log",
    "state": ".flow-states/centralize-flow-states-path.json"
  },
  "session_tty": "/dev/ttys003",
  "session_id": "23e4f037-b3d7-49af-94cb-94255fb596c8",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/23e4f037-b3d7-49af-94cb-94255fb596c8.jsonl",
  "notes": [],
  "prompt": "Centralize .flow-states path construction with FlowPaths struct #1044",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-12T10:28:00-07:00",
      "completed_at": "2026-04-12T10:28:32-07:00",
      "session_started_at": null,
      "cumulative_seconds": 32,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-12T10:28:43-07:00",
      "completed_at": "2026-04-12T10:34:12-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-12T10:35:00-07:00",
      "completed_at": "2026-04-12T12:02:57-07:00",
      "session_started_at": null,
      "cumulative_seconds": 5277,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-12T12:03:10-07:00",
      "completed_at": "2026-04-12T12:16:16-07:00",
      "session_started_at": null,
      "cumulative_seconds": 786,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-12T12:16:29-07:00",
      "completed_at": "2026-04-12T12:23:04-07:00",
      "session_started_at": null,
      "cumulative_seconds": 395,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-12T12:23:17-07:00",
      "completed_at": "2026-04-12T12:23:36-07:00",
      "session_started_at": null,
      "cumulative_seconds": 19,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-12T10:28:43-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-12T10:35:00-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-12T12:03:10-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-12T12:16:29-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-12T12:23:17-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 9,
  "code_task_name": "Final CI verification",
  "code_task": 9,
  "diff_stats": {
    "files_changed": 66,
    "insertions": 622,
    "deletions": 244,
    "captured_at": "2026-04-12T12:02:57-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "findings": [
    {
      "finding": "Tests bypass FlowPaths by doing flow_states_dir(dir).join(format!(...))",
      "reason": "Superseded by deletion of unused flow_paths/flow_paths_with_dir helpers",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T12:10:18-07:00"
    },
    {
      "finding": "adversarial_test_prefix trailing-separator test",
      "reason": "Existing test adversarial_test_prefix_ends_in_dot verifies the invariant — suggested test covers callers, not FlowPaths",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T12:10:19-07:00"
    },
    {
      "finding": "Helper naming hazard between flow_states_dir and flow_paths_with_dir",
      "reason": "Subsumed by F1 — unused helpers being deleted",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T12:10:20-07:00"
    },
    {
      "finding": "FlowPaths preserves path traversal for slash-in-branch names",
      "reason": "Pre-existing behavior faithfully preserved from inline construction; sanitization is upstream via branch_name()",
      "outcome": "filed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T12:11:13-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1047"
    },
    {
      "finding": "FlowPaths empty-branch instances can call branch-scoped accessors without guard",
      "reason": "API design question — empty-branch is an intentional but undocumented pattern; requires design discussion to decide between debug_assert, type split, or docs",
      "outcome": "filed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T12:11:14-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1048"
    },
    {
      "finding": "flow_paths and flow_paths_with_dir helpers are dead code",
      "reason": "Unused public API; deleted both helpers from tests/common/mod.rs so the abstraction surface matches actual usage (flow_states_dir only)",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T12:12:42-07:00"
    },
    {
      "finding": "start_lock.rs inline test hardcodes .flow-states literal",
      "reason": "Migrated to FlowPaths::new(root, '').flow_states_dir().join(QUEUE_DIRNAME) so the test tracks production path construction",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T12:12:43-07:00"
    },
    {
      "finding": "plan_extract.rs dag_rel/plan_rel inline strings diverge from FlowPaths",
      "reason": "Derive dag_rel/plan_rel from the absolute path via strip_prefix so state file and on-disk location stay in sync under future FlowPaths layout changes",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T12:12:44-07:00"
    },
    {
      "finding": "code_task counter lacks mid-phase scope correction tracking",
      "reason": "Hypothetical — plan was updated during Plan phase, no actual drift in this flow; scope_corrections[] is a speculative design proposal not grounded in observed failure",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-12T12:18:53-07:00"
    },
    {
      "finding": "Plan task descriptions do not reflect discovered scope corrections",
      "reason": "The actual Task 8 description in the final plan file (line 173) WAS updated to reflect 21 test files. No drift occurred — the learning-analyst conflated the initial issue body scope with the final plan scope",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-12T12:18:54-07:00"
    },
    {
      "finding": "No protocol for mid-task scope correction in Code phase",
      "reason": "Not a real gap in this flow — scope correction happened during Plan phase before Code started; Code phase never encountered unexpected scope",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-12T12:18:55-07:00"
    },
    {
      "finding": "Plan-phase scope verification not enforced against task descriptions",
      "reason": "Duplicate of dismissed findings on plan scope correction; already handled by scope-enumeration rule and Plan-phase exploration",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-12T12:18:57-07:00"
    },
    {
      "finding": "Autonomous phases need discipline against self-imposed pauses",
      "reason": "User observed twice in PR #1046 Code phase that session paused mid-flow despite continue:auto — encoded as new rule with specific prohibited patterns",
      "outcome": "rule_written",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-12T12:19:45-07:00",
      "path": ".claude/rules/autonomous-phase-discipline.md"
    },
    {
      "finding": "Autonomous phase self-pauses need hook-level enforcement",
      "reason": "Rule added in same PR is instruction-level; user observed twice that instructions are insufficient to prevent the behavior mid-flow. Filed escalation to add PreToolUse hook that blocks AskUserQuestion during continue:auto phases",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-12T12:22:50-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1049"
    }
  ],
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "FlowPaths preserves path traversal for slash-in-branch names",
      "url": "https://github.com/benkruger/flow/issues/1047",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T12:11:10-07:00"
    },
    {
      "label": "Tech Debt",
      "title": "FlowPaths empty-branch instances can call branch-scoped accessors without guard",
      "url": "https://github.com/benkruger/flow/issues/1048",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-12T12:11:12-07:00"
    },
    {
      "label": "Flow",
      "title": "Enforce autonomous-phase-discipline rule via PreToolUse hook",
      "url": "https://github.com/benkruger/flow/issues/1049",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-12T12:22:48-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/centralize-flow-states-path.log</summary>

```text
2026-04-12T10:28:00-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-12T10:28:00-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-12T10:28:00-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-12T10:28:00-07:00 [Phase 1] create .flow-states/centralize-flow-states-path.json (exit 0)
2026-04-12T10:28:00-07:00 [Phase 1] freeze .flow-states/centralize-flow-states-path-phases.json (exit 0)
2026-04-12T10:28:00-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-12T10:28:02-07:00 [Phase 1] start-init — label-issues (labeled: [1044], failed: [])
2026-04-12T10:28:08-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-12T10:28:08-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-12T10:28:09-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-12T10:28:18-07:00 [Phase 1] start-workspace — worktree .worktrees/centralize-flow-states-path (ok)
2026-04-12T10:28:22-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-12T10:28:22-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-12T10:28:22-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-12T10:28:32-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-12T10:28:32-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-12T10:28:43-07:00 [Phase 2] plan-extract — gate check passed (exit 0)
2026-04-12T10:28:43-07:00 [Phase 2] plan-extract — issue #1044 fetched, decomposed label detected (exit 0)
2026-04-12T10:28:43-07:00 [Phase 2] plan-extract — DAG file written: .flow-states/centralize-flow-states-path-dag.md (exit 0)
2026-04-12T10:28:43-07:00 [Phase 2] plan-extract — plan extracted, 9 tasks, written: .flow-states/centralize-flow-states-path-plan.md (exit 0)
2026-04-12T10:28:45-07:00 [Phase 2] plan-extract — PR body rendered (exit 0)
2026-04-12T10:28:45-07:00 [Phase 2] plan-extract — phase complete (<1m) (exit 0)
2026-04-12T10:34:12-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-12T10:35:00-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-12T10:45:02-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-12T10:45:06-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-12T10:48:29-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-12T10:48:32-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-12T10:57:35-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-12T10:57:39-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-12T11:01:50-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-12T11:01:53-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-12T11:07:08-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-12T11:07:12-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-12T11:07:21-07:00 [stop-continue] first stop, conditional continue: pending=commit
2026-04-12T11:12:36-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-12T11:12:39-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-12T11:23:58-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-12T11:24:02-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-12T12:00:14-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-12T12:00:18-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-12T12:02:57-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-12T12:03:10-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-12T12:15:54-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-12T12:15:57-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-12T12:16:16-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-12T12:16:29-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-12T12:21:48-07:00 [Phase 5] finalize-commit — ci (ok)
2026-04-12T12:21:52-07:00 [Phase 5] finalize-commit — done ("ok")
2026-04-12T12:23:04-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-12T12:23:36-07:00 [Phase 6] complete-finalize — starting
2026-04-12T12:23:36-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-12T12:23:36-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | FlowPaths preserves path traversal for slash-in-branch names | Code Review | #1047 |
| Tech Debt | FlowPaths empty-branch instances can call branch-scoped accessors without guard | Code Review | #1048 |
| Flow | Enforce autonomous-phase-discipline rule via PreToolUse hook | Learn | #1049 |

<!-- end:Issues Filed -->