### PR TITLE
Coverage Pattern Completefast

### DIFF
--- a/.claude/rules/docs-with-behavior.md
+++ b/.claude/rules/docs-with-behavior.md
@@ -70,6 +70,20 @@ cannot reach. Every entry must:
   Code Review finding in their own right: either drop the waiver
   (cover the line) or back it with a plan-level architectural
   argument.
+- **Pass the Forward-Facing Test from
+  `.claude/rules/comment-quality.md`.** Waiver prose is
+  documentation, and documentation describes current code. Phrases
+  like "former inline ... from pre-refactor", "moved out of", or
+  "was extracted from" are backward-facing — they explain the
+  waiver only to a reader who already knows the history. Rewrite
+  every waiver entry using present-tense descriptions of what the
+  code currently does and why it is architecturally unreachable.
+  PR #1155 (issue #1137) is the reference incident — the initial
+  waiver prose said `production_ci_decider` "contains the former
+  inline CI dirty-check body from pre-refactor `run_impl`" and
+  was flagged in Code Review; the rewrite describes the function
+  as owning the current CI dirty-check body without referencing
+  history.
 
 When a PR adds architecturally-unreachable code that survives
 coverage enforcement, the waiver entry lands in the same commit

--- a/.claude/rules/external-input-validation.md
+++ b/.claude/rules/external-input-validation.md
@@ -27,6 +27,17 @@ slashes (`feature/foo`, `dependabot/*`). Five hook entry points and
 standard git branch. Adversarial testing caught it; planning should
 have.
 
+Issue #1137 surfaced a second instance of the same class — this time
+in a CLI subcommand rather than a hook. `bin/flow complete-fast
+--branch feature/foo` panicked in `src/complete_fast.rs:read_state`
+because `read_state` called `FlowPaths::new(root, branch)` directly
+with the unvalidated `--branch` CLI override. The rule's callsite
+inventory listed only `src/hooks/*.rs`, so the Plan phase did not
+audit the CLI-entry callsite. The fix used `FlowPaths::try_new` with
+a structured error return. The motivating lesson is that **any CLI
+subcommand accepting a `--branch` override is a branch-validation
+callsite just like a hook**, and must use the fallible constructor.
+
 ## Mechanical Enforcement
 
 The Plan-phase prose audit gate (`bin/flow plan-check`) catches
@@ -77,10 +88,14 @@ For any FLOW type that accepts a parameter from git (branch names,
 tags, commit SHAs), the public API must expose at least one fallible
 constructor alongside the panicking one. Callers that receive the
 value from `current_branch()`, `resolve_branch()`, `resolve_branch_in()`,
-or any subprocess running `git` must use the fallible variant. The
-panicking variant is reserved for callers that have already validated
-the value at a prior boundary (state-file keyspace, `branch_name()`
-output, upstream `try_new` success).
+or any subprocess running `git` must use the fallible variant. **A
+`--branch` CLI override is also an external input** — `clap` accepts
+any string the shell passes, including slash-containing and empty
+values, so the override is no more trusted than a git subprocess
+result. Callers that accept `--branch` must use the fallible variant.
+The panicking variant is reserved for callers that have already
+validated the value at a prior boundary (state-file keyspace,
+`branch_name()` output, upstream `try_new` success).
 
 The reference implementation is `FlowPaths::new` / `FlowPaths::try_new`:
 
@@ -109,6 +124,26 @@ The current hook inventory that receives a branch from git includes
 `validate_ask_user.rs`, and `validate_claude_paths.rs`. Any new hook
 that joins this list must follow the same discipline.
 
+### CLI subcommand entry callsite discipline
+
+CLI subcommands that accept a `--branch` override (or any other
+branch-valued CLI arg) are the same category of caller as hooks:
+the string comes from outside the process and is unvalidated before
+it reaches the FLOW-side invariant. A panic in a CLI subcommand
+terminates the user's shell invocation with a Rust backtrace — a
+user-visible failure indistinguishable from a session-lifecycle
+hook panic.
+
+The CLI subcommand entry inventory that receives a branch via
+`--branch` (and therefore must guard with `FlowPaths::try_new` or
+pre-validate via `FlowPaths::is_valid_branch`) includes
+`src/complete_fast.rs:read_state` (commit `12b098f6`, the issue
+#1137 fix). Any new CLI subcommand that accepts `--branch` and
+constructs a `FlowPaths` must follow the same discipline. When
+refactoring an existing CLI subcommand, audit its `read_state` /
+`FlowPaths::new` callsites against this discipline before declaring
+the refactor complete.
+
 ### Code Review enforcement
 
 During Code Review, the reviewer agent and adversarial agent check
@@ -126,3 +161,10 @@ characters). Hooks that use the fallible variant must have an
 integration test that exercises the "no active flow" branch — the
 test passes a slash-containing branch or a branch with no state file
 and asserts the hook exits 0 / returns early without panicking.
+
+CLI subcommands that accept `--branch` must include a regression
+test that exercises the slash-branch path and asserts a structured
+error (not a panic). The issue-#1137 fix added
+`read_state_slash_branch_returns_structured_error_no_panic` and
+`run_impl_inner_slash_branch_returns_structured_error_no_panic` as
+the reference pattern.

--- a/bin/test
+++ b/bin/test
@@ -66,5 +66,5 @@ fi
 exec cargo llvm-cov --no-cfg-coverage --no-clean \
   --fail-under-lines 93 \
   --fail-under-regions 94 \
-  --fail-under-functions 91 \
+  --fail-under-functions 92 \
   nextest --status-level none --final-status-level fail "$@"

--- a/src/complete_fast.rs
+++ b/src/complete_fast.rs
@@ -1358,6 +1358,20 @@ mod tests {
             .contains("Push failed after freshness merge"));
     }
 
+    // --- production_ci_decider ---
+
+    #[test]
+    fn production_ci_decider_tree_changed_returns_not_skipped() {
+        // When main was merged into the branch, tree_changed=true forces
+        // a fresh CI run regardless of sentinel state. The decider
+        // short-circuits and returns (false, None) without touching the
+        // sentinel, so fast_inner's ci_stale path surfaces.
+        let dir = tempfile::tempdir().unwrap();
+        let (skipped, failed) = production_ci_decider(dir.path(), dir.path(), "test-feature", true);
+        assert!(!skipped);
+        assert!(failed.is_none());
+    }
+
     // --- run_impl_inner ---
 
     fn no_ci(_: &Path, _: &Path, _: &str, _: bool) -> (bool, Option<String>) {

--- a/src/complete_fast.rs
+++ b/src/complete_fast.rs
@@ -1038,6 +1038,281 @@ mod tests {
             .contains("push failed"));
     }
 
+    // --- fast_inner error paths ---
+
+    #[test]
+    fn test_fast_inner_unknown_gh_ci_status_proceeds() {
+        // Unknown gh_ci_status values fall through the `_` arm and
+        // continue to freshness + merge (L198).
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        let state_path = setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![ok(r#"{"status": "up_to_date"}"#), ok("merged")]);
+
+        let result = fast_inner(
+            "test-feature",
+            &state,
+            &state_path,
+            true,
+            false,
+            "/fake/bin/flow",
+            false,
+            true,
+            None,
+            "unknown", // unexpected status — `_` arm
+            &runner,
+        );
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["path"], "merged");
+    }
+
+    #[test]
+    fn test_fast_inner_freshness_runner_err() {
+        // check-freshness subprocess spawn failure (L223-232).
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        let state_path = setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![Err("spawn failed".to_string())]);
+
+        let result = fast_inner(
+            "test-feature",
+            &state,
+            &state_path,
+            true,
+            false,
+            "/fake/bin/flow",
+            false,
+            true,
+            None,
+            "pass",
+            &runner,
+        );
+
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("check-freshness failed"));
+    }
+
+    #[test]
+    fn test_fast_inner_freshness_invalid_json() {
+        // check-freshness returns unparseable stdout (L234-243).
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        let state_path = setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![ok("not json")]);
+
+        let result = fast_inner(
+            "test-feature",
+            &state,
+            &state_path,
+            true,
+            false,
+            "/fake/bin/flow",
+            false,
+            true,
+            None,
+            "pass",
+            &runner,
+        );
+
+        assert_eq!(result["status"], "error");
+        assert!(result["message"].as_str().unwrap().contains("Invalid JSON"));
+    }
+
+    #[test]
+    fn test_fast_inner_unexpected_freshness_status() {
+        // check-freshness returns a status the match does not recognize (L377-384).
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        let state_path = setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![ok(r#"{"status": "rabbit"}"#)]);
+
+        let result = fast_inner(
+            "test-feature",
+            &state,
+            &state_path,
+            true,
+            false,
+            "/fake/bin/flow",
+            false,
+            true,
+            None,
+            "pass",
+            &runner,
+        );
+
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Unexpected check-freshness status"));
+    }
+
+    #[test]
+    fn test_fast_inner_squash_merge_spawn_err() {
+        // gh pr merge subprocess spawn failure (L325-331).
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        let state_path = setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![
+            ok(r#"{"status": "up_to_date"}"#),
+            Err("gh not found".to_string()),
+        ]);
+
+        let result = fast_inner(
+            "test-feature",
+            &state,
+            &state_path,
+            true,
+            false,
+            "/fake/bin/flow",
+            false,
+            true,
+            None,
+            "pass",
+            &runner,
+        );
+
+        assert_eq!(result["status"], "error");
+        assert!(result["message"].as_str().unwrap().contains("gh not found"));
+    }
+
+    #[test]
+    fn test_fast_inner_squash_merge_base_branch_policy() {
+        // gh pr merge fails with "base branch policy" stderr → ci_pending (L353-365).
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        let state_path = setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![
+            ok(r#"{"status": "up_to_date"}"#),
+            Ok((
+                1,
+                String::new(),
+                "base branch policy: required status check".to_string(),
+            )),
+        ]);
+
+        let result = fast_inner(
+            "test-feature",
+            &state,
+            &state_path,
+            true,
+            false,
+            "/fake/bin/flow",
+            false,
+            true,
+            None,
+            "pass",
+            &runner,
+        );
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["path"], "ci_pending");
+    }
+
+    #[test]
+    fn test_fast_inner_squash_merge_generic_failure() {
+        // gh pr merge fails with non-policy stderr → error (L367-372).
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        let state_path = setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![
+            ok(r#"{"status": "up_to_date"}"#),
+            Ok((1, String::new(), "Merge conflict detected".to_string())),
+        ]);
+
+        let result = fast_inner(
+            "test-feature",
+            &state,
+            &state_path,
+            true,
+            false,
+            "/fake/bin/flow",
+            false,
+            true,
+            None,
+            "pass",
+            &runner,
+        );
+
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Merge conflict"));
+    }
+
+    #[test]
+    fn test_fast_inner_freshness_merged_push_success() {
+        // Freshness reports main moved; push succeeds → ci_stale (L305-317).
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        let state_path = setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![ok(r#"{"status": "merged"}"#), ok("")]);
+
+        let result = fast_inner(
+            "test-feature",
+            &state,
+            &state_path,
+            true,
+            false,
+            "/fake/bin/flow",
+            false,
+            true,
+            None,
+            "pass",
+            &runner,
+        );
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["path"], "ci_stale");
+        assert!(result["reason"].as_str().unwrap().contains("main moved"));
+    }
+
+    #[test]
+    fn test_fast_inner_freshness_merged_runner_err_on_push() {
+        // Freshness reports main moved; push runner returns Err (L290-297).
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        let state_path = setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![
+            ok(r#"{"status": "merged"}"#),
+            Err("no network".to_string()),
+        ]);
+
+        let result = fast_inner(
+            "test-feature",
+            &state,
+            &state_path,
+            true,
+            false,
+            "/fake/bin/flow",
+            false,
+            true,
+            None,
+            "pass",
+            &runner,
+        );
+
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Push failed after freshness merge"));
+    }
+
     // --- parse_gh_checks_output ---
 
     #[test]

--- a/src/complete_fast.rs
+++ b/src/complete_fast.rs
@@ -6,6 +6,34 @@
 //!
 //! Usage: bin/flow complete-fast [--branch <name>] [--auto] [--manual]
 //!
+//! # Architecture
+//!
+//! Two injectable seams make the dispatch unit-testable without real
+//! subprocesses or a real CI run:
+//!
+//! - `runner: &dyn Fn(&[&str], u64) -> CmdResult` — every `gh`, `git`, and
+//!   `bin/flow check-freshness` subprocess call goes through this closure.
+//! - `ci_decider: &CiDecider` — the Complete-phase CI dirty-check block
+//!   (sentinel lookup, tree-snapshot comparison, `ci::run_impl` invocation
+//!   on miss) goes through this closure.
+//!
+//! Production code threads `run_cmd_with_timeout` and `production_ci_decider`
+//! into `run_impl_inner`; unit tests pass mock closures. `run_impl` is a
+//! three-line wrapper that resolves `project_root()` and delegates.
+//!
+//! Shape:
+//!
+//! ```text
+//! run(args) [CLI entry, process::exit on error]
+//!   └─ run_impl(args) [threads production deps]
+//!        └─ run_impl_inner(args, root, runner, ci_decider) [pure dispatch]
+//!             ├─ check_pr_status(..., runner)
+//!             ├─ merge_main(runner)
+//!             ├─ ci_decider(root, cwd, branch, tree_changed) → (ci_skipped, ci_failed_output)
+//!             ├─ runner(&["gh", "pr", "checks", ...])
+//!             └─ fast_inner(..., runner) [mode/freshness/squash-merge dispatch]
+//! ```
+//!
 //! Output (JSON to stdout):
 //!   Merged:       {"status": "ok", "path": "merged", ...}
 //!   Already:      {"status": "ok", "path": "already_merged", ...}
@@ -48,8 +76,22 @@ pub struct Args {
 }
 
 /// Read and parse a state file, returning (state_value, state_path).
+///
+/// Uses `FlowPaths::try_new` so a branch that contains '/' (e.g.
+/// `feature/foo`, `dependabot/*`) produces a structured error instead
+/// of panicking — `--branch` from the CLI is external input per
+/// `.claude/rules/external-input-validation.md`.
 fn read_state(root: &Path, branch: &str) -> Result<(Value, PathBuf), String> {
-    let state_path = FlowPaths::new(root, branch).state_file();
+    let state_path = FlowPaths::try_new(root, branch)
+        .ok_or_else(|| {
+            format!(
+                "Branch name '{}' is not a valid FLOW branch (contains '/' or is empty). \
+                 FLOW state files use a flat layout that cannot address slash-containing \
+                 branches; resume the flow in its canonical branch name.",
+                branch
+            )
+        })?
+        .state_file();
     if !state_path.exists() {
         return Err(format!(
             "No state file found for branch '{}'. Run /flow:flow-start first.",
@@ -395,16 +437,19 @@ pub type CiDecider = dyn Fn(&Path, &Path, &str, bool) -> (bool, Option<String>);
 /// Production CI-decider for the Complete phase dirty-check block.
 ///
 /// Returns `(ci_skipped, ci_failed_output)`:
-/// - `ci_skipped` is `true` when the sentinel file's stored tree
-///   snapshot matches the current cwd's snapshot, meaning a prior
-///   `bin/flow ci` run on this same tree already passed.
+/// - `ci_skipped` is `true` only when the sentinel file's stored tree
+///   snapshot matches the current cwd's snapshot — a prior
+///   `bin/flow ci` run on this same tree already passed and the
+///   current `complete-fast` call can skip re-running CI.
 /// - `ci_failed_output` is `Some(msg)` when CI runs and fails; `None`
 ///   when CI is skipped or runs and passes.
 ///
 /// A `tree_changed` input (main was merged into the branch, dirtying
-/// the tree) forces a fresh CI run by returning `(false, None)` — the
-/// caller's fast_inner dispatch then surfaces this as a `ci_stale`
-/// path.
+/// the tree) short-circuits to `(false, None)` without invoking CI.
+/// The `ci_stale` path itself is produced by `fast_inner` from its
+/// own `tree_changed` argument, not from this return value — the same
+/// `(false, None)` is returned when CI runs and passes, which does
+/// not produce `ci_stale`.
 fn production_ci_decider(
     root: &Path,
     cwd: &Path,
@@ -1663,6 +1708,34 @@ mod tests {
         fs::write(&state_path, "[]").unwrap();
         let err = read_state(dir.path(), "arr").unwrap_err();
         assert!(err.contains("Corrupt state file"));
+    }
+
+    #[test]
+    fn read_state_slash_branch_returns_structured_error_no_panic() {
+        // External input via `--branch` CLI override can carry slashes
+        // (`feature/foo`, `dependabot/*`). FlowPaths::new would panic;
+        // read_state must return a structured error instead.
+        let dir = tempfile::tempdir().unwrap();
+        let err = read_state(dir.path(), "feature/foo").unwrap_err();
+        assert!(err.contains("not a valid FLOW branch"));
+        assert!(err.contains("feature/foo"));
+    }
+
+    #[test]
+    fn run_impl_inner_slash_branch_returns_structured_error_no_panic() {
+        // End-to-end guard: --branch dependabot/cargo/serde-1.0.0 must
+        // produce a structured error through the entry point, not a
+        // process panic.
+        let dir = tempfile::tempdir().unwrap();
+        let runner = mock_runner(vec![]);
+        let args = Args {
+            branch: Some("dependabot/cargo/serde-1.0.0".to_string()),
+            auto: true,
+            manual: false,
+        };
+        let result = run_impl_inner(&args, dir.path(), &runner, &no_ci);
+        let err = result.unwrap_err();
+        assert!(err.contains("not a valid FLOW branch"));
     }
 
     #[test]

--- a/src/complete_fast.rs
+++ b/src/complete_fast.rs
@@ -384,16 +384,94 @@ pub fn fast_inner(
     }
 }
 
-/// Core complete-fast logic. Returns Ok(json) on success paths (including
-/// unhappy paths like ci_failed that the skill handles interactively),
-/// Err(string) only for infrastructure failures.
-pub fn run_impl(args: &Args) -> Result<Value, String> {
-    let root = project_root();
-    let branch = resolve_branch(args.branch.as_deref(), &root)
-        .ok_or("Could not determine current branch")?;
+/// Signature of the Complete-phase CI dirty-check seam.
+///
+/// Inputs: `(root, cwd, branch, tree_changed)`.
+/// Output: `(ci_skipped, ci_failed_output)` — `ci_skipped` is true when
+/// a prior CI run on the same tree-snapshot passed; `ci_failed_output`
+/// carries a failure message when CI ran and failed.
+pub type CiDecider = dyn Fn(&Path, &Path, &str, bool) -> (bool, Option<String>);
+
+/// Production CI-decider for the Complete phase dirty-check block.
+///
+/// Returns `(ci_skipped, ci_failed_output)`:
+/// - `ci_skipped` is `true` when the sentinel file's stored tree
+///   snapshot matches the current cwd's snapshot, meaning a prior
+///   `bin/flow ci` run on this same tree already passed.
+/// - `ci_failed_output` is `Some(msg)` when CI runs and fails; `None`
+///   when CI is skipped or runs and passes.
+///
+/// A `tree_changed` input (main was merged into the branch, dirtying
+/// the tree) forces a fresh CI run by returning `(false, None)` — the
+/// caller's fast_inner dispatch then surfaces this as a `ci_stale`
+/// path.
+fn production_ci_decider(
+    root: &Path,
+    cwd: &Path,
+    branch: &str,
+    tree_changed: bool,
+) -> (bool, Option<String>) {
+    if tree_changed {
+        return (false, None);
+    }
+
+    let snapshot = ci::tree_snapshot(cwd, None);
+    let sentinel = ci::sentinel_path(root, branch);
+
+    let ci_skipped = if sentinel.exists() {
+        std::fs::read_to_string(&sentinel)
+            .map(|c| c == snapshot)
+            .unwrap_or(false)
+    } else {
+        false
+    };
+
+    if ci_skipped {
+        return (true, None);
+    }
+
+    let ci_args = ci::Args {
+        force: false,
+        retry: 0,
+        branch: Some(branch.to_string()),
+        simulate_branch: None,
+    };
+    let (ci_result, ci_code) = ci::run_impl(&ci_args, cwd, root, false);
+    if ci_code != 0 {
+        let msg = ci_result
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("CI failed")
+            .to_string();
+        (false, Some(msg))
+    } else {
+        (false, None)
+    }
+}
+
+/// Core complete-fast logic with injectable `root`, `runner`, and
+/// `ci_decider` seams for testability.
+///
+/// All subprocess calls (gh, git, check-freshness) go through `runner`.
+/// The Complete-phase CI dirty-check block goes through `ci_decider`,
+/// which in production wraps `ci::run_impl` and returns
+/// `(ci_skipped, ci_failed_output)` for the given `(root, cwd, branch,
+/// tree_changed)` inputs.
+///
+/// Returns Ok(json) on success paths (including unhappy paths like
+/// `ci_failed` that the skill handles interactively), Err(string) only
+/// for infrastructure failures that prevent any path determination.
+pub fn run_impl_inner(
+    args: &Args,
+    root: &Path,
+    runner: &dyn Fn(&[&str], u64) -> CmdResult,
+    ci_decider: &CiDecider,
+) -> Result<Value, String> {
+    let branch =
+        resolve_branch(args.branch.as_deref(), root).ok_or("Could not determine current branch")?;
 
     // Read state file
-    let (state, state_path) = read_state(&root, &branch)?;
+    let (state, state_path) = read_state(root, &branch)?;
 
     // Gate: Learn phase must be complete
     let learn_status = state
@@ -424,7 +502,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     let pr_state = match check_pr_status(
         state.get("pr_number").and_then(|v| v.as_i64()),
         &branch,
-        &run_cmd_with_timeout,
+        runner,
     ) {
         Ok(s) => s,
         Err(e) => {
@@ -459,7 +537,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     }
 
     // --- Merge main into branch ---
-    let (merge_status, merge_data) = merge_main(&run_cmd_with_timeout);
+    let (merge_status, merge_data) = merge_main(runner);
     let tree_changed = merge_status == "merged";
 
     if merge_status == "conflict" {
@@ -487,53 +565,13 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
 
     // --- CI dirty check (no simulate-branch) ---
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let ci_skipped;
-    let ci_failed_output: Option<String>;
-
-    if tree_changed {
-        ci_skipped = false;
-        ci_failed_output = None;
-    } else {
-        let snapshot = ci::tree_snapshot(&cwd, None);
-        let sentinel = ci::sentinel_path(&root, &branch);
-
-        ci_skipped = if sentinel.exists() {
-            std::fs::read_to_string(&sentinel)
-                .map(|c| c == snapshot)
-                .unwrap_or(false)
-        } else {
-            false
-        };
-
-        if !ci_skipped {
-            let ci_args = ci::Args {
-                force: false,
-                retry: 0,
-                branch: Some(branch.clone()),
-                simulate_branch: None,
-            };
-            let (ci_result, ci_code) = ci::run_impl(&ci_args, &cwd, &root, false);
-            if ci_code != 0 {
-                ci_failed_output = Some(
-                    ci_result
-                        .get("message")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("CI failed")
-                        .to_string(),
-                );
-            } else {
-                ci_failed_output = None;
-            }
-        } else {
-            ci_failed_output = None;
-        }
-    }
+    let (ci_skipped, ci_failed_output) = ci_decider(root, &cwd, &branch, tree_changed);
 
     // --- GitHub CI check ---
     let pr_number = state.get("pr_number").and_then(|v| v.as_i64());
     let gh_ci_status = if let Some(pr_num) = pr_number {
         let pr_str = pr_num.to_string();
-        match run_cmd_with_timeout(&["gh", "pr", "checks", &pr_str], NETWORK_TIMEOUT) {
+        match runner(&["gh", "pr", "checks", &pr_str], NETWORK_TIMEOUT) {
             Ok((_, stdout, _)) => parse_gh_checks_output(&stdout),
             Err(_) => "none".to_string(),
         }
@@ -554,8 +592,15 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         ci_skipped,
         ci_failed_output.as_deref(),
         &gh_ci_status,
-        &run_cmd_with_timeout,
+        runner,
     ))
+}
+
+/// CLI entry wrapper: threads the production root, runner, and
+/// CI-decider into `run_impl_inner`.
+pub fn run_impl(args: &Args) -> Result<Value, String> {
+    let root = project_root();
+    run_impl_inner(args, &root, &run_cmd_with_timeout, &production_ci_decider)
 }
 
 /// CLI entry point.
@@ -1311,6 +1356,230 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("Push failed after freshness merge"));
+    }
+
+    // --- run_impl_inner ---
+
+    fn no_ci(_: &Path, _: &Path, _: &str, _: bool) -> (bool, Option<String>) {
+        (true, None) // default: sentinel hit, no CI failure
+    }
+
+    fn ci_failed_decider(_: &Path, _: &Path, _: &str, _: bool) -> (bool, Option<String>) {
+        (false, Some("ci failed on sample test".to_string()))
+    }
+
+    fn inner_args(branch: &str) -> Args {
+        Args {
+            branch: Some(branch.to_string()),
+            auto: true,
+            manual: false,
+        }
+    }
+
+    #[test]
+    fn test_run_impl_inner_learn_gate_pending_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("pending", None);
+        setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![]);
+        let args = inner_args("test-feature");
+
+        let result = run_impl_inner(&args, dir.path(), &runner, &no_ci).unwrap();
+
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Phase 5: Learn must be complete"));
+    }
+
+    #[test]
+    fn test_run_impl_inner_pr_status_runner_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        setup_state_file(dir.path(), "test-feature", &state);
+
+        // First runner call is check_pr_status's `gh pr view`; return Err.
+        let runner = mock_runner(vec![Err("gh not found".to_string())]);
+        let args = inner_args("test-feature");
+
+        let result = run_impl_inner(&args, dir.path(), &runner, &no_ci).unwrap();
+
+        assert_eq!(result["status"], "error");
+        assert!(result["message"].as_str().unwrap().contains("gh not found"));
+    }
+
+    #[test]
+    fn test_run_impl_inner_pr_merged_returns_already_merged() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![ok("MERGED")]);
+        let args = inner_args("test-feature");
+
+        let result = run_impl_inner(&args, dir.path(), &runner, &no_ci).unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["path"], "already_merged");
+    }
+
+    #[test]
+    fn test_run_impl_inner_pr_closed_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        setup_state_file(dir.path(), "test-feature", &state);
+
+        let runner = mock_runner(vec![ok("CLOSED")]);
+        let args = inner_args("test-feature");
+
+        let result = run_impl_inner(&args, dir.path(), &runner, &no_ci).unwrap();
+
+        assert_eq!(result["status"], "error");
+        assert!(result["message"].as_str().unwrap().contains("closed"));
+    }
+
+    #[test]
+    fn test_run_impl_inner_merge_main_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        setup_state_file(dir.path(), "test-feature", &state);
+
+        // gh pr view → OPEN; fetch ok; is-ancestor non-zero (not ancestor);
+        // merge non-zero; status --porcelain shows UU conflict marker.
+        let runner = mock_runner(vec![
+            ok("OPEN"),                                // check_pr_status
+            ok(""),                                    // git fetch
+            Ok((1, String::new(), String::new())),     // is-ancestor → not
+            Ok((1, String::new(), "conflict".into())), // git merge fails
+            ok("UU src/conflicting.rs\n"),             // git status --porcelain
+        ]);
+        let args = inner_args("test-feature");
+
+        let result = run_impl_inner(&args, dir.path(), &runner, &no_ci).unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["path"], "conflict");
+        let files = result["conflict_files"].as_array().unwrap();
+        assert!(files
+            .iter()
+            .any(|v| v.as_str().unwrap() == "src/conflicting.rs"));
+    }
+
+    #[test]
+    fn test_run_impl_inner_merge_main_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        setup_state_file(dir.path(), "test-feature", &state);
+
+        // gh pr view → OPEN; fetch fails.
+        let runner = mock_runner(vec![ok("OPEN"), Err("network down".to_string())]);
+        let args = inner_args("test-feature");
+
+        let result = run_impl_inner(&args, dir.path(), &runner, &no_ci).unwrap();
+
+        assert_eq!(result["status"], "error");
+        assert!(result["message"].as_str().unwrap().contains("network down"));
+    }
+
+    #[test]
+    fn test_run_impl_inner_ci_skipped_sentinel_hit() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        setup_state_file(dir.path(), "test-feature", &state);
+
+        // gh pr view → OPEN; merge_main clean (fetch ok + is-ancestor 0);
+        // gh pr checks → pass; freshness up_to_date; squash merge → success.
+        let runner = mock_runner(vec![
+            ok("OPEN"),                            // check_pr_status
+            ok(""),                                // git fetch
+            Ok((0, String::new(), String::new())), // is-ancestor ok → clean
+            ok("CI\tpass\t\n"),                    // gh pr checks
+            ok(r#"{"status": "up_to_date"}"#),     // check-freshness
+            ok("merged"),                          // gh pr merge --squash
+        ]);
+        let args = inner_args("test-feature");
+
+        let result = run_impl_inner(&args, dir.path(), &runner, &no_ci).unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["path"], "merged");
+        assert_eq!(result["ci_skipped"], true);
+    }
+
+    #[test]
+    fn test_run_impl_inner_ci_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        setup_state_file(dir.path(), "test-feature", &state);
+
+        // gh pr view → OPEN; merge clean; gh pr checks → pass; ci_decider
+        // reports failure → fast_inner returns ci_failed before freshness.
+        let runner = mock_runner(vec![
+            ok("OPEN"),                            // check_pr_status
+            ok(""),                                // git fetch
+            Ok((0, String::new(), String::new())), // is-ancestor ok
+            ok("CI\tpass\t\n"),                    // gh pr checks
+        ]);
+        let args = inner_args("test-feature");
+
+        let result = run_impl_inner(&args, dir.path(), &runner, &ci_failed_decider).unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["path"], "ci_failed");
+        assert!(result["output"]
+            .as_str()
+            .unwrap()
+            .contains("ci failed on sample test"));
+    }
+
+    #[test]
+    fn test_run_impl_inner_gh_ci_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state("complete", None);
+        setup_state_file(dir.path(), "test-feature", &state);
+
+        // gh pr view → OPEN; merge clean; gh pr checks → pending.
+        let runner = mock_runner(vec![
+            ok("OPEN"),                            // check_pr_status
+            ok(""),                                // git fetch
+            Ok((0, String::new(), String::new())), // is-ancestor ok
+            ok("CI\tpending\t\n"),                 // gh pr checks
+        ]);
+        let args = inner_args("test-feature");
+
+        let result = run_impl_inner(&args, dir.path(), &runner, &no_ci).unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["path"], "ci_pending");
+    }
+
+    #[test]
+    fn test_run_impl_inner_no_pr_number_skips_gh_check() {
+        let dir = tempfile::tempdir().unwrap();
+        // Build a state with no pr_number (Null).
+        let mut state = make_state("complete", None);
+        state["pr_number"] = serde_json::Value::Null;
+        setup_state_file(dir.path(), "test-feature", &state);
+
+        // check_pr_status falls back to branch identifier and still makes
+        // one runner call. The gh pr checks call is SKIPPED because
+        // pr_number is None, so the queue has no entry for it.
+        let runner = mock_runner(vec![
+            ok("OPEN"),                            // check_pr_status (by branch)
+            ok(""),                                // git fetch
+            Ok((0, String::new(), String::new())), // is-ancestor ok
+            // no gh pr checks entry — should not be invoked
+            ok(r#"{"status": "up_to_date"}"#), // check-freshness
+            ok("merged"),                      // gh pr merge --squash
+        ]);
+        let args = inner_args("test-feature");
+
+        let result = run_impl_inner(&args, dir.path(), &runner, &no_ci).unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["path"], "merged");
     }
 
     // --- parse_gh_checks_output ---

--- a/test_coverage.md
+++ b/test_coverage.md
@@ -79,14 +79,12 @@ the compiled binary with `--issues-json` fixtures.
 
 ## src/complete_fast.rs
 
-After the `run_impl_inner` extraction (issue #1137), `run_impl` is a
-3-line wrapper threading production dependencies into the testable
-inner function, and the CI dirty-check body lives in
-`production_ci_decider`. The remaining uncovered regions fall into
-two architectural categories: the `run()` CLI entry (terminates the
-test process via `process::exit`) and the `production_ci_decider`
-paths that delegate to `ci::run_impl` (require a real CI
-subprocess).
+`run_impl` is a thin wrapper that threads the production runner and
+CI-decider into `run_impl_inner`; the CI dirty-check body lives in
+`production_ci_decider`. The uncovered regions fall into two
+architectural categories: the `run()` CLI entry (terminates the test
+process via `process::exit`) and the `production_ci_decider` paths
+that delegate to `ci::run_impl` (require a real CI subprocess).
 
 ### `run()` CLI wrapper (lines 607-620)
 
@@ -111,9 +109,10 @@ module.
 
 ### `production_ci_decider` real-CI delegation (lines 408-450)
 
-`production_ci_decider` contains the former inline CI dirty-check
-body from pre-refactor `run_impl` (issue #1137). Its branches split
-into testable structure and untestable delegation:
+`production_ci_decider` owns the Complete-phase CI dirty-check body:
+sentinel lookup, tree-snapshot comparison, and `ci::run_impl`
+invocation on miss. Its branches split into testable structure and
+untestable delegation:
 
 - `src/complete_fast.rs:414-416` — `tree_changed=true` early return.
   Covered by `production_ci_decider_tree_changed_returns_not_skipped`.

--- a/test_coverage.md
+++ b/test_coverage.md
@@ -77,6 +77,72 @@ All other lines in `src/analyze_issues.rs` are covered by the
 inline unit test module and the integration CLI tests that spawn
 the compiled binary with `--issues-json` fixtures.
 
+## src/complete_fast.rs
+
+After the `run_impl_inner` extraction (issue #1137), `run_impl` is a
+3-line wrapper threading production dependencies into the testable
+inner function, and the CI dirty-check body lives in
+`production_ci_decider`. The remaining uncovered regions fall into
+two architectural categories: the `run()` CLI entry (terminates the
+test process via `process::exit`) and the `production_ci_decider`
+paths that delegate to `ci::run_impl` (require a real CI
+subprocess).
+
+### `run()` CLI wrapper (lines 607-620)
+
+`run()` invokes `run_impl(&args)` and routes the result: on `Ok`
+with `status == "error"` it prints and calls `std::process::exit(1)`;
+on `Err` it prints the error JSON and calls `std::process::exit(1)`.
+Both exit calls terminate the calling test process, so the exit arms
+cannot be reached from inside a Rust `#[test]`. The testable surface
+is `run_impl` / `run_impl_inner`, both covered by the inline test
+module.
+
+- `src/complete_fast.rs:609-614` — `Ok` branch with `println!` of
+  the result and the error-status exit arm. Reached indirectly via
+  any integration test that drives the CLI subcommand; the exit call
+  cannot be reached from inside a Rust `#[test]`. Standard
+  CLI-entry pattern per `.claude/rules/rust-patterns.md` (CLI
+  Testability — run_impl Pattern).
+- `src/complete_fast.rs:615-618` — `Err` branch. Same pattern; the
+  testable surface is `run_impl_inner` which returns
+  `Result<Value, String>` and is exercised by the
+  `test_run_impl_inner_*` cases.
+
+### `production_ci_decider` real-CI delegation (lines 408-450)
+
+`production_ci_decider` contains the former inline CI dirty-check
+body from pre-refactor `run_impl` (issue #1137). Its branches split
+into testable structure and untestable delegation:
+
+- `src/complete_fast.rs:414-416` — `tree_changed=true` early return.
+  Covered by `production_ci_decider_tree_changed_returns_not_skipped`.
+- `src/complete_fast.rs:418-427` — `tree_changed=false` sentinel
+  lookup and snapshot comparison. Requires a live `cwd` with a real
+  `tree_snapshot` and a sentinel file whose contents match that
+  snapshot. Achievable only from an integration test that runs in a
+  prepared git tree — unit-test fixtures using `tempfile::tempdir()`
+  cannot produce matching `tree_snapshot` output because
+  `tree_snapshot` reads HEAD, diff, and untracked files via git
+  subprocess.
+- `src/complete_fast.rs:429-449` — CI invocation path. Calls
+  `ci::run_impl(&ci_args, cwd, root, false)` which spawns the
+  full `bin/format` / `bin/lint` / `bin/build` / `bin/test` chain in
+  `cwd`. Unit tests cannot inject this path without running real CI
+  on the host system; the test seam `run_impl_inner(args, root,
+  runner, ci_decider)` exists specifically to bypass this callsite
+  in unit tests by supplying a mock closure. The branches inside
+  this arm (zero vs non-zero `ci_code`, `message` field lookup) are
+  exercised by the `run_impl_inner` tests that pass
+  `ci_failed_decider` and `no_ci` mock closures — those closures
+  return the same two outputs this production arm produces.
+
+The testable surface — `run_impl_inner` plus its ten `test_run_impl_inner_*`
+cases — covers every dispatch branch downstream of this decider.
+The decider itself is intentionally thin (a glue layer over
+`ci::tree_snapshot`, `ci::sentinel_path`, and `ci::run_impl`, each
+of which has its own test coverage in `src/ci.rs`).
+
 ### Note: `fetch_blockers` error-path coverage
 
 The plan (PR #1153, Task 5) originally listed named tests for


### PR DESCRIPTION
## What

work on issue #1137.

Closes #1137

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/coverage-pattern-completefast-plan.md` |
| DAG | `.flow-states/coverage-pattern-completefast-dag.md` |
| Log | `.flow-states/coverage-pattern-completefast.log` |
| State | `.flow-states/coverage-pattern-completefast.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/fe29651f-a188-4af2-80eb-3aafabf5c2c6.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Implementation Plan: Coverage Pattern — `complete_fast.rs`

Issue: benkruger/flow#1137
PR: benkruger/flow#1155

## Context

`src/complete_fast.rs` is currently at 72.76% regions, 70.21% lines,
69.35% functions with 224 uncovered lines concentrated in `run_impl`
and a handful of unreached arms inside `fast_inner`. The issue asks for
100% coverage (or explicit waivers) on this file plus a ratchet bump of
the `bin/test` coverage floors to capture the gain. Most gaps are
testable through the existing `fast_inner` mock-runner harness; the
`run_impl` body is not currently injectable because it calls
`ci::run_impl()` and `std::env::current_dir()` directly.

## Exploration

### Source structure (`src/complete_fast.rs`, 576 production lines, 1122 total)

| Function | Lines | Status | Notes |
|---|---|---|---|
| `read_state` | L51–70 | Fully covered | 4 error variants covered by `read_state_*` tests |
| `parse_gh_checks_output` | L74–100 | Fully covered | 11 parser tests cover `none`/`pass`/`pending`/`fail` |
| `fast_inner` | L112–385 | Partially covered | 9 unreached arms; harness works, no new machinery needed |
| `run_impl` | L390–559 | Largely uncovered | Requires refactor to inject `runner` + `ci_decider` |
| `run` | L562–575 | Unreachable from tests | `process::exit(1)` sites; waiver territory |

### Uncovered arms inside `fast_inner`

| Line range | Branch | Current harness handles it? |
|---|---|---|
| L198 | Unknown `gh_ci_status` falls through `_` arm | Yes |
| L223–232 | `check-freshness` runner returns `Err(...)` | Yes |
| L234–243 | `check-freshness` returns unparseable JSON | Yes |
| L290–297 | Freshness `merged` + push `Err(...)` | Yes |
| L305–317 | Freshness `merged` + push succeeds → `ci_stale` | Yes |
| L325–331 | `gh pr merge` runner returns `Err(...)` | Yes |
| L353–365 | `gh pr merge` fails with `base branch policy` | Yes |
| L367–372 | `gh pr merge` fails with other stderr | Yes |
| L377–384 | Unexpected freshness status (`other` arm) | Yes |

### Uncovered regions inside `run_impl`

`run_impl` (L390–559) currently performs: `read_state` → learn-phase gate
→ `phase_enter` → `check_pr_status` → `merge_main` → CI dirty check
(calls `ci::run_impl()` directly) → `gh pr checks` parse → delegation
to `fast_inner`. The sub-helpers `check_pr_status` (L197 in
`complete_preflight.rs`) and `merge_main` (L246 there) already accept a
`runner: &dyn Fn(&[&str], u64) -> CmdResult` parameter, but the
`run_impl` body itself wires `run_cmd_with_timeout` in and calls
`ci::run_impl()` directly, so the branches at L405–543 are not reachable
from unit tests.

Affected line ranges inside `run_impl`:

- L405–410 — learn gate returns error JSON
- L413–421 — `phase_enter` + step counter mutation (indirectly exercised)
- L424–437 — `check_pr_status` error arm
- L439–451 — PR `MERGED` → `already_merged` path
- L453–459 — PR `CLOSED` → error path
- L462–486 — `merge_main` conflict / error arms
- L488–530 — CI dirty check block (calls `ci::run_impl`, `tree_snapshot`,
  `sentinel_path`)
- L533–543 — `gh pr checks` parse and fallback

### Existing test harness (`src/complete_fast.rs:577–1121`)

- `mock_runner(Vec<CmdResult>)` — pops responses in order, does not
  validate which command was invoked
- `ok(stdout)` shorthand for `Ok((0, stdout.to_string(), String::new()))`
- `make_state(learn_status, skills)` — canonical state with `pr_number=42`
- `setup_state_file(root, branch, state)` — writes state file into
  tempdir
- 25+ existing test functions covering happy path, all fast_inner-level
  error arms we already touch, and all `read_state`/`parse_gh_checks_output`
  variants

The harness accepts `Err(String)`, `Ok((non_zero, "", stderr))`, and
`ok("invalid-json")` responses — which is everything Category A needs.

### `bin/test` coverage floors (current)

```
--fail-under-lines 93
--fail-under-regions 94
--fail-under-functions 91
```

The accompanying comment in `bin/test` describes the ratchet semantics:
each threshold is `floor(actual_whole_percent)` and only moves up when
coverage crosses into a new whole-percent range.

### `test_coverage.md` waiver format

Existing entries follow: filename heading, section per architectural
category, bullet per `src/<file>.rs:LINE` with a one-sentence reason.
The `run()` waiver we add mirrors the existing `analyze_issues.rs`
`std::process::exit(1)` waiver idiom.

## Risks

1. **`run_impl` refactor visibility in diff** — B0 moves the current
   `run_impl` body into a new `run_impl_inner` that takes a runner and
   a CI-decider closure. The behavior is preserved exactly, but the
   function signature changes. Mitigation: the refactor lands in a
   single commit with a message that labels it as a pure extraction
   and references this plan, so reviewers look for shape-preservation
   rather than behavior change.

2. **CI-decider seam boundary** — the CI dirty-check block at L488–530
   touches `std::env::current_dir()`, `ci::tree_snapshot`,
   `ci::sentinel_path`, and `ci::run_impl`. Where we cut the seam
   determines how much of that block we can unit-test. The plan cuts
   at the block level: extract `fn production_ci_decider(root: &Path,
   cwd: &Path, branch: &str, tree_changed: bool) -> (bool,
   Option<String>)` containing the current L488–530 logic verbatim,
   and inject a closure of the same signature into `run_impl_inner`.
   This matches the `check_pr_status` / `merge_main` pattern already
   in use.

3. **Full-suite profdata requirement for threshold measurement** —
   `bin/flow test -- <filter>` does not persist a merged profdata
   file (confirmed during decompose Node 1: filtered runs leave only
   raw `*.profraw` files). Threshold measurement must use the
   full-suite `bin/flow ci` path to produce `flow.profdata` and a
   fresh TOTAL. Mitigation: T5 explicitly runs the full-suite gate.

4. **Waiver discipline** — T4 adds one waiver entry. Per
   `.claude/rules/docs-with-behavior.md`, every waiver must be tied
   to a plan task with an architectural justification. The
   justification is: `src/complete_fast.rs:563–574` calls
   `std::process::exit(1)` on both arms; this terminates the calling
   test process and cannot be exercised from inside it. The pattern
   matches the existing `analyze_issues.rs:524 / :564 / :607` waivers
   and `.claude/rules/rust-patterns.md` "CLI Testability — run_impl
   Pattern".

5. **Category A tests should pass against unchanged code** — the A1–A9
   cases exercise arms that already exist in `fast_inner`; they are
   unreached, not broken. If any A-test fails at landing time, that
   failure is a behavioral regression (not a test-first RED). The
   Code phase must diagnose rather than loosen the assertion.

6. **Test-naming consistency with existing section markers** — the
   existing test module uses `// --- <topic> ---` section markers
   (e.g. `// --- parse_gh_checks_output ---`, `// --- read_state ---`).
   New fast_inner cases go under a `// --- fast_inner error paths ---`
   marker (or extend existing markers). New `run_impl_inner` cases
   go under a `// --- run_impl_inner ---` marker.

## Approach

Three parallel workstreams, sequenced by dependency:

1. **Category A — `fast_inner` test additions (no refactor).** Nine new
   cases driving existing unreached arms via the current `mock_runner`
   harness. These should pass against unchanged production code — the
   arms exist, they are just currently unreached.

2. **Category B — `run_impl` refactor + tests.** One structural
   refactor extracting `run_impl_inner(args, runner, ci_decider)` plus
   ten unit tests for the newly injectable branches. The refactor is a
   pure extraction: `run_impl(args)` becomes a 3-line wrapper that
   calls `run_impl_inner(args, &run_cmd_with_timeout,
   &production_ci_decider)`. The CI dirty-check body at L488–530 moves
   into `production_ci_decider` with no logic change.

3. **Category C — waiver entry.** One new section in `test_coverage.md`
   covering `src/complete_fast.rs:563–574` (the `run()` CLI wrapper)
   under the architecturally unreachable `process::exit(1)` pattern.

After all three workstreams land, run the full-suite CI path to
produce fresh profdata, measure the new TOTAL, and ratchet the
`bin/test` coverage floors up by whatever whole-percent amount the
improvement earned.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add A1–A9 `fast_inner` test cases | test | — |
| 2. Refactor: extract `run_impl_inner` + `production_ci_decider` | refactor | — |
| 3. Add B1–B10 `run_impl_inner` test cases | test | 2 |
| 4. Add `complete_fast.rs` section to `test_coverage.md` | docs | — |
| 5. Run full-suite `bin/flow ci`, record new TOTAL | validation | 1, 3, 4 |
| 6. Ratchet `bin/test` `--fail-under-*` floors | config | 5 |
| 7. Re-run full-suite `bin/flow ci` to confirm ratchet holds | validation | 6 |

Tasks 2 and 3 form an atomic commit group: the refactor and the tests
that validate its behavior-preservation must land together so no
intermediate commit leaves the inner function untested. Task 1 and
Task 4 are independent and may land in their own commits. Tasks 5–7
are a strict sequence.

## Tasks

### 1. Add A1–A9 `fast_inner` test cases

**Files:** `src/complete_fast.rs` (tests module, lines 577–1121).

**Description:** Add nine new `#[test]` functions that drive currently
unreached arms of `fast_inner` via the existing `mock_runner` harness.
Add a `// --- fast_inner error paths ---` section marker (or extend an
existing marker group if more natural given surrounding tests).

**TDD notes:** Every case should pass on first run against unchanged
production code. If any test fails, the task is to diagnose the
discrepancy between the plan's expected behavior and the current code,
not to loosen the test. See Risk #5.

Test list:

| Test name | Scenario | Expected path |
|---|---|---|
| `test_fast_inner_unknown_gh_ci_status_proceeds` | `gh_ci_status="unknown"`; freshness `up_to_date`; `gh pr merge` returns success | `path == "merged"` (L170–199 `_` arm falls through) |
| `test_fast_inner_freshness_runner_err` | First runner call returns `Err("spawn failed".to_string())` | `status == "error"`; message contains `"check-freshness failed"` (L223–232) |
| `test_fast_inner_freshness_invalid_json` | First runner returns `ok("not json")` | `status == "error"`; message contains `"Invalid JSON"` (L234–243) |
| `test_fast_inner_unexpected_freshness_status` | Freshness returns `{"status":"rabbit"}` | `status == "error"`; message contains `"Unexpected check-freshness status"` (L377–384) |
| `test_fast_inner_squash_merge_spawn_err` | Freshness `up_to_date`; second runner returns `Err("gh not found")` | `status == "error"`; message contains `"gh not found"` (L325–331) |
| `test_fast_inner_squash_merge_base_branch_policy` | Freshness `up_to_date`; second runner returns `Ok((1, "", "base branch policy: required status check"))` | `path == "ci_pending"` (L353–365) |
| `test_fast_inner_squash_merge_generic_failure` | Freshness `up_to_date`; second runner returns `Ok((1, "", "Merge conflict detected"))` | `status == "error"`; message contains `"Merge conflict"` (L367–372) |
| `test_fast_inner_freshness_merged_push_success` | Freshness `{"status":"merged"}`; push returns `ok("")` | `path == "ci_stale"`; reason contains `"main moved"` (L305–317) |
| `test_fast_inner_freshness_merged_runner_err_on_push` | Freshness `{"status":"merged"}`; push returns `Err("no network")` | `status == "error"`; message contains `"Push failed after freshness merge"` (L290–297) |

### 2. Refactor: extract `run_impl_inner` and `production_ci_decider`

**Files:** `src/complete_fast.rs` (production module, L390–559).

**Description:** Extract two new items from the current `run_impl` body:

1. `fn production_ci_decider(root: &Path, cwd: &Path, branch: &str,
   tree_changed: bool) -> (bool, Option<String>)` — contains the
   existing L488–530 body verbatim: sentinel lookup, tree snapshot
   comparison, `ci::run_impl` invocation on miss, and computation of
   `(ci_skipped, ci_failed_output)`. No logic change. Add a doc
   comment naming the invariant: "Returns (ci_skipped, ci_failed_output)
   for the Complete-phase CI dirty-check block; real production path
   calls `ci::run_impl` when the sentinel does not match."

2. `pub fn run_impl_inner(args: &Args, runner: &dyn Fn(&[&str], u64)
   -> CmdResult, ci_decider: &dyn Fn(&Path, &Path, &str, bool) ->
   (bool, Option<String>)) -> Result<Value, String>` — contains the
   existing `run_impl` body with every `run_cmd_with_timeout` call
   replaced by `runner` and the L488–530 block replaced by a single
   `ci_decider(&root, &cwd, &branch, tree_changed)` call. Add a doc
   comment describing the two seam parameters.

`run_impl(args: &Args)` becomes a 3-line wrapper:

```rust
pub fn run_impl(args: &Args) -> Result<Value, String> {
    run_impl_inner(args, &run_cmd_with_timeout, &production_ci_decider)
}
```

**TDD notes:** The refactor preserves behavior exactly. The existing
tests (which drive `fast_inner` directly) continue to pass unchanged.
The new B1–B10 tests in Task 3 are the behavior-preservation proof.
This refactor and Task 3 land in one commit (atomic pair).

### 3. Add B1–B10 `run_impl_inner` test cases

**Files:** `src/complete_fast.rs` (tests module).

**Description:** Add ten new `#[test]` functions driving
`run_impl_inner` via mock `runner` and mock `ci_decider` closures. Add
a `// --- run_impl_inner ---` section marker.

**TDD notes:** These tests validate that Task 2's extraction preserves
behavior across the seam. They land atomically with Task 2 so no
intermediate commit leaves the inner function without coverage.

Test list:

| Test name | Setup | Expected |
|---|---|---|
| `test_run_impl_inner_learn_gate_pending_returns_error` | state with `flow-learn.status = "pending"` | result.status == `"error"`, message contains `"Phase 5: Learn must be complete"` |
| `test_run_impl_inner_pr_status_runner_err` | runner first call returns `Err(...)` | result.status == `"error"` |
| `test_run_impl_inner_pr_merged_returns_already_merged` | `check_pr_status` runner returns stdout yielding `MERGED` | result.path == `"already_merged"` |
| `test_run_impl_inner_pr_closed_returns_error` | `check_pr_status` yields `CLOSED` | result.status == `"error"`, message contains `"closed"` |
| `test_run_impl_inner_merge_main_conflict` | `merge_main` runner returns conflict shape | result.path == `"conflict"`, `conflict_files` populated |
| `test_run_impl_inner_merge_main_error` | `merge_main` runner returns fetch failure | result.status == `"error"` |
| `test_run_impl_inner_ci_skipped_sentinel_hit` | mock `ci_decider` returns `(true, None)`; freshness `up_to_date`; push succeeds | result.path == `"merged"`, `ci_skipped == true` |
| `test_run_impl_inner_ci_failed` | mock `ci_decider` returns `(false, Some("ci msg"))` | result.path == `"ci_failed"`, output contains `"ci msg"` |
| `test_run_impl_inner_gh_ci_pending` | mock `ci_decider` returns `(true, None)`; `gh pr checks` runner returns `pending` | result.path == `"ci_pending"` |
| `test_run_impl_inner_no_pr_number_skips_gh_check` | state has no `pr_number` (or `null`); mock `ci_decider` returns `(true, None)`; freshness `up_to_date`; push succeeds | `gh pr checks` runner is not invoked (response queue has no entry for it); result.path in the success set |

The test module already has a `mock_runner` helper that does not
validate command identity; B10 relies on queue-exhaustion semantics
<!-- external-input-audit: not-a-tightening -->
(if `gh pr checks` were invoked, `pop_front` would panic on empty
queue) to verify the skip.

### 4. Add `complete_fast.rs` waiver section to `test_coverage.md`

**Files:** `test_coverage.md`.

**Description:** Append a new section following the existing format:

```markdown
## src/complete_fast.rs

### run() CLI wrapper — std::process::exit(1) (lines 563–574)

`run()` calls `run_impl` and routes the result: on `Ok` with
`status == "error"` it invokes `std::process::exit(1)`; on `Err` it
prints the message and `std::process::exit(1)`. Both exit calls
terminate the calling test process, so the two exit arms cannot be
reached from inside a Rust test. External observation of the exit
code is covered by integration tests that spawn the compiled binary
(`tests/complete_fast.rs` via the `CARGO_BIN_EXE_flow-rs` harness, if
present) and by the production `bin/flow complete-fast` CLI path
itself.

- `src/complete_fast.rs:565` — `println!` of the OK result. Reached
  indirectly via any integration test that drives the CLI subcommand.
- `src/complete_fast.rs:566–568` — error-status exit branch. Standard
  CLI entry pattern per `.claude/rules/rust-patterns.md` (CLI
  Testability — run_impl Pattern).
- `src/complete_fast.rs:570–573` — `Err` branch. Same pattern; the
  testable surface is `run_impl` / `run_impl_inner` which return
  `Result<Value, String>` and are exercised by the inline tests.
```

**TDD notes:** No test change. This is a documentation addition tied
to the architectural justification in Risk #4.

### 5. Run full-suite `bin/flow ci`, record new TOTAL

**Files:** none modified.

**Description:** After Tasks 1–4 land, run `bin/flow ci` on the
worktree. Wait for the run to produce `target/llvm-cov-target/flow.profdata`
and the final coverage report. Record the new TOTAL regions / lines /
functions percentages verbatim in the Code-phase notes (via `bin/flow
log`) so Task 6 has authoritative numbers to ratchet against.

**TDD notes:** Not a code change. If CI fails (unrelated tests, new
warnings, format drift), diagnose and fix before proceeding — do not
proceed to the threshold bump on a red baseline.

### 6. Ratchet `bin/test` coverage floors

**Files:** `bin/test`.

**Description:** Read the three new TOTAL percentages recorded in
Task 5. For each, compute `floor(new_whole_percent)`. If the new
floor exceeds the current threshold, update the `--fail-under-lines`,
`--fail-under-regions`, and `--fail-under-functions` values in
`bin/test` lines 67–69. If a particular metric's floor did not
advance a whole-percent boundary, leave that threshold unchanged.

**TDD notes:** No new tests. The ratchet is enforced by the existing
`bin/test` contract tests (`tests/bin_test.rs`) plus the CI run in
Task 7. Commit message names each old→new value explicitly so future
auditors can follow the ratchet history.

### 7. Re-run full-suite `bin/flow ci` to confirm ratchet holds

**Files:** none modified.

**Description:** Run `bin/flow ci` one more time after Task 6. The
new thresholds must pass — if they fail, Task 6 overshot the actual
floor and the threshold must be lowered to match. This final CI run
is also the gate for committing Task 6.

**TDD notes:** Not a code change. This is the verification step for
the threshold ratchet.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Close coverage gaps in src/complete_fast.rs (issue #1137)

```xml
<dag goal="Close coverage gaps in src/complete_fast.rs (issue #1137)" mode="full">
  <plan>
    <node id="1" name="Enumerate uncovered regions" type="research" depends="[]" parallel_with="[2,3]">
      <objective>Run llvm-cov show on complete_fast.rs and capture every uncovered branch, line, and region with its function context.</objective>
    </node>
    <node id="2" name="Read complete_fast.rs source" type="research" depends="[]" parallel_with="[1,3]">
      <objective>Map the run_impl dispatch: every match arm, early-return, error path, and the fast_inner seam boundary.</objective>
    </node>
    <node id="3" name="Read existing fast_inner tests" type="research" depends="[]" parallel_with="[1,2]">
      <objective>Understand the mock-runner shape, what inputs/state the harness already accepts, and what fixture helpers exist.</objective>
    </node>
    <node id="4" name="Classify uncovered regions" type="analysis" depends="[1,2,3]" parallel_with="[]">
      <objective>Bucket each uncovered region into (A) fast_inner-reachable with new input, (B) external-infra deferred (Slack/gh — other pattern issues), or (C) architecturally unreachable waiver.</objective>
    </node>
    <node id="5" name="Mock-runner extension analysis" type="analysis" depends="[4]" parallel_with="[7]">
      <objective>Identify what mock-runner behaviors (new error modes, state shapes, exit codes) must be addable to exercise every Category A region.</objective>
    </node>
    <node id="6" name="Design test cases" type="creative" depends="[5]" parallel_with="[7]">
      <objective>Enumerate each new fast_inner test case: input shape, mock responses, assertions, and TDD order.</objective>
    </node>
    <node id="7" name="Design waiver entries" type="creative" depends="[4]" parallel_with="[5,6]">
      <objective>For Category B (deferred to pattern issues) and Category C (architecturally unreachable), draft test_coverage.md entries with line coordinates and architectural reasons.</objective>
    </node>
    <node id="8" name="Threshold bump math" type="analysis" depends="[6,7]" parallel_with="[]">
      <objective>Compute the new TOTAL after tests + waivers and propose rounded --fail-under-lines/regions/functions values (~1% buffer below actual).</objective>
    </node>
    <node id="9" name="Validate DoD alignment" type="validation" depends="[6,7,8]" parallel_with="[]">
      <objective>Confirm each DoD checkbox (100% or waiver, CI green, thresholds raised, uncovered label handling) maps to a concrete task.</objective>
    </node>
    <node id="10" name="Synthesis — implementation DAG" type="synthesis" depends="[6,7,8,9]" parallel_with="[]">
      <objective>Emit the final TDD-ordered task DAG the Plan phase will consume — tests first, waivers second, threshold bumps last.</objective>
    </node>
  </plan>
</dag>
```

Validation: 10 nodes, no cycles, three parallel research branches, two parallel design branches, single terminal synthesis. Scale = Standard.

---

## PHASE 1: EXECUTE

### NODE 1: Enumerate uncovered regions

Ran `/opt/homebrew/opt/llvm/bin/llvm-cov show --instr-profile=target/llvm-cov-target/flow.profdata --sources src/complete_fast.rs --region-coverage-lt=100`. Result: `flow.profdata` does not exist in the worktree; running `bin/flow test -- complete_fast` generated raw `.profraw` files but did not produce a merged `.profdata`. Filtered runs do not persist merged profdata.

**Key finding (Node 1):** Coverage enumeration requires a full `bin/flow ci` profdata run (filtered runs don't persist merged profdata). Plan phase must execute `bin/flow ci` and then `llvm-cov show --region-coverage-lt=100` on a populated profdata to get authoritative region-level data. For this decompose, structural analysis from source is sufficient to shape the DAG.

Quality: 7/10 — Ran the coverage tool, confirmed the profdata bootstrapping constraint, established that Plan must run full CI first. Partial without region-level enumeration.

### NODE 2: Read complete_fast.rs source

Read `src/complete_fast.rs` (576 lines total; 1122 including tests).

**Structural map:**

- **`read_state` (L51-70)** — 4 error branches (missing file, read failure, parse failure, non-object root); all tested by existing `read_state_*` cases.
- **`parse_gh_checks_output` (L74-100)** — 4 result states (none/fail/pending/pass); 11 existing test cases cover all arms.
- **`fast_inner` (L112-385)** — injectable-runner seam with 11 parameters. Branches:
  - L141-153: `tree_changed` → `ci_stale` (tested)
  - L155-167: `ci_failed_output` → `ci_failed` (tested)
  - L170-199: `gh_ci_status` match — pass/none (continue, tested), pending (tested), fail (untested), `_` unknown arm (untested, L198)
  - L202-214: manual mode → `confirm` (tested)
  - L218-232: check-freshness runner — Err arm (L223-232, UNTESTED)
  - L234-243: JSON parse failure (L234-243, UNTESTED)
  - L250-384: freshness status match — `max_retries` (tested), `error` (partially tested, L263-273), `conflict` (tested), `merged` (push Ok-nonzero tested L298-304, push Err UNTESTED L290-297, push success UNTESTED L305-317), `up_to_date` (happy path tested, base-branch-policy UNTESTED L353-365, generic failure UNTESTED L367-372, spawn Err UNTESTED L325-331), unknown status `other` UNTESTED L377-384.
- **`run_impl` (L390-559)** — primary coverage gap. NOT injectable at this level:
  - L405-410: learn gate failure (UNTESTED)
  - L413-421: phase_enter mutation (UNTESTED in integration)
  - L424-437: check_pr_status Err (UNTESTED)
  - L439-451: PR MERGED → already_merged (UNTESTED at run_impl level)
  - L453-459: PR CLOSED (UNTESTED)
  - L462-486: merge_main conflict/error arms (UNTESTED)
  - L488-530: CI dirty-check block — calls `ci::run_impl()` and `std::env::current_dir()` directly
  - L533-543: gh pr checks via `run_cmd_with_timeout` (not injectable here)
- **`run` (L562-575)** — `process::exit(1)` sites on error. Waiver territory.

Quality: 9/10 — Complete structural map, all uncovered arms identified by line range.

### NODE 3: Read existing fast_inner tests

`src/complete_fast.rs` lines 577-1121 contain 25+ tests.

**Harness shape:**
- `mock_runner(Vec<CmdResult>)` — pops responses blindly; does NOT validate which command was invoked.
- `ok(stdout)` shorthand for `Ok((0, stdout, ""))`.
- `make_state(learn_status, skills)` — builds canonical state JSON with pr_number=42.
- `setup_state_file(root, branch, state)` — writes state to temp directory.

**Existing coverage:**
- Happy path: `test_merged_path_happy`, `test_ci_sentinel_skip`
- Unhappy paths: `test_ci_stale_after_main_merge`, `test_ci_failed`, `test_ci_pending_github`, `test_conflict_from_freshness`, `test_max_retries`, `test_confirm_manual_mode`
- Error paths: `test_freshness_error_without_message_uses_fallback`, `test_freshness_merged_push_failure` (Ok non-zero branch)
- Parse: 11 `parse_gh_checks_output_*` cases
- Gate: `test_gate_failure_learn_not_complete` (state-inspection only), `test_gate_failure_no_state` (calls `read_state` directly)
- read_state: 4 variants

**Harness limit:** `mock_runner` ignores command. Tests cannot assert command-ordering — only response-ordering.

Quality: 8/10 — Harness is adequate for Category A expansion; no new machinery needed for fast_inner cases.

### NODE 4: Classify uncovered regions

Based on source structure (Node 2) and harness capability (Node 3):

**Category A — fast_inner-reachable (existing harness, ~100-110 uncovered lines):**

| Line range | Branch | Mock shape |
|---|---|---|
| L198 | unknown gh_ci_status `_` arm | `gh_ci_status="unknown"` plus runner responses for continuation |
| L223-232 | freshness runner Err | `Err("spawn failed")` |
| L234-243 | freshness invalid JSON | `ok("not json")` |
| L377-384 | unexpected freshness status | `ok({"status":"rabbit"})` |
| L325-331 | squash runner Err | `ok(up_to_date)` then `Err("gh")` |
| L353-365 | base branch policy hint | `ok(up_to_date)` then `Ok((1, "", "base branch policy: required"))` |
| L367-372 | generic squash failure | `ok(up_to_date)` then `Ok((1, "", "other"))` |
| L305-317 | freshness merged → push success → ci_stale | `ok({"status":"merged"})` then `ok("")` |
| L290-297 | freshness merged → push spawn Err | `ok({"status":"merged"})` then `Err("no network")` |

**Category B — run_impl-reachable via refactor (~100 uncovered lines):**

| Line range | Branch | Required action |
|---|---|---|
| L405-410 | learn gate failure | Refactor to inject runner + ci_decider |
| L424-437 | check_pr_status Err | Already a runner-consuming function |
| L439-451 | PR MERGED → already_merged | |
| L453-459 | PR CLOSED | |
| L462-486 | merge_main conflict/error | `merge_main` already takes runner |
| L488-530 | CI dirty-check block | Extract `ci_decider` helper |
| L533-543 | gh pr checks call | Route through injected runner |

**Category C — architectural waiver (~10 lines):**

- L563-574: `run` function. `process::exit` sites; standard CLI-entry pattern per `.claude/rules/rust-patterns.md` "CLI Testability — run_impl Pattern".

Quality: 9/10 — Every uncovered line has a bucket. Refactor path unlocks Category B without external-infra dependencies.

### NODE 5: Mock-runner extension analysis

**For Category A:** existing harness supports every case:
- `Err(String)` already works for spawn-failure paths
- `Ok((code≠0, stdout, stderr))` already works for non-zero-exit paths
- `ok("not json")` already works for JSON-parse-failure paths

No new mock-runner machinery required for Category A.

**For Category B:** a new seam must be added to `run_impl`:

```rust
pub fn run_impl_inner(
    args: &Args,
    runner: &dyn Fn(&[&str], u64) -> CmdResult,
    ci_decider: &dyn Fn(&Path, &PathBuf, &str, bool) -> (bool, Option<String>),
) -> Result<Value, String> { /* body from run_impl */ }

pub fn run_impl(args: &Args) -> Result<Value, String> {
    run_impl_inner(args, &run_cmd_with_timeout, &production_ci_decider)
}

fn production_ci_decider(
    root: &Path,
    cwd: &PathBuf,
    branch: &str,
    tree_changed: bool,
) -> (bool, Option<String>) {
    // Extracted verbatim from current L488-530 body.
}
```

Tests call `run_impl_inner` with mock closures, entirely bypassing real CI and real gh subprocess calls.

Quality: 8/10 — Minimal seam addition, threads existing runner pattern through.

### NODE 6: Design test cases

**Category A tests — fast_inner extensions (9 new cases, no refactor):**

| # | Test name | Mock responses | Assertion |
|---|---|---|---|
| A1 | `test_fast_inner_unknown_gh_ci_status_proceeds` | `gh_ci_status="unknown"`; `ok(up_to_date)`, `ok("merged")` | `path=="merged"` (falls through L198 `_` arm) |
| A2 | `test_fast_inner_freshness_runner_err` | `Err("spawn failed".to_string())` | `status=="error"`, msg contains `"check-freshness failed"` |
| A3 | `test_fast_inner_freshness_invalid_json` | `ok("not json")` | `status=="error"`, msg contains `"Invalid JSON"` |
| A4 | `test_fast_inner_unexpected_freshness_status` | `ok(r#"{"status":"rabbit"}"#)` | `status=="error"`, msg contains `"Unexpected check-freshness status"` |
| A5 | `test_fast_inner_squash_merge_spawn_err` | `ok(up_to_date)`, `Err("gh not found".to_string())` | `status=="error"`, msg contains `"gh not found"` |
| A6 | `test_fast_inner_squash_merge_base_branch_policy` | `ok(up_to_date)`, `Ok((1, String::new(), "base branch policy: required status check".to_string()))` | `path=="ci_pending"` |
| A7 | `test_fast_inner_squash_merge_generic_failure` | `ok(up_to_date)`, `Ok((1, String::new(), "Merge conflict detected".to_string()))` | `status=="error"`, msg contains `"Merge conflict"` |
| A8 | `test_fast_inner_freshness_merged_push_success` | `ok(r#"{"status":"merged"}"#)`, `ok("")` | `path=="ci_stale"`, reason contains `"main moved"` |
| A9 | `test_fast_inner_freshness_merged_runner_err_on_push` | `ok(r#"{"status":"merged"}"#)`, `Err("no network".to_string())` | `status=="error"`, msg contains `"Push failed after freshness merge"` |

Note: A9 complements existing `test_freshness_merged_push_failure` (which tests Ok non-zero push; A9 tests the Err arm at L290-297).

**Category B — refactor + tests:**

| # | Task | Details |
|---|---|---|
| B0 | REFACTOR: extract `run_impl_inner` | Signature per Node 5. `run_impl` becomes 3-line wrapper. |
| B1 | `test_run_impl_inner_learn_gate_pending_returns_error` | learn_status="pending" → error msg "Phase 5: Learn must be complete" |
| B2 | `test_run_impl_inner_pr_status_runner_err` | runner returns Err on `gh pr view` call → error json with message |
| B3 | `test_run_impl_inner_pr_merged_returns_already_merged` | runner returns `ok("MERGED")` → path=="already_merged" |
| B4 | `test_run_impl_inner_pr_closed_returns_error` | runner returns `ok("CLOSED")` → error "PR is closed" |
| B5 | `test_run_impl_inner_merge_main_conflict` | runner returns conflict shape from merge_main → path=="conflict", conflict_files populated |
| B6 | `test_run_impl_inner_merge_main_error` | runner returns error shape from merge_main → error |
| B7 | `test_run_impl_inner_ci_skipped_sentinel_hit` | ci_decider returns (true, None) → fast_inner path |
| B8 | `test_run_impl_inner_ci_failed` | ci_decider returns (false, Some("ci msg")) → path=="ci_failed" |
| B9 | `test_run_impl_inner_gh_ci_pending` | runner returns pending gh output → path=="ci_pending" |
| B10 | `test_run_impl_inner_no_pr_number_skips_gh_check` | state has no pr_number → gh_ci_status treated as "none" path |

**Category C:**

| # | Task | File |
|---|---|---|
| C1 | Add waiver for `run` function | `test_coverage.md` (new section for `src/complete_fast.rs`) |

TDD ordering: A1-A9 RED-first (all should pass against existing code — arms exist, just unreached). Then B0 (refactor), then B1-B10 (tests validate refactor preserves behavior). Then C1 waiver. Then measurement + threshold bump.

Quality: 9/10 — Complete, concrete, TDD-ordered.

### NODE 7: Design waiver entries

Draft `test_coverage.md` addition:

```markdown
## src/complete_fast.rs

- **`run` function (src/complete_fast.rs:563-574)** — `process::exit(1)`
  sites unreachable from inside the calling test process; standard CLI
  entrypoint pattern documented in `.claude/rules/rust-patterns.md`
  "CLI Testability — run_impl Pattern". The testable `run_impl` /
  `run_impl_inner` surface carries the behavior.
```

No Category B waivers needed if B0 refactor lands (preferred path).

Quality: 8/10 — Matches waiver discipline in `.claude/rules/docs-with-behavior.md`.

### NODE 8: Threshold bump math

Procedure (exact numbers require post-implementation measurement):

1. Land A1-A9 tests + B0 refactor + B1-B10 tests + C1 waiver.
2. Run full-suite `bin/flow ci` (filtered runs do not produce merged profdata).
3. Read new TOTAL from the llvm-cov report.
4. Read current `--fail-under-lines`, `--fail-under-regions`, `--fail-under-functions` from `bin/test`.
5. Compute new thresholds = `floor(new_TOTAL_percent) - 1` (~1% buffer per DoD spec).
6. Edit `bin/test` to update values.
7. Re-run `bin/flow ci` to confirm thresholds hold.

Expected file delta: complete_fast.rs 72.76%→~100% regions, 70.21%→~100% lines, 69.35%→~100% functions. TOTAL shifts modestly (file is ~500 lines of ~32k total lines). Absolute threshold bump depends on full-suite measurement.

Quality: 7/10 — Correct procedure; exact values come from measurement.

### NODE 9: Validate DoD alignment

| DoD checkbox | Task coverage |
|---|---|
| 100% regions/lines/functions OR explicit waiver | A1-A9 (fast_inner gaps) + B0-B10 (run_impl refactor + tests) + C1 (waiver for `run`) |
| `bin/flow ci` passes | Each task gates on ci green; A-block and B-block separately ci-green before commits |
| Thresholds raised to match new TOTAL | Task T6 (measure + edit bin/test after A/B/C land) |
| `uncovered` label removed on close | Post-merge Complete-phase concern; not a plan task |

All DoD items have owners. Quality: 9/10.

### NODE 10: Synthesis — Implementation DAG

Final task DAG the Plan phase consumes:

| Task | Type | Depends On | Summary |
|------|------|------------|---------|
| T1 | test | — | Add A1-A9 fast_inner tests (9 new cases using existing harness). RED-first; all should pass against current code — they exercise unreached arms. |
| T2 | refactor | — | B0: Extract `run_impl_inner(args, runner, ci_decider)` from `run_impl`. Factor CI dirty-check block (L488-530) into a `production_ci_decider` helper. `run_impl` becomes 3-line wrapper. No behavior change — pure structural refactor. |
| T3 | test | T2 | Add B1-B10 run_impl_inner tests (10 new cases). Use mock runner + mock ci_decider. All should pass post-refactor. |
| T4 | docs | T1, T3 | Add waiver section for `src/complete_fast.rs` to `test_coverage.md` covering L563-574 (`run` function). |
| T5 | validation | T1, T3, T4 | Run full-suite `bin/flow ci`. Read new TOTAL from llvm-cov output. |
| T6 | config | T5 | Edit `bin/test` to raise `--fail-under-lines`, `--fail-under-regions`, `--fail-under-functions` to `floor(new_TOTAL) - 1`. |
| T7 | validation | T6 | Re-run `bin/flow ci` to confirm new thresholds hold. |

**Parallelism:** T1 and T2 are independent — one fixes fast_inner gaps, the other refactors run_impl. T3 depends on T2 (new seam). T4 can land alongside T3 or T1. T5 merges the measurement front. T6-T7 serialize the threshold bump.

**Atomic commit groups:**
- T1: single commit (fast_inner test additions)
- T2+T3: atomic pair (refactor + tests land together — the tests validate the refactor behavior preservation)
- T4: can land alone or with T2+T3
- T5+T6+T7: threshold bump sequence — T6 and T7 must be atomic (threshold edit + verification)

**Risks to flag in plan Risks section:**

1. **`run_impl` refactor visibility in diff** — B0 is a pure structural refactor, but changes the function signature. PR reviewers need the refactor labeled as such so they don't look for behavior changes. Mitigation: single-commit refactor with clear commit message "Extract run_impl_inner for testability".
2. **`ci_decider` seam boundary** — the CI dirty check at L488-530 touches `std::env::current_dir()`, `ci::tree_snapshot`, `ci::sentinel_path`, and `ci::run_impl`. Extracting a clean seam requires deciding where to cut. The cleanest cut is at the function level: `fn production_ci_decider(...) -> (bool, Option<String>)`. Mitigation: refactor task description names the exact signature.
3. **Full-suite profdata requirement** — threshold measurement (T5) requires `bin/flow ci` to run fresh, not a filtered run. Mitigation: T5 task notes "full-suite only; filtered runs don't produce merged profdata".
4. **Waiver discipline** — T4 introduces a waiver that must be tied to the plan per `.claude/rules/docs-with-behavior.md`. The plan-task justification is: "L563-574 calls `std::process::exit(1)` which terminates the test process; standard CLI pattern per `.claude/rules/rust-patterns.md`."

**Confidence:** 80% | **Nodes:** 10 | **Parallel branches:** 2 (research × 3, design × 2)

**vs. Vanilla Claude (what linear reasoning would have missed):**
- **Dependency between coverage target and test harness shape** — a linear response would propose "add more tests" without distinguishing the fast_inner-reachable cases (zero new machinery) from the run_impl cases (requires refactor). The split into Category A/B/C is load-bearing for scope estimation.
- **Threshold measurement ordering** — a linear response would propose editing `bin/test` alongside the test additions; this fails because the threshold must be computed from post-land measurement, not pre-land estimation. T5→T6 ordering is critical.
- **Refactor vs waiver trade-off for run_impl** — a linear response would default to "add waivers for CI-calling code"; the refactor path (B0) unlocks ~100 lines with a single structural change and matches existing patterns (`check_pr_status`, `merge_main` already take runner params).
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 13m |
| Code | 47m |
| Code Review | 17m |
| Learn | 15m |
| Complete | <1m |
| **Total** | **1h 34m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/coverage-pattern-completefast.json</summary>

```json
{
  "schema_version": 1,
  "branch": "coverage-pattern-completefast",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1155,
  "pr_url": "https://github.com/benkruger/flow/pull/1155",
  "started_at": "2026-04-14T17:28:27-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/coverage-pattern-completefast-plan.md",
    "dag": ".flow-states/coverage-pattern-completefast-dag.md",
    "log": ".flow-states/coverage-pattern-completefast.log",
    "state": ".flow-states/coverage-pattern-completefast.json"
  },
  "session_tty": "/dev/ttys002",
  "session_id": "fe29651f-a188-4af2-80eb-3aafabf5c2c6",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/fe29651f-a188-4af2-80eb-3aafabf5c2c6.jsonl",
  "notes": [],
  "prompt": "work on issue #1137",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-14T17:28:27-07:00",
      "completed_at": "2026-04-14T17:29:10-07:00",
      "session_started_at": null,
      "cumulative_seconds": 43,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-14T17:29:22-07:00",
      "completed_at": "2026-04-14T17:43:02-07:00",
      "session_started_at": null,
      "cumulative_seconds": 820,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-14T17:44:33-07:00",
      "completed_at": "2026-04-14T18:31:49-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2836,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-14T18:32:03-07:00",
      "completed_at": "2026-04-14T18:49:19-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1036,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-14T18:49:34-07:00",
      "completed_at": "2026-04-14T19:05:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 931,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-14T19:05:25-07:00",
      "completed_at": "2026-04-14T19:05:52-07:00",
      "session_started_at": null,
      "cumulative_seconds": 27,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-14T17:29:22-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-14T17:44:33-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-14T18:32:03-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-14T18:49:34-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-14T19:05:25-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 7,
  "code_task_name": "Ratchet bin/test coverage floors",
  "code_task": 7,
  "diff_stats": {
    "files_changed": 3,
    "insertions": 678,
    "deletions": 54,
    "captured_at": "2026-04-14T18:31:49-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "findings": [
    {
      "finding": "CiDecider type alias not mentioned in CLAUDE.md",
      "reason": "Internal refactor seam inside a single file; does not match docs-with-behavior.md 'New CLI subcommand or changed state mutations' scope for CLAUDE.md entries. The generic CLI-testability pattern is already documented in .claude/rules/rust-patterns.md which this refactor follows verbatim.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T18:38:44-07:00"
    },
    {
      "finding": "complete-fast panics in read_state -> FlowPaths::new when --branch contains '/' (feature/foo, dependabot/*)",
      "reason": "Fixed: read_state now uses FlowPaths::try_new and returns a structured error. run_impl_inner surfaces the error via its Err return. Two regression tests added: read_state_slash_branch_returns_structured_error_no_panic and run_impl_inner_slash_branch_returns_structured_error_no_panic.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T18:39:56-07:00"
    },
    {
      "finding": "test_coverage.md src/complete_fast.rs section used backward-facing phrases referencing 'pre-refactor run_impl'",
      "reason": "Fixed: rewrote the opening paragraph and the production_ci_decider subsection to describe current behavior without historical-provenance phrasing. Satisfies .claude/rules/comment-quality.md Forward-Facing Test applied to documentation files.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T18:40:36-07:00"
    },
    {
      "finding": "production_ci_decider doc comment misstated causality: (false, None) return does not produce ci_stale; tree_changed=true passed separately to fast_inner does",
      "reason": "Fixed: rewrote doc comment to name the actual cause (fast_inner's own tree_changed arg) and note the ambiguity of the (false, None) return (same value returned when CI runs and passes).",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T18:40:58-07:00"
    },
    {
      "finding": "Module-level doc comment at src/complete_fast.rs:1-18 did not describe the refactored architecture (CiDecider seam, run_impl_inner, production_ci_decider)",
      "reason": "Fixed: added Architecture section to module doc describing the two injectable seams (runner + ci_decider), the three-tier shape (run/run_impl/run_impl_inner), and the call chain. Satisfies .claude/rules/docs-with-behavior.md 'Changed type signatures or module architecture → module-level doc comment'.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-14T18:41:29-07:00"
    },
    {
      "finding": "external-input-validation.md listed only hooks as branch-validation callsites; the read_state callsite in complete_fast.rs (invoked via CLI --branch override) violated the rule without being in the inventory",
      "reason": "Rule clarified: added CLI subcommand entry callsite discipline section enumerating src/complete_fast.rs:read_state and generalizing the pattern to any CLI subcommand accepting --branch. Updated codebase-wide rule to state that --branch CLI override is external input. Added testing-discipline requirement for slash-branch regression tests on CLI entries.",
      "outcome": "rule_clarified",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-14T18:53:15-07:00",
      "path": ".claude/rules/external-input-validation.md"
    },
    {
      "finding": "docs-with-behavior.md Waiver Discipline did not cross-reference comment-quality.md Forward-Facing Test; waivers could be authored backward-facing without a Plan/Code check",
      "reason": "Rule clarified: added a bullet to Waiver Discipline requiring every waiver entry to pass the Forward-Facing Test from comment-quality.md, with PR #1155 cited as the reference incident (production_ci_decider waiver initially backward-facing, flagged in Code Review).",
      "outcome": "rule_clarified",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-14T18:54:52-07:00",
      "path": ".claude/rules/docs-with-behavior.md"
    },
    {
      "finding": "code_task counter can only increment by 1, creating awkward workflow for atomic commit groups",
      "reason": "Plugin process gap filed for follow-up. State counter semantics conflict with plan-commit-atomicity.md 'atomic group' semantics.",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-14T19:04:27-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1158"
    },
    {
      "finding": "Measurement-only tasks (CI re-run, threshold verification) lack a documented commit pathway",
      "reason": "Plugin process gap filed for follow-up. Sessions hitting measurement tasks invent ad-hoc workarounds.",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-14T19:04:33-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1159"
    },
    {
      "finding": "Plan phase doesn't enumerate new helper branches when a task extracts code into a new function, causing scope expansion mid-Code",
      "reason": "Plugin process gap filed for follow-up. Extract-helper refactors consistently surface new uncovered code that wasn't in the plan.",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-14T19:04:40-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1160"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "issues_filed": [
    {
      "label": "Flow",
      "title": "code_task counter awkward with atomic-group commits",
      "url": "https://github.com/benkruger/flow/issues/1158",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-14T19:04:11-07:00"
    },
    {
      "label": "Flow",
      "title": "Measurement-only tasks have no documented commit pathway",
      "url": "https://github.com/benkruger/flow/issues/1159",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-14T19:04:15-07:00"
    },
    {
      "label": "Flow",
      "title": "Plan phase should enumerate new helper branches during extract-helper refactors",
      "url": "https://github.com/benkruger/flow/issues/1160",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-14T19:04:21-07:00"
    }
  ],
  "complete_steps_total": 6,
  "complete_step": 6,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/coverage-pattern-completefast.log</summary>

```text
2026-04-14T17:23:58-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-14T17:24:47-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-14T17:25:28-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-14T17:26:28-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-14T17:27:27-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-14T17:28:26-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-14T17:28:26-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-14T17:28:27-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-14T17:28:27-07:00 [Phase 1] create .flow-states/coverage-pattern-completefast.json (exit 0)
2026-04-14T17:28:27-07:00 [Phase 1] freeze .flow-states/coverage-pattern-completefast-phases.json (exit 0)
2026-04-14T17:28:27-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-14T17:28:28-07:00 [Phase 1] start-init — label-issues (labeled: [1137], failed: [])
2026-04-14T17:28:46-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-14T17:28:47-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-14T17:28:47-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-14T17:28:58-07:00 [Phase 1] start-workspace — worktree .worktrees/coverage-pattern-completefast (ok)
2026-04-14T17:29:02-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-14T17:29:02-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-14T17:29:02-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-14T17:29:10-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-14T17:29:10-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-14T17:36:11-07:00 [stop-continue] first stop, conditional continue: pending=decompose
2026-04-14T17:43:02-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-14T17:44:33-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-14T17:47:08-07:00 [Phase 3] Task 1 — A1-A9 tests pass (9/9)
2026-04-14T17:57:34-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-14T17:57:37-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-14T18:12:13-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-14T18:12:17-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-14T18:21:27-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-14T18:21:31-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-14T18:22:18-07:00 [Phase 3] Task 5 — new TOTAL: regions 94.63%, lines 93.91%, functions 92.46%. Ratchet: functions 91 -> 92.
2026-04-14T18:30:55-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-14T18:31:00-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-14T18:31:49-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-14T18:32:03-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-14T18:48:49-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-14T18:48:55-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-14T18:49:19-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-14T18:49:34-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-14T19:01:46-07:00 [Phase 5] Waiting for learn-commit CI to complete
2026-04-14T19:01:57-07:00 wait tick
2026-04-14T19:02:12-07:00 [Phase 5] finalize-commit — ci (ok)
2026-04-14T19:02:16-07:00 [Phase 5] finalize-commit — done ("ok")
2026-04-14T19:05:05-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-14T19:05:52-07:00 [Phase 6] complete-finalize — starting
2026-04-14T19:05:52-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-14T19:05:52-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Flow | code_task counter awkward with atomic-group commits | Learn | #1158 |
| Flow | Measurement-only tasks have no documented commit pathway | Learn | #1159 |
| Flow | Plan phase should enumerate new helper branches during extract-helper refactors | Learn | #1160 |

<!-- end:Issues Filed -->