### PR TITLE
Measurement Only Tasks Have No

### DIFF
--- a/.claude/rules/testing-gotchas.md
+++ b/.claude/rules/testing-gotchas.md
@@ -137,3 +137,122 @@ How to apply: during Plan phase, enumerate every `ends_with` pattern
 the implementation will use, then add one test per pattern for each
 form (bare + absolute). The test count is small — two tests per
 pattern — and it locks the intended match surface.
+
+## Subsection-Local Assertions in Contract Tests
+
+When a contract test asserts that a file contains specific content
+inside a named section — a Markdown heading, a Rust `mod` block, a
+YAML sub-document — bound the assertion's search scope to the
+section itself, not the entire file. The failure mode is silent: a
+test that splits on a heading and checks `contains()` over the
+remainder will be satisfied by unrelated content elsewhere in the
+file, so a refactor that guts the section passes CI as long as any
+sibling section still carries the expected substring.
+
+### Why
+
+When a new section is added to a multi-section file (for example,
+a subsection inside `skills/flow-code/SKILL.md` whose job is to
+route a specific task shape to `/flow:flow-commit`), a contract
+test proves the subsection exists and carries the correct routing.
+A naive implementation looks like:
+
+```rust
+// WRONG — after_heading covers everything from the heading to EOF
+let after_heading = c
+    .split("Measurement-Only Tasks")
+    .nth(1)
+    .expect("heading checked above");
+assert!(after_heading.contains("/flow:flow-commit"));
+```
+
+`split("H").nth(1)` returns the *entire* remainder of the file from
+the first occurrence of `"H"` forward. Any later section in the
+same file that happens to mention `/flow:flow-commit` satisfies the
+assertion — including the standard Commit section that every
+iteration of the skill has always had. A malicious (or merely
+careless) refactor that empties the new subsection of its
+`/flow:flow-commit` reference while leaving the rest of the file
+intact passes CI because the later unrelated mention still lives in
+`after_heading`.
+
+The same class of gap appears whenever the assertion scope exceeds
+the logical unit under test. If the test's English claim is "the
+Measurement-Only Tasks subsection routes through `/flow:flow-commit`,"
+the slice must cover only that subsection, not everything after its
+opening heading.
+
+### The pattern
+
+Walk the slice to the section start, then walk it to the next
+section boundary:
+
+```rust
+// CORRECT — subsection covers only the content between the
+// heading and the next level-3 heading
+let tail_at_heading = c
+    .split_once("### Measurement-Only Tasks")
+    .map(|(_, tail)| tail)
+    .expect("heading checked above");
+let subsection = tail_at_heading
+    .split_once("\n### ")
+    .map(|(section, _)| section)
+    .unwrap_or(tail_at_heading);
+assert!(subsection.contains("/flow:flow-commit"));
+```
+
+`split_once` is preferred over `split().nth(1)` because it makes
+the intent explicit (one split, two pieces) and avoids the iterator
+`nth()` ambiguity on strings that contain multiple occurrences of
+the split delimiter.
+
+For Markdown files, "next section boundary" is usually the next
+heading of the same or higher level. The end delimiter should
+match the heading marker of the section being tested:
+
+- For a `### ` subsection, split on `"\n### "` (stops at the next
+  `### ` or a higher-level `## `/`# ` by virtue of the newline
+  anchor and the assumption that the subsection's parent ends with
+  `## `, not `### `).
+- For a `## ` section, split on `"\n## "`.
+
+For Rust source files, use the `fn ` or `mod ` tokens that bound
+the unit under test. For YAML, use the top-level key that bounds
+the sub-document.
+
+### Fallback to EOF
+
+When the section being tested is the last section in the file, the
+next-section split returns no matches. Use `.unwrap_or(tail)` so
+the assertion scope falls back to the end of the file rather than
+panicking. This keeps the test robust against a future edit that
+reorders sections and leaves the one under test at EOF.
+
+### How to apply
+
+When writing a new contract test that asserts content inside a
+named section:
+
+1. Identify the heading or boundary marker that starts the section.
+2. Identify the marker that ends the section (the next peer heading,
+   the next mod block, the next top-level key).
+3. Walk to the start using `split_once(start_marker)`.
+4. Walk to the end using a second `split_once(end_marker)` on the
+   tail, falling back to the tail itself via `unwrap_or(tail)`.
+5. Run all content assertions against the bounded `subsection`
+   slice, never against the full file content.
+
+When reviewing an existing contract test that uses
+`split(marker).nth(n)` or a raw `contains()` over the full file,
+grep the file being tested for the asserted substrings. If any of
+them appear in multiple sections, the test is fragile — replace it
+with the bounded-slice pattern above.
+
+The motivating incident is benkruger/flow#1167 — the initial
+contract test for the Measurement-Only Tasks subsection matched
+`/flow:flow-commit` anywhere after the heading, including the
+standard Commit section ~L443 of `skills/flow-code/SKILL.md`. A
+gutted subsection passed the test. The fix bounded the slice with
+`split_once("### Measurement-Only Tasks")` followed by
+`split_once("\n### ")`. This rule codifies the pattern so future
+contract tests ship bounded from the start.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ Key test files: `tests/structural.rs` (config invariants, version consistency), 
 ## Conventions
 
 - **Never invoke `/flow-release` unless the user explicitly runs it** — fixing a bug does not authorize a release. Committing a fix and releasing it are separate decisions. The user decides when to ship.
-- All commits via `/flow:flow-commit` skill — no exceptions, no shortcuts, no "just this once". Infrastructure commits during `start-gate` (e.g., `commit_deps` for dependency lock files) are the sole carve-out: they commit directly via Rust under the start lock, before any worktree exists.
+- All commits via `/flow:flow-commit` skill — no exceptions, no shortcuts, no "just this once". Measurement-only tasks (e.g., a coverage TOTAL capture or a threshold verification re-run) still route through `/flow:flow-commit` — the commit skill's `git diff --cached` check handles the empty diff via its "Nothing to commit" return path, so the session never needs a shortcut. Infrastructure commits during `start-gate` (e.g., `commit_deps` for dependency lock files) are the sole carve-out: they commit directly via Rust under the start lock, before any worktree exists.
 - All changes require `bin/flow ci` green before committing — tests are the gate
 - New skills are automatically covered by `tests/skill_contracts.rs` (glob-based discovery)
 - Namespace is `flow:` — plugin.json name is `"flow"`

--- a/docs/skills/flow-code.md
+++ b/docs/skills/flow-code.md
@@ -50,6 +50,20 @@ by exactly 1 per task; only the commit is deferred.
 
 ---
 
+## Measurement-Only Tasks
+
+Some plan tasks produce no file changes — a final coverage TOTAL capture
+for the PR body, a threshold verification re-run, or a final regression
+re-run the plan names explicitly. The Code phase still routes these
+through `/flow-commit`, which detects the empty diff, prints "Nothing to
+commit", and returns to the caller without running `finalize-commit`.
+The `code_task` counter advances normally and the self-invocation at the
+end of the Commit sequence fires unchanged, so every task — file-changing
+or not — flows through the same commit funnel and honors the "All commits
+via `/flow-commit`" convention.
+
+---
+
 ## Project Architecture Enforced
 
 Architecture checks are defined by the project's CLAUDE.md. Each project documents its own conventions for reading code before writing, using test infrastructure correctly, and following its own architecture rules.

--- a/skills/flow-code/SKILL.md
+++ b/skills/flow-code/SKILL.md
@@ -225,19 +225,27 @@ These tasks still route through the standard Commit flow below so
 every task honors CLAUDE.md's "All commits via `/flow:flow-commit`"
 convention and never invents a shortcut.
 
-Execute the task (run `bin/flow ci`, log the measurement, or do
-whatever the task description specifies), then follow the Commit
-section exactly as a file-changing task would: advance `code_task`
-via `set-timestamp`, set `_continue_context` and `_continue_pending=commit`,
-and invoke `/flow:flow-commit`. The commit skill's Round 4 runs
-`git add -A` followed by `git diff --cached`; when the diff is
-empty it prints "Nothing to commit", prints its COMPLETE banner,
-and returns to the caller without calling `finalize-commit`. The
-self-invocation at the end of the Commit section then fires
-unchanged — it runs after `/flow:flow-commit` returns, independent
-of whether a commit was actually produced. Do not skip
-`/flow:flow-commit` even when you already know the diff will be
-empty.
+Skip the TDD Cycle (there is no test or implementation to write
+for a task that produces no file changes) and perform the task's
+measurement action as the task body — for example, `bin/flow ci`
+to verify a threshold or `bin/flow log` to record a TOTAL into the
+session log. Then proceed through the `bin/flow ci` Gate section
+below just like a file-changing task would: the CI HARD-GATE still
+applies, and `bin/flow ci` must be green before the Commit step
+runs. (When the measurement action already invoked `bin/flow ci`,
+the gate's sentinel skip makes the second invocation a fast no-op.)
+After the CI Gate passes, follow the Commit section exactly as a
+file-changing task would: advance `code_task` via `set-timestamp`,
+set `_continue_context` and `_continue_pending=commit`, and invoke
+`/flow:flow-commit`. The commit skill stages all changes via
+`git add -A` in Round 3, then runs `git diff --cached` in Round 4;
+when the staged diff is empty it prints "Nothing to commit",
+prints its COMPLETE banner, and returns to the caller without
+calling `finalize-commit`. The self-invocation at the end of the
+Commit section then fires unchanged — it runs after
+`/flow:flow-commit` returns, independent of whether a commit was
+actually produced. Do not skip `/flow:flow-commit` even when you
+already know the diff will be empty.
 
 ### Before Starting a Task
 

--- a/skills/flow-code/SKILL.md
+++ b/skills/flow-code/SKILL.md
@@ -216,6 +216,29 @@ Add <what the group accomplished> — Tasks <first>-<last> of <total>
 **Self-invoke** as usual after the group commit to continue with
 the next task after the group.
 
+### Measurement-Only Tasks
+
+Some plan tasks produce no file changes — a final `coverage TOTAL`
+capture for the PR body, a `threshold verification` re-run, or a
+`final regression re-run` that the plan explicitly names as a task.
+These tasks still route through the standard Commit flow below so
+every task honors CLAUDE.md's "All commits via `/flow:flow-commit`"
+convention and never invents a shortcut.
+
+Execute the task (run `bin/flow ci`, log the measurement, or do
+whatever the task description specifies), then follow the Commit
+section exactly as a file-changing task would: advance `code_task`
+via `set-timestamp`, set `_continue_context` and `_continue_pending=commit`,
+and invoke `/flow:flow-commit`. The commit skill's Round 4 runs
+`git add -A` followed by `git diff --cached`; when the diff is
+empty it prints "Nothing to commit", prints its COMPLETE banner,
+and returns to the caller without calling `finalize-commit`. The
+self-invocation at the end of the Commit section then fires
+unchanged — it runs after `/flow:flow-commit` returns, independent
+of whether a commit was actually produced. Do not skip
+`/flow:flow-commit` even when you already know the diff will be
+empty.
+
 ### Before Starting a Task
 
 Persist the task name to the state file for TUI display:

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -1843,24 +1843,35 @@ fn code_has_plan_test_verification() {
 fn code_documents_measurement_only_task_pathway() {
     let c = common::read_skill("flow-code");
     assert!(
-        c.contains("Measurement-Only Tasks"),
-        "Code skill must document the measurement-only task pathway as a named subsection"
+        c.contains("### Measurement-Only Tasks"),
+        "Code skill must document the measurement-only task pathway as a named `### ` subsection"
     );
-    assert!(
-        c.contains("Nothing to commit"),
-        "Code skill must reference the /flow:flow-commit empty-diff return path"
-    );
-    // The /flow:flow-commit reference must sit in or after the
-    // Measurement-Only Tasks subsection so the prose routes
-    // measurement tasks through the commit skill instead of
-    // leaving the reader to invent a shortcut.
-    let after_heading = c
-        .split("Measurement-Only Tasks")
-        .nth(1)
+    // Bound the slice to the subsection itself. Splitting on the
+    // heading string alone would leave `after_heading` covering
+    // everything from the heading to EOF, so a later section (e.g.
+    // the standard Commit section around L443) could satisfy the
+    // /flow:flow-commit and "Nothing to commit" assertions even if
+    // the subsection itself were gutted. Splitting the tail on the
+    // next `### ` heading keeps the checks local to the subsection.
+    let tail_at_heading = c
+        .split_once("### Measurement-Only Tasks")
+        .map(|(_, tail)| tail)
         .expect("heading presence asserted above");
+    let subsection = tail_at_heading
+        .split_once("\n### ")
+        .map(|(section, _)| section)
+        .unwrap_or(tail_at_heading);
     assert!(
-        after_heading.contains("/flow:flow-commit"),
+        subsection.contains("/flow:flow-commit"),
         "Measurement-only subsection must route through /flow:flow-commit"
+    );
+    assert!(
+        subsection.contains("Nothing to commit"),
+        "Measurement-only subsection must reference the empty-diff return path"
+    );
+    assert!(
+        subsection.contains("bin/flow ci"),
+        "Measurement-only subsection must keep the bin/flow ci Gate mandatory"
     );
 }
 

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -1839,6 +1839,31 @@ fn code_has_plan_test_verification() {
     );
 }
 
+#[test]
+fn code_documents_measurement_only_task_pathway() {
+    let c = common::read_skill("flow-code");
+    assert!(
+        c.contains("Measurement-Only Tasks"),
+        "Code skill must document the measurement-only task pathway as a named subsection"
+    );
+    assert!(
+        c.contains("Nothing to commit"),
+        "Code skill must reference the /flow:flow-commit empty-diff return path"
+    );
+    // The /flow:flow-commit reference must sit in or after the
+    // Measurement-Only Tasks subsection so the prose routes
+    // measurement tasks through the commit skill instead of
+    // leaving the reader to invent a shortcut.
+    let after_heading = c
+        .split("Measurement-Only Tasks")
+        .nth(1)
+        .expect("heading presence asserted above");
+    assert!(
+        after_heading.contains("/flow:flow-commit"),
+        "Measurement-only subsection must route through /flow:flow-commit"
+    );
+}
+
 // --- Learn phase ---
 
 #[test]


### PR DESCRIPTION
## What

work on issue #1159.

Closes #1159

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/measurement-only-tasks-have-no-plan.md` |
| DAG | `.flow-states/measurement-only-tasks-have-no-dag.md` |
| Log | `.flow-states/measurement-only-tasks-have-no.log` |
| State | `.flow-states/measurement-only-tasks-have-no.json` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Implementation Plan: Measurement-Only Tasks Pathway (#1159)

Issue: benkruger/flow#1159
PR: benkruger/flow#1167

## Context

The FLOW Code phase has no documented pathway for measurement-only
tasks — plan tasks that produce no file changes (running CI to record
a new coverage TOTAL, a threshold-verification re-run, a final
regression check). The motivating incident was PR #1155 Task 5
("Run full-suite `bin/flow ci`, record new TOTAL"). That session:

1. Ran `bin/flow ci` (sentinel-skipped because no changes)
2. Logged the numbers via `bin/flow log`
3. Advanced `code_task=5` via `set-timestamp`
4. Skipped `/flow:flow-commit` entirely
5. Self-invoked `flow:flow-code --continue-step --auto` directly

Skipping `/flow:flow-commit` violated CLAUDE.md's convention at
`CLAUDE.md:208`: "All commits via `/flow:flow-commit` skill — no
exceptions, no shortcuts, no 'just this once'." The session invented
a shortcut because the skill had no written pathway for a task whose
diff is empty. Every future session hitting a measurement-only task
would invent its own workaround, yielding non-deterministic behavior
under autonomous flows.

The fix is small: add a short "Measurement-Only Tasks" subsection to
`skills/flow-code/SKILL.md` that directs the session to still invoke
`/flow:flow-commit`, which already handles the empty-diff case by
printing "Nothing to commit" and returning to the caller. All the
counter-advance and continuation-flag scaffolding in flow-code's
Commit section runs BEFORE `/flow:flow-commit` is invoked, so the
self-invocation machinery fires unchanged when the commit skill
returns on an empty diff. Zero new machinery is needed — the gap is
purely instructional.

## Exploration

The four production files that need edits (named to comply with the
scope-enumeration rule — see the Risks section):

| File | Current state | Change |
|------|---------------|--------|
| `skills/flow-code/SKILL.md` | Execute Next Task (L147), Atomic Task Group (L155-217), Before Starting a Task (L219), Commit (L395-431). No measurement-task carve-out. | Insert `### Measurement-Only Tasks` subsection between Atomic Task Group (ends L217) and Before Starting a Task (L219) |
| `tests/skill_contracts.rs` | Existing `flow-code` content tests at L1797-1840 (`code_has_resume_check`, `code_commit_self_invokes`, `code_commit_records_task`, `code_skill_has_atomic_group_handling`, `code_has_plan_test_verification`) | Add one new test adjacent to these |
| `CLAUDE.md` | Conventions section bullet at L208: "All commits via `/flow:flow-commit` skill — no exceptions..." | Extend the bullet with a parenthetical noting measurement-only tasks still route through `/flow:flow-commit` |
| `docs/skills/flow-code.md` | Mirror file describing the phase. Current sections: One Task Per Invocation (L19), Atomic Task Groups (L39), Project Architecture Enforced (L53), Flaky Test Detection (L59), Test Runs (L68), Mode (L76), Gates (L82) | Insert a short "Measurement-Only Tasks" section after Atomic Task Groups |

Supporting files that inform the approach but do not change:

- `skills/flow-commit/SKILL.md:115` — `"If `git diff --cached` is
  empty, tell the user 'Nothing to commit', print the COMPLETE
  banner, and return to the caller."` — confirms the empty-diff
  return path already exists.
- `.claude/rules/code-task-counter.md` — `code_task` increments once
  per plan task regardless of commit grouping. A measurement task
  advances the counter the same way every other task does.
- `.claude/rules/plan-commit-atomicity.md` — atomic groups are about
  commit boundaries, orthogonal to whether a task produces a diff.
- `.claude/rules/skill-authoring.md` — "Simplest Approach First"
  rule authorizes Pathway 1; "Purpose Preamble for Behavioral
  Sections" requires a 2-3 sentence preamble; "Negative-Assertion
  Test Compatibility" requires the contract test to use positive
  assertions.
- `.claude/rules/docs-with-behavior.md` — requires the behavior
  change and its doc mirror to land in the same commit.
- `.claude/rules/hook-vs-instruction.md` — instructions are
  advisory; mitigated by CLAUDE.md's existing convention
  enforcement.

## Risks

### Skill instructions are advisory

Per `.claude/rules/hook-vs-instruction.md`, skill instructions can be
ignored at runtime. A session that encounters a measurement-only task
could still choose to bypass `/flow:flow-commit` despite the new
subsection.

**Mitigation:** The CLAUDE.md convention at L208 already declares
"no exceptions, no shortcuts, no 'just this once'." The new SKILL.md
subsection reinforces that convention for the empty-diff edge case
— it does not introduce a new policy. If future Learn-phase audits
detect recurring noncompliance, escalation to a hook (observing
`_continue_pending=commit` being cleared without a `/flow:flow-commit`
invocation) is the next-step option per the hook-vs-instruction
escalation pattern. Iteration 1 is prose-only because the
instruction-first discipline matches every other FLOW convention in
this tree.

### Contract test must assert positive content only

Per `.claude/rules/skill-authoring.md` "Negative-Assertion Test
Compatibility", a test that scans SKILL.md for a prohibited string
will trigger its own assertion if the SKILL.md explains what to
avoid. Positive-content assertions (`contains("Measurement-Only
Tasks")` and similar) are safe.

**Mitigation:** Task 1 writes a test that asserts the heading and
`/flow:flow-commit` reference are present, never that a specific
string is absent.

### Docs mirror drift

Per `.claude/rules/docs-with-behavior.md` "Changed skill behavior",
`docs/skills/<name>.md` must be updated when the skill behavior
changes. CI's `tests/docs_sync.rs` enforces structural presence but
not content match — a mirror that omits the new section would not
fail CI automatically.

**Mitigation:** Task 4 updates `docs/skills/flow-code.md` as part
of the atomic commit group.

### Multi-task atomic commit

Per `.claude/rules/docs-with-behavior.md` "Multi-Task Plans" and
`.claude/rules/plan-commit-atomicity.md`, a behavior change and its
documentation must land together in the same commit. In addition,
the contract test (Task 1) cannot pass until the SKILL.md prose
exists (Task 2) — if Task 1's test lands first, CI fails; if Task 2's
SKILL.md change lands first, the test-first TDD discipline is broken.

**Mitigation:** Tasks 1, 2, 3, 4 form an atomic commit group. The
"why" is stated in the Tasks section below: atomic because the
contract test cannot pass without the SKILL.md prose, and the
docs-with-behavior rule requires the SKILL.md change and the
CLAUDE.md + docs mirror updates to land together.

### State-dependent gate ordering (not applicable)

Per `.claude/rules/skill-authoring.md` "State-Dependent Gate
Ordering in Multi-Step Skills", a gate that reads state must run
after the state is written. This plan adds no new gate command —
the SKILL.md subsection points at existing scaffolding
(`code_task`, `_continue_pending`, `_continue_context`, `/flow:flow-commit`).
No state-dependent gate ordering concerns arise.

### External-input audit (not applicable)

Per `.claude/rules/external-input-audit-gate.md`, plans that propose
adding `panic!`, `assert!`, or constructor-level invariant checks
must include a caller audit table. This plan adds no such checks —
it is prose-only in skill and doc files, plus a positive-assertion
contract test in Rust. Not applicable.
<!-- external-input-audit: not-a-tightening -->

### Supersession (not applicable)

Per `.claude/rules/supersession.md`, a plan that adds a replacement
or guard must delete any superseded code in the same PR. This plan
adds instructional prose without deprecating any existing code path
— the Execute Next Task, Atomic Task Group, Before Starting a Task,
TDD Cycle, Review, `bin/flow ci` Gate, Plan Test Verification, and
Commit sections of `skills/flow-code/SKILL.md` all remain as-is.
Nothing is superseded.

### Scope enumeration discipline

Per `.claude/rules/scope-enumeration.md`, plan prose and SKILL.md
prose that use universal quantifiers on code-family nouns must name
the concrete siblings. Both this plan file and the new SKILL.md
subsection describe measurement-task scenarios by named example
only — `coverage TOTAL capture`, `threshold verification`, `final
regression re-run` — not by universal quantifier over a code
family. The prose does not combine "every" / "all" / "each" with
a code-family noun (subcommand, runner, mutator, etc.), so no
scope-enumeration violations are expected.

## Approach

**Chosen pathway: Pathway 1 — document explicitly.**

Insert a short `### Measurement-Only Tasks` subsection in
`skills/flow-code/SKILL.md` immediately after the Atomic Task Group
subsection (ends at L217) and before Before Starting a Task (L219).
The subsection:

1. **Opens with a 2-3 sentence purpose preamble** (per
   `.claude/rules/skill-authoring.md` "Purpose Preamble for
   Behavioral Sections") explaining why the subsection exists:
   some plan tasks produce no file changes (example scenarios
   named), and the session must still route those tasks through
   `/flow:flow-commit` to honor CLAUDE.md's "All commits via
   /flow:flow-commit" convention.
2. **Directs the session to execute the standard Commit sequence
   unchanged**: advance `code_task` via `set-timestamp`, set
   `_continue_context`, set `_continue_pending=commit`, invoke
   `/flow:flow-commit`, and self-invoke
   `flow:flow-code --continue-step` after it returns. No new
   commands.
3. **Explains the empty-diff return path**: notes that
   `/flow:flow-commit` detects the empty diff via its Round 4
   `git diff --cached` check, prints "Nothing to commit", and
   returns cleanly to the caller. The self-invocation at the end
   of the Commit section fires unchanged because it runs AFTER
   `/flow:flow-commit` returns, not dependent on whether a commit
   was actually made.
4. **Lists the legitimate scenarios by name** (scope-enumeration
   discipline): `coverage TOTAL capture` (PR #1155 Task 5 is the
   motivating precedent), `threshold verification`, and
   `final regression re-run`. Named examples — no universal
   quantifiers.

Supporting edits:

- **Contract test** in `tests/skill_contracts.rs` asserting the
  subsection exists and references `/flow:flow-commit` and
  `"Nothing to commit"`. Positive-assertion content check.
- **CLAUDE.md reinforcement** — extend the L208 "All commits via
  /flow:flow-commit" bullet with a one-line parenthetical covering
  measurement-only tasks.
- **Docs mirror** — add a short "Measurement-Only Tasks" section
  to `docs/skills/flow-code.md` after "Atomic Task Groups".

All four edits form an atomic commit group per the Risks section
reasoning.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Write contract test `code_documents_measurement_only_task_pathway` | test | — |
| 2. Add Measurement-Only Tasks subsection to `skills/flow-code/SKILL.md` | implement | 1 |
| 3. Extend CLAUDE.md Conventions bullet with measurement-task cross-reference | docs | 2 |
| 4. Add Measurement-Only Tasks section to `docs/skills/flow-code.md` | docs | 2 |

## Tasks

**Atomic commit group: Tasks 1, 2, 3, 4 land in one commit.**

Reason: atomic because the contract test (Task 1) cannot pass
until the SKILL.md prose (Task 2) exists — if Task 1 commits first,
`bin/flow ci` fails. And per `.claude/rules/docs-with-behavior.md`
"Multi-Task Plans", the SKILL.md behavior change (Task 2) and its
documentation updates (Tasks 3, 4) must land in the same commit so
no intermediate state shows stale documentation. All four tasks
advance the `code_task` counter individually per
`.claude/rules/code-task-counter.md`, then land as a single commit
per `.claude/rules/plan-commit-atomicity.md`.

### Task 1 — Write contract test `code_documents_measurement_only_task_pathway`

**File:** `tests/skill_contracts.rs`

**Placement:** Adjacent to the existing `flow-code` content tests
(`code_has_plan_test_verification` at L1833-1840). Insert the new
test directly after that test, before the `// --- Learn phase ---`
section marker.

**Test body:** The test reads `skills/flow-code/SKILL.md` via
`common::read_skill("flow-code")` and asserts, using positive
content checks only:

- The string `Measurement-Only Tasks` appears (heading presence)
- The string `Nothing to commit` appears (empty-diff handler
  reference, quoted from `skills/flow-commit/SKILL.md:115`)
- The string `/flow:flow-commit` appears near the measurement-task
  subsection (verified by splitting on the heading and searching
  the following section)

The assertion messages must describe the positive invariant, not
the absence of something. Example form:

```rust
#[test]
fn code_documents_measurement_only_task_pathway() {
    let c = common::read_skill("flow-code");
    assert!(
        c.contains("Measurement-Only Tasks"),
        "Code must document the measurement-only task pathway"
    );
    assert!(
        c.contains("Nothing to commit"),
        "Code must reference the empty-diff return path"
    );
    // Ensure the /flow:flow-commit reference sits in or after the
    // measurement-task subsection, not just elsewhere in the file.
    let after_heading = c
        .split("Measurement-Only Tasks")
        .nth(1)
        .expect("heading checked above");
    assert!(
        after_heading.contains("/flow:flow-commit"),
        "Measurement-only subsection must route through /flow:flow-commit"
    );
}
```

**TDD note:** Run `bin/flow test -- code_documents_measurement_only_task_pathway`
first — the test MUST fail before the SKILL.md change lands.
Confirm the failure messages match the assertions. Increment
`code_task=1` via `set-timestamp` after the test is written and
the failure is confirmed.

### Task 2 — Add `### Measurement-Only Tasks` subsection to `skills/flow-code/SKILL.md`

**File:** `skills/flow-code/SKILL.md`

**Placement:** Insert a new `### Measurement-Only Tasks` subsection
between the Atomic Task Group subsection (ends at L217) and the
Before Starting a Task subsection (L219). The insertion is peer-
level with the other two carve-out/pre-task subsections.

**Content shape** (actual wording to be written during Code phase,
these are the required elements):

1. **Heading:** `### Measurement-Only Tasks`
2. **Purpose preamble** (2-3 sentences): "Some plan tasks produce
   no file changes — for example, a final coverage TOTAL capture
   for the PR body, a threshold verification re-run, or a final
   regression check the plan names explicitly. The Commit sequence
   below handles these identically to file-changing tasks so every
   task routes through `/flow:flow-commit` and honors CLAUDE.md's
   no-shortcut convention."
3. **Body** (1 paragraph): "Advance `code_task` via
   `set-timestamp` exactly as the standard flow does, set
   `_continue_context` and `_continue_pending=commit`, and invoke
   `/flow:flow-commit`. The commit skill's Round 4 `git diff
   --cached` detects the empty diff, prints 'Nothing to commit',
   and returns to the caller. The self-invocation at the end of
   the Commit section fires unchanged — it runs after
   `/flow:flow-commit` returns, not conditional on whether a
   commit was made. Do not skip `/flow:flow-commit` even when you
   know the diff will be empty."
4. **Example scenarios** listed inline by name: coverage TOTAL
   capture, threshold verification, final regression re-run.

**Constraints:**

- Purpose preamble is non-optional per
  `.claude/rules/skill-authoring.md` "Purpose Preamble for
  Behavioral Sections".
- No universal-quantifier phrases over code-family nouns
  (scope-enumeration rule). Use named scenario examples only.
- No new commands introduced — the subsection must reference the
  existing Commit section rather than duplicating its instructions.
- No prohibited-string phrasings that would trip the contract test
  in Task 1.

**TDD note:** After writing the subsection, run
`bin/flow test -- code_documents_measurement_only_task_pathway`
to confirm the test from Task 1 now passes. Increment `code_task=2`
via `set-timestamp` after the test passes.

### Task 3 — Extend CLAUDE.md Conventions bullet with measurement-task cross-reference

**File:** `CLAUDE.md`

**Placement:** Line ~208 — the existing "All commits via
`/flow:flow-commit`" bullet in the Conventions section.

**Change:** Extend the existing bullet with a parenthetical or
trailing sentence noting that measurement-only tasks (tasks that
produce no file changes, like a coverage TOTAL capture) still
route through `/flow:flow-commit`, which handles the empty diff
and returns cleanly. The existing "Infrastructure commits during
`start-gate` ... are the sole carve-out" clause must remain —
this is an addition, not a replacement.

**Content shape** (actual wording to be written during Code phase):
After the existing sentence, append: "Measurement-only tasks (e.g.,
a coverage TOTAL capture or a threshold verification re-run) still
route through `/flow:flow-commit` — the commit skill handles the
empty diff via its 'Nothing to commit' return path."

**Constraints:**

- Single addition to an existing bullet; do not create a new
  bullet.
- Do not remove or reword the existing "no exceptions" clause.
- Do not introduce scope-enumeration triggers (use named examples,
  not universal quantifiers).

**TDD note:** No test change; this is a documentation addition
that the contract test from Task 1 already covers for SKILL.md.
Increment `code_task=3` via `set-timestamp`.

### Task 4 — Add Measurement-Only Tasks section to `docs/skills/flow-code.md`

**File:** `docs/skills/flow-code.md`

**Placement:** After the existing "Atomic Task Groups" section
(ends at L51), before the "Project Architecture Enforced" section
(L53).

**Content shape** (actual wording to be written during Code phase):
A short section (~4-6 lines of prose) titled "Measurement-Only
Tasks" explaining:

- Some plan tasks produce no file changes — a final coverage TOTAL
  capture, a threshold verification re-run, a final regression
  check named explicitly in the plan.
- The session still routes these through `/flow-commit`, which
  handles the empty diff by printing "Nothing to commit" and
  returning to the caller.
- The `code_task` counter advances normally, and the self-
  invocation fires unchanged.

**Constraints:**

- Maintain the docs-reader voice (present tense, third person,
  no fenced bash blocks unless they appear in sibling sections —
  the existing doc file uses prose paragraphs and bullet lists,
  no bash blocks).
- Do not introduce new features or commands that the SKILL.md
  does not already describe — the mirror must match behavior
  described in SKILL.md.
- Do not trip scope-enumeration: use named example scenarios.

**TDD note:** No test change. Increment `code_task=4` via
`set-timestamp`.

**After Task 4:** All four tasks are complete. Run `bin/flow ci`
to verify the full suite passes (the contract test from Task 1
should be green). Commit the atomic group via `/flow:flow-commit`
as a single commit with a message referencing the atomic group
("Add measurement-only task pathway to flow-code — Tasks 1-4 of 4").
Per `.claude/rules/plan-commit-atomicity.md`, the commit message
body should explain the atomic grouping reason.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Issue #1159 — Measurement-Only Tasks Have No Documented Pathway

## Goal

Pick best pathway for measurement-only Code-phase tasks and produce implementation plan.

## Context

FLOW Code phase has no documented pathway for measurement-only tasks (tasks
that produce no file changes, such as running CI and recording coverage TOTAL,
verifying a threshold). During PR #1155 Task 5 was "Run full-suite bin/flow ci,
record new TOTAL" — a measurement-only task. The session ran ci (sentinel-
skipped), logged numbers, advanced `code_task=5`, skipped `/flow:flow-commit`
entirely, and self-invoked `flow:flow-code --continue-step` directly. This
violated the skill's stated pattern of "After committing, self-invoke to handle
the next task in a fresh skill invocation," and violated CLAUDE.md's convention
"All commits via `/flow:flow-commit`".

The `/flow:flow-commit` skill already handles the no-changes case ("Nothing to
commit") gracefully, so invoking it for measurement tasks is a safe fallback —
but not documented. Three possible pathways:

1. **Document explicitly.** Add a section to `skills/flow-code/SKILL.md` for
   measurement-only tasks: "For tasks with no file changes, still invoke
   `/flow:flow-commit` — it detects the empty diff, prints the completion
   banner, and returns."
2. **Plan discipline.** Add a rule discouraging measurement-only mid-phase
   tasks; require them to be terminal phase actions (e.g., Code's "All Tasks
   Complete" sweep already plays this role).
3. **State-file handling.** Have `set-timestamp --set code_task` for a
   measurement task also log a machine-readable marker so future inspection can
   distinguish measurement advances from real-task advances.

## DAG Plan

```xml
<dag goal="Pick best pathway for measurement-only Code-phase tasks and produce implementation plan" mode="full">
  <plan>
    <node id="1" name="Read flow-code SKILL" type="research" depends="[]" parallel_with="2,3,4">
      <objective>Read skills/flow-code/SKILL.md's Execute Next Task and Commit sections to map the current self-invocation pattern</objective>
    </node>
    <node id="2" name="Read flow-commit SKILL" type="research" depends="[]" parallel_with="1,3,4">
      <objective>Read skills/flow-commit/SKILL.md to confirm the empty-diff handling and its observable effect</objective>
    </node>
    <node id="3" name="Read counter and atomicity rules" type="research" depends="[]" parallel_with="1,2,4">
      <objective>Read .claude/rules/code-task-counter.md and .claude/rules/plan-commit-atomicity.md to ground the constraints on code_task semantics</objective>
    </node>
    <node id="4" name="Audit legitimate measurement-only task scenarios" type="research" depends="[]" parallel_with="1,2,3">
      <objective>Grep plans/rules/CLAUDE for existing measurement-task precedent to quantify how common this pattern is</objective>
    </node>
    <node id="5" name="Characterize the gap" type="analysis" depends="[1,2,3,4]" parallel_with="[]">
      <objective>Name the exact missing instruction and enumerate legitimate measurement-task scenarios</objective>
    </node>
    <node id="6" name="Pathway 1 — document explicitly" type="analysis" depends="[5]" parallel_with="7,8">
      <objective>Evaluate tradeoffs of adding a measurement-only section to flow-code SKILL.md</objective>
    </node>
    <node id="7" name="Pathway 2 — plan discipline" type="analysis" depends="[5]" parallel_with="6,8">
      <objective>Evaluate tradeoffs of banning mid-phase measurement tasks via a new plan-authoring rule</objective>
    </node>
    <node id="8" name="Pathway 3 — machine-readable marker" type="analysis" depends="[5]" parallel_with="6,7">
      <objective>Evaluate tradeoffs of writing a measurement-task marker into the state file</objective>
    </node>
    <node id="9" name="Pick the pathway(s)" type="decision" depends="[6,7,8]" parallel_with="[]">
      <objective>Score the three pathways and select the combination that minimizes complexity while eliminating the workaround</objective>
    </node>
    <node id="10" name="Implementation plan synthesis" type="synthesis" depends="[9]" parallel_with="[]">
      <objective>Produce the Context/Exploration/Risks/Approach/DAG/Tasks plan for the chosen pathway</objective>
    </node>
  </plan>
</dag>
```

## Node Execution

### Node 1 — Read flow-code SKILL (Quality: 8/10)

Mapped the Execute Next Task / Commit sequence in `skills/flow-code/SKILL.md`:

- **Execute Next Task** (lines 147–152): "Execute only this single task — do not
  look ahead to subsequent tasks. After committing, self-invoke to handle the
  next task in a fresh skill invocation."
- **Commit section** (lines 396–431): the standard funnel for task completion.
  Sets `code_task=<n>` via `set-timestamp`, sets `_continue_context` and
  `_continue_pending=commit`, invokes `/flow:flow-commit`, then self-invokes
  `flow:flow-code --continue-step`.
- **Atomic group section** (lines 155–217) exists but still assumes every task
  produces a file change; no measurement-task carve-out.

Key finding: The Commit section is the single funnel for task completion.
Every task advances the counter, sets continuation flags, invokes
`/flow:flow-commit`, and self-invokes. Any measurement-task pathway must plug
into this funnel — not bypass it.

### Node 2 — Read flow-commit SKILL (Quality: 9/10)

Confirmed the empty-diff handling in `skills/flow-commit/SKILL.md`:

- Round 3 (line 100): `git add -A` stages everything.
- Round 4 (lines 105–115): Shows the diff via `git status` + `git diff --cached`.
- **Line 115**: "If `git diff --cached` is empty, tell the user 'Nothing to
  commit', print the COMPLETE banner, and return to the caller."

No `finalize-commit` invocation on empty diff. No CI run. No state mutation
from within `/flow:flow-commit`. Just a clean return to the caller.

Key finding: The empty-diff path returns cleanly to caller. Critically, all the
counter advance and continuation-flag scaffolding in `skills/flow-code/SKILL.md`
happens BEFORE `/flow:flow-commit` is invoked — so measurement tasks that route
through the empty-diff path inherit the entire self-invocation machinery for
free. Zero new machinery needed.

### Node 3 — Counter and atomicity rules (Quality: 9/10)

- `.claude/rules/code-task-counter.md` — `code_task` increments **once per plan
  task** regardless of commit grouping. TDD pairs = 2 increments even in one
  commit. The counter must match the plan task count.
- `.claude/rules/plan-commit-atomicity.md` — Atomic commit groups may be split
  when (a) each intermediate commit is shippable, (b) no test spans the
  boundary, (c) the split clarifies logical structure. About commit boundaries,
  not about whether a task produces a file.

Key finding: Neither rule prohibits measurement-only tasks. The counter rule
requires `code_task++` per plan task regardless. The atomicity rule governs
commit boundaries, not task shape. So a measurement-only task is fully
legitimate under existing rules — what's missing is the skill instruction
naming the pathway.

### Node 4 — Audit legitimate measurement-only task scenarios (Quality: 7/10)

- **PR #1155 Task 5** is the canonical motivating precedent: "Run full-suite
  bin/flow ci, record new TOTAL" — coverage ratchet capture.
- Adjacent legitimate scenarios:
  - Threshold verification tasks ("verify new floor passes")
  - Final regression re-runs that are explicitly named in the plan
  - Coverage TOTAL recording in log/PR body

Some of these could roll into `/flow:flow-code`'s "All Tasks Complete" sweep
(lines 448–471), which already runs final CI + coverage without task
scaffolding. But when the plan explicitly names a measurement task, the Code
phase must execute it — "roll it into the terminal sweep" is not a retroactive
option.

Key finding: Measurement-only tasks are a real, recurring plan shape. PR #1155
is the documented incident; others will recur. The Code phase needs an
authoritative pattern.

### Node 5 — Characterize the gap (Quality: 9/10)

**The missing instruction:** `skills/flow-code/SKILL.md` Execute Next Task /
Commit sections never mention "what to do when the task produces no file
change." The prose assumes a diff. Sessions encountering a measurement-only
task have three observable options:

1. Invoke `/flow:flow-commit` anyway (correct — empty-diff handler returns
   cleanly).
2. Skip `/flow:flow-commit` and self-invoke directly (what PR #1155 did —
   violates CLAUDE.md's "All commits via `/flow:flow-commit`" convention).
3. Error out and ask the user (interruption).

**Failure mode:** Each session invents its own workaround. Under autonomous
flows, non-determinism is a reliability hazard. Option 2 is the most tempting
because "nothing to commit" is an easy rationalization — but it bypasses the
`/flow:flow-commit` skill convention that CLAUDE.md declares non-negotiable.

**What scaffolding already works:** The counter advance, `_continue_pending`,
`_continue_context`, and self-invocation machinery in flow-code's Commit
section all run BEFORE `/flow:flow-commit` is invoked. They don't depend on
whether a diff exists. When `/flow:flow-commit` returns on empty diff, the
self-invocation at the end of flow-code's Commit section fires unchanged.
**Zero new machinery is needed** — just documentation.

Key finding: The gap is purely instructional. All scaffolding composes; the
session just needs permission-by-documentation to route measurement tasks
through `/flow:flow-commit`.

### Node 6 — Pathway 1: Document explicitly (Quality: 9/10)

**Proposal:** Short subsection in `skills/flow-code/SKILL.md` Execute Next Task
section explaining that measurement-only tasks still invoke `/flow:flow-commit`.
Single-paragraph instruction, no new commands, no state changes.

**Pros:**

- Matches "Simplest Approach First" rule in `.claude/rules/skill-authoring.md`.
- Uses existing scaffolding — zero new machinery.
- Honors CLAUDE.md's "All commits via `/flow:flow-commit`" convention.
- Makes session deterministic across flows.
- Small diff, easy contract test.
- Composes with atomic-group rule.

**Cons:**

- Skill instructions are advisory per `.claude/rules/hook-vs-instruction.md`.
- Doesn't mechanically block a session from skipping `/flow:flow-commit`.

**Mitigation:** The convention is already enforced at the CLAUDE.md level.
The new subsection is a reinforcement. If noncompliance proves recurring, a
future Learn cycle can escalate to a hook.

Key finding: Pathway 1 is the minimal intervention that fully solves the
problem. Existing scaffolding makes implementation essentially free.

### Node 7 — Pathway 2: Plan discipline (Quality: 6/10)

**Proposal:** New rule forbidding mid-phase measurement-only tasks; require
them to be terminal. Enforce via plan-check scanner or contract test.

**Pros:**

- Eliminates problem at source.
- "All Tasks Complete" sweep already plays the terminal-measurement role.

**Cons:**

- Prohibits legitimate plan shapes (mid-sequence verification).
- Scanner complexity — mechanically detecting "produces no file change" from
  plan prose is high false-positive/false-negative surface.
- Scope expansion — rule file + scanner + plan-check integration + docs sweep.
- Doesn't fix retroactively.
- Wrong-level fix — the bug is in Code phase guidance, not Plan phase hygiene.

Key finding: Pathway 2 solves a symptom by prohibiting a legitimate plan shape.
Higher cost, lower flexibility, doesn't cover existing plans.

### Node 8 — Pathway 3: Machine-readable marker (Quality: 4/10)

**Proposal:** Extend `bin/flow set-timestamp` to write a measurement flag into
state, distinguishing measurement advances from real-task advances.

**Pros:**

- Adds machine-readable signal for future audits.

**Cons:**

- **Speculative.** No current consumer. Violates "Simplest Approach First".
- **Doesn't solve core problem.** Session still needs instruction.
- **Large diff.** Touches Rust, state schema docs, contract tests.
- **Encourages shortcut.** Session might learn marker = bypass `/flow:flow-commit`.
- **Confuses responsibility.** State mutations should be mechanical.

Key finding: Pathway 3 is speculative infrastructure with no named consumer.
Orthogonal to the actual gap. Larger in every dimension than Pathway 1.

### Node 9 — Decision: Pathway 1 alone (Quality: 10/10)

| Pathway | Quality | Diff size | Solves gap | Violates rules |
|---------|---------|-----------|-----------|----------------|
| 1. Document explicitly | 9/10 | Tiny | Yes | None |
| 2. Plan discipline | 6/10 | Medium | Partially | Prohibits legit plans |
| 3. State marker | 4/10 | Large | No (orthogonal) | "Simplest Approach First" |

**Decision: Pathway 1 alone.**

Reasoning:

- Solves exact gap named by the issue.
- Smallest diff by an order of magnitude.
- Uses existing scaffolding — empty-diff return, counter machinery, self-
  invocation all compose without modification.
- Honors "Simplest Approach First" — cannot articulate in one sentence why
  the simple approach fails.
- Reinforces existing CLAUDE.md convention.
- Pathway 2 is wrong-level.
- Pathway 3 is speculative.

Implementation: one short subsection in `skills/flow-code/SKILL.md` plus a
contract test in `tests/skill_contracts.rs` asserting the subsection exists
and references `/flow:flow-commit` as the measurement-task route.

### Node 10 — Implementation plan synthesis (Quality: 10/10)

See Synthesis Block below for the complete plan shape.

## Synthesis Block

```text
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

**Decision:** Pathway 1 — document measurement-only tasks in
`skills/flow-code/SKILL.md` as a short subsection that instructs the session
to still invoke `/flow:flow-commit`. The skill already handles the empty-diff
case cleanly and returns to the caller. All existing scaffolding (counter
advance, continuation flags, self-invocation) works unchanged.

**Implementation shape:**

1. **Test task (TDD-first).** Add a contract test in
   `tests/skill_contracts.rs` asserting `skills/flow-code/SKILL.md` contains
   both a measurement-task subsection and an instruction routing those tasks
   through `/flow:flow-commit`. Write test first — MUST fail before the
   SKILL.md change is written.
2. **Implementation task.** Add a "Measurement-Only Tasks" subsection to
   `skills/flow-code/SKILL.md` under Execute Next Task. Open with a 2–3
   sentence purpose preamble. State that some plan tasks produce no file
   changes (threshold verification, coverage record, final regression re-run)
   and name PR #1155 Task 5 as the motivating precedent. Direct the session to
   still advance `code_task`, set `_continue_pending=commit`, set
   `_continue_context`, and invoke `/flow:flow-commit` exactly as the standard
   flow does. Note that `/flow:flow-commit` detects the empty diff via its
   Round 4 `git diff --cached` check and returns to the caller after printing
   the COMPLETE banner. Self-invocation fires unchanged from the end of the
   Commit section.
3. **CLAUDE.md task.** Extend the Conventions section's "All commits via
   `/flow:flow-commit`" bullet to explicitly cover measurement-only tasks as
   a cross-reference to the new SKILL.md subsection. One-line addition.
4. **docs/skills/flow-code.md task.** Mirror the new subsection in the docs
   per `.claude/rules/docs-with-behavior.md` "Changed skill behavior" rule.

**Risks:**

- Skill instruction is advisory per `.claude/rules/hook-vs-instruction.md`.
  Mitigated by CLAUDE.md convention already enforcing "no exceptions".
- Contract test must use positive assertions per `.claude/rules/skill-authoring.md`
  "Negative-Assertion Test Compatibility".
- Docs mirror drift per `.claude/rules/docs-with-behavior.md`.
- Atomic commit per `.claude/rules/docs-with-behavior.md` "Multi-Task Plans".

**Supersession check:** No code superseded. Pure addition.

**External-input audit check:** No panics/asserts added. Not applicable.

**No-waivers check:** Contract test covers added prose. No gaps.

Confidence: 95%  |  Nodes: 10  |  Parallel branches: 4 + 3

vs. Vanilla Claude (what linear reasoning would have missed):

- Would likely jump to Pathway 3 (machine-readable marker) as "most thorough"
  without recognizing no consumer exists for the signal.
- Would likely miss that counter + continuation scaffolding runs BEFORE
  `/flow:flow-commit` and is unaffected by empty diffs.
- Would likely miss that Pathway 2 (plan discipline) is wrong-level.
- Would likely miss the CLAUDE.md convention that already authorizes Pathway 1.

```text
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 11m |
| Code | 18m |
| Code Review | 8h 29m |
| Learn | 8m |
| Complete | <1m |
| **Total** | **9h 9m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/measurement-only-tasks-have-no.json</summary>

```json
{
  "schema_version": 1,
  "branch": "measurement-only-tasks-have-no",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1167,
  "pr_url": "https://github.com/benkruger/flow/pull/1167",
  "started_at": "2026-04-14T22:23:33-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/measurement-only-tasks-have-no-plan.md",
    "dag": ".flow-states/measurement-only-tasks-have-no-dag.md",
    "log": ".flow-states/measurement-only-tasks-have-no.log",
    "state": ".flow-states/measurement-only-tasks-have-no.json"
  },
  "session_tty": "/dev/ttys002",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #1159",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-14T22:23:33-07:00",
      "completed_at": "2026-04-14T22:24:17-07:00",
      "session_started_at": null,
      "cumulative_seconds": 44,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-14T22:24:26-07:00",
      "completed_at": "2026-04-14T22:35:53-07:00",
      "session_started_at": null,
      "cumulative_seconds": 687,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-14T22:37:08-07:00",
      "completed_at": "2026-04-14T22:55:18-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1090,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-14T22:55:31-07:00",
      "completed_at": "2026-04-15T07:25:15-07:00",
      "session_started_at": null,
      "cumulative_seconds": 30584,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-15T07:25:26-07:00",
      "completed_at": "2026-04-15T07:34:13-07:00",
      "session_started_at": null,
      "cumulative_seconds": 527,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-15T07:34:32-07:00",
      "completed_at": "2026-04-15T07:35:19-07:00",
      "session_started_at": null,
      "cumulative_seconds": 22,
      "visit_count": 2
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-14T22:24:26-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-14T22:37:08-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-14T22:55:31-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-15T07:25:26-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-15T07:34:32-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-15T07:34:57-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 4,
  "code_task_name": "Add Measurement-Only Tasks section to docs/skills/flow-code.md",
  "code_task": 4,
  "diff_stats": {
    "files_changed": 4,
    "insertions": 63,
    "deletions": 1,
    "captured_at": "2026-04-14T22:55:18-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "findings": [
    {
      "finding": "Pre-mortem F2: stale _continue_pending=commit after empty-diff return",
      "reason": "Narrow window; standard Commit section overwrites _continue_pending=commit before the next commit anyway. Self-invocation fires immediately after flow-commit returns with no user-facing impact.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T07:17:02-07:00"
    },
    {
      "finding": "Pre-mortem F3: overly broad measurement-only classification",
      "reason": "This IS the feature: letting plans name no-op tasks route through the commit funnel. Plan authors already control task content; no new attack surface is introduced.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T07:17:14-07:00"
    },
    {
      "finding": "Documentation F1: SKILL.md /flow:flow-commit vs docs /flow-commit",
      "reason": "Both layers are internally consistent with their own siblings. SKILL.md consistently uses namespaced form; docs mirror consistently uses bare form (matching line 33 One Task Per Invocation sibling). Intentional cross-layer convention, not drift.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T07:17:30-07:00"
    },
    {
      "finding": "Documentation F2: purpose preamble missing explicit why",
      "reason": "Preamble second sentence ('still route through the standard Commit flow below SO every task honors CLAUDE.md convention') does answer why the subsection exists per .claude/rules/skill-authoring.md Purpose Preamble rule.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T07:17:42-07:00"
    },
    {
      "finding": "Documentation F4: test function missing doc comment",
      "reason": "Sibling tests in tests/skill_contracts.rs (code_has_plan_test_verification etc.) follow the no-doc-comment convention. Test name is self-explanatory. .claude/rules/testing-gotchas.md Test Doc Comment rule applies when doc comment exists, not as a mandatory requirement.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T07:17:51-07:00"
    },
    {
      "finding": "Reviewer F1 / Adversarial F1: SKILL.md mis-attributed git add -A to Round 4 of flow-commit",
      "reason": "Rewrote the subsection to correctly say Round 3 stages via git add -A and Round 4 runs git diff --cached. Peer-skill description drift is now fixed.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T07:19:30-07:00"
    },
    {
      "finding": "Pre-mortem F1: Measurement-Only Tasks subsection made bin/flow ci Gate optional",
      "reason": "Rewrote the subsection to explicitly route measurement tasks through the standard bin/flow ci Gate section. The HARD-GATE still applies; the sentinel skip keeps the second invocation fast when the task action already ran ci. Plan-author-written measurement tasks can no longer silently bypass CI.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T07:19:39-07:00"
    },
    {
      "finding": "Reviewer F2 / Adversarial F2: contract test split/nth(1) matched /flow:flow-commit anywhere after heading",
      "reason": "Bounded the subsection slice with split_once on the heading and then split_once on the next level-3 heading. Also added a bin/flow ci assertion so the CI Gate requirement is locked in alongside the routing requirement.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T07:19:56-07:00"
    },
    {
      "finding": "Learn T3: missing rule — subsection-local assertions in contract tests",
      "reason": "Contract tests that use split(heading).nth(1) or raw contains() over full-file content can pass spuriously when a sibling section carries the asserted substring. Bounded-slice pattern (split_once start, split_once end) is now documented as the canonical approach. Motivated by benkruger/flow#1167 Reviewer F2 / Adversarial F2.",
      "outcome": "rule_written",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-15T07:28:48-07:00",
      "path": ".claude/rules/testing-gotchas.md"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/measurement-only-tasks-have-no.log</summary>

```text
2026-04-14T22:19:11-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-14T22:19:43-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-14T22:20:36-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-14T22:21:34-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-14T22:22:35-07:00 [Phase 1] start-init — lock acquire ("locked")
2026-04-14T22:23:33-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-14T22:23:33-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-14T22:23:33-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-14T22:23:33-07:00 [Phase 1] create .flow-states/measurement-only-tasks-have-no.json (exit 0)
2026-04-14T22:23:33-07:00 [Phase 1] freeze .flow-states/measurement-only-tasks-have-no-phases.json (exit 0)
2026-04-14T22:23:33-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-14T22:23:35-07:00 [Phase 1] start-init — label-issues (labeled: [1159], failed: [])
2026-04-14T22:23:52-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-14T22:23:52-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-14T22:23:53-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-14T22:24:02-07:00 [Phase 1] start-workspace — worktree .worktrees/measurement-only-tasks-have-no (ok)
2026-04-14T22:24:06-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-14T22:24:06-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-14T22:24:06-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-14T22:24:17-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-14T22:24:17-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-14T22:35:53-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-14T22:37:08-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-14T22:54:29-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-14T22:54:32-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-14T22:55:18-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-14T22:55:31-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-15T07:24:52-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-15T07:24:56-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-15T07:25:15-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-15T07:25:26-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-15T07:33:20-07:00 [Phase 5] finalize-commit — ci (ok)
2026-04-15T07:33:23-07:00 [Phase 5] finalize-commit — done ("ok")
2026-04-15T07:34:13-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-15T07:35:19-07:00 [Phase 6] complete-finalize — starting
2026-04-15T07:35:19-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-15T07:35:19-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>