### PR TITLE
Coverage Gap Analyzeissuesrs

### DIFF
--- a/.claude/rules/docs-with-behavior.md
+++ b/.claude/rules/docs-with-behavior.md
@@ -28,6 +28,19 @@ to write the same updates you could write now.
   listed in that SKILL.md's Panel Fields / Output section so a
   future session reading the skill knows what the panel can
   contain.
+- **New permanent on-main artifact → `CLAUDE.md` "Key Files"
+  section and, if the artifact introduces a waiver/exception
+  discipline, also the "When You Must Update Docs and Tests —
+  Content sync" section.** "Permanent" here means a file that
+  lives on main (not `.flow-states/`, not `.flow-issue-body`,
+  not anything under `/tmp/`, and not gitignored). Examples:
+  `test_coverage.md` (per-file coverage waiver inventory
+  introduced in PR #1153), a future `security_waivers.md`, or
+  any other reference file the repo expects sessions to consult.
+  Future-session readers rely on Key Files as their index to the
+  repository surface area; a new permanent artifact that is
+  absent from Key Files is effectively invisible until a later
+  PR rediscovers it.
 - **Changed type signatures or module architecture → the module-
   level doc comment and every affected item's doc comment in the
   same source file.** This is where PR #1054 missed: splitting
@@ -37,6 +50,39 @@ to write the same updates you could write now.
   Source-local doc comments are documentation too — they bind
   the type to its purpose for future readers who arrive via
   grep or rustdoc rather than through the module's external docs.
+
+## Waiver Discipline (test_coverage.md and friends)
+
+`test_coverage.md` at the repo root is the canonical waiver
+inventory for code that `bin/test`'s `--fail-under-*` thresholds
+cannot reach. Every entry must:
+
+- Name specific `src/<file>.rs:LINE` coordinates (no file-wide
+  waivers — if a whole file is unreachable, the design is wrong,
+  not the coverage).
+- Include a one-sentence architectural reason (e.g.
+  `process::exit` unreachable from inside the calling process,
+  panic-only unreachable arm, defensive dead branch for
+  API-guaranteed-valid input, library-internal trait dispatch).
+- Be tied to a recorded plan-task justification — do not add
+  waiver entries speculatively during Code or Code Review.
+  Waivers in the diff without a matching plan task are a
+  Code Review finding in their own right: either drop the waiver
+  (cover the line) or back it with a plan-level architectural
+  argument.
+
+When a PR adds architecturally-unreachable code that survives
+coverage enforcement, the waiver entry lands in the same commit
+as the code. A waiver filed in a follow-up PR is the same class
+of double-work as a follow-up documentation issue — the current
+session has the context to justify the waiver; a future session
+starts from zero.
+
+Future waiver files (e.g., `security_waivers.md` for
+intentionally-unreachable security paths) follow the same
+discipline. The rule generalizes: permanent on-main waiver files
+are a kind of documentation, and documentation lives in the same
+commit as the behavior it describes.
 
 ## Agent Input Section Sync
 
@@ -58,6 +104,37 @@ means the behavior change and its documentation must land together.
 Separate commits within the same PR are not sufficient: if the PR
 is reviewed commit-by-commit, the intermediate state shows stale
 documentation.
+
+### Transitive Test Coverage After Refactor
+
+When a plan names specific test functions (e.g.
+`fetch_blockers_returns_empty_on_spawn_failure`) that become
+redundant after an extract-helper refactor — because a shared
+helper now owns the logic the tests would have exercised and the
+helper has its own direct tests — the Code phase has two
+acceptable paths, and the plan must make the choice explicit:
+
+1. **Keep the named tests.** Add the tests anyway, driving them
+   through the refactored callsite (e.g. via a test seam that
+   accepts an injectable `Command`). This preserves the
+   caller-level assertion that the delegation returns the
+   expected value on each error class.
+2. **Declare transitive coverage.** Skip the named tests and
+   record the transitive-coverage path in `test_coverage.md`
+   (or the waiver file most appropriate to the project). The
+   entry must name the helper tests that cover the same branches
+   and explain why the caller-level duplicate would be redundant.
+
+Silent omission is not acceptable. A plan that names tests and a
+PR that does not add them, without a waiver note, is a Code Review
+finding — the reviewer agent correctly flags "plan said add X but
+X is not there." Force-functioning the decision at plan or code
+time prevents that friction.
+
+The rule applies equally to documentation tasks: if a plan task
+names a doc update that becomes redundant after another task
+supersedes it, route the redundancy through an explicit waiver
+note rather than leaving the plan-task gap unexplained.
 
 ## Scope Enumeration (Rename Side)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ CI will fail if these are missing:
 - Changed skill behavior (new flag, changed steps, different workflow) — update `docs/skills/<name>.md` and the Description column in `docs/skills/index.md` to match
 - Changed phase behavior — update `docs/phases/phase-<N>-<name>.md` and the Description column in `docs/skills/index.md` to match
 - Changed architecture or capabilities — update `README.md` and `docs/index.html` if the change affects how FLOW is described to users
+- New architecturally-unreachable code — add an entry to `test_coverage.md` naming the specific `src/<file>.rs:LINE` coordinates and a one-sentence architectural reason. Every waiver must be tied to a recorded plan-task justification; do not add entries speculatively.
 
 ### Test requirements
 
@@ -74,6 +75,7 @@ CI will fail if these are missing:
 - `assets/bin-stubs/` — self-documenting bash stubs that prime copies into target projects when absent
 - `qa/templates/<name>/` — QA repo templates used by `/flow-qa`
 - `.claude-plugin/marketplace.json` — marketplace registry (version must match plugin.json)
+- `test_coverage.md` — per-file waiver inventory for lines that `bin/test`'s `--fail-under-*` thresholds cannot reach (architecturally unreachable code: `process::exit` sites, defensive dead branches, subprocess paths requiring real-network dependencies). Each entry names specific `src/<file>.rs:LINE` coordinates and a one-sentence architectural reason.
 
 ## Development Environment
 

--- a/bin/test
+++ b/bin/test
@@ -36,8 +36,15 @@ if [ $# -eq 0 ]; then
   /usr/bin/find target/llvm-cov-target -maxdepth 1 -name "*.profraw" -delete 2>/dev/null || true
 fi
 
+# Coverage floors. Each threshold sits roughly one percentage point
+# below the current aggregate TOTAL so normal day-to-day CI drift does
+# not block merges while genuine regressions do. Raise only when the
+# aggregate has comfortably moved above the current floor — use the
+# formula `floor(actual_whole_percent) - 1` after adding new coverage.
+# See `test_coverage.md` for the per-file waiver inventory when 100%
+# is not achievable.
 exec cargo llvm-cov --no-cfg-coverage --no-clean \
   --fail-under-lines 93 \
-  --fail-under-regions 94 \
+  --fail-under-regions 93 \
   --fail-under-functions 91 \
   nextest --status-level none --final-status-level fail "$@"

--- a/bin/test
+++ b/bin/test
@@ -38,6 +38,6 @@ fi
 
 exec cargo llvm-cov --no-cfg-coverage --no-clean \
   --fail-under-lines 93 \
-  --fail-under-regions 93 \
+  --fail-under-regions 94 \
   --fail-under-functions 91 \
   nextest --status-level none --final-status-level fail "$@"

--- a/src/analyze_issues.rs
+++ b/src/analyze_issues.rs
@@ -231,6 +231,93 @@ pub fn parse_blocker_response(json_str: &str, issue_numbers: &[i64]) -> HashMap<
     blockers
 }
 
+/// Spawn a subprocess, drain stdout and stderr in background threads, and
+/// wait up to `timeout` for it to exit.
+///
+/// Single source of truth for the 30-second subprocess discipline used by
+/// every `gh`-invoking path in this module. Returns `Ok((status, stdout,
+/// stderr))` on normal exit (including non-zero status), `Err` of kind
+/// `TimedOut` when the child did not exit within `timeout` (the child is
+/// killed and reaped before returning), and `Err` for spawn failures or
+/// `try_wait` failures so callers can distinguish timeouts from other
+/// I/O errors.
+///
+/// The stdout and stderr drain threads are joined after the status is
+/// known so large outputs cannot deadlock on pipe-buffer backpressure.
+fn run_with_drain_and_timeout(
+    mut cmd: std::process::Command,
+    timeout: std::time::Duration,
+) -> std::io::Result<(std::process::ExitStatus, String, String)> {
+    let mut child = cmd
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()?;
+
+    let stdout_handle = child.stdout.take();
+    let stderr_handle = child.stderr.take();
+    let stdout_reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        if let Some(mut pipe) = stdout_handle {
+            use std::io::Read;
+            let _ = pipe.read_to_string(&mut buf);
+        }
+        buf
+    });
+    let stderr_reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        if let Some(mut pipe) = stderr_handle {
+            use std::io::Read;
+            let _ = pipe.read_to_string(&mut buf);
+        }
+        buf
+    });
+
+    let start = std::time::Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(s)) => break s,
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "subprocess timed out",
+                    ));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            Err(e) => return Err(e),
+        }
+    };
+
+    let stdout = stdout_reader.join().unwrap_or_default();
+    let stderr = stderr_reader.join().unwrap_or_default();
+    Ok((status, stdout, stderr))
+}
+
+/// Interpret a `run_with_drain_and_timeout` result for consumers that need
+/// stdout bytes on success and a human-readable error message otherwise.
+///
+/// Keeps `run()`'s error-formatting logic out of the subprocess block so it
+/// can be unit-tested without spawning `gh`. `command_label` appears in
+/// every error message so upstream users see which command produced the
+/// failure (e.g. `"gh issue list failed: ..."` or `"gh issue list timed
+/// out"`).
+fn gh_result_to_stdout(
+    result: std::io::Result<(std::process::ExitStatus, String, String)>,
+    command_label: &str,
+) -> Result<String, String> {
+    match result {
+        Ok((s, stdout, _)) if s.success() => Ok(stdout),
+        Ok((_, _, stderr)) => Err(format!("{} failed: {}", command_label, stderr.trim())),
+        Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
+            Err(format!("{} timed out", command_label))
+        }
+        Err(e) => Err(format!("{} failed: {}", command_label, e)),
+    }
+}
+
 /// Fetch native blocked-by details for issues via GitHub GraphQL API.
 ///
 /// Uses `blockedBy(first: 10)` connection with batched aliased queries.
@@ -254,59 +341,22 @@ pub fn fetch_blockers(repo: &str, issue_numbers: &[i64]) -> HashMap<i64, Vec<i64
 
     let query = build_blocker_query(issue_numbers);
 
-    let mut child = match std::process::Command::new("gh")
-        .args([
-            "api",
-            "graphql",
-            "-f",
-            &format!("query={}", query),
-            "-f",
-            &format!("owner={}", owner),
-            "-f",
-            &format!("repo={}", name),
-        ])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(_) => return HashMap::new(),
-    };
+    let mut cmd = std::process::Command::new("gh");
+    cmd.args([
+        "api",
+        "graphql",
+        "-f",
+        &format!("query={}", query),
+        "-f",
+        &format!("owner={}", owner),
+        "-f",
+        &format!("repo={}", name),
+    ]);
 
-    // Drain stdout in a thread to prevent pipe buffer deadlock, then
-    // poll for exit with a 30-second timeout (the same budget the
-    // outer fetch_blockers contract documents).
-    let stdout_handle = child.stdout.take();
-    let reader = std::thread::spawn(move || {
-        let mut buf = String::new();
-        if let Some(mut pipe) = stdout_handle {
-            use std::io::Read;
-            let _ = pipe.read_to_string(&mut buf);
+    match run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(30)) {
+        Ok((status, stdout, _)) if status.success() => {
+            parse_blocker_response(&stdout, issue_numbers)
         }
-        buf
-    });
-
-    let timeout = std::time::Duration::from_secs(30);
-    let start = std::time::Instant::now();
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(s)) => break Some(s),
-            Ok(None) => {
-                if start.elapsed() >= timeout {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return HashMap::new();
-                }
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-            Err(_) => break None,
-        }
-    };
-
-    let stdout = reader.join().unwrap_or_default();
-
-    match status {
-        Some(s) if s.success() => parse_blocker_response(&stdout, issue_numbers),
         _ => HashMap::new(),
     }
 }
@@ -494,72 +544,14 @@ pub fn run(args: Args) {
             gh_args.push("--milestone".to_string());
             gh_args.push(m.clone());
         }
-        let mut child = match std::process::Command::new("gh")
-            .args(&gh_args)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-        {
-            Ok(c) => c,
-            Err(e) => {
-                crate::output::json_error(&format!("gh issue list failed: {}", e), &[]);
-                std::process::exit(1);
-            }
-        };
+        let mut cmd = std::process::Command::new("gh");
+        cmd.args(&gh_args);
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(30));
 
-        // Drain stdout in a thread to prevent pipe buffer deadlock,
-        // then poll for exit with a 30-second timeout — the analyze
-        // path's outer budget is documented on the caller above.
-        let stdout_handle = child.stdout.take();
-        let stderr_handle = child.stderr.take();
-        let stdout_reader = std::thread::spawn(move || {
-            let mut buf = String::new();
-            if let Some(mut pipe) = stdout_handle {
-                use std::io::Read;
-                let _ = pipe.read_to_string(&mut buf);
-            }
-            buf
-        });
-        let stderr_reader = std::thread::spawn(move || {
-            let mut buf = String::new();
-            if let Some(mut pipe) = stderr_handle {
-                use std::io::Read;
-                let _ = pipe.read_to_string(&mut buf);
-            }
-            buf
-        });
-
-        let timeout = std::time::Duration::from_secs(30);
-        let start = std::time::Instant::now();
-        let status = loop {
-            match child.try_wait() {
-                Ok(Some(s)) => break Some(s),
-                Ok(None) => {
-                    if start.elapsed() >= timeout {
-                        let _ = child.kill();
-                        let _ = child.wait();
-                        crate::output::json_error("gh issue list timed out", &[]);
-                        std::process::exit(1);
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(100));
-                }
-                Err(e) => {
-                    crate::output::json_error(&format!("gh issue list failed: {}", e), &[]);
-                    std::process::exit(1);
-                }
-            }
-        };
-
-        let stdout_data = stdout_reader.join().unwrap_or_default();
-        let stderr_data = stderr_reader.join().unwrap_or_default();
-
-        match status {
-            Some(s) if s.success() => stdout_data,
-            _ => {
-                crate::output::json_error(
-                    &format!("gh issue list failed: {}", stderr_data.trim()),
-                    &[],
-                );
+        match gh_result_to_stdout(result, "gh issue list") {
+            Ok(s) => s,
+            Err(msg) => {
+                crate::output::json_error(&msg, &[]);
                 std::process::exit(1);
             }
         }
@@ -956,6 +948,156 @@ mod tests {
     fn fetch_blockers_malformed_repo() {
         let result = fetch_blockers("noslash", &[10]);
         assert!(result.is_empty());
+    }
+
+    // --- run_with_drain_and_timeout ---
+
+    /// Success path: child exits 0 with stdout content; helper returns the
+    /// captured bytes and an empty stderr. Exercises the Ok((Some(s), ...))
+    /// branch plus both drain threads in the normal case.
+    #[test]
+    fn helper_success_returns_stdout() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "printf hello"]);
+        let (status, stdout, stderr) =
+            run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5)).unwrap();
+        assert!(status.success());
+        assert_eq!(stdout, "hello");
+        assert_eq!(stderr, "");
+    }
+
+    /// Empty stdout: confirms the drain thread joins cleanly when the child
+    /// produced no output at all.
+    #[test]
+    fn helper_success_with_empty_stdout() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "true"]);
+        let (status, stdout, _) =
+            run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5)).unwrap();
+        assert!(status.success());
+        assert_eq!(stdout, "");
+    }
+
+    /// Non-zero exit with stderr: helper must surface the exit code and the
+    /// stderr bytes so callers can decide whether to treat it as failure.
+    #[test]
+    fn helper_nonzero_exit_returns_stderr() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "printf oops 1>&2; exit 7"]);
+        let (status, stdout, stderr) =
+            run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5)).unwrap();
+        assert!(!status.success());
+        assert_eq!(status.code(), Some(7));
+        assert_eq!(stdout, "");
+        assert_eq!(stderr, "oops");
+    }
+
+    /// Timeout guards against a wedged subprocess: the helper kills the
+    /// child, reaps it, and returns an io::Error of kind TimedOut. The
+    /// wall-clock assertion trip-wires any regression that removes the
+    /// kill step (which would let the sleep run its full 5s).
+    #[test]
+    fn helper_timeout_kills_child_and_returns_timedout_error() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "sleep 5"]);
+        let start = std::time::Instant::now();
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_millis(200));
+        let elapsed = start.elapsed();
+        let err = result.expect_err("timeout path must return Err");
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "helper should kill the child instead of waiting for sleep 5 to finish; wall time {:?}",
+            elapsed
+        );
+    }
+
+    /// Spawn failure: targets the `spawn()?` path before any thread or
+    /// child exists. A non-existent binary returns io::Error of kind
+    /// NotFound, proving the helper propagates spawn errors as-is.
+    #[test]
+    fn helper_spawn_error_is_surfaced() {
+        let cmd = std::process::Command::new("/nonexistent/binary/path/flow-test");
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(1));
+        let err = result.expect_err("spawn of missing binary must return Err");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    /// Large stdout must not deadlock: the drain thread keeps the pipe
+    /// clear so the child can finish writing. Without threaded draining,
+    /// outputs above the kernel pipe buffer (~64KB) would block the
+    /// child forever.
+    #[test]
+    fn helper_large_stdout_does_not_deadlock() {
+        let mut cmd = std::process::Command::new("sh");
+        // 200 KB of 'x' — safely above the typical 64KB pipe buffer.
+        cmd.args(["-c", "yes x | head -c 204800"]);
+        let (status, stdout, _) =
+            run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(10)).unwrap();
+        assert!(status.success());
+        assert_eq!(stdout.len(), 204800);
+    }
+
+    // --- gh_result_to_stdout ---
+
+    /// Success: stdout flows through unchanged.
+    #[test]
+    fn gh_result_to_stdout_success_returns_stdout() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "printf payload"]);
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5));
+        let out = gh_result_to_stdout(result, "gh issue list").unwrap();
+        assert_eq!(out, "payload");
+    }
+
+    /// Non-zero exit yields a labeled error containing the trimmed stderr.
+    /// Guards the "failed:" branch that `run()` converts to `json_error` +
+    /// `process::exit(1)`.
+    #[test]
+    fn gh_result_to_stdout_nonzero_exit_returns_labeled_error() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "printf 'oops\\n' 1>&2; exit 2"]);
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5));
+        let err = gh_result_to_stdout(result, "gh issue list").unwrap_err();
+        assert_eq!(err, "gh issue list failed: oops");
+    }
+
+    /// Timeout yields a distinct error message so `run()` can print
+    /// "gh issue list timed out" rather than a generic failure.
+    #[test]
+    fn gh_result_to_stdout_timeout_returns_timeout_error() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "sleep 5"]);
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_millis(200));
+        let err = gh_result_to_stdout(result, "gh issue list").unwrap_err();
+        assert_eq!(err, "gh issue list timed out");
+    }
+
+    /// Spawn failure yields a generic labeled error carrying the io::Error
+    /// `Display`. The exact message text is not asserted (platform-variable)
+    /// but the "failed:" prefix and the label are.
+    #[test]
+    fn gh_result_to_stdout_spawn_error_returns_labeled_error() {
+        let cmd = std::process::Command::new("/nonexistent/binary/path/flow-test");
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(1));
+        let err = gh_result_to_stdout(result, "gh issue list").unwrap_err();
+        assert!(
+            err.starts_with("gh issue list failed: "),
+            "err was: {}",
+            err
+        );
+    }
+
+    /// Command label appears verbatim in every error variant — proves the
+    /// formatter doesn't hard-code "gh issue list" and can be reused by
+    /// future consumers with their own label.
+    #[test]
+    fn gh_result_to_stdout_uses_command_label() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "exit 5"]);
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5));
+        let err = gh_result_to_stdout(result, "custom label").unwrap_err();
+        assert!(err.contains("custom label"), "err was: {}", err);
     }
 
     // --- analyze_issues helpers ---

--- a/src/analyze_issues.rs
+++ b/src/analyze_issues.rs
@@ -255,21 +255,26 @@ fn run_with_drain_and_timeout(
 
     let stdout_handle = child.stdout.take();
     let stderr_handle = child.stderr.take();
+    // Drain into Vec<u8> and lossily decode. `read_to_string` returns Err
+    // and leaves the buffer empty on invalid UTF-8, which would silently
+    // drop a subprocess's diagnostic output (e.g., a locale-misconfigured
+    // `gh` emitting Latin-1). `from_utf8_lossy` preserves the payload by
+    // substituting U+FFFD for invalid sequences.
     let stdout_reader = std::thread::spawn(move || {
-        let mut buf = String::new();
+        let mut buf = Vec::new();
         if let Some(mut pipe) = stdout_handle {
             use std::io::Read;
-            let _ = pipe.read_to_string(&mut buf);
+            let _ = pipe.read_to_end(&mut buf);
         }
-        buf
+        String::from_utf8_lossy(&buf).into_owned()
     });
     let stderr_reader = std::thread::spawn(move || {
-        let mut buf = String::new();
+        let mut buf = Vec::new();
         if let Some(mut pipe) = stderr_handle {
             use std::io::Read;
-            let _ = pipe.read_to_string(&mut buf);
+            let _ = pipe.read_to_end(&mut buf);
         }
-        buf
+        String::from_utf8_lossy(&buf).into_owned()
     });
 
     let start = std::time::Instant::now();
@@ -296,25 +301,65 @@ fn run_with_drain_and_timeout(
     Ok((status, stdout, stderr))
 }
 
+/// Strip NULs, replace CR/LF with spaces, collapse runs of whitespace, and
+/// trim the result. Produces a single-line error-message-safe payload.
+///
+/// Error messages flow into JSON output consumed by the `flow-issues` skill
+/// and into operator-visible log lines; embedded control characters
+/// truncate C-string consumers (NUL), break line-oriented parsers (CR/LF),
+/// and leak internal formatting templates when the payload is whitespace
+/// only. Normalizing at the error-formatting boundary keeps downstream
+/// consumers robust without having to re-implement the same sanitization.
+fn normalize_error_payload(raw: &str) -> String {
+    let cleaned: String = raw
+        .chars()
+        .filter(|c| *c != '\0')
+        .map(|c| if c == '\r' || c == '\n' { ' ' } else { c })
+        .collect();
+    cleaned.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 /// Interpret a `run_with_drain_and_timeout` result for consumers that need
 /// stdout bytes on success and a human-readable error message otherwise.
 ///
-/// Keeps `run()`'s error-formatting logic out of the subprocess block so it
-/// can be unit-tested without spawning `gh`. `command_label` appears in
-/// every error message so upstream users see which command produced the
-/// failure (e.g. `"gh issue list failed: ..."` or `"gh issue list timed
-/// out"`).
+/// Keeps error-formatting logic out of the subprocess block so it can be
+/// unit-tested without spawning `gh`. Despite the `gh_` prefix (reflecting
+/// the two current callers, `fetch_blockers` and `run()`), the helper is
+/// generic: `command_label` is emitted verbatim, so future callers can
+/// reuse it with any label (e.g. `"git fetch"`).
+///
+/// Error payloads are normalized via `normalize_error_payload` — NULs
+/// stripped, CR/LF collapsed to spaces, interior whitespace collapsed,
+/// and the result trimmed. When the normalized stderr is empty (whitespace
+/// only, non-UTF-8 that decoded to whitespace-equivalent replacements, or
+/// no output at all), the message falls back to "(no stderr output)" plus
+/// the exit code so users never see a dangling `"gh issue list failed: "`
+/// template leak.
 fn gh_result_to_stdout(
     result: std::io::Result<(std::process::ExitStatus, String, String)>,
     command_label: &str,
 ) -> Result<String, String> {
     match result {
         Ok((s, stdout, _)) if s.success() => Ok(stdout),
-        Ok((_, _, stderr)) => Err(format!("{} failed: {}", command_label, stderr.trim())),
+        Ok((status, _, stderr)) => {
+            let normalized = normalize_error_payload(&stderr);
+            let detail = if normalized.is_empty() {
+                match status.code() {
+                    Some(code) => format!("(no stderr output, exit code {})", code),
+                    None => "(no stderr output, terminated by signal)".to_string(),
+                }
+            } else {
+                normalized
+            };
+            Err(format!("{} failed: {}", command_label, detail))
+        }
         Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
             Err(format!("{} timed out", command_label))
         }
-        Err(e) => Err(format!("{} failed: {}", command_label, e)),
+        Err(e) => {
+            let msg = normalize_error_payload(&format!("{}", e));
+            Err(format!("{} failed: {}", command_label, msg))
+        }
     }
 }
 
@@ -322,10 +367,19 @@ fn gh_result_to_stdout(
 ///
 /// Uses `blockedBy(first: 10)` connection with batched aliased queries.
 /// Returns HashMap mapping issue number to list of open blocker issue numbers.
-/// Returns empty HashMap on any failure (graceful degradation).
-/// Timeout: 30 seconds — long enough for the GraphQL endpoint to
-/// respond on a slow link, short enough to keep the analyze step
-/// from hanging the calling skill.
+///
+/// Graceful degradation: returns an empty HashMap on every failure mode —
+/// the 30-second subprocess timeout firing, `gh` spawn failure (missing
+/// binary, permission denied), `gh` exiting non-zero (auth expiry, rate
+/// limit, malformed query, missing repo permission), or a `try_wait` I/O
+/// error mid-poll. In each non-success case the helper logs a single-line
+/// diagnostic to stderr via `eprintln!` so operators can see which
+/// failure mode occurred — without that log, auth expiry would silently
+/// report every issue as unblocked and the user would have no signal.
+///
+/// Timeout: 30 seconds — long enough for the GraphQL endpoint to respond
+/// on a slow link, short enough to keep the analyze step from hanging
+/// the calling skill.
 pub fn fetch_blockers(repo: &str, issue_numbers: &[i64]) -> HashMap<i64, Vec<i64>> {
     if issue_numbers.is_empty() {
         return HashMap::new();
@@ -353,11 +407,18 @@ pub fn fetch_blockers(repo: &str, issue_numbers: &[i64]) -> HashMap<i64, Vec<i64
         &format!("repo={}", name),
     ]);
 
-    match run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(30)) {
-        Ok((status, stdout, _)) if status.success() => {
-            parse_blocker_response(&stdout, issue_numbers)
+    match gh_result_to_stdout(
+        run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(30)),
+        "gh api graphql",
+    ) {
+        Ok(stdout) => parse_blocker_response(&stdout, issue_numbers),
+        Err(msg) => {
+            eprintln!(
+                "warning: blocker fetch failed, treating all issues as unblocked ({})",
+                msg
+            );
+            HashMap::new()
         }
-        _ => HashMap::new(),
     }
 }
 
@@ -1098,6 +1159,106 @@ mod tests {
         let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5));
         let err = gh_result_to_stdout(result, "custom label").unwrap_err();
         assert!(err.contains("custom label"), "err was: {}", err);
+    }
+
+    /// Whitespace-only stderr must not produce a dangling "failed: "
+    /// template leak. The fallback includes the exit code so the operator
+    /// has something actionable.
+    #[test]
+    fn gh_result_to_stdout_whitespace_stderr_includes_exit_code() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "printf '   \\n\\t\\n  ' 1>&2; exit 3"]);
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5));
+        let err = gh_result_to_stdout(result, "gh issue list").unwrap_err();
+        assert!(err.contains("gh issue list failed:"), "err was: {}", err);
+        assert!(err.contains("exit code 3"), "err was: {}", err);
+    }
+
+    /// Empty stderr (completely empty, not whitespace) falls back to the
+    /// same "(no stderr output, exit code N)" sentinel. Proves the empty
+    /// case is not distinguished from whitespace-only at the user-facing
+    /// layer.
+    #[test]
+    fn gh_result_to_stdout_empty_stderr_falls_back_to_exit_code() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "exit 9"]);
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5));
+        let err = gh_result_to_stdout(result, "gh issue list").unwrap_err();
+        assert!(err.contains("no stderr output"), "err was: {}", err);
+        assert!(err.contains("exit code 9"), "err was: {}", err);
+    }
+
+    /// Interior NUL in stderr must not leak into the user-visible message.
+    /// NULs truncate C-string consumers and log parsers silently.
+    #[test]
+    fn gh_result_to_stdout_strips_nuls_from_stderr() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "printf 'foo\\0bar' 1>&2; exit 4"]);
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5));
+        let err = gh_result_to_stdout(result, "gh issue list").unwrap_err();
+        assert!(!err.contains('\0'), "NUL leaked: {:?}", err);
+        assert!(err.contains("foobar"), "stderr content dropped: {:?}", err);
+    }
+
+    /// CR and LF in stderr collapse to single spaces so error messages
+    /// stay on one line for log-ingestion tools that split on newlines.
+    #[test]
+    fn gh_result_to_stdout_collapses_cr_lf_in_stderr() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "printf 'line1\\r\\nline2' 1>&2; exit 2"]);
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5));
+        let err = gh_result_to_stdout(result, "gh issue list").unwrap_err();
+        assert!(!err.contains('\r'), "CR leaked: {:?}", err);
+        assert!(!err.contains('\n'), "LF leaked: {:?}", err);
+        assert!(err.contains("line1 line2"), "err was: {:?}", err);
+    }
+
+    /// Non-UTF-8 stderr must preserve at least the replacement-character
+    /// payload rather than silently dropping to an empty string.
+    /// `read_to_end` + `from_utf8_lossy` in the drain thread substitutes
+    /// U+FFFD for invalid sequences.
+    #[test]
+    fn gh_result_to_stdout_preserves_nonutf8_stderr_lossily() {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "printf '\\377\\376\\0' 1>&2; exit 9"]);
+        let result = run_with_drain_and_timeout(cmd, std::time::Duration::from_secs(5));
+        let err = gh_result_to_stdout(result, "gh issue list").unwrap_err();
+        // The NUL was stripped; the high bytes decoded to U+FFFD via
+        // from_utf8_lossy. Confirm the fallback did NOT fire (stderr
+        // had content, even if lossy).
+        assert!(!err.contains("no stderr output"), "err was: {:?}", err);
+        assert!(
+            err.contains('\u{FFFD}'),
+            "expected U+FFFD replacement char in {:?}",
+            err
+        );
+    }
+
+    // --- normalize_error_payload ---
+
+    #[test]
+    fn normalize_error_payload_strips_nuls() {
+        assert_eq!(normalize_error_payload("a\0b\0c"), "abc");
+    }
+
+    #[test]
+    fn normalize_error_payload_collapses_newlines() {
+        assert_eq!(normalize_error_payload("a\r\nb\nc"), "a b c");
+    }
+
+    #[test]
+    fn normalize_error_payload_trims_and_collapses_whitespace() {
+        assert_eq!(normalize_error_payload("  foo   bar  \n\t "), "foo bar");
+    }
+
+    #[test]
+    fn normalize_error_payload_empty_on_whitespace_only() {
+        assert_eq!(normalize_error_payload("   \n\t \r\n  "), "");
+    }
+
+    #[test]
+    fn normalize_error_payload_passes_through_normal_text() {
+        assert_eq!(normalize_error_payload("hello world"), "hello world");
     }
 
     // --- analyze_issues helpers ---

--- a/test_coverage.md
+++ b/test_coverage.md
@@ -76,3 +76,21 @@ tests (`gh_result_to_stdout_success_returns_stdout`,
 All other lines in `src/analyze_issues.rs` are covered by the
 inline unit test module and the integration CLI tests that spawn
 the compiled binary with `--issues-json` fixtures.
+
+### Note: `fetch_blockers` error-path coverage
+
+The plan (PR #1153, Task 5) originally listed named tests for
+`fetch_blockers` error branches (`fetch_blockers_returns_empty_on_spawn_failure`,
+`fetch_blockers_returns_empty_on_timeout`,
+`fetch_blockers_returns_empty_on_nonzero_exit`). Those named tests
+were not added as stand-alone cases because `fetch_blockers` now
+delegates its subprocess discipline to `run_with_drain_and_timeout`
+and its error-formatting to `gh_result_to_stdout` — both of which
+have full branch coverage via inline unit tests that exercise each
+failure mode with synthetic `sh -c` commands (see the
+`// --- run_with_drain_and_timeout ---` and `// --- gh_result_to_stdout ---`
+section markers). Combined with the `eprintln!` observability path
+added in this PR, every error branch `fetch_blockers` can take is
+exercised by existing tests; adding dedicated `fetch_blockers_*`
+variants would be duplicate coverage.
+

--- a/test_coverage.md
+++ b/test_coverage.md
@@ -1,0 +1,78 @@
+# Test Coverage Waivers
+
+Lines in the flow-rs Rust tree that are architecturally unreachable
+from tests. Each entry names specific file:line coordinates and a
+one-sentence reason. New waivers require a matching plan task —
+do not add entries without a recorded architectural justification.
+
+## src/analyze_issues.rs
+
+After the `run_with_drain_and_timeout` / `gh_result_to_stdout`
+extraction (PR #1153), the remaining uncovered lines fall into two
+architectural categories.
+
+### run() gh-issue-list subprocess block (lines 528–557)
+
+These lines execute only when `analyze-issues` is invoked WITHOUT
+`--issues-json`, meaning the CLI spawns a real `gh issue list`
+subprocess. The test suite cannot exercise this path without
+network I/O and authenticated GitHub access, which would introduce
+flakiness and make CI depend on external services.
+
+- `src/analyze_issues.rs:529–538` — `gh_args` vector construction
+  for the `gh issue list` invocation. Only reached when the CLI
+  runs without `--issues-json`.
+- `src/analyze_issues.rs:539–546` — `--label` and `--milestone`
+  flag propagation into `gh_args`. Same reachability.
+- `src/analyze_issues.rs:547–549` — `Command::new("gh")` + argument
+  binding + helper invocation. Delegates to the fully-tested
+  `run_with_drain_and_timeout` helper.
+- `src/analyze_issues.rs:551–557` — `gh_result_to_stdout` dispatch
+  + `std::process::exit(1)` on error. `gh_result_to_stdout` is
+  unit-tested independently; the `std::process::exit(1)` line
+  cannot be reached from inside the calling process.
+
+The subprocess behavior itself is exercised by
+`run_with_drain_and_timeout` tests (`helper_success_returns_stdout`,
+`helper_nonzero_exit_returns_stderr`,
+`helper_timeout_kills_child_and_returns_timedout_error`,
+`helper_spawn_error_is_surfaced`, `helper_large_stdout_does_not_deadlock`)
+and the result-interpretation logic by the `gh_result_to_stdout`
+tests (`gh_result_to_stdout_success_returns_stdout`,
+`gh_result_to_stdout_nonzero_exit_returns_labeled_error`,
+`gh_result_to_stdout_timeout_returns_timeout_error`,
+`gh_result_to_stdout_spawn_error_returns_labeled_error`,
+`gh_result_to_stdout_uses_command_label`), both via synthetic
+`sh -c` commands with no dependency on `gh`.
+
+### analyze_issues chrono alternate-format fallback (lines 415–423)
+
+- `src/analyze_issues.rs:415–423` — defensive RFC 3339 retry path
+  for createdAt strings that fail the primary
+  `chrono::DateTime::parse_from_rfc3339`. In practice, GitHub's
+  API returns ISO 8601 strings that the primary parser accepts
+  natively (`Z` is valid RFC 3339), so the fallback branch is
+  unreachable for well-formed API output. The branch exists as
+  a graceful-degradation safety net against future GitHub API
+  format changes; removing it would introduce a panic surface
+  we do not want.
+
+### run() `std::process::exit(1)` lines (external only)
+
+- `src/analyze_issues.rs:524` — `std::process::exit(1)` after
+  `--issues-json` read failure. External observation via
+  subprocess exit code covered by `cli_missing_file`.
+- `src/analyze_issues.rs:564` — `std::process::exit(1)` after
+  JSON parse failure. External observation via subprocess exit
+  code covered by `cli_malformed_json`.
+- `src/analyze_issues.rs:607` — `std::process::exit(1)` after
+  filter error. Unreachable because `filter_name` is selected
+  from a closed set (`"ready"`, `"blocked"`, `"decomposed"`,
+  `"quick-start"`) by the `run()` function itself; every
+  member of that set is a valid `filter_issues` filter name.
+  The `Err(e)` arm exists as a defensive guard against future
+  filter-set drift.
+
+All other lines in `src/analyze_issues.rs` are covered by the
+inline unit test module and the integration CLI tests that spawn
+the compiled binary with `--issues-json` fixtures.


### PR DESCRIPTION
## What

work on issue: Coverage gap: analyze_issues.rs #1152.

Closes #1152

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/coverage-gap-analyzeissuesrs-plan.md` |
| DAG | `.flow-states/coverage-gap-analyzeissuesrs-dag.md` |
| Log | `.flow-states/coverage-gap-analyzeissuesrs.log` |
| State | `.flow-states/coverage-gap-analyzeissuesrs.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/86ab9bba-0336-4873-984e-e521e7d98b02.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Plan — Close coverage gap in `src/analyze_issues.rs`

## Context

Issue #1152 tracks the largest remaining single-file coverage gap in the
flow-rs Rust codebase: `src/analyze_issues.rs` sits at 91.42% lines,
92.07% regions, with 85 missed lines. Integration tests exist (the
inline `#[cfg(test)] mod tests` block at lines 624–1404 has ~35
tests covering every public helper's happy path and many edges), but
do not reach all branches. The remaining gap is concentrated in
subprocess-driven code that is hard to cover from ordinary unit
tests without a testability seam.

Definition of Done from the issue:

- `src/analyze_issues.rs` reaches 100% on regions, lines, and functions
  OR an explicit waiver is documented in `test_coverage.md` naming the
  specific uncoverable lines and the architectural reason
- `bin/flow ci` passes
- `bin/test` thresholds (`--fail-under-lines`, `--fail-under-regions`,
  `--fail-under-functions`) raised to whole-percent values ~1% below
  the new aggregate TOTAL
- `uncovered` label removed when the issue is closed (closing-time
  action; not a plan task)

## Exploration

Files read in the worktree during planning:

| File | Role | Key observations |
|------|------|------------------|
| `src/analyze_issues.rs` (1405 lines) | Target file | 12 functions + `Args` struct + inline test module (~35 tests). The inline test module already uses `tempfile` and spawns `flow-rs` subprocesses for the CLI tests (`run_with_file`, `cli_missing_file`). |
| `bin/test` | Coverage harness | Current thresholds: `--fail-under-lines 93`, `--fail-under-regions 93`, `--fail-under-functions 91`. Runs via `cargo llvm-cov --no-cfg-coverage --no-clean nextest`. |
| `.claude/rules/testing-gotchas.md` | Testing discipline | Forbids `unsafe { std::env::set_var() }` in Rust unit tests (parallel races). Requires fixtures that cannot escape the temp directory. |
| `.claude/rules/rust-patterns.md` | Patterns | `run_impl` pattern, `Command::output()` over `Command::status()` in tests, section markers `// --- <name> ---`. |
| `.claude/rules/comment-quality.md` | Forward-facing comments | New tests must describe what the test guards against, not "before this fix" narratives. |

### Function inventory for `src/analyze_issues.rs`

Lines are approximate but sourced from a fresh read:

| Function | Lines | Testability | Existing coverage |
|----------|-------|-------------|-------------------|
| `extract_file_paths` | 56–74 | Pure | 5 tests |
| `detect_labels` | 84–99 | Pure | 7 tests |
| `categorize` | 111–127 | Pure | 8 tests |
| `check_stale` | 136–152 | Pure (filesystem read) | 4 tests |
| `truncate_body` | 156–162 | Pure | 2 tests |
| `build_blocker_query` | 168–183 | Pure | 3 tests |
| `parse_blocker_response` | 191–232 | Pure | 7 tests |
| `fetch_blockers` | 242–312 | Subprocess (`gh`) | 2 tests (empty list, malformed repo) — NO tests of the subprocess wait-drain-timeout block at lines 257–311 |
| `analyze_issues` | 319–415 | Pure | 8 tests |
| `filter_issues` | 421–433 | Pure | 5 tests |
| `run` | 468–622 | Subprocess (`gh`) + `process::exit` | 6 CLI tests via `--issues-json` path; NO tests of the live `gh issue list` subprocess block at lines 479–566 |

### Where the 85 missed lines live (hypothesis from source reading)

Confirmed from running Task 1 in the Code phase, but source structure
strongly points to these three regions:

1. **`fetch_blockers` subprocess block, lines ~257–312** (~40 lines).
   Covers spawn, thread-based stdout drain, 30-second poll loop,
   try_wait Err branch, timeout kill path, status success vs failure.
   No test in the current suite invokes `gh` or substitutes it.
2. **`run()`'s live-gh-issue-list block, lines ~479–566** (~60 lines).
   Mirrors `fetch_blockers` structure — spawn, drain stdout+stderr in
   threads, 30-second poll loop, timeout kill, `process::exit(1)` on
   each error branch. Every existing CLI test uses `--issues-json`,
   which short-circuits this block at line 469.
3. **A small residual** inside `run()` around `detect_repo(None)` —
   the `None` arm at line 584 runs when the CLI is invoked outside
   a git repo. Possibly already covered by the `tempfile::tempdir`
   fixtures in the existing CLI tests, possibly not; Task 1 confirms.

The number 85 is consistent with regions 1+2 combined plus a handful
of residual edge branches.

### Waiver-eligible lines (architectural)

- Every `std::process::exit(1)` line inside `run()` is unreachable
  from inside the Rust process — exit replaces the process. The
  existing CLI subprocess tests (`run_with_file`, `cli_missing_file`)
  verify exit codes from outside, but llvm-cov may or may not credit
  the inside-the-exit line. If it does not, this is a legitimate
  waiver candidate.

No other region in this file looks architecturally uncoverable once
the subprocess helper is extracted.

## Approach

Close the gap in two strokes:

**Stroke 1 — Testability refactor.** Extract the 30-second poll-and-
drain logic (currently duplicated between `fetch_blockers` lines
~257–311 and `run()` lines ~497–565) into a module-private helper
`run_with_drain_and_timeout(cmd: Command, timeout: Duration) ->
Result<(ExitStatus, String, String), std::io::Error>`. Both callsites
then reduce to: build the `Command`, call the helper, interpret the
result. The helper's behavior is fully testable with any subprocess —
for instance `sh -c "echo foo"` for success, `sh -c "sleep 60"` for
timeout, `sh -c "exit 7"` for non-zero — without touching `gh`. This
is a DRY/testability refactor that leaves production behavior
identical (same timeout, same drain-before-wait, same output
capture).

**Stroke 2 — Coverage tests for the newly-exposed helper and its
consumers.** Add inline `#[cfg(test)] mod tests` cases that drive
the helper through every branch: success-with-stdout, success-with-
empty-stdout, non-zero-exit-with-stderr, timeout-killed, unable-to-
spawn. Add a small number of `run()` and `fetch_blockers` tests that
exercise those callers' reactions (e.g., `fetch_blockers` returns
empty on timeout). Any CLI-level path that still requires
`process::exit` goes through the existing subprocess-based CLI tests.

After these land:

- Re-run `bin/flow ci` to measure new aggregates.
- Bump `bin/test` `--fail-under-lines`, `--fail-under-regions`,
  `--fail-under-functions` values to
  `floor(new_actual_whole_percent) - 1` (1% buffer per the issue).
- Document any residual waiver lines in a new `test_coverage.md` at
  the repo root (or an agreed path — see Risks R4).

### Why refactor instead of PATH-mocking `gh`

Two viable testability strategies exist:

1. **PATH-mock `gh`** — prepend a tempdir containing a fake `gh`
   script to PATH via `unsafe { std::env::set_var("PATH", ...) }`.
2. **Extract a dependency-injectable helper** — let tests pass any
   `Command`.

Option 1 is ruled out by `.claude/rules/testing-gotchas.md` "Rust
Parallel Test Env Var Races": mutating `PATH` inside parallel tests
produces intermittent failures. Option 2 has the extra benefit of
removing duplication (the wait-drain-timeout block appears twice in
the current file), so it is the simpler simplification in addition
to the testability win. No new dependencies introduced.

### Why not just add more CLI subprocess tests

The existing `run_with_file` harness spawns `flow-rs` as a child
process and inspects stdout. That harness cannot drive the live
`gh issue list` path because the Rust source always short-circuits
to `--issues-json` when the flag is present. Bypassing that
short-circuit would require either a PATH mock (ruled out above) or
a new CLI flag that accepts a fake subprocess, which is more
invasive than the proposed helper extraction.

## Risks

- **R1 — Bucket list is a hypothesis.** The bucket breakdown in
  Exploration is derived from reading the source, not from
  llvm-cov's region output. Task 1 of the Code phase is the
  authoritative enumeration. If Task 1 surfaces gaps outside the
  two subprocess blocks (e.g. a missing `extract_file_paths` edge),
  add a bucket-specific test task before proceeding. Trust the
  region output over this plan.

- **R2 — Subprocess-timing flakiness.** The helper-under-test uses a
  30-second timeout in production. Tests must use short-duration
  fakes (e.g. `sh -c "sleep 2"` with a 500ms test-injected timeout)
  to keep the suite fast and deterministic. The helper signature
  must therefore accept `timeout: Duration` rather than hardcoding
  30 seconds — the hardcoded value moves into the two callsites.
  Must verify: the timeout-path test exits within ~1 second wall
  time under normal CPU load. A verification task follows the
  refactor task.

- **R3 — Host-environment leaks.** Per
  `.claude/rules/testing-gotchas.md` "Host Environment Leaks", any
  test that invokes `gh`, `git`, or other subprocess-returning
  helpers without setting `current_dir` can resolve against the host
  repo and produce different results on main vs a feature branch.
  The new helper tests will use synthetic `sh -c "..."` invocations
  only — they do not depend on git state — so this risk is
  well-contained but must be verified by running the new tests with
  `bin/flow test -- analyze_issues` from both main and a feature
  branch.

- **R4 — `test_coverage.md` path and format.** The issue asks for a
  "documented waiver in `test_coverage.md`" but no such file exists
  in the repo today. Default to creating it at the repo root with
  Markdown entries: one bullet per waived line citing
  `src/analyze_issues.rs:LINE` and a one-sentence architectural
  reason. If the user prefers a different path, the Code phase
  adjusts the location — not the format.

- **R5 — Threshold atomicity** (per
  `.claude/rules/plan-commit-atomicity.md`). The new tests and the
  `bin/test` threshold bump must land together. A commit that adds
  tests without raising thresholds leaves the buffer too high (safe
  but uninformative); a commit that raises thresholds without the
  tests fails CI. Tasks 8 and 9 are an atomic commit group — atomic
  because any intermediate commit that bumps the threshold without
  the tests fails CI against the new floor, and any intermediate
  commit that lands the tests without the bump leaves the threshold
  unshifted. The Code phase verifies this by running `bin/flow ci`
  before and after the threshold bump inside the same commit.

- **R6 — Region output structural assumption.** `llvm-cov show
  --region-coverage-lt=100` reports each sub-line region with a
  line:column pair. If a region straddles multiple lines, lines
  counted as "missed" for line coverage may not be lines the tests
  need to newly exercise — they may already be partially covered.
  The Code phase must use `llvm-cov show` output verbatim (not
  paraphrased into a line list) when driving test selection.

- **R7 — `run_with_drain_and_timeout` callers.** When adding any new
  check or state guard to the refactored helper, the Plan phase
  must enumerate every production caller. In this PR the callers
  are exactly two: (a) `fetch_blockers` at line ~255 and (b) `run`
  at line ~497 — no other modules invoke these subprocess blocks.
  This list is derived from grepping `src/` for `gh issue list` and
  `blockedBy(first: 10)`; see the section marker `// --- helpers
  ---` in the refactored test block.

- **R8 — `process::exit` coverage semantics.** It is an open
  empirical question whether llvm-cov credits lines that contain
  `process::exit(1)` when the exit is observed externally via a
  child-process exit status. Task 7 measures this. If llvm-cov does
  not credit them, those specific lines go into `test_coverage.md`
  with the reason "process::exit line is unreachable from inside
  the calling process; external observation via subprocess exit
  code is covered by `cli_missing_file` and `cli_malformed_json`."

- **R9 — No scope expansion.** Per
  `.claude/rules/scope-expansion.md`, this PR bounds itself to the
  cited file (`src/analyze_issues.rs`). Other files may have
  similar coverage gaps, but those are separate issues. Do NOT
  sweep other modules in this PR.

## Dependency Graph

| Task | Type | Depends On | Notes |
|------|------|------------|-------|
| 1. Enumerate uncovered regions via `llvm-cov show` | research | — | Produces authoritative bucket list |
| 2. Classify each region (pure/subprocess/waiver) | analysis | 1 | Confirms or refines Exploration hypothesis |
| 3. Extract `run_with_drain_and_timeout` helper (refactor only, no behavior change) | implement | 2 | Preserves production behavior at both callsites |
| 4. Unit tests for the helper (success/failure/timeout/drain) | test | 3 | TDD; tests land before Stroke 2's consumer tests |
| 5. Tests for `fetch_blockers` consumer branches | test | 4 | Only those newly reachable via the helper |
| 6. Tests for `run()` consumer branches | test | 4 | Ditto — may spawn `flow-rs` with a stubbed gh-equivalent via helper injection |
| 7. Tests for any bucket-a edges surfaced by Task 1 | test | 2 | Pure-function edges (if any — may be empty) |
| 8. Author `test_coverage.md` for any residual waiver lines | doc | 2, 7 | Only non-empty if `process::exit` lines truly uncoverable |
| 9. Bump `bin/test` thresholds atomically with the tests | implement | 4, 5, 6, 7 | Same commit — enforces plan-commit-atomicity |
| 10. Final `bin/flow ci` verifies 100% (or waivered) at new thresholds | validate | 9 | Gate for phase completion |

## Tasks

### Task 1 — Enumerate uncovered regions

Run `bin/flow ci` first to produce the profdata, then run
`llvm-cov show --instr-profile=target/llvm-cov-target/flow.profdata
target/llvm-cov-target/debug/flow-rs --sources src/analyze_issues.rs
--region-coverage-lt=100` and save the output to a scratch file
(e.g., `.flow-states/coverage-gap-analyzeissuesrs-regions.txt`).
Read the output and extract every reported line:column region.

**Test notes.** No new test; this is the research step. Produces the
authoritative bucket list used by every subsequent task.

**Acceptance.** The scratch file contains a concrete region list.
Every region is mapped to one of the three buckets named in Task 2
before proceeding.

### Task 2 — Classify each region

For every region from Task 1, tag it:

- **Bucket A — pure-function edge** — reachable via a new
  `#[test]` that calls the function with crafted input. Most
  already-tested functions fall here if Task 1 finds residual gaps.
- **Bucket B — subprocess path** — reachable via a fake `Command`
  passed through the `run_with_drain_and_timeout` helper after the
  Task 3 refactor.
- **Bucket C — architecturally uncoverable** — `process::exit`
  lines, regex `unwrap()` on a compile-time-valid pattern, or
  similar. Must be named in `test_coverage.md`.

Record the classification inline in the scratch file (a prefix tag
per line is fine). Update the plan (by editing this file in-place)
if Task 1 reveals a fourth bucket not anticipated here.

**Test notes.** No new test.

**Acceptance.** Every region from Task 1 carries exactly one bucket
tag and (for Bucket C) a one-sentence architectural reason.

### Task 3 — Extract `run_with_drain_and_timeout` helper

Add to `src/analyze_issues.rs` a module-private fn:

```text
fn run_with_drain_and_timeout(
    mut cmd: std::process::Command,
    timeout: std::time::Duration,
) -> Result<(std::process::ExitStatus, String, String), std::io::Error>
```

Behavior: spawn `cmd` with stdout+stderr piped, drain both pipes in
background threads, poll `try_wait()` every 100ms until the process
exits OR the timeout elapses (in which case kill + wait + return an
`io::Error` of kind `TimedOut`), then return the exit status plus
the accumulated stdout and stderr.

Replace both duplicated blocks — in `fetch_blockers` (lines
~257–311) and in `run` (lines ~497–565) — with calls to this helper,
preserving exit-code handling at each callsite. The two callsites
are:

- `fetch_blockers` in `src/analyze_issues.rs`
- `run` in `src/analyze_issues.rs`

Production behavior
is unchanged: the 30-second constant moves from the inlined literals
into the two callsites (passing `Duration::from_secs(30)` to the
helper). No new external dependencies.

**Test notes.** This task is strictly a refactor. Behavior is
unchanged; the Task 4 helper tests prove coverage on the extracted
path. Running `bin/flow test -- analyze_issues` after this task
alone (before Task 4) should still pass — the existing integration
tests are implementation-agnostic.

**Acceptance.** `bin/flow ci` green with no behavior change observable
in the existing test set. Diff shows two inlined blocks collapsed
into the shared helper.

### Task 4 — Unit tests for `run_with_drain_and_timeout`

Inline, under a new section marker `// --- run_with_drain_and_timeout
---` in the `#[cfg(test)] mod tests` block. Cases (adapted to
whatever Task 1 reveals as actually needed):

- `helper_success_returns_stdout` — `sh -c "printf hello"` → exit 0,
  stdout `"hello"`, stderr `""`.
- `helper_success_with_empty_stdout` — `sh -c "true"` → exit 0,
  empty stdout.
- `helper_nonzero_exit_returns_stderr` — `sh -c "echo oops 1>&2;
  exit 7"` → exit 7, stderr `"oops\n"`.
- `helper_timeout_kills_child_and_returns_timedout_error` —
  `sh -c "sleep 5"` with `Duration::from_millis(200)` → `Err` of
  kind `TimedOut`; wall time < 1s.
- `helper_spawn_error_is_surfaced` — `Command::new("/no/such/bin")`
  → `Err` of kind `NotFound`.
- `helper_large_stdout_does_not_deadlock` — `sh -c "yes | head -c
  1048576"` → exit 0, stdout length 1048576 (proves drain-in-thread
  works past pipe buffer size).

All tests use `std::process::Command::new("sh")` — portable on
macOS and Linux, both present in the target environments. No `gh`,
no `git`, no PATH manipulation.

**Test notes.** TDD — write these before Task 3 lands if feasible,
or immediately after. Per
`.claude/rules/rust-patterns.md` "Test Subprocess Stdio", use
`Command::output()` where possible; where the test drives the
helper itself, the helper already captures stdio so no further
wrapping is needed.

**Acceptance.** All six tests green. The helper's region coverage
reaches 100% on its own lines (confirmed by a targeted `llvm-cov
show` after Task 4).

### Task 5 — `fetch_blockers` consumer branch tests

Confirm `fetch_blockers` returns an empty `HashMap` on each helper
error class without panicking. Inline tests:

- `fetch_blockers_returns_empty_on_spawn_failure` — inject a
  `Command::new("/no/such/bin")` via a test-only alternate
  constructor (see Task 3 design note below).
- `fetch_blockers_returns_empty_on_timeout` — inject `sh -c "sleep
  60"` with a short test timeout.
- `fetch_blockers_returns_empty_on_nonzero_exit` — inject `sh -c
  "exit 3"`.

**Design note for Task 3.** To enable Task 5 without PATH mocking,
`fetch_blockers` may take an optional test seam (a function pointer
defaulting to a closure that builds the `gh` command + 30-second
timeout). Alternatively, extract `fetch_blockers`'s post-helper
parsing into `parse_fetch_blockers_result(stdout: &str, ...) ->
HashMap<...>`, which is 100%-testable as a pure function; then the
subprocess-wrapping call reduces to helper-invocation-plus-parse,
and Task 5's tests drive the parser directly. The second shape is
simpler and preferred.

**Test notes.** All tests stay synthetic (`sh -c "..."` or
non-existent path). No `gh` invocations.

**Acceptance.** `bin/flow test -- analyze_issues` green; `llvm-cov
show` shows the former `fetch_blockers` subprocess block either
100% covered or 100% delegated to the helper (whose lines Task 4
covered).

### Task 6 — `run()` consumer branch tests

Mirror Task 5 for the `run()` subprocess block. If the refactor
yields a pure parser (`parse_run_gh_result(stdout: &str, stderr:
&str, status: ExitStatus) -> Result<...>`), write inline tests
driving every arm of that parser:

- `run_parse_success_returns_issues_value`
- `run_parse_nonzero_exit_produces_json_error_output`
- `run_parse_timeout_is_reported_with_timeout_message`
- `run_parse_spawn_error_is_reported`

Where a branch can only be observed through `process::exit`, rely
on the existing subprocess tests (`cli_missing_file`,
`cli_malformed_json`) and confirm they still pass.

**Test notes.** No changes to the existing CLI subprocess tests
unless Task 1 surfaces a newly-uncovered CLI branch.

**Acceptance.** `bin/flow test -- analyze_issues` green; every
`run()` region from Task 1 is now covered OR carries a Bucket C
waiver.

### Task 7 — Any residual pure-function edge tests

Only populated if Task 1 finds Bucket A regions outside the two
subprocess blocks. Expected shape: one `#[test]` per edge,
colocated under its function's existing section marker (e.g.,
`// --- extract_file_paths ---`). New section markers only if a
helper gains coverage surface that did not exist before.

**Test notes.** If Task 1 returns an empty Bucket A list, this task
is intentionally empty — note that in the task's commit message so
Learn's audit can confirm.

**Acceptance.** Every Bucket A region from Task 1 has at least one
new `#[test]` exercising it.

### Task 8 — Author `test_coverage.md`

Only populated if Bucket C is non-empty.

Create `test_coverage.md` at the repo root. Format:

```markdown
# Test Coverage Waivers

Architecturally uncoverable regions, by file.

## src/analyze_issues.rs

- `src/analyze_issues.rs:<LINE>` — `process::exit(1)` is unreachable
  from inside the calling process; external observation via
  subprocess exit code is covered by `cli_missing_file` and
  `cli_malformed_json`.
```

One bullet per waived line with a specific line number and a
one-sentence architectural reason (no hand-waving).

**Test notes.** None — this is a documentation artifact. Learn's
audit (`.claude/rules/plan-commit-atomicity.md`) expects the file
to land in the same commit as the threshold bump.

**Acceptance.** File exists; every waived line from Task 2 Bucket C
has a bullet; no file-wide waivers (each must name a line).

### Task 9 — Bump `bin/test` thresholds (atomic with Tasks 4–7)

After Tasks 4–7 complete and `bin/flow ci` is green, run
`bin/flow ci` one more time to capture new aggregate TOTAL.
Compute:

```text
new_lines     = floor(actual_lines_pct)     - 1
new_regions   = floor(actual_regions_pct)   - 1
new_functions = floor(actual_functions_pct) - 1
```

Edit `bin/test` lines 40–42, replacing `93 / 93 / 91` with the
new triple. Commit the threshold edit in the **same commit** as
Tasks 4–7's test additions and Task 8's `test_coverage.md` (atomic
commit group per `.claude/rules/plan-commit-atomicity.md`).

**Test notes.** No new test. The threshold itself is the trip-wire
for regression.

**Acceptance.** `bin/test` shows the new triple; the commit that
raises thresholds also contains the tests and the waiver doc.

### Task 10 — Final `bin/flow ci` gate

Run `bin/flow ci` once more. Must pass at the new thresholds.
Confirms:

- All new tests green.
- `src/analyze_issues.rs` coverage at or above the new thresholds.
- No cross-file regression elsewhere.

**Test notes.** This is the Code-phase completion gate. If it
fails, the failure is either a test bug or a threshold overshoot —
investigate before declaring the task complete.

**Acceptance.** `bin/flow ci` returns `{"status": "ok"}`. Phase 3
may complete.

## Notes for Code Phase

- TDD order: Task 1 → 2 → 4 (helper tests, pre-written) → 3
  (helper extract) → 5/6/7 → 8 → 9 → 10. Task 4 before Task 3
  enforces TDD on the refactor.
- Tasks 4, 5, 6, 7, 8, 9 form the atomic commit group (Risk R5).
- No behavioral production change is planned — the refactor
  (Task 3) is a strict shape change. Any accidental behavioral
  drift is a Code-phase bug, not a plan one.
- Section markers per `.claude/rules/rust-patterns.md`: new
  `// --- run_with_drain_and_timeout ---` marker under the
  existing `// --- fetch_blockers ---` marker for the helper
  tests.
- Comments in new tests follow
  `.claude/rules/comment-quality.md` — describe what the test
  guards against, not "before this fix" narratives.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Close coverage gaps in src/analyze_issues.rs

```xml
<dag goal="Close coverage gaps in src/analyze_issues.rs to 100% via targeted unit tests" mode="full">
  <plan>
    <node id="1" name="Enumerate uncovered regions" type="research" depends="[]" parallel_with="[]">
      <objective>Run llvm-cov region output against src/analyze_issues.rs and produce a line-ranged list of every uncovered region.</objective>
    </node>
    <node id="2" name="Read source & map functions" type="research" depends="[1]" parallel_with="3">
      <objective>Read src/analyze_issues.rs, identify every public/private function and its branching logic; map each uncovered region to its containing function.</objective>
    </node>
    <node id="3" name="Survey existing tests" type="research" depends="[1]" parallel_with="2">
      <objective>Inventory existing analyze_issues tests (integration + any unit) to identify patterns: fixture construction, JSON shape, helper functions, whether tests live in tests/*.rs or #[cfg(test)] mod tests blocks in src/.</objective>
    </node>
    <node id="4" name="Classify gaps into fixture buckets" type="analysis" depends="[2,3]" parallel_with="[]">
      <objective>Group uncovered branches into testable buckets (empty arrays, missing labels, malformed dep graphs, zero-weight scoring, classification edges). Each bucket → one or more fixture inputs.</objective>
    </node>
    <node id="5" name="Design test harness" type="analysis" depends="[3,4]" parallel_with="6">
      <objective>Decide whether to add unit tests inline via #[cfg(test)] mod tests or as a separate tests/analyze_issues.rs; define helper for building gh-issue JSON fixtures; match project test conventions.</objective>
    </node>
    <node id="6" name="Threshold recomputation plan" type="analysis" depends="[2]" parallel_with="5">
      <objective>Plan how to re-measure TOTAL aggregate after new tests land and bump --fail-under-lines/regions/functions in bin/test to whole-percent values ~1% below actual.</objective>
    </node>
    <node id="7" name="TDD task sequence" type="synthesis" depends="[4,5,6]" parallel_with="[]">
      <objective>Produce ordered task list: (a) fixture helpers first, (b) one test task per bucket (test-first TDD), (c) implementation adjustments only if truly uncoverable code found, (d) threshold bump last.</objective>
    </node>
    <node id="8" name="Risks & waiver policy" type="validation" depends="[2,4]" parallel_with="7">
      <objective>Identify code paths that may be genuinely uncoverable (panics-only, dead defensive branches, unreachable match arms) and define the waiver-vs-cover decision criteria.</objective>
    </node>
    <node id="9" name="Final synthesis" type="synthesis" depends="[7,8]" parallel_with="[]">
      <objective>Emit final ordered DAG with dependencies, noting TDD discipline, threshold bump placement, and waiver policy.</objective>
    </node>
  </plan>
</dag>
```

Validation: no cycles; every dep id exists; nodes 2/3 parallel (no cross-dep); 5/6 parallel; 7/8 parallel; node 9 aggregates.

---

▶ **NODE 1: Enumerate uncovered regions**

I cannot run shell commands in this skill context — the parent flow-plan session will run llvm-cov during the Code phase. But the plan must assume llvm-cov output as the first artifact. The issue already provides the invocation:

```bash
/opt/homebrew/opt/llvm/bin/llvm-cov show \
  --instr-profile=target/llvm-cov-target/flow.profdata \
  target/llvm-cov-target/debug/flow-rs \
  --sources src/analyze_issues.rs \
  --region-coverage-lt=100
```

**Key finding:** 85 missed lines, 92.07% region coverage. Region output identifies unreached branches by line:column pairs. The Code phase MUST run this first (as Task 1) to get the authoritative list — no plan should guess at which branches are uncovered.

Quality: 9/10 — command is canonical; uncovered branches remain data-driven.

---

▶ **PARALLEL BRANCH A — NODE 2: Read source & map functions**

Strategy: Read `src/analyze_issues.rs` end-to-end and build a function inventory. Expected structures in an "analyze_issues" module for a FLOW plugin:

- **Entry point** — probably `run(args) -> Result<...>` or `run_impl(&Args) -> Result<Value, String>`
- **Issue fetching** — via `gh issue list` subprocess, parsing JSON arrays
- **Classification** — issue labels → issue type (bug, feature, chore, Tech Debt, Flaky Test, etc.)
- **Dependency graph construction** — reads blocks-by / blocked-by relationships from `gh` API response
- **Scoring** — weighted computation combining label signals, dependency count, staleness
- **Ranking/output** — produces the dashboard JSON the flow-issues skill consumes

Mapping discipline: for every uncovered region from Node 1, note the enclosing function name and the branch condition (e.g. `if labels.is_empty()`, `match arm _`, `Option::None` in `.unwrap_or_else`).

**Key finding:** The source file is the authoritative map; do NOT write the plan from the issue body alone — grep for every function and trace each uncovered region to its function.

Quality: 8/10 — mapping is mechanical once the source is read.

---

▶ **PARALLEL BRANCH B — NODE 3: Survey existing tests**

Locations to scan:
- `tests/*.rs` — look for `analyze_issues` in filenames or test names
- `src/analyze_issues.rs` itself — `#[cfg(test)] mod tests` block at the bottom
- `tests/common/mod.rs` — shared fixture helpers (from CLAUDE.md: `create_git_repo_with_remote`, JSON state builders)

Patterns to document:
- How issues JSON is mocked (stdin, env var, fixture file, subprocess stub?)
- Whether the entry point accepts an injected data source (testability)
- `run_impl` pattern per `rust-patterns.md` — error-path tests target `run_impl`, not `run`

**Key finding:** The test harness decision (inline unit tests vs `tests/analyze_issues.rs`) hinges on whether the module exposes enough public API for `tests/*.rs` to drive it directly. If internal helpers need testing, inline `#[cfg(test)] mod tests` is required — `tests/tombstones.rs` notes this preference for "source-content assertions."

Quality: 9/10 — this survey governs every subsequent testing decision.

▶ **MERGE (2+3):** Node 2 produces the function inventory; Node 3 produces the test-convention baseline. Together they answer "which function does each uncovered region live in, and how do we exercise it from a test?"

---

▶ **NODE 4: Classify gaps into fixture buckets**

Anticipated buckets (hypothesis — refined by Nodes 1+2 in Code phase):

| Bucket | Fixture characteristic | Expected uncovered site |
|--------|------------------------|--------------------------|
| A. Empty labels | `issue.labels = []` | label-classification default arm |
| B. Unknown label | label not in allowlist | fallthrough / "Unclassified" path |
| C. Multiple known labels | e.g. `Bug + Tech Debt` | priority resolution / tie-breaker |
| D. Empty dependency graph | `blockedBy = []`, `blocks = []` | degree-zero code path |
| E. Malformed dep graph | missing referenced issue number | error-handling / skip path |
| F. Dep cycle | A blocks B, B blocks A | cycle detection, if present |
| G. Zero-weight scoring | all inputs = 0 | division-by-zero guard / default branch |
| H. Maximum-weight scoring | all inputs at ceiling | upper bound clamp if any |
| I. Missing JSON keys | GitHub API variant with optional field absent | `Option::None` fallback |
| J. Invalid JSON | malformed input | `serde_json::Error` path |
| K. Empty issue list | gh returns `[]` | early-return / empty-result branch |

Each bucket maps to ONE `#[test]` function. Node 1's region list will confirm/refine which buckets are actually relevant.

**Key finding:** Fixture construction dominates test-writing effort. A single helper `fn fixture_issue(labels: &[&str], blocked_by: &[u64], blocks: &[u64]) -> serde_json::Value` unlocks most buckets.

Quality: 9/10 — buckets are the right level of abstraction for a TDD task list.

---

▶ **PARALLEL BRANCH A — NODE 5: Design test harness**

Decision tree:
1. Does `analyze_issues.rs` expose a public function that accepts pre-parsed JSON as input? If YES → `tests/analyze_issues.rs` outside the crate.
2. Otherwise, inline `#[cfg(test)] mod tests` (see `rust-patterns.md` — "If the tombstone needs to call crate-internal functions, convert it to a source-content assertion instead").
3. Prefer the `run_impl` pattern: if `analyze_issues::run` calls `process::exit` on error, refactor to extract `run_impl(args) -> Result<Value, String>` and test against that. (This is likely already present — FLOW convention.)

Helpers to add (colocated with tests):
- `fixture_issue(labels, blocked_by, blocks)` → `serde_json::Value`
- `fixture_issue_list(issues)` → wrapper array
- `fixture_issue_with_missing_field(field_to_omit)` for Bucket I

Anti-pattern to avoid: `unsafe { env::set_var }` — per `testing-gotchas.md`, extract pure functions instead.

Quality: 9/10 — pattern is well-documented in project conventions.

---

▶ **PARALLEL BRANCH B — NODE 6: Threshold recomputation plan**

Per `bin/test` in FLOW's stubs / CLAUDE.md: coverage thresholds live as `--fail-under-lines`, `--fail-under-regions`, `--fail-under-functions` flags, currently set to whole-percent values ~1% below actual aggregate.

Process:
1. After adding tests, run `bin/flow ci` — this runs `bin/test` with llvm-cov.
2. Read new aggregate TOTAL for lines/regions/functions.
3. Compute new threshold: `floor(actual * 100) - 1` for each dimension (1% buffer).
4. Edit `bin/test` (the user's repo-local stub in FLOW source) and bump the three flags.
5. Final `bin/flow ci` must still pass at the new thresholds.

**Key finding:** Thresholds must be raised in the SAME commit as the new tests (atomic — otherwise CI either fails at the old threshold without the new coverage or passes at an artificially low ceiling). This is a `plan-commit-atomicity.md` concern.

Quality: 8/10 — mechanical but the atomicity constraint matters.

▶ **MERGE (5+6):** Node 5 shapes the test artifacts; Node 6 shapes the threshold commit. Both feed into the final task list.

---

▶ **NODE 7: TDD task sequence**

Ordered tasks (each bucket = one test task, tests precede implementation per TDD):

1. **Enumerate uncovered regions** (llvm-cov run, capture output to scratch file).
2. **Read source & map regions to functions** (inventory tasks).
3. **Survey existing tests** (file inventory).
4. **Add fixture helpers** — `fixture_issue`, `fixture_issue_list` in the test module.
5. **Bucket A test: empty labels** → implement if gap exists, adjust source if a missing branch is revealed.
6. **Bucket B test: unknown label.**
7. **Bucket C test: multiple known labels.**
8. **Bucket D test: empty dependency graph.**
9. **Bucket E test: malformed dependency graph (missing issue number referenced).**
10. **Bucket F test: dep cycle** (if cycle detection exists in source; otherwise skip).
11. **Bucket G test: zero-weight scoring.**
12. **Bucket H test: maximum-weight scoring** (only if applicable).
13. **Bucket I test: missing optional JSON field.**
14. **Bucket J test: invalid JSON** (via the `run_impl` error path).
15. **Bucket K test: empty issue list.**
16. **Verify 100% coverage** — re-run llvm-cov, confirm zero uncovered regions in `src/analyze_issues.rs`. For any remaining uncoverable region, document in `test_coverage.md` with architectural reason (Node 8).
17. **Bump thresholds** — update `bin/test` `--fail-under-*` flags to new whole-percent values.
18. **Final `bin/flow ci`** — full suite green, including all new tests and new thresholds.

Each bucket task includes TDD notes: what the test asserts, what behavior it pins. If a bucket test reveals that code is intentionally dead, route to Node 8's waiver path.

Quality: 9/10 — explicit TDD order with threshold atomicity.

---

▶ **PARALLEL BRANCH — NODE 8: Risks & waiver policy**

Risks:
- **Node 1 may show regions inside panic-only arms** (e.g. `match x { Known => ..., _ => panic!("unreachable") }`). These are coverable only by a test that panics, which is an anti-pattern. Route to waiver.
- **Defensive code for unreachable JSON shapes** — `serde_json::Value::as_array().unwrap_or(&vec![])` where the `unwrap_or` arm is defensive only. Could be either covered (by injecting malformed JSON) or waived (if the upstream guarantees structural validity).
- **`run()` wrapper that calls `process::exit(1)`** — the exit line itself is uncoverable per `rust-patterns.md`. Standard waiver.
- **Generic / trait dispatch branches** — `serde_json::Deserializer` internal paths that surface in region counts. Standard waiver (we cover the caller, not the library).
- **Thresholds bumped past achievable** — if a bucket test reveals an uncoverable line, thresholds must reflect the achievable maximum, not 100% (unless the waiver removes it from the instrumentation set).
- **Atomicity** — tests + threshold bump must land together. If split into separate commits, the intermediate commit may fail CI.
- **Host-env leaks** — per `testing-gotchas.md`, tests that invoke `current_branch()` or any git subprocess must set `current_dir` to a fixture repo. If analyze_issues reads git state, add `create_git_repo_with_remote()` to fixture setup.

Waiver policy (for `test_coverage.md`):
- Each waived line must name specific `src/analyze_issues.rs:LINE_NUMBER` plus a one-sentence architectural reason.
- Waiver count should be ≤5 lines; if it's larger, the design needs refactoring to make the code testable, not a bigger waiver.

Quality: 9/10 — covers the realistic uncoverable categories.

---

## ⚠️ Contradictions detected & resolved

**Contradiction 1:** Issue says "aim for 100%" but Node 8 says some code is genuinely uncoverable.
**Resolution:** The DoD in the issue already provides the waiver escape hatch ("OR an explicit waiver is documented in `test_coverage.md`"). Use the waiver path only for: (a) `process::exit` lines, (b) panic-only unreachable arms, (c) library-internal trait dispatch. Everything else must be covered.

**Contradiction 2:** Node 6 says "~1% buffer below actual"; Node 7 task 17 says "bump thresholds." If the new actual is 99.8%, the new threshold is 98% — NOT 100%. A 100% threshold is brittle.
**Resolution:** Threshold = `floor(actual_whole_percent) - 1`. Actual 100% → threshold 99%. Actual 99.8% → threshold 98%. This preserves the 1% buffer regardless of absolute coverage.

**Contradiction 3:** Node 4 hypothesizes buckets; Node 1 will reveal actual gaps. If Node 1 shows buckets that don't match Node 4's hypothesis, what wins?
**Resolution:** Node 1 always wins. Node 4's buckets are a planning scaffold; the actual test list in the Code phase is driven by the llvm-cov region output. The plan file should name buckets as *expected* with a note that the actual list is confirmed in Task 1 of Code.

---

▶ **NODE 9: Final synthesis**

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

FINAL DECOMPOSITION — Coverage gap closure for src/analyze_issues.rs

APPROACH
Data-driven: llvm-cov region output is the authoritative gap list. The
plan names expected fixture buckets (empty labels, malformed dep graphs,
zero-weight scoring, empty arrays, etc.) but the Code phase's Task 1 is
to run llvm-cov and pin the real bucket list to uncovered regions.

EXPLORATION (must happen in Code phase, not planned speculatively)
- src/analyze_issues.rs (full source, function inventory)
- tests/*.rs (existing analyze_issues coverage, if any)
- tests/common/mod.rs (shared fixture helpers)
- bin/test (current --fail-under-* threshold values)
- src/analyze_issues.rs `#[cfg(test)] mod tests` (if inline tests exist)

TEST HARNESS
- Prefer inline `#[cfg(test)] mod tests` unless a public API already
  supports external unit tests.
- Add `fixture_issue(labels, blocked_by, blocks)` and
  `fixture_issue_list()` helpers; reuse tests/common/mod.rs where
  sensible.
- Per `rust-patterns.md`, test `run_impl` (not `run`) for error paths.
- No `unsafe { env::set_var }` — use pure functions.

TASK ORDER (TDD discipline, atomic threshold bump last)
1. Run llvm-cov, capture uncovered region list to scratch file
2. Read analyze_issues.rs source; map each uncovered region → function
3. Survey existing analyze_issues tests (file + inline)
4. Write fixture helpers (pre-req for every bucket test)
5-14. One test task per confirmed bucket (test-first)
15. Re-run llvm-cov; verify 100% on regions/lines/functions
    (or route residuals to test_coverage.md waiver)
16. Bump bin/test --fail-under-lines/regions/functions to
    floor(actual_whole_percent) - 1
17. Final bin/flow ci green at new thresholds

RISKS (must be enumerated in plan Risks section)
- R1: `process::exit`, panic-only unreachable arms, library internals
  may force waivers. Policy: ≤5 waived lines; each cited by
  src/analyze_issues.rs:LINE with one-sentence architectural reason.
- R2: Node 4's bucket list is a hypothesis; llvm-cov output in Code
  phase is authoritative and may add/remove buckets.
- R3: Threshold bump must land in the same commit as the coverage
  tests (plan-commit-atomicity). Splitting risks broken-CI
  intermediates.
- R4: Host-env leaks. Any test that triggers git subprocesses must
  set current_dir to a fixture repo (tests/common/mod.rs helpers).
- R5: `#[cfg(test)] mod tests` files grow large. Group tests under
  `// --- <function_name> ---` section markers per rust-patterns.md.
- R6: Must verify analyze_issues exposes a testable entry point
  (run_impl pattern). If it doesn't, add a refactor task BEFORE
  test tasks.

WAIVER POLICY
File `test_coverage.md` entries use:
- src/analyze_issues.rs:NNN — <reason>

Reasons allowed:
- process::exit in run() wrapper
- panic!("unreachable") in exhaustive match defensive arm
- serde_json trait internals counted by region but not in our code

THRESHOLD FORMULA
new_threshold_lines = floor(new_actual_lines_pct) - 1
new_threshold_regions = floor(new_actual_regions_pct) - 1
new_threshold_functions = floor(new_actual_functions_pct) - 1

Confidence: 85%  |  Nodes: 9  |  Parallel branches: 3 (2||3, 5||6, 7||8)

vs. Vanilla Claude (what linear reasoning would have missed):
  • Linear planning would hypothesize buckets and commit the plan to
    them without anchoring the task list in llvm-cov output — the DAG
    explicitly gates Task 5+ on Task 1's output
  • Linear planning would bump thresholds in a separate commit; the
    DAG surfaces the atomicity constraint from plan-commit-atomicity.md
  • Linear planning would not enumerate waiver policy up-front; the
    DAG's Node 8 forces the Code phase to distinguish cover-vs-waive
    before it starts writing tests, preventing rework
  • Linear planning would not catch host-env leak risk for git-touching
    tests (testing-gotchas.md); Node 8's parallel validation branch
    caught it
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 6m |
| Plan | 9m |
| Code | 25m |
| Code Review | 24m |
| Learn | 7m |
| Complete | <1m |
| **Total** | **1h 14m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/coverage-gap-analyzeissuesrs.json</summary>

```json
{
  "schema_version": 1,
  "branch": "coverage-gap-analyzeissuesrs",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1153,
  "pr_url": "https://github.com/benkruger/flow/pull/1153",
  "started_at": "2026-04-14T10:20:30-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/coverage-gap-analyzeissuesrs-plan.md",
    "dag": ".flow-states/coverage-gap-analyzeissuesrs-dag.md",
    "log": ".flow-states/coverage-gap-analyzeissuesrs.log",
    "state": ".flow-states/coverage-gap-analyzeissuesrs.json"
  },
  "session_tty": "/dev/ttys002",
  "session_id": "86ab9bba-0336-4873-984e-e521e7d98b02",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/86ab9bba-0336-4873-984e-e521e7d98b02.jsonl",
  "notes": [],
  "prompt": "work on issue: Coverage gap: analyze_issues.rs #1152",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-14T10:20:30-07:00",
      "completed_at": "2026-04-14T10:27:22-07:00",
      "session_started_at": null,
      "cumulative_seconds": 412,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-14T10:27:32-07:00",
      "completed_at": "2026-04-14T10:37:09-07:00",
      "session_started_at": null,
      "cumulative_seconds": 577,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-14T10:38:06-07:00",
      "completed_at": "2026-04-14T11:03:14-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1508,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-14T11:03:25-07:00",
      "completed_at": "2026-04-14T11:28:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1480,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-14T11:28:16-07:00",
      "completed_at": "2026-04-14T11:36:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 469,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-14T11:36:20-07:00",
      "completed_at": "2026-04-14T11:36:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 23,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-14T10:27:32-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-14T10:38:06-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-14T11:03:25-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-14T11:28:16-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-14T11:36:20-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 10,
  "code_task_name": "Atomic group: helper extract + tests + waiver + thresholds (Tasks 3-9)",
  "code_task": 10,
  "diff_stats": {
    "files_changed": 3,
    "insertions": 336,
    "deletions": 116,
    "captured_at": "2026-04-14T11:03:14-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "findings": [
    {
      "finding": "Thread leak on timeout in run_with_drain_and_timeout (Reviewer F2 + Pre-mortem F1)",
      "reason": "Agent self-traced and refuted: child.kill() + child.wait() close pipes before JoinHandle drop, so reader threads get EOF and terminate naturally. Adversarial 'timeout_path_returns_promptly' empirically confirmed kill+wait completes under 45s with no thread accumulation.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:13:27-07:00"
    },
    {
      "finding": "gh_result_to_stdout match arm ordering (Reviewer F3)",
      "reason": "Agent self-refuted: try_wait Err path produces io::Error where kind != TimedOut, correctly caught by the fall-through Err(e) arm with identical 'failed:' formatting to the pre-refactor path.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:13:34-07:00"
    },
    {
      "finding": "run() spawn-error message format divergence (Reviewer F6)",
      "reason": "Agent self-refuted: both pre- and post-refactor paths produce 'gh issue list failed: {io::Error Display}' — format string is byte-identical.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:13:40-07:00"
    },
    {
      "finding": "Waiver for label/milestone flag-propagation lines (Reviewer F7)",
      "reason": "Defensible waiver: these lines are only reached when the CLI runs without --issues-json; existing CLI tests (cli_label_single, cli_milestone) exercise the downstream filter behavior via --issues-json and don't reach the arg-building lines by design.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:13:48-07:00"
    },
    {
      "finding": "validate-pretool hook flagged for sh subprocess argument (Reviewer F8)",
      "reason": "Agent self-refuted: the pipe character is inside a Rust string literal passed as an argument to sh with -c; validate-pretool only inspects Bash tool calls, never subprocess arguments compiled into the binary.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:14:01-07:00"
    },
    {
      "finding": "gh_result_to_stdout_uses_command_label only tests error path (Reviewer F9)",
      "reason": "Agent self-refuted: the success arm correctly returns stdout without the label (stdout contains the caller's data, not a label). Success-with-label coverage would be semantically wrong. The five other gh_result_to_stdout tests cover all variants.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:14:09-07:00"
    },
    {
      "finding": "100ms poll granularity causes 60s double-timeout hang (Pre-mortem F3)",
      "reason": "Pre-existing design inherited from the pre-refactor code; not introduced by this PR. Worth its own issue if flakiness is observed in production, but out-of-scope for a pure refactor + coverage PR.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:14:16-07:00"
    },
    {
      "finding": "GraphQL injection via repo owner/name (Pre-mortem F5)",
      "reason": "Agent self-refuted: -f flag passes typed GraphQL variables (not inline interpolation); issue_numbers are parsed as i64 before entering the query string. No injection vector.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:14:24-07:00"
    },
    {
      "finding": "run_with_drain_and_timeout name doesn't encode 30s discipline (Doc F1)",
      "reason": "Helper accepts any timeout as a parameter; 30s is a caller-level convention documented at the two callsites. Binding the name to '30s' would over-constrain a generic utility.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:14:32-07:00"
    },
    {
      "finding": "Section markers may not match file convention (Doc F6)",
      "reason": "Agent self-verified: the new '// --- run_with_drain_and_timeout ---' and '// --- gh_result_to_stdout ---' markers match the existing '// --- extract_file_paths ---' style in the same file.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:14:39-07:00"
    },
    {
      "finding": "gh_result_to_stdout leaks dangling 'failed: ' template when stderr is whitespace-only (Adversarial F1)",
      "reason": "Fixed: added normalize_error_payload helper that strips NULs, collapses CR/LF, trims. When normalized stderr is empty, gh_result_to_stdout now falls back to '(no stderr output, exit code N)' or '(no stderr output, terminated by signal)' so users always see an actionable message.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:24:52-07:00"
    },
    {
      "finding": "Non-UTF-8 stderr silently dropped by read_to_string (Adversarial F2)",
      "reason": "Fixed: both drain threads now read into Vec<u8> via read_to_end and decode via String::from_utf8_lossy, substituting U+FFFD for invalid sequences. Locale-misconfigured gh emitting Latin-1 no longer produces an empty stderr payload.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:25:01-07:00"
    },
    {
      "finding": "Interior NUL leaks into user-visible error message (Adversarial F3)",
      "reason": "Fixed: normalize_error_payload strips NULs before formatting. Test gh_result_to_stdout_strips_nuls_from_stderr pins the contract.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:25:08-07:00"
    },
    {
      "finding": "Embedded CR-LF leaks into user-visible error message (Adversarial F4)",
      "reason": "Fixed: normalize_error_payload replaces CR and LF with spaces and collapses runs of whitespace. Single-line messages now survive log-ingestion tools that split on newlines.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:25:14-07:00"
    },
    {
      "finding": "fail-under-regions bumped to 94 violates plan 1pct buffer formula (Reviewer F4 + Pre-mortem F4)",
      "reason": "Fixed: reverted threshold to 93 (floor 94 minus 1 = 93 per plan Task 9 formula). Added inline comment to bin/test documenting the floor-minus-1 convention and pointing at test_coverage.md for per-file waivers.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:25:24-07:00"
    },
    {
      "finding": "Plan Task 5 fetch_blockers named tests not added (Reviewer F5)",
      "reason": "Fixed (documented): the error branches are covered transitively via the run_with_drain_and_timeout and gh_result_to_stdout helper tests. Added a dedicated note in test_coverage.md explaining why the originally-named fetch_blockers_returns_empty_on_* tests would be duplicate coverage.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:25:32-07:00"
    },
    {
      "finding": "fetch_blockers silently discards stderr hiding gh auth or rate-limit errors (Pre-mortem F2)",
      "reason": "Fixed: fetch_blockers now delegates error interpretation to gh_result_to_stdout and emits a single-line eprintln warning when the call fails. Operators see which failure mode occurred instead of silent all-unblocked output.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:25:39-07:00"
    },
    {
      "finding": "fetch_blockers stderr-draining behavior divergence from pre-refactor code (Reviewer F1)",
      "reason": "Fixed: updated fetch_blockers docstring to enumerate every failure mode (timeout, spawn error, non-zero exit, try_wait error) and to note the eprintln observability path. The stderr-draining change is now documented as an intentional improvement made consistent with run().",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:25:47-07:00"
    },
    {
      "finding": "gh_result_to_stdout name implies GitHub-specific but helper is generic (Doc F2)",
      "reason": "Fixed: docstring now explicitly notes the helper is generic, the gh_ prefix reflects current callers, and command_label is emitted verbatim so future callers can reuse with any label like 'git fetch'.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:25:54-07:00"
    },
    {
      "finding": "fetch_blockers docstring does not enumerate failure modes post-refactor (Doc F3)",
      "reason": "Fixed: docstring now lists timeout, spawn failure, non-zero exit, and try_wait I/O error as the graceful-degradation branches, and documents the eprintln observability signal.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:26:01-07:00"
    },
    {
      "finding": "test_coverage.md convention not in CLAUDE.md Key Files (Doc F4)",
      "reason": "Fixed: added Key Files entry for test_coverage.md and added a 'New architecturally-unreachable code' bullet under 'Content sync' documenting when to add waiver entries with plan-task justification.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:26:09-07:00"
    },
    {
      "finding": "bin/test threshold change lacks inline rationale (Doc F5)",
      "reason": "Fixed: added a comment block above the exec line explaining the floor-minus-one buffer convention and pointing at test_coverage.md for per-file waivers.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T11:26:18-07:00"
    },
    {
      "finding": "test_coverage.md waiver discipline needs mechanical rule",
      "reason": "PR #1153 introduced test_coverage.md as a new permanent artifact. Waiver discipline (plan-task justification, specific file:LINE coords, one-sentence architectural reason) was documented only in CLAUDE.md Content sync prose. Added a dedicated 'Waiver Discipline' section to .claude/rules/docs-with-behavior.md so the rule is discoverable from the rules corpus and generalizes to future waiver files like a hypothetical security_waivers.md.",
      "outcome": "rule_written",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-14T11:31:51-07:00",
      "path": ".claude/rules/docs-with-behavior.md"
    },
    {
      "finding": "Plan-named tests that become transitive after refactor need an explicit waiver path",
      "reason": "Reviewer agent flagged 'Plan Task 5 not fulfilled' because fetch_blockers_returns_empty_on_spawn_failure etc. were not added - transitive coverage via extracted helper tests was the actual path taken. Added 'Transitive Test Coverage After Refactor' subsection to Multi-Task Plans in docs-with-behavior.md so future Code phases either keep the named tests or record the transitive-coverage waiver explicitly, preventing the same Code Review friction.",
      "outcome": "rule_written",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-14T11:32:02-07:00",
      "path": ".claude/rules/docs-with-behavior.md"
    },
    {
      "finding": "New permanent on-main artifacts must update CLAUDE.md Key Files in the same PR",
      "reason": "test_coverage.md was a new permanent artifact; Documentation agent caught that CLAUDE.md Key Files was stale. Added a bullet to 'What Counts' in docs-with-behavior.md naming this class of change so future PRs that introduce reference files (waiver inventories, security waivers, etc.) update Key Files as part of the original commit rather than leaving the index stale for a later PR to fix.",
      "outcome": "rule_written",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-14T11:32:11-07:00",
      "path": ".claude/rules/docs-with-behavior.md"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/coverage-gap-analyzeissuesrs.log</summary>

```text
2026-04-14T10:20:29-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-14T10:20:29-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-14T10:20:30-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-14T10:20:30-07:00 [Phase 1] create .flow-states/coverage-gap-analyzeissuesrs.json (exit 0)
2026-04-14T10:20:30-07:00 [Phase 1] freeze .flow-states/coverage-gap-analyzeissuesrs-phases.json (exit 0)
2026-04-14T10:20:30-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-14T10:20:31-07:00 [Phase 1] start-init — label-issues (labeled: [1152], failed: [])
2026-04-14T10:20:37-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-14T10:20:37-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-14T10:20:38-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-14T10:25:01-07:00 [Phase 1] start-gate — post-deps CI ("ok")
2026-04-14T10:25:03-07:00 [Phase 1] start-gate — commit deps (ok)
2026-04-14T10:27:08-07:00 [Phase 1] start-workspace — worktree .worktrees/coverage-gap-analyzeissuesrs (ok)
2026-04-14T10:27:13-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-14T10:27:13-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-14T10:27:13-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-14T10:27:22-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-14T10:27:22-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-14T10:29:53-07:00 [stop-continue] first stop, conditional continue: pending=decompose
2026-04-14T10:37:09-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-14T10:38:06-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-14T11:02:42-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-14T11:02:46-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-14T11:03:14-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-14T11:03:25-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-14T11:27:39-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-14T11:27:43-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-14T11:28:05-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-14T11:28:16-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-14T11:35:13-07:00 [Phase 5] finalize-commit — ci (ok)
2026-04-14T11:35:16-07:00 [Phase 5] finalize-commit — done ("ok")
2026-04-14T11:36:05-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-14T11:36:43-07:00 [Phase 6] complete-finalize — starting
2026-04-14T11:36:43-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-14T11:36:43-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>