### PR TITLE
Plan Phase Should Enumerate New

### DIFF
--- a/.claude/rules/docs-with-behavior.md
+++ b/.claude/rules/docs-with-behavior.md
@@ -66,6 +66,12 @@ Separate commits within the same PR are not sufficient: if the PR
 is reviewed commit-by-commit, the intermediate state shows stale
 documentation.
 
+For the sibling Plan-phase discipline covering **new branches
+introduced by extraction refactors** — the plan must enumerate each
+extracted helper's branches with a testability classification
+before Code phase begins — see
+`.claude/rules/extract-helper-refactor.md`.
+
 ### Named Tests After Refactor
 
 When a plan names specific test functions and a refactor lands

--- a/.claude/rules/extract-helper-refactor.md
+++ b/.claude/rules/extract-helper-refactor.md
@@ -1,0 +1,209 @@
+# Extract-Helper Branch Enumeration
+
+When a Plan-phase task extracts a block of code into a new helper
+function, the plan must enumerate the helper's internal branches at
+Plan time — before the Code phase runs into them — and commit to a
+concrete testing strategy for each branch.
+
+This rule is the mechanical complement to the
+**Extract-Helper Branch Enumeration** subsection in
+`skills/flow-plan/SKILL.md` Step 3. The SKILL.md subsection is the
+Plan-phase trigger; this file is the full reference the subsection
+cross-references.
+
+## Why
+
+A plan that counts tests against the seam a refactor introduces is
+not the same as a plan that enumerates the branches of the extracted
+helper. The first measures the caller's test surface; the second
+measures the helper's. When the two diverge, the Code phase
+discovers uncovered branches inside the helper only after the
+extraction has landed — and the branch-level test design ends up
+negotiated ad hoc instead of by design.
+
+PR #1155 surfaced this. Task 2 extracted the Complete-phase CI
+dirty-check block from `run_impl` into a new `production_ci_decider`
+helper and added ten tests for the `run_impl_inner` seam that
+delegates to the decider. The plan counted those ten tests and
+stopped. But `production_ci_decider` itself had four internal
+branches (`tree_changed == true`, sentinel hit, CI failure on miss,
+CI success on miss) that the plan never named. Three of the four
+branches were not reached by the seam tests, and the Code phase had
+to decide each branch's test strategy after the extraction was
+already written.
+
+The rule force-functions the enumeration conversation at Plan time:
+the plan author enumerates the helper's branches before the Code
+phase begins, names a concrete test for each one, and refactors
+further if any branch cannot fit under one of the three
+classifications.
+
+## The Rule
+
+The rule fires when a Plan task description or Approach prose
+proposes extracting a block of code into a new helper function,
+method, seam, or closure — or any equivalent refactor-for-testability
+phrasing. Canonical trigger phrasings:
+
+- "extract *X* into a new *Y*"
+- "lift the *X* block into *Y*"
+- "hoist *X* out of *Y*"
+- "factor out *X* into a helper"
+- "pull out *X* into a seam"
+- "refactor *X* into an inner function"
+- "introduce a trait seam for *X*"
+
+When a trigger phrasing appears, the plan's Exploration or Approach
+section must include a **Branch Enumeration Table** within a few
+lines of the trigger. The table has four columns:
+
+| Branch | Condition | Classification | Test |
+|---|---|---|---|
+| A | `tree_changed == true` | Testable directly | `production_ci_decider_tree_changed_returns_not_skipped` |
+| B | `tree_changed == false` ∧ sentinel matches | Testable directly | `production_ci_decider_sentinel_hit_returns_skipped` |
+| C | CI dirty-check dispatches to `ci::run_impl` | Testable via seam | (lift `ci::run_impl` into an injectable parameter and test via a mock) |
+
+Column definitions:
+
+- **Branch** — a letter or number label identifying the branch
+- **Condition** — the guard expression or prose condition
+- **Classification** — one of the three values in the next section
+- **Test** — the named test function that will exercise this branch,
+  or (when the classification is reached via further refactoring) a
+  concrete description of the sub-refactor and the test it unlocks
+
+## The Three Classifications
+
+- **Testable via seam** — the caller injects a closure, trait
+  object, or `Command` via a parameter, and the branch is exercised
+  by passing a mock implementation. Reference pattern:
+  `run_impl_inner(args, root, runner, ci_decider)` in
+  `src/complete_fast.rs`, where `ci_decider` is a `&CiDecider`
+  closure the tests can replace with a mock.
+- **Testable directly** — a unit test with a self-contained fixture
+  exercises the branch without any mocking or indirection. Typical
+  fixtures: a `tempfile::TempDir`, a prepared state-file JSON, or an
+  in-memory value. Reference pattern:
+  `production_ci_decider_tree_changed_returns_not_skipped` in
+  `src/complete_fast.rs` — a unit test that passes `tree_changed =
+  true` and asserts the early-return path.
+- **Testable via subprocess** — the test spawns the compiled binary
+  through `tests/main_dispatch.rs` and exercises the branch through
+  the real CLI surface. cargo-llvm-cov instruments subprocess calls
+  when they spawn the same binary, so the branch's lines appear in
+  the coverage report. Reference pattern: `check_phase_first_phase_exits_0`
+  in `tests/main_dispatch.rs`.
+
+If a branch cannot be classified under one of the three, the
+extraction design is wrong. The remedy is to refactor further: push
+the untested surface behind a seam so the branch becomes Testable
+via seam, fold the branch into its caller so it becomes Testable
+directly at the caller, or delete the branch entirely if it is
+unreachable from any production path. Every branch must land under
+one of the three classifications before the plan is complete.
+
+## Opt-Out Grammar
+
+When the plan prose mentions extraction in discussion rather than as
+a proposal — for example, when the Risks section references a prior
+extraction or when the Approach discusses rejected alternatives that
+involved extraction — add the opt-out comment
+`<!-- extract-helper-refactor: not-an-extraction -->` on:
+
+- the trigger line itself (same-line, anywhere on the line),
+- the line directly above the trigger, or
+- two lines above with a single blank line in between.
+
+Larger gaps do not chain — the rule is "the next non-blank line with
+at most one blank line separating them," matching the sibling
+opt-out grammar in `.claude/rules/scope-enumeration.md` and
+`.claude/rules/external-input-audit-gate.md`.
+
+## How to Apply
+
+**Plan phase.** After writing the plan's task list, scan every task
+and every Approach paragraph for the trigger phrasings listed in
+**The Rule**. For each trigger:
+
+1. Identify the function the plan will extract into. Read the source
+   block the plan will move.
+2. Enumerate the branches inside that block. Each `if`, `match` arm,
+   early return, or conditional expression is a candidate branch.
+3. For every branch, classify it under one of the three labels.
+4. For every classification, name the concrete test function that
+   will exercise the branch. The test function name commits the plan
+   author to writing that test in Code phase.
+5. If any branch fails the classification step, revise the extraction
+   design until every branch fits. Do not ship the plan with an
+   unclassified branch.
+
+**Code phase.** Execute the plan tasks in order. For each branch the
+plan enumerated, write the named test before or alongside the
+implementation per the `.claude/rules/skill-authoring.md` Plan Task
+Ordering rule. A Plan Test Verification check at commit time
+confirms every plan-named test function exists in the codebase.
+
+**Code Review phase.** The reviewer agent cross-references the plan's
+Branch Enumeration Table against the landed tests. Any plan-named
+test function missing from the codebase is a Real finding fixed in
+Step 4 per `.claude/rules/code-review-scope.md`.
+
+## Motivating Incident
+
+PR #1155 (`Coverage Pattern Completefast`, merge commit `8cb5e80c`)
+is the incident that produced this rule. The PR's plan for Task 2
+extracted the Complete-phase CI dirty-check block from
+`src/complete_fast.rs::run_impl` into a new `production_ci_decider`
+helper, and Task 3 added ten behavior-preservation tests exercising
+the `run_impl_inner` seam through a mock `ci_decider`. The ten seam
+tests proved that `run_impl_inner`'s dispatch branches were correct,
+but they did not exercise the four branches inside the real
+`production_ci_decider` wrapper.
+
+The four branches were:
+
+1. `tree_changed == true` → early return `(false, None)`
+2. `tree_changed == false` ∧ sentinel file exists ∧ snapshot
+   matches → `(true, None)` skip
+3. `tree_changed == false` ∧ sentinel miss → dispatches to
+   `ci::run_impl`, CI fails → `(false, Some(msg))`
+4. Same as (3) but CI succeeds → `(false, None)`
+
+Only Branch 1 has a direct unit test today
+(`production_ci_decider_tree_changed_returns_not_skipped` at
+`src/complete_fast.rs:1409`). Branches 2, 3, and 4 require either a
+deeper trait seam around `ci::run_impl` (so the test can inject a
+mock CI runner) or subprocess tests that spawn the binary and drive
+it through a fixture with a pre-seeded sentinel file.
+
+Had PR #1155's plan enumerated the four branches up front, the
+design conversation would have surfaced the need for the deeper
+`ci::run_impl` seam before the extraction landed. This rule exists
+to force that conversation at Plan time on every future
+extract-helper refactor.
+
+Commit references:
+
+- `8cb5e80c` — PR #1155 merge commit
+- `59844b30` — Extract `run_impl_inner` seam and add ten
+  behavior-preservation tests (Task 2+3 of PR #1155)
+- `fcc9a69c` — Record the missing branches of
+  `production_ci_decider` (Task 4 of PR #1155, later superseded by
+  the full rule framework on main)
+
+## Cross-References
+
+- `skills/flow-plan/SKILL.md` Step 3 — the SKILL.md subsection that
+  invokes this rule during Plan phase.
+- `.claude/rules/supersession.md` — the structural sibling rule.
+  Supersession enumerates code a refactor makes redundant;
+  extract-helper enumeration enumerates branches a refactor
+  introduces. The two rules run at the same Plan-phase step and
+  share the prose-only enforcement model.
+- `.claude/rules/skill-authoring.md` — Plan Task Ordering (TDD order)
+  and Simplest Approach First (iteration 1 is instructional only, no
+  mechanical scanner).
+- `src/complete_fast.rs` lines 429–495 — the reference
+  `production_ci_decider` helper cited throughout this rule.
+- `tests/main_dispatch.rs` — the reference subprocess test surface
+  used by the `Testable via subprocess` classification.

--- a/.claude/rules/extract-helper-refactor.md
+++ b/.claude/rules/extract-helper-refactor.md
@@ -11,6 +11,24 @@ This rule is the mechanical complement to the
 Plan-phase trigger; this file is the full reference the subsection
 cross-references.
 
+## Vocabulary
+
+- **seam** — a parameterized injection point in a function's
+  signature that lets tests substitute a mock for a concrete
+  dependency. When this rule says "lift X into a seam," it means
+  turning `X` into a parameter the caller passes in rather than a
+  hard-coded call inside the function body.
+- **decider** — a closure or trait object that encapsulates a
+  yes/no or branch-selection decision, passed into a function as a
+  seam so tests can control the decision.
+- **sentinel** — a small cached marker file that records the tree
+  state from the most recent successful `bin/flow ci` run. See
+  `src/ci.rs::tree_snapshot` and `src/ci.rs::sentinel_path` for
+  the canonical readers/writers.
+- **CiDecider** — the concrete type alias in `src/complete_fast.rs`
+  for the Complete-phase CI dirty-check seam:
+  `dyn Fn(&Path, &Path, &str, bool) -> (bool, Option<String>)`.
+
 ## Why
 
 A plan that counts tests against the seam a refactor introduces is
@@ -102,6 +120,36 @@ directly at the caller, or delete the branch entirely if it is
 unreachable from any production path. Every branch must land under
 one of the three classifications before the plan is complete.
 
+## Enforcement
+
+Iteration 1 of this rule is **prose-only** — there is no scanner
+in `src/plan_check.rs` that mechanically blocks a Plan phase from
+completing without a Branch Enumeration Table. This is a deliberate
+choice per `.claude/rules/skill-authoring.md` "Simplest Approach
+First," mirroring `.claude/rules/supersession.md`'s model.
+
+The enforcement layers in iteration 1 are:
+
+1. **The rule file itself** (this file) — the primary instrument.
+   Plan authors read it via the cross-reference from
+   `skills/flow-plan/SKILL.md` Step 3.
+2. **The SKILL.md subsection** — reminds the Plan phase of the
+   discipline at authoring time.
+3. **The Code Review reviewer agent** — cross-references the plan's
+   Branch Enumeration Table against the landed tests and raises a
+   Real finding per `.claude/rules/code-review-scope.md` when a
+   plan-named test is missing.
+4. **The adversarial agent in Code Review** — writes failing tests
+   against uncovered branches, surfacing the same gap as test
+   failures.
+
+If a future iteration adds a mechanical scanner, the natural home
+is `src/extract_helper_refactor.rs` following the topology of
+`src/scope_enumeration.rs` and `src/external_input_audit.rs`. That
+scanner is **not present today**; any session that goes looking
+for one should stop at this section rather than spending turns
+searching.
+
 ## Opt-Out Grammar
 
 When the plan prose mentions extraction in discussion rather than as
@@ -118,6 +166,10 @@ Larger gaps do not chain — the rule is "the next non-blank line with
 at most one blank line separating them," matching the sibling
 opt-out grammar in `.claude/rules/scope-enumeration.md` and
 `.claude/rules/external-input-audit-gate.md`.
+
+The grammar is documented now as part of the rule's stable API so
+that when a scanner is eventually implemented it inherits the
+placement rules verbatim. Today the comment is inert.
 
 ## How to Apply
 
@@ -203,7 +255,7 @@ Commit references:
 - `.claude/rules/skill-authoring.md` — Plan Task Ordering (TDD order)
   and Simplest Approach First (iteration 1 is instructional only, no
   mechanical scanner).
-- `src/complete_fast.rs` lines 429–495 — the reference
+- `src/complete_fast.rs` lines 453–495 — the reference
   `production_ci_decider` helper cited throughout this rule.
 - `tests/main_dispatch.rs` — the reference subprocess test surface
   used by the `Testable via subprocess` classification.

--- a/.claude/rules/tests-guard-real-regressions.md
+++ b/.claude/rules/tests-guard-real-regressions.md
@@ -1,0 +1,124 @@
+# Tests Guard Real Regression Paths
+
+Every test must guard a real regression path with a named consumer.
+Before adding a test, name the specific regression it guards and the
+code path that produces that regression. If neither exists, the test
+is speculation, not verification.
+
+## Why
+
+Tests earn their place in the suite by preventing specific bugs. A
+test added "for safety" without a concrete regression to prevent
+bloats the suite without catching anything that would have shipped
+broken. Speculative tests have three costs:
+
+1. They run on every CI invocation forever.
+2. They invite expansion — "while we're here, let's also scan for
+   X" — and never contract.
+3. They mislead future readers into believing the property they
+   assert is actively at risk, when in fact no code path produces
+   the risk today.
+
+The project already has strong mechanical enforcement for the
+drift surfaces that matter: tombstones in `tests/tombstones.rs`,
+corpus scanners like `tests/scope_enumeration.rs` and
+`tests/external_input_audit.rs` (each with a named trigger
+vocabulary backed by a concrete incident), and plan-check gates.
+Adding broader "safety net" scans on top of that accumulates test
+code without covering new regressions.
+
+## The Rule
+
+When adding any test — unit test, integration test, contract test,
+corpus scan, tombstone — state the following before writing it:
+
+1. **The specific regression.** What exact change to the code, prose,
+   or configuration would break the property this test asserts?
+2. **The code path that produces the regression.** What mechanism
+   — a merge conflict, a refactor, an accidental edit, a missing
+   cross-reference — would cause that change to land?
+3. **The named consumer.** What rule, skill, hook, or other test
+   relies on the property being true? Name it.
+
+If any of (1), (2), or (3) cannot be named, the test is
+speculation. Delete it, or rewrite it to guard a regression you can
+name.
+
+### Three valid test shapes under this rule
+
+- **Tombstones** — guard a specific named deletion. The regression
+  is a merge-conflict resurrection; the consumer is the fact that
+  the deleted content is gone. See
+  `.claude/rules/tombstone-tests.md`.
+- **Structural contract tests** — assert a specific invariant in a
+  specific file (e.g., "flow-plan SKILL.md contains the
+  Extract-Helper Branch Enumeration subsection"). The regression
+  is an accidental edit; the consumer is the skill's cross-
+  reference or the subsection's role in the workflow.
+- **Targeted corpus scans** — the scanner must have a named
+  trigger vocabulary tied to a documented incident and a named
+  consumer (the rule file that authorizes the scan). See
+  `tests/scope_enumeration.rs` and
+  `tests/external_input_audit.rs`. Broader scans without a named
+  incident or vocabulary are speculative.
+
+### Forbidden patterns
+
+- **"Just in case"** scans over broad file sets without a named
+  regression path.
+- **"For future drift"** tests where the drift mechanism is
+  unspecified.
+- **Duplicate guards** for a property already covered by an
+  existing tombstone, plan-check scanner, or structural contract
+  test.
+- **Corpus-wide scans for a forbidden substring** when the
+  substring's only known occurrences are in files that must
+  legitimately discuss the forbidden term (requiring an ever-
+  growing exemption list).
+
+## How to Apply
+
+**Plan phase.** When a plan task adds a test, the task description
+must include a one-line statement of (1), (2), and (3). A test
+task that cannot state them is incomplete — revise the task or
+drop it.
+
+**Code phase.** Before writing a test, state (1), (2), and (3)
+internally. If you are about to write "This test guards against
+future drift" or "This test ensures no regressions," stop — name
+the specific regression or delete the test.
+
+**Code Review phase.** The reviewer agent treats any test that
+cannot be traced to a named regression as a Real finding. The fix
+is either tightening the test to a specific invariant or
+deleting it.
+
+**Learn phase.** User corrections that flag speculative tests
+surface as missing-rule findings. This rule is the reference.
+
+## Motivating Incident
+
+Issue #1160 / PR #1168 surfaced this. During the Code phase, I
+added a `no_waiver_language_in_authoring_corpus` contract test
+that scanned `.claude/rules/*.md`, `CLAUDE.md`, `skills/**/SKILL.md`,
+and `.claude/skills/**/SKILL.md` for forbidden waiver substrings,
+with an exemption list for `no-waivers.md` and the new
+`extract-helper-refactor.md`. The test was ~100 lines of Rust. The
+user flagged it: main already has three specific tombstones
+covering the three surfaces where waivers had been historically
+introduced (`test_coverage.md`, `docs-with-behavior.md` Waiver
+Discipline section, CLAUDE.md `test_coverage.md` references), plus
+the `.claude/rules/no-waivers.md` rule prose, plus plan-check
+scanners. The corpus scan's only realistic regression paths were
+already covered; the scan would only fire on the exempt files
+themselves (silently). I reverted the test.
+
+## Cross-References
+
+- `.claude/rules/tombstone-tests.md` — the canonical form for
+  guarding named deletions.
+- `.claude/rules/scope-enumeration.md` and
+  `.claude/rules/external-input-audit-gate.md` — canonical forms
+  for targeted corpus scans with named trigger vocabularies.
+- `.claude/rules/skill-authoring.md` "Plan Task Ordering" — TDD
+  discipline that this rule complements.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,5 +217,6 @@ Key test files: `tests/structural.rs` (config invariants, version consistency), 
 - **Repo-level targets only** — see `.claude/rules/repo-level-only.md`
 - **Scope enumeration for universal-coverage claims** — see `.claude/rules/scope-enumeration.md`
 - **External-input audit for panic/assert tightenings** — see `.claude/rules/external-input-audit-gate.md`
+- **Extract-helper branch enumeration for refactor plans** — see `.claude/rules/extract-helper-refactor.md`
 - **No `run_in_background` during FLOW phases**; `bin/flow` (any subcommand) is never allowed in the background regardless of mode — see `.claude/rules/ci-is-a-gate.md`. Enforced by `bin/flow hook validate-pretool`.
 - **User evidence is ground truth** — when a user provides screenshots, error output, or logs that contradict your code analysis, trust the evidence. Your code reading is a hypothesis; the user's evidence is an observation. Never explain away evidence to preserve your analysis.

--- a/skills/flow-plan/SKILL.md
+++ b/skills/flow-plan/SKILL.md
@@ -412,6 +412,63 @@ trigger vocabulary, the table-detection heuristic, and the
 enforcement topology (`bin/flow plan-check` plus both
 `src/plan_extract.rs` callsites).
 
+### Extract-Helper Branch Enumeration
+
+When a plan task extracts a block of code into a new helper function,
+the new helper introduces its own internal branches that the plan
+must enumerate at Plan time — before the Code phase runs into them.
+Without enumeration, the Code phase discovers new branches mid-flow
+and is pressured to classify them ad hoc, which defeats the discipline
+documented in `.claude/rules/no-waivers.md`.
+
+When the plan proposes extracting a block into a new function, helper,
+or seam — or lifts, hoists, factors out, or pulls out an existing
+block — the plan's Exploration or Approach section must include a
+Branch Enumeration Table near the task description. The table has
+four columns:
+
+| Branch | Condition | Classification | Test |
+|---|---|---|---|
+| A | `tree_changed == true` | Testable directly | `production_ci_decider_tree_changed_returns_not_skipped` |
+
+Column definitions:
+
+- **Branch** — a letter or number label identifying the branch
+- **Condition** — the guard expression or prose condition
+- **Classification** — one of the three positive values below
+- **Test** — the named test function that will exercise this branch
+
+The three positive classifications:
+
+- **Testable via seam** — an injected closure, trait object, or
+  Command parameter; branches exercised by passing mock
+  implementations. Reference pattern:
+  `run_impl_inner(args, root, runner, ci_decider)` in
+  `src/complete_fast.rs`.
+- **Testable directly** — a unit test with a self-contained fixture
+  (TempDir, prepared state file, in-memory value). Reference pattern:
+  `production_ci_decider_tree_changed_returns_not_skipped`.
+- **Testable via subprocess** — spawn the compiled binary through
+  `tests/main_dispatch.rs`; cargo-llvm-cov instruments subprocess
+  calls when they spawn the same binary. Reference pattern:
+  `check_phase_first_phase_exits_0`.
+
+When no classification fits, the fourth response per
+`.claude/rules/no-waivers.md` is to refactor further or delete the
+branch — never to file a waiver.
+
+If the plan prose mentions extraction in discussion rather than as a
+proposal, add the opt-out comment
+`<!-- extract-helper-refactor: not-an-extraction -->` on the trigger
+line itself, on the line directly above, or two lines above with a
+single blank line in between (no chaining across more than one
+blank line).
+
+See `.claude/rules/extract-helper-refactor.md` for the full trigger
+vocabulary, the motivating PR #1155 incident, and the cross-
+references to `.claude/rules/no-waivers.md` and
+`.claude/rules/docs-with-behavior.md`.
+
 ### Supersession Enumeration
 
 `.claude/rules/supersession.md` requires plans that add replacements,

--- a/skills/flow-plan/SKILL.md
+++ b/skills/flow-plan/SKILL.md
@@ -430,6 +430,8 @@ four columns:
 | Branch | Condition | Classification | Test |
 |---|---|---|---|
 | A | `tree_changed == true` | Testable directly | `production_ci_decider_tree_changed_returns_not_skipped` |
+| B | `tree_changed == false` ∧ sentinel matches | Testable directly | `production_ci_decider_sentinel_hit_returns_skipped` |
+| C | CI dirty-check dispatches to `ci::run_impl` | Testable via seam | (lift `ci::run_impl` into an injectable parameter and test via a mock) |
 
 Column definitions:
 

--- a/skills/flow-plan/SKILL.md
+++ b/skills/flow-plan/SKILL.md
@@ -417,9 +417,9 @@ enforcement topology (`bin/flow plan-check` plus both
 When a plan task extracts a block of code into a new helper function,
 the new helper introduces its own internal branches that the plan
 must enumerate at Plan time — before the Code phase runs into them.
-Without enumeration, the Code phase discovers new branches mid-flow
-and is pressured to classify them ad hoc, which defeats the discipline
-documented in `.claude/rules/no-waivers.md`.
+Without up-front enumeration, the Code phase discovers the new
+branches only after the extraction lands, and the branch-level test
+strategy ends up decided ad hoc instead of by design.
 
 When the plan proposes extracting a block into a new function, helper,
 or seam — or lifts, hoists, factors out, or pulls out an existing
@@ -435,10 +435,10 @@ Column definitions:
 
 - **Branch** — a letter or number label identifying the branch
 - **Condition** — the guard expression or prose condition
-- **Classification** — one of the three positive values below
+- **Classification** — one of the three values below
 - **Test** — the named test function that will exercise this branch
 
-The three positive classifications:
+The three classifications:
 
 - **Testable via seam** — an injected closure, trait object, or
   Command parameter; branches exercised by passing mock
@@ -453,9 +453,11 @@ The three positive classifications:
   calls when they spawn the same binary. Reference pattern:
   `check_phase_first_phase_exits_0`.
 
-When no classification fits, the fourth response per
-`.claude/rules/no-waivers.md` is to refactor further or delete the
-branch — never to file a waiver.
+If a branch cannot be classified under one of the three, the
+extraction design is wrong — refactor further (push the untested
+surface behind a seam, fold the branch into the caller, or delete
+the branch entirely) until every branch lands in one of the three
+classifications.
 
 If the plan prose mentions extraction in discussion rather than as a
 proposal, add the opt-out comment
@@ -465,9 +467,7 @@ single blank line in between (no chaining across more than one
 blank line).
 
 See `.claude/rules/extract-helper-refactor.md` for the full trigger
-vocabulary, the motivating PR #1155 incident, and the cross-
-references to `.claude/rules/no-waivers.md` and
-`.claude/rules/docs-with-behavior.md`.
+vocabulary and the motivating PR #1155 incident.
 
 ### Supersession Enumeration
 

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2913,6 +2913,62 @@ fn plan_has_supersession_enumeration() {
 }
 
 #[test]
+fn flow_plan_skill_has_extract_helper_branch_enumeration() {
+    // The Extract-Helper Branch Enumeration subsection is the Plan-phase
+    // discipline from .claude/rules/extract-helper-refactor.md: when a
+    // plan task extracts a block into a new helper, the plan must
+    // enumerate the helper's branches with testability classifications
+    // before Code phase begins. The subsection lives inside Step 3 of
+    // flow-plan/SKILL.md alongside Supersession Enumeration.
+    let c = common::read_skill("flow-plan");
+
+    assert!(
+        c.contains("### Extract-Helper Branch Enumeration"),
+        "flow-plan/SKILL.md Step 3 must include an '### Extract-Helper Branch Enumeration' \
+         subsection per .claude/rules/extract-helper-refactor.md"
+    );
+
+    // Step headings are h2 (`## Step N`); subsections inside a step are
+    // h3 (`### Name`). The new subsection must sit between the Step 3
+    // h2 and the Step 4 h2.
+    let step3 = c.find("## Step 3").expect("Step 3 heading must exist");
+    let step4 = c.find("## Step 4").expect("Step 4 heading must exist");
+    let subsection = c
+        .find("### Extract-Helper Branch Enumeration")
+        .expect("Extract-Helper Branch Enumeration subsection must exist");
+    assert!(
+        subsection > step3 && subsection < step4,
+        "### Extract-Helper Branch Enumeration must sit inside Step 3 \
+         (between '## Step 3' and '## Step 4')"
+    );
+
+    // Isolate the subsection body: from the heading to the next '### ' heading.
+    let rest = &c[subsection..];
+    let sub_end_rel = rest[1..]
+        .find("\n### ")
+        .map(|i| i + 1)
+        .unwrap_or(rest.len());
+    let sub_body = &rest[..sub_end_rel];
+
+    assert!(
+        sub_body.contains(".claude/rules/extract-helper-refactor.md"),
+        "Extract-Helper Branch Enumeration subsection must cross-reference \
+         '.claude/rules/extract-helper-refactor.md'"
+    );
+
+    for cls in [
+        "Testable via seam",
+        "Testable directly",
+        "Testable via subprocess",
+    ] {
+        assert!(
+            sub_body.contains(cls),
+            "Extract-Helper Branch Enumeration subsection must name classification: {cls}"
+        );
+    }
+}
+
+#[test]
 fn code_review_step_2_launches_four_agents() {
     let c = common::read_skill("flow-code-review");
     assert!(

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2966,6 +2966,26 @@ fn flow_plan_skill_has_extract_helper_branch_enumeration() {
             "Extract-Helper Branch Enumeration subsection must name classification: {cls}"
         );
     }
+
+    // The subsection must present a Branch Enumeration Table (four
+    // columns: Branch / Condition / Classification / Test). The
+    // header row and separator together guarantee authors see the
+    // table shape inline instead of anchoring on an abbreviated
+    // prose summary.
+    assert!(
+        sub_body.contains("| Branch | Condition | Classification | Test |"),
+        "Extract-Helper Branch Enumeration subsection must include the \
+         four-column Branch Enumeration Table header"
+    );
+
+    // The subsection must document the opt-out comment token inline
+    // so Plan authors learn the escape hatch without having to
+    // follow the cross-reference to the rule file.
+    assert!(
+        sub_body.contains("extract-helper-refactor: not-an-extraction"),
+        "Extract-Helper Branch Enumeration subsection must document \
+         the opt-out comment token 'extract-helper-refactor: not-an-extraction'"
+    );
 }
 
 #[test]
@@ -3004,6 +3024,35 @@ fn extract_helper_refactor_rule_has_expected_structure() {
     assert!(
         content.contains("PR #1155"),
         "extract-helper-refactor.md must cite the motivating PR #1155 incident"
+    );
+
+    // The rule file must carry the canonical section structure the
+    // SKILL.md cross-reference promises. A future edit that removes
+    // Why, The Rule, The Three Classifications, or Enforcement
+    // leaves the rule without its substantive scaffolding; these
+    // assertions fail CI on that regression.
+    for section in [
+        "## Vocabulary",
+        "## Why",
+        "## The Rule",
+        "## The Three Classifications",
+        "## Enforcement",
+        "## Opt-Out Grammar",
+        "## How to Apply",
+        "## Motivating Incident",
+    ] {
+        assert!(
+            content.contains(section),
+            "extract-helper-refactor.md must contain section heading: {section}"
+        );
+    }
+
+    // The canonical four-column Branch Enumeration Table must appear
+    // in the rule file as the reference for Plan authors.
+    assert!(
+        content.contains("| Branch | Condition | Classification | Test |"),
+        "extract-helper-refactor.md must include the four-column \
+         Branch Enumeration Table header"
     );
 }
 

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2969,6 +2969,45 @@ fn flow_plan_skill_has_extract_helper_branch_enumeration() {
 }
 
 #[test]
+fn extract_helper_refactor_rule_has_expected_structure() {
+    // The SKILL.md Extract-Helper Branch Enumeration subsection
+    // cross-references .claude/rules/extract-helper-refactor.md for the
+    // full trigger vocabulary, the three classifications, the opt-out
+    // grammar, and the motivating PR #1155 incident. This test asserts
+    // that rule file exists and contains the canonical elements the
+    // SKILL.md cross-reference promises, so a broken cross-reference
+    // or a missing section fails CI instead of silently shipping.
+    let path = common::repo_root()
+        .join(".claude")
+        .join("rules")
+        .join("extract-helper-refactor.md");
+    let content = std::fs::read_to_string(&path)
+        .expect(".claude/rules/extract-helper-refactor.md must exist");
+
+    for cls in [
+        "Testable via seam",
+        "Testable directly",
+        "Testable via subprocess",
+    ] {
+        assert!(
+            content.contains(cls),
+            "extract-helper-refactor.md must name classification: {cls}"
+        );
+    }
+
+    assert!(
+        content.contains("extract-helper-refactor: not-an-extraction"),
+        "extract-helper-refactor.md must document the opt-out comment token \
+         'extract-helper-refactor: not-an-extraction'"
+    );
+
+    assert!(
+        content.contains("PR #1155"),
+        "extract-helper-refactor.md must cite the motivating PR #1155 incident"
+    );
+}
+
+#[test]
 fn code_review_step_2_launches_four_agents() {
     let c = common::read_skill("flow-code-review");
     assert!(


### PR DESCRIPTION
## What

work on issue #1160.

Closes #1160

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/plan-phase-should-enumerate-new-plan.md` |
| DAG | `.flow-states/plan-phase-should-enumerate-new-dag.md` |
| Log | `.flow-states/plan-phase-should-enumerate-new.log` |
| State | `.flow-states/plan-phase-should-enumerate-new.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/89f216cc-b9c7-4012-9e34-2177df4316d6.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Plan: Plan-Phase Extract-Helper Branch Enumeration Discipline

## Context

Issue #1160 observes a Plan-phase gap: when a task extracts a block of
code into a new helper function (the standard refactor-for-testability
pattern), the new helper introduces its own branches that the plan does
not enumerate. The reference incident is PR #1155 Task 2 — the Complete-
phase CI dirty-check block was extracted from `run_impl` into a new
`production_ci_decider` helper. The plan estimated ten tests for Task 3
covering the `run_impl_inner` seam that delegates to the decider, but
the new helper itself had four internal branches (tree_changed=true,
sentinel hit, CI fail, CI pass) that the plan never named. Three of
those branches shipped with waivers in `test_coverage.md`.

Between PR #1155 merging and this issue being filed, the waiver regime
was abolished: commit `868d6989` deleted `test_coverage.md` and the
Waiver Discipline section, and PR #1156 Phase 5 Learn created
`.claude/rules/no-waivers.md` codifying the three responses to a
hard-to-reach branch (subprocess test, refactor for testability, delete
unreachable design). The issue body's original recommendation — "For
each Untestable in unit scope branch, include a waiver task" — is
therefore superseded and must be adapted to the no-waivers regime.

The goal of this PR is to close the Plan-phase gap by adding a new
rule and SKILL.md subsection that forces plans to enumerate an
extracted helper's branches at Plan time, and to classify each branch
against the no-waivers three-response framework before Code phase
begins.

## Exploration

### Files to Create

- `.claude/rules/extract-helper-refactor.md` — new rule file describing
  when the discipline fires, the required Branch Enumeration Table
  format, the three positive testability classifications, the forbidden
  prose, the opt-out comment grammar, and the motivating PR #1155
  incident. Structurally modeled on `.claude/rules/supersession.md`
  (prose-only Plan-phase discipline, no mechanical scanner in iteration
  1).

### Files to Modify

- `skills/flow-plan/SKILL.md` — add a new `### Extract-Helper Branch
  Enumeration` subsection in Step 3, placed between the existing
  "External-Input Audit for Panic/Assert Tightenings" subsection
  (around line 378) and the "Supersession Enumeration" subsection
  (around line 415). Includes a 2-3 sentence purpose preamble per
  `.claude/rules/skill-authoring.md` "Purpose Preamble for Behavioral
  Sections", trigger prose, the Branch Enumeration Table format, and a
  cross-reference to the new rule file.
- `tests/skill_contracts.rs` — add the contract test
  `flow_plan_skill_has_extract_helper_branch_enumeration` that reads
  `skills/flow-plan/SKILL.md` and asserts the new subsection exists
  between `### Step 3` and `### Step 4`, with the expected cross-
  references and classification names.
- `tests/tombstones.rs` — add the corpus-scan test
  `no_waiver_language_in_authoring_corpus` that walks `CLAUDE.md`,
  `.claude/rules/*.md`, `skills/**/SKILL.md`, and
  `.claude/skills/**/SKILL.md`, asserting no file contains the
  forbidden waiver substrings with per-file exemptions for
  `.claude/rules/no-waivers.md` and
  `.claude/rules/extract-helper-refactor.md` (where the prohibited
  phrases appear as negative examples, not as positive instructions).
- `CLAUDE.md` — add a Conventions bullet pointing at the new rule for
  discoverability (matching the existing pattern of bullets like
  `**Scope enumeration for universal-coverage claims** — see
  .claude/rules/scope-enumeration.md`).

### Files to Investigate (Already Read)

- `.claude/rules/no-waivers.md` — the authoritative rule the new
  discipline applies to the extract-helper shape. The three valid
  responses are subprocess test, refactor for testability, delete the
  branch. Waivers are forbidden.
- `.claude/rules/docs-with-behavior.md` Multi-Task Plans / Named Tests
  After Refactor subsection — structurally adjacent but distinct
  concern (post-refactor test retention vs. new-branch enumeration).
  Cross-reference only; no content moves.
- `.claude/rules/supersession.md` — the closest architectural sibling
  for the new rule. Supersession is a prose-only Plan-phase discipline
  that triggers on a specific refactor shape, lives in its own rule
  file, and has no mechanical scanner. The new rule follows the same
  structural template.
- `.claude/rules/skill-authoring.md` — three sub-rules apply:
  "Simplest Approach First" (iteration 1 is instructional only, no
  scanner), "Plan Task Ordering" (TDD order mandatory — test tasks
  before implementation), and "Purpose Preamble for Behavioral
  Sections" (new SKILL.md subsection must open with 2-3 sentence why).
- `skills/flow-plan/SKILL.md` Step 3 (lines 246–495) — already has
  two sibling Plan-phase disciplines as subsections: "External-Input
  Audit for Panic/Assert Tightenings" (line 378) with a mechanical
  scanner, and "Supersession Enumeration" (line 415) prose-only. New
  subsection sits between them.
- `tests/scope_enumeration.rs` — reference pattern for a corpus-scan
  contract test. The `read_md_files` walker and per-surface test
  shape is the template for `no_waiver_language_in_authoring_corpus`.
- `tests/tombstones.rs` — existing waiver-closure tombstones
  (`test_coverage_md_must_not_exist`,
  `docs_with_behavior_no_waiver_discipline_section`,
  `claude_md_no_test_coverage_references`) cover three specific
  artifacts. The new corpus test extends the coverage to the full
  authoring corpus.
- `tests/skill_contracts.rs` — reference pattern for per-skill content
  assertions. The new `flow_plan_skill_has_extract_helper_branch_
  enumeration` test follows the existing shape.
- `src/complete_fast.rs` lines 429–495 — the
  `production_ci_decider` helper (4 branches) and the `run_impl_inner`
  seam (injectable decider). Cited in the rule's Motivating Incident
  section as the reference pattern for "Testable via seam" vs.
  "Testable directly" classifications.
- `tests/main_dispatch.rs` — reference pattern for subprocess tests
  (cargo-llvm-cov instruments subprocess calls that spawn the compiled
  binary). Cited in the rule as the reference pattern for "Testable
  via subprocess".

### Reference Incident (Motivating PR #1155)

- Commit `59844b30` — Extract `run_impl_inner` seam and add ten
  behavior-preservation tests. The plan counted ten tests for the seam
  and stopped there.
- Commit `fcc9a69c` — Waive `run()` and `production_ci_decider`
  delegation in `test_coverage.md`. The helper's four internal branches
  were waived instead of tested.
- Commit `868d6989` — Close the coverage-waiver loophole by deleting
  `test_coverage.md` and the Waiver Discipline rule section.

### Superseded Code

Per `.claude/rules/supersession.md`, this PR does not supersede any
existing code or rules. The new rule complements no-waivers.md and
docs-with-behavior.md without replacing either. No deletion tasks are
required.

## Risks

### 1. New Rule File Prose May Trigger Existing Scanners

The new `.claude/rules/extract-helper-refactor.md` discusses waivers,
panics, assertions, and coverage in prose. Two existing scanners will
run against the committed rule file:

- `tests/scope_enumeration.rs` scans all `.claude/rules/*.md` files for
  universal-coverage language lacking enumeration. The rule's prose
  must avoid vocabulary nouns like `caller`, `callsite`, `subcommand`,
  `runner`, `entry point`, `state mutator`, `CLI variant`, `CLI entry`,
  `dispatch path`, `handler` when paired with universal quantifiers
  (`every`, `all`, `each`) — or must enumerate the named siblings
  inline.
- `tests/external_input_audit.rs` scans the same corpus for
  panic/assert tightening proposals without an audit table. The rule's
  prose mentions assertions and panics as examples of code that
  triggers the audit — those mentions must use the opt-out comment
  `<!-- external-input-audit: not-a-tightening -->` or be rephrased to
  avoid the trigger vocabulary.

Must verify: run `bin/flow ci` after creating the rule file and before
finalizing the commit. If either scanner fires, add the appropriate
opt-out comment or rephrase the offending line.

### 2. Plan File Itself Must Pass Plan-Check

This plan file discusses extractions, helpers, branches, waivers, and
assertions. The `bin/flow plan-check` gate in Step 4 will scan the
plan file with both `scope_enumeration::scan` and
`external_input_audit::scan`. The plan's prose must avoid the same
scanner triggers as the rule file. Discussion of "assert" and "panic"
below is framed as retrospective commentary on PR #1155, not as
proposals to add new assertions — the plan proposes only text files
and contract tests.

Must verify: when `bin/flow plan-check` runs in Step 4 of this plan
phase, it returns `"status": "ok"`. If not, edit the plan file to fix
each violation per the Plan-check gate repair loop.

<!-- external-input-audit: not-a-tightening -->
### 3. Opt-Out Comment Placement in the Rule File

The new rule file's own prose must use the `external-input-audit:
not-a-tightening` opt-out comment where it mentions `assert!` or
`panic!` as examples. The opt-out's walk-back window is at most one
blank line, so each mention must have an opt-out on the trigger line,
the line directly above, or two lines above with one blank line in
between. Rule file authoring must be careful to place the opt-outs
correctly. Contract tests catch incorrect placement on CI.

### 4. Contract Test Exemption List Must Stay Narrow

The `no_waiver_language_in_authoring_corpus` test will exempt
`.claude/rules/no-waivers.md` and
`.claude/rules/extract-helper-refactor.md` from the forbidden-substring
scan (because both files discuss the prohibited phrases as negative
examples). The exemption list is a one-line `const EXEMPT_FILES: &[&str]`
array in the test source. Any future exemption request must pass code
review and must be demonstrably authoring waiver prohibition rather
than waiver authorization. The risk is that a future PR expands the
exemption list to cover drift. Mitigation: the exemption list is short
and auditable.

### 5. DAG Is Fresh — No Freshness Check Needed

The DAG for this plan was produced by `/decompose:decompose` in Step 2
of the current session, with all referenced files read from the
current worktree. No DAG Freshness Check is required per the SKILL.md
"When to skip" rule.

### 6. No Script Behavior Claims to Verify

The issue body makes no specific claims about script behavior that
require Script Behavior Verification. It asserts that PR #1155 Task 2
extracted `production_ci_decider` and that the plan estimated 10 tests
— both verified via `git show 59844b30` and `git show fcc9a69c` in
the DAG investigation phase.

### 7. No Target Path Concerns

All file targets are repo-local: `skills/flow-plan/SKILL.md`,
`.claude/rules/extract-helper-refactor.md`, `tests/skill_contracts.rs`,
`tests/tombstones.rs`, `CLAUDE.md`. No user-level paths are involved.
Per `.claude/rules/repo-level-only.md` and the "Hard rule for
`.claude/rules/` and `CLAUDE.md`" in Target Path Validation, all
writes target the worktree tree.

## Approach

### Design Decision 1: Drop the waiver category

The issue body proposes three testability classifications ending in
"Untestable in unit scope → waiver task". `.claude/rules/no-waivers.md`
forbids waivers. The rule adopts three positive classifications that
map onto no-waivers.md's three responses:

- **Testable via seam** — injected closure, trait object, or Command
  parameter; branches exercised by passing mock implementations.
  Reference pattern: `run_impl_inner(args, root, runner, ci_decider)`
  from PR #1155 Task 2.
- **Testable directly** — unit test with a self-contained fixture
  (TempDir, prepared state file, in-memory value).
  Reference pattern: `production_ci_decider_tree_changed_returns_not_skipped`.
- **Testable via subprocess** — spawn the compiled binary through
  `tests/main_dispatch.rs`; cargo-llvm-cov instruments subprocess
  calls when they spawn the same binary.
  Reference pattern: `check_phase_first_phase_exits_0` from PR #1156
  Task 11.

When no classification fits, the fourth response per no-waivers.md
is **"Refactor further or delete the branch"** — never a waiver. If
the extraction produced a branch that no production path can reach,
the design is wrong and must be fixed in the same PR that introduced
the extraction.

### Design Decision 2: New rule file, not an extension

The new discipline is structurally a sibling of
`.claude/rules/supersession.md` — a single-topic Plan-phase rule
triggered by a specific refactor shape. Extending
`.claude/rules/docs-with-behavior.md` would compound that file's
already-overloaded scope (documentation sync vs. coverage discipline).
Create `.claude/rules/extract-helper-refactor.md` as a standalone file,
with a cross-reference bullet added to
`.claude/rules/docs-with-behavior.md` Multi-Task Plans section so
readers arriving from there find the new rule.

### Design Decision 3: Instructional-only in iteration 1

Per `.claude/rules/skill-authoring.md` "Simplest Approach First",
iteration 1 ships:
1. Rule file prose
2. SKILL.md subsection invoking the rule
3. Skill contract test asserting the subsection exists
4. Corpus contract test asserting no waiver language outside exempt files
5. CLAUDE.md discoverability bullet

Iteration 1 does NOT include a mechanical `src/extract_helper_refactor.rs`
scanner. Supersession.md works fine without a scanner, and the
extract-helper trigger vocabulary ("extract", "lift", "hoist", "factor
out", "helper", "function", "seam") is common enough in prose to risk
high false-positive rates for a naive scanner. A scanner can land in a
follow-up PR if drift surfaces. Building one now violates the
"Simplest Approach First" rule.

### Design Decision 4: Branch Enumeration Table has four columns

The required artifact in a plan is a markdown table with four columns:

| Branch | Condition | Classification | Test |
|---|---|---|---|
| A | `tree_changed == true` | Testable directly | `production_ci_decider_tree_changed_returns_not_skipped` |

The **Test** column is the forcing function. Naming a specific test
function commits the plan author to writing that test. An entry that
cannot name a test is not a valid classification — it's a signal that
the design needs further refactoring. This prevents abstract
classifications that ship without backing tests.

### Design Decision 5: Opt-out grammar mirrors existing scanners

The opt-out comment is `<!-- extract-helper-refactor: not-an-extraction -->`,
placed on the trigger line itself, the line directly above the
trigger, or two lines above with one blank line between. This is a
byte-for-byte mirror of the grammar from
`.claude/rules/external-input-audit-gate.md` and
`.claude/rules/scope-enumeration.md`. No new precedent is established
— iteration 1 is instructional so no scanner parses the opt-out yet,
but the grammar is reserved for a future scanner follow-up.

## Dependency Graph

| Task | Type | Depends On | Atomic Group |
|------|------|------------|--------------|
| 1. Write contract test `flow_plan_skill_has_extract_helper_branch_enumeration` | test | — | A |
| 2. Add `### Extract-Helper Branch Enumeration` subsection to `skills/flow-plan/SKILL.md` | implement | 1 | A |
| 3. Write corpus-scan test `no_waiver_language_in_authoring_corpus` | test | — | B |
| 4. Create `.claude/rules/extract-helper-refactor.md` via `bin/flow write-rule` | implement | 3 | B |
| 5. Add CLAUDE.md Conventions bullet for discoverability | implement | 4 | — |
| 6. Add cross-reference bullet to `.claude/rules/docs-with-behavior.md` Multi-Task Plans section | implement | 4 | — |

Group A is atomic because the contract test from Task 1 asserts the
subsection added in Task 2 exists; separating them would leave the
test failing between commits.

Group B is atomic because the corpus-scan test from Task 3 includes
`.claude/rules/extract-helper-refactor.md` on its exemption list, and
the rule file from Task 4 contains the forbidden substrings that make
the exemption load-bearing; separating them would either have the
test pass trivially (before the file exists) or fail (after the file
exists without the exemption landing in the test source).

Tasks 5 and 6 are standalone documentation updates — independent
commits per the `.claude/rules/docs-with-behavior.md` "same commit"
rule is not required because CLAUDE.md and docs-with-behavior.md are
not tests or code; they are cross-reference bullets pointing at the
already-committed rule file. Ordering within the PR is flexible.

## Tasks

### Task 1 — [Test] Add `flow_plan_skill_has_extract_helper_branch_enumeration` contract test

**File:** `tests/skill_contracts.rs`

**Description:** Add a new contract test that reads
`skills/flow-plan/SKILL.md` and asserts:

- The string `### Extract-Helper Branch Enumeration` appears at least
  once.
- The subsection heading falls textually between `### Step 3` and
  `### Step 4` (byte offsets).
- The subsection body contains the cross-reference
  `.claude/rules/extract-helper-refactor.md`.
- The subsection body names the three classifications exactly:
  `Testable via seam`, `Testable directly`, `Testable via subprocess`.

**TDD notes:** The test starts red. Task 2 makes it pass by adding the
subsection to SKILL.md. Increment the `code_task` counter to 1 before
committing.

**Atomic group:** A (with Task 2).

### Task 2 — [Implement] Add `### Extract-Helper Branch Enumeration` subsection to SKILL.md

**File:** `skills/flow-plan/SKILL.md` Step 3

**Description:** Insert a new `### Extract-Helper Branch Enumeration`
subsection between the existing `### External-Input Audit for
Panic/Assert Tightenings` subsection (around line 378) and
`### Supersession Enumeration` subsection (around line 415). The
subsection content:

- 2-3 sentence purpose preamble explaining why the discipline exists
  (prevents mid-Code-phase scope expansion when extractions introduce
  new branches)
- Trigger prose: when a plan task proposes extracting a block into a
  new function/helper/seam
- The required Branch Enumeration Table format (four columns: Branch
  / Condition / Classification / Test)
- Named list of the three classifications with reference patterns
- Cross-reference to `.claude/rules/extract-helper-refactor.md` and
  `.claude/rules/no-waivers.md`
- The opt-out comment grammar for discussion mentions

**TDD notes:** Task 1's contract test starts red. After Task 2 adds
the subsection, the test passes. Verify locally with
`bin/flow test -- flow_plan_skill_has_extract_helper_branch_enumeration`
before committing. Increment `code_task` to 2 before committing.

**Atomic group:** A (with Task 1). Both tasks land in one commit per
the Contract Test Atomicity rule in skill-authoring.md: "When a plan
removes content that a contract test asserts exists, and a later task
re-adds it at a different location, the plan must mark those tasks as
atomically dependent — they must be in the same commit."

### Task 3 — [Test] Add `no_waiver_language_in_authoring_corpus` corpus-scan test

**File:** `tests/tombstones.rs`

**Description:** Add a new test that scans the committed authoring
corpus for forbidden waiver substrings:

- Walks four surfaces: `CLAUDE.md`, `.claude/rules/*.md`,
  `skills/**/SKILL.md`, `.claude/skills/**/SKILL.md` (using the same
  `read_md_files` walker pattern as `tests/scope_enumeration.rs`).
- Asserts no file contains any of the forbidden substrings:
  `"untestable in unit scope"`, `"coverage waiver"`, `"waiver task"`,
  `"file a test_coverage.md entry"`, `"test_coverage.md entry for"`.
- Exemption list: `const EXEMPT_FILES: &[&str] = &["no-waivers.md",
  "extract-helper-refactor.md"];` — paths matched by canonical file
  name suffix.
- Failure message names the offending file and substring.

**TDD notes:** Before Task 4 creates the rule file, the test scans the
corpus and finds zero violations (no authoring file currently contains
the forbidden substrings other than no-waivers.md, which is already
on the exemption list). The test trivially passes. After Task 4 adds
the rule file with forbidden substrings as negative examples, the
exemption is load-bearing and the test continues to pass. Increment
`code_task` to 3 before committing.

**Atomic group:** B (with Task 4). The exemption for
`extract-helper-refactor.md` must be in the test source before Task 4
lands the rule file, otherwise CI fails in the intermediate state.

### Task 4 — [Implement] Create `.claude/rules/extract-helper-refactor.md`

**Files:**
- `.claude/rules/extract-helper-refactor.md` (new file, created via
  `bin/flow write-rule --path .claude/rules/extract-helper-refactor.md
  --content-file <worktree>/.flow-rule-body`)

**Description:** Write the new rule file with these sections:

1. **Title** — "Extract-Helper Branch Enumeration"
2. **Purpose** — why the rule exists, citing PR #1155 Task 2
3. **The Rule** — the Plan-phase trigger, the required Branch
   Enumeration Table with its four columns (Branch / Condition /
   Classification / Test), and the forbidden classifications
4. **The Three Classifications** — with reference patterns:
   - `Testable via seam` — `run_impl_inner(args, root, runner, ci_decider)`
     (PR #1155 Task 2, commit `59844b30`)
   - `Testable directly` — `production_ci_decider_tree_changed_returns_not_skipped`
   - `Testable via subprocess` — `check_phase_first_phase_exits_0`
     (PR #1156 Task 11, `tests/main_dispatch.rs`)
5. **Forbidden Plan Prose** — lists prohibited substrings, cross-
   referencing `.claude/rules/no-waivers.md` Forbidden Plan Prose.
   Each mention of `assert` or `panic` inside this section uses the
   `<!-- external-input-audit: not-a-tightening -->` opt-out comment
   with correct walk-back placement (trigger line, line directly
   above, or two lines above with one blank line between).
6. **Opt-Out Grammar** — the `extract-helper-refactor: not-an-extraction`
   comment with placement rules mirroring
   `.claude/rules/scope-enumeration.md`.
7. **How to Apply (Plan Phase)** — step-by-step checklist: (1) identify
   extractions from the DAG and task list; (2) enumerate the new
   function's branches from the planned source shape; (3) classify
   each with a testing strategy; (4) name each test function; (5)
   order test tasks before implementation tasks per the TDD discipline
   in `.claude/rules/skill-authoring.md` Plan Task Ordering.
8. **Motivating Incident** — the PR #1155 narrative with commit
   references and the waiver regime transition.
9. **Cross-References** — `no-waivers.md`, `docs-with-behavior.md`
   Named Tests After Refactor, `supersession.md`, `skill-authoring.md`
   Plan Task Ordering and Simplest Approach First.

**Subprocess discipline:** The rule file is written via `bin/flow
write-rule --path .claude/rules/extract-helper-refactor.md
--content-file <absolute-worktree>/.flow-rule-body`. The content is
first written to `<worktree>/.flow-rule-body` with the Write tool, then
passed to `write-rule` which reads and deletes the content file. This
bypasses the `validate-claude-paths` PreToolUse hook that blocks
Edit/Write on `.claude/rules/` during active FLOW phases.

**TDD notes:** Task 3's corpus test trivially passes before this task
(the file doesn't exist). After this task lands the file, the exempt-
file list from Task 3 keeps the test green. Increment `code_task` to
4 before committing.

**Atomic group:** B (with Task 3).

### Task 5 — [Implement] Add CLAUDE.md Conventions bullet for discoverability

**File:** `CLAUDE.md` Conventions section

**Description:** Add a new bullet in the Conventions section
(following the same pattern as the existing
`**Scope enumeration for universal-coverage claims** — see
.claude/rules/scope-enumeration.md` bullet):

```markdown
- **Extract-helper branch enumeration for refactor plans** — see
  `.claude/rules/extract-helper-refactor.md`
```

Placement: alongside the existing Plan-phase discipline bullets
(scope enumeration, external-input audit).

**TDD notes:** No contract test asserts this bullet; it's a
discoverability improvement. The existing
`tests/scope_enumeration.rs::claude_md_has_no_unenumerated_universal_claims`
will scan the added line — the bullet uses safe vocabulary ("branch
enumeration", "refactor plans" — neither is in the scope-enumeration
trigger vocabulary) so no scanner violation is expected. Increment
`code_task` to 5 before committing.

### Task 6 — [Implement] Add cross-reference bullet to `.claude/rules/docs-with-behavior.md` Multi-Task Plans section

**File:** `.claude/rules/docs-with-behavior.md` Multi-Task Plans section

**Description:** Add a one-line cross-reference bullet at the end of
the Multi-Task Plans section's preamble, before the Named Tests After
Refactor subsection:

```markdown
For the sibling discipline covering **new branches introduced by
extraction refactors**, see `.claude/rules/extract-helper-refactor.md`.
```

This ensures readers arriving at docs-with-behavior.md find the new
rule without the cross-reference being deep inside a sub-sub-section.

**Subprocess discipline:** Uses `bin/flow write-rule` since
`.claude/rules/` is protected by `validate-claude-paths`.

**TDD notes:** No contract test; existing scanners
(`tests/scope_enumeration.rs`, `tests/external_input_audit.rs`,
`tests/tombstones.rs::docs_with_behavior_no_waiver_discipline_section`)
all run against the file. Verify each passes after the edit. The
bullet text does not contain "Waiver Discipline" or "test_coverage.md"
so the existing tombstones stay green. Increment `code_task` to 6
before committing.

## Final Verification (not a counted task)

After Tasks 1–6 have landed, `bin/flow ci` runs automatically inside
`finalize-commit` for each commit. There is no separate verification
commit. The green gate for each atomic-group commit confirms:

- Group A commit: `flow_plan_skill_has_extract_helper_branch_enumeration`
  passes; `tests/scope_enumeration.rs` passes against the modified
  SKILL.md.
- Group B commit: `no_waiver_language_in_authoring_corpus` passes with
  the exemption load-bearing; `tests/scope_enumeration.rs` and
  `tests/external_input_audit.rs` pass against the new rule file.
- Standalone commits (Task 5, Task 6):
  `tests/tombstones.rs::docs_with_behavior_no_waiver_discipline_section`
  remains green after the cross-reference bullet lands.

If any scanner fires during Code phase, follow the plan-check repair
loop from the flow-plan SKILL.md Step 4: read the violation, edit the
target file, re-run `bin/flow ci`, iterate until green.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Plan-Phase Extract-Helper Refactor Discipline

```xml
<dag goal="Design Plan-phase discipline for extract-helper refactors (branch enumeration + testability classification) under the no-waivers regime" mode="full">
  <plan>
    <node id="1" name="Investigate current coverage rules and no-waivers regime" type="research" depends="[]" parallel_with="[2,3]">
      <objective>Read .claude/rules/no-waivers.md, docs-with-behavior.md, supersession.md, skill-authoring.md to establish the current coverage discipline and identify the waiver/no-waiver tension in the issue recommendation</objective>
    </node>
    <node id="2" name="Investigate PR #1155 incident" type="research" depends="[]" parallel_with="[1,3]">
      <objective>Read PR #1155 commits 59844b30 and fcc9a69c to understand what extract-helper refactor happened, what new branches surfaced, and how it was ultimately resolved under no-waivers</objective>
    </node>
    <node id="3" name="Investigate SKILL.md invocation surface" type="research" depends="[]" parallel_with="[1,2]">
      <objective>Read skills/flow-plan/SKILL.md Step 3 (Explore and write plan) and tests/skill_contracts.rs to identify where a new rule would be invoked and how it would be enforced</objective>
    </node>
    <node id="4" name="Resolve waiver/no-waivers contradiction" type="decision" depends="[1,2]" parallel_with="[]">
      <objective>Decide how to map the issue's three-category taxonomy (seam/direct/untestable+waiver) to the no-waivers regime's three responses (subprocess/refactor/design change)</objective>
    </node>
    <node id="5" name="Decide rule placement — new file vs extension" type="decision" depends="[1,3]" parallel_with="[4]">
      <objective>Choose between extending docs-with-behavior.md Multi-Task Plans section and creating .claude/rules/extract-helper-refactor.md, with rationale anchored in sibling rules</objective>
    </node>
    <node id="6" name="Design testability taxonomy and trigger language" type="creative" depends="[4]" parallel_with="[7]">
      <objective>Produce the final three-category testability taxonomy plus the Plan-phase trigger prose (when does the discipline fire? what must the plan enumerate?)</objective>
    </node>
    <node id="7" name="Design Plan-phase integration and enforcement" type="analysis" depends="[3,5]" parallel_with="[6]">
      <objective>Specify how SKILL.md Step 3 references the rule, whether a contract test in tests/skill_contracts.rs is needed, and whether a mechanical scanner (like scope-enumeration) is feasible at issue time</objective>
    </node>
    <node id="8" name="Enumerate dependencies and failure modes" type="validation" depends="[6,7]" parallel_with="[]">
      <objective>Cross-check the design against no-waivers, docs-with-behavior, skill-authoring, and contract test patterns; catch rule conflicts and missing verification risks</objective>
    </node>
    <node id="9" name="Synthesize plan tasks with TDD ordering and DAG" type="synthesis" depends="[8]" parallel_with="[]">
      <objective>Produce the final ordered task list with TDD order, atomic commit groups, file paths, and dependency graph for the Plan phase to consume</objective>
    </node>
  </plan>
</dag>
```

**Validation checklist:**
- [x] No cycles
- [x] Every dependency ID exists
- [x] Parallel nodes (1/2/3 and 4/5 and 6/7) are genuinely independent
- [x] Terminal synthesis node (9) aggregates everything
- [x] Node count matches task complexity (9 = Standard)

---

## PHASE 1: EXECUTE

### ▶ NODE 1: Investigate current coverage rules and no-waivers regime

Quality: **9/10** — rule conflict identified upfront.

Key finding: `.claude/rules/no-waivers.md` is **definitive and contradicts** the issue's `Untestable in unit scope + waiver task` recommendation. The rule mandates exactly three responses: subprocess test, refactor for testability, or delete unreachable branches. The taxonomy must drop the waiver category and adopt the no-waivers three-response framework. This is the most important finding of the whole DAG and resolves the central design question.

---

### ▶ NODE 2: Investigate PR #1155 incident — complete

Quality: **9/10** — full timeline reconstructed.

Timeline:
1. **PR #1155 (8cb5e80c)** — Task 2: extracted `run_impl_inner` seam + `production_ci_decider`. Task 3: 10 tests for `run_impl_inner`. Task 4: waived `run()` + `production_ci_decider` delegation in `test_coverage.md` (commit fcc9a69c). The plan did NOT enumerate the helper's 4 branches.
2. **868d6989 (direct-to-main)** — user asserted "FIXED NO WAIVERS EVER", deleted `test_coverage.md`, removed Waiver Discipline section, added 3 tombstones. This was the turning point.
3. **PR #1156 (44213e91)** — Coverage Pattern Testable. Created `run_impl_main` + dispatch pattern to lift `check_phase`, `phase_transition`, `format_status`, `tui_data` to in-process testability. Phase 5 Learn in PR #1156 created `.claude/rules/no-waivers.md` and `code-task-counter.md`.
4. **PR #1157** — Coverage Pattern Http Client — extended the trait-seam pattern.

Key finding: PR #1155 extracted `run_impl_inner` seam specifically to test the dispatch logic via a mock `ci_decider` closure — ten in-process tests exercise the `run_impl_inner` side. The real production wrapper (`production_ci_decider`) has four branches (tree_changed=true, sentinel hit, ci fail, ci pass) — only Branch A is unit-tested today (line 1409). The plan for PR #1155 counted `run_impl_inner` tests but never enumerated the `production_ci_decider` branches themselves. Branches B/C/D were waived in `test_coverage.md` (commit fcc9a69c). After PR #1155 merged, the user deleted `test_coverage.md` (commit 868d6989) and PR #1156 added `.claude/rules/no-waivers.md`. The Plan-phase gap is: when a task says "extract helper X", the Plan phase must enumerate X's branches **and** classify them against no-waivers responses — not just count tests against the seam that delegates to X.

---

### ▶ NODE 3: Investigate SKILL.md invocation surface — complete

Quality: **9/10**

Key finding: `skills/flow-plan/SKILL.md` Step 3 already has two sibling Plan-phase disciplines that fit the pattern: **External-Input Audit for Panic/Assert Tightenings** (line 378, with a mechanical `bin/flow plan-check` scanner) and **Supersession Enumeration** (line 415, prose-only). The new discipline should live as a sibling subsection in Step 3. Supersession is the closest architectural analog — prose-only, no scanner, rule-file-as-primary-instrument. Iteration 1 should follow the Supersession pattern (instructional rule only) per `.claude/rules/skill-authoring.md` "Simplest Approach First" — a mechanical scanner can be added if drift surfaces later.

---

### ▶ NODE 4: Resolve waiver/no-waivers contradiction (depends on 1, 2)

**Premise.** The issue body proposes a three-category taxonomy ending in `Untestable in unit scope → waiver task`. `.claude/rules/no-waivers.md` explicitly forbids waivers.

**Trace.**
- Issue #1160 was filed describing PR #1155's behavior
- PR #1155 landed WITH waivers on 2026-04-14
- User direct-commit 868d6989 deleted `test_coverage.md` the same day ("FIXED NO WAIVERS EVER")
- PR #1156 Phase 5 Learn added `.claude/rules/no-waivers.md` codifying the three responses: subprocess / refactor / delete
- PR #1157 merged with coverage-pattern-http-client which ratcheted the trait-seam pattern

**Conclude.** The issue's waiver recommendation is **superseded**. The taxonomy must drop the waiver category. The three valid classifications under no-waivers are:

| Classification | Meaning | Reference pattern |
|---|---|---|
| **Testable via seam** | Caller injects a closure, trait object, or `Command` via a parameter; branches are exercised by passing mock implementations | `run_impl_inner(args, root, runner, ci_decider)` — PR #1155 Task 2 pattern |
| **Testable directly** | Unit test with a self-contained fixture (TempDir, prepared state file, in-memory value) | `production_ci_decider_tree_changed_returns_not_skipped` |
| **Testable via subprocess** | Spawn the compiled binary through `tests/main_dispatch.rs` and exercise the path through the real CLI surface; cargo-llvm-cov instruments the subprocess | `no_command_writes_stderr_and_exits_1`, `check_phase_first_phase_exits_0` — PR #1156 pattern |

When no classification fits, the fourth response per no-waivers.md Section "The Rule" is **"Refactor further / delete the branch"** — if the extraction produced an untestable branch that no production caller can reach, the design is wrong. Fix the design, don't document the gap.

Quality: **10/10** — the contradiction is resolved by mechanical rule precedence.

Key finding: **The rule must rename the third category from "Untestable in unit scope" to "Testable via subprocess," and must include a fourth response ("refactor further or delete") — never a waiver.** Plans that propose an extraction with no testability strategy for any branch are incomplete and must be rewritten, not waived.

---

### ▶ NODE 5: Decide rule placement — new file vs extension (parallel with 4, depends on 1, 3)

**Candidate A: Extend `docs-with-behavior.md` Multi-Task Plans section.**
- Pro: Already has a "Named Tests After Refactor" sub-rule covering a related concern (post-refactor coverage continuity). Sibling placement keeps all refactor-related Plan discipline in one file.
- Pro: No new rule file → lower rule-file inventory.
- Con: `docs-with-behavior.md` is conceptually about *documentation* staying in sync with *behavior*. Extract-helper branch enumeration is about *test coverage*, not documentation. The concern is already mis-filed and this would compound that.
- Con: The file is ~280 lines. Adding a large subsection makes it harder to navigate.

**Candidate B: Create `.claude/rules/extract-helper-refactor.md`.**
- Pro: Single-topic file, discoverable by name (matches `scope-enumeration.md`, `external-input-audit-gate.md`, `supersession.md` naming pattern).
- Pro: Clean cross-references from `skills/flow-plan/SKILL.md` Step 3, `.claude/rules/no-waivers.md`, and `.claude/rules/docs-with-behavior.md`.
- Pro: A future mechanical scanner could follow the `scope-enumeration.md` / `external-input-audit-gate.md` topology without refactoring two files.
- Con: Adds one file to `.claude/rules/` inventory.

**Decision: Candidate B — create `.claude/rules/extract-helper-refactor.md`.**

Rationale: The concern is structurally a sibling of `supersession.md` (a Plan-phase discipline triggered by a specific refactor shape), not a documentation-sync concern. Supersession has its own file for exactly this reason. The naming pattern is already established: single-concern rule files are the norm in this codebase. Candidate A would worsen `docs-with-behavior.md`'s already-overloaded scope.

Quality: **9/10** — decision is anchored in existing architectural precedent.

Key finding: Create `.claude/rules/extract-helper-refactor.md`. Add a brief cross-reference line to `.claude/rules/docs-with-behavior.md` Multi-Task Plans section pointing at the new rule (so readers arriving at docs-with-behavior find the extract-helper discipline without duplicating content).

---

### ▶ NODE 6: Design testability taxonomy and trigger language (parallel with 7, depends on 4)

**Trigger prose.** The rule fires when a plan task description or approach contains any of:

- **Extraction verbs + refactor nouns**: "extract", "lift", "hoist", "factor out", "pull out", "refactor into" + "helper", "function", "method", "seam", "closure", "trait", "block", "inner function"
- **Direct pattern**: "extract <X> into a new <Y>", "lift the <X> block into <Y>", "introduce a trait seam for <X>"
- **Task type**: A plan's Dependency Graph row with `type = refactor` or `type = extract` or `type = seam`

**Required artifact: Branch enumeration table.** For every extraction task, the plan must include a table within ~10 non-blank lines of the trigger:

| Branch | Condition | Classification | Test |
|---|---|---|---|
| A | `tree_changed == true` | Testable directly | `production_ci_decider_tree_changed_returns_not_skipped` |
| B | `tree_changed == false` ∧ sentinel matches | Testable directly | `production_ci_decider_sentinel_hit_returns_skipped` |
| C | `tree_changed == false` ∧ sentinel miss ∧ CI fails | Testable via seam | (lift `ci::run_impl` into a second injectable parameter, test via `ci_failed_decider` mock) |
| D | `tree_changed == false` ∧ sentinel miss ∧ CI passes | Testable via seam | (same mechanism as C) |

Column definitions:

- **Branch** — a letter or number label (A/B/C/... or 1/2/3/...)
- **Condition** — the precise guard condition, written as an expression or prose
- **Classification** — one of `Testable via seam` / `Testable directly` / `Testable via subprocess` / `Refactor further` (never a waiver; never "untestable")
- **Test** — the named test function that will exercise this branch, OR (for `Refactor further`) the planned sub-refactor and the test it unlocks

**Forbidden prose.** A plan that contains any of these is rejected by the rule:

- "Untestable in unit scope"
- "Waive this branch"
- "Coverage waiver"
- "File a test_coverage.md entry"
- "Untestable — justify in Phase 5 Learn"

**Opt-out grammar.** A plan section that uses the word "extract" in discussion (not as a proposal) can carry the opt-out comment `<!-- extract-helper-refactor: not-an-extraction -->` on the trigger line, the line directly above, or two lines above with one blank line in between. This mirrors the opt-out grammar from `.claude/rules/external-input-audit-gate.md` and `.claude/rules/scope-enumeration.md` exactly — no new precedent.

**TDD integration.** Because the classification column names a test function, the test tasks naturally precede the implementation tasks. The plan's Tasks section must list a test task for every branch in the table **before** the extraction task that introduces the branch. This follows `.claude/rules/skill-authoring.md` "Plan Task Ordering" — TDD order is already mandatory.

Quality: **10/10** — taxonomy is grounded in no-waivers responses and the PR #1155 reference incident.

Key finding: The table has four columns (Branch / Condition / Classification / Test) and the Test column is the forcing function — naming a test commits the author to writing it. An "untestable" entry is a forbidden value, not a valid classification.

---

### ▶ NODE 7: Design Plan-phase integration and enforcement (parallel with 6, depends on 3, 5)

**SKILL.md integration.** Add a new subsection to `skills/flow-plan/SKILL.md` Step 3, placed between the existing "External-Input Audit for Panic/Assert Tightenings" (line 378) and "Supersession Enumeration" (line 415) subsections. The new subsection name: **"Extract-Helper Branch Enumeration"**.

Subsection content: 2-3 sentence purpose preamble (per `.claude/rules/skill-authoring.md` "Purpose Preamble for Behavioral Sections"), followed by:
- When it fires (trigger prose)
- The required branch enumeration table format
- Cross-reference to `.claude/rules/extract-helper-refactor.md` and `.claude/rules/no-waivers.md`
- The opt-out comment grammar

**Contract test discipline.** Add a test in `tests/skill_contracts.rs` asserting:
1. `skills/flow-plan/SKILL.md` contains the subsection heading "Extract-Helper Branch Enumeration"
2. The subsection sits in Step 3 (after `### Step 3` and before `### Step 4`)
3. The subsection body names `.claude/rules/extract-helper-refactor.md` as a cross-reference
4. The body names the three valid classifications: "Testable via seam", "Testable directly", "Testable via subprocess"

This follows the pattern established by existing skill contract tests like `phase_skills_no_inline_time_computation`.

**Corpus contract test (optional).** Add an optional contract test in `tests/skill_contracts.rs` or a new `tests/extract_helper_refactor.rs` that scans the committed prose corpus (`CLAUDE.md`, `.claude/rules/*.md`, `skills/**/SKILL.md`, `.claude/skills/**/SKILL.md`) for the forbidden prose patterns (`"untestable in unit scope"`, `"coverage waiver"`, `"file a test_coverage.md entry"`). This mirrors the `tests/scope_enumeration.rs` drift-tripwire pattern.

**Mechanical plan-check scanner — deferred.** Per `.claude/rules/skill-authoring.md` "Simplest Approach First," iteration 1 uses rule-file prose + SKILL.md subsection + contract test only. A `src/extract_helper_refactor.rs` scanner following the `src/scope_enumeration.rs` topology can land in a follow-up PR if instructional enforcement proves insufficient. Do NOT over-engineer iteration 1 — supersession.md works fine without a scanner, and extract-helper is structurally similar.

**State-dependent gate ordering.** Per `.claude/rules/skill-authoring.md` "State-Dependent Gate Ordering in Multi-Step Skills" — the new subsection does NOT add a new gate command, so there is no state ordering concern. The existing `bin/flow plan-check` gate in Step 4 reads `files.plan`, and the state mutation sequence is unchanged.

Quality: **9/10** — integration is minimal and follows the "Simplest Approach First" rule.

Key finding: Iteration 1 is SKILL.md subsection + rule file + contract test asserting subsection presence and mention of key terms. No mechanical scanner in iteration 1. Corpus contract test for forbidden prose can piggy-back on existing `tests/scope_enumeration.rs` pattern or land as a new `tests/extract_helper_refactor.rs` file.

---

### ▶ NODE 8: Enumerate dependencies and failure modes (depends on 6, 7)

**Contradictions resolved through the DAG:**

1. Issue body proposes waivers, no-waivers.md forbids them → resolved in Node 4 (drop waiver category, add "Testable via subprocess" and "Refactor further / delete" as the only non-direct paths).
2. Issue body proposes extending docs-with-behavior.md OR creating a new file → resolved in Node 5 (create new file, mirror supersession.md).
3. Issue body proposes "For each 'Untestable in unit scope' branch, include a waiver task" → resolved in Nodes 4 and 6 (replace with "For each branch, name a test function; no plan can classify any branch as waiver-eligible").

**Failure modes identified and mitigated:**

| Failure Mode | Mitigation |
|---|---|
| Rule text contains the word "extract" and triggers its own scanner (if one were added) | Use opt-out comment in the rule file's own prose, OR add the rule file to the corpus contract test's ignore list (same pattern used by `tests/scope_enumeration.rs` for its own prose) |
| Contract test searches for literal "Testable via seam" and that phrase appears in no-waivers.md or rust-patterns.md already | Contract test searches specifically within the new rule file and the SKILL.md subsection — not the whole corpus. Verified in Node 7. |
| Plan author writes a "Branch Enumeration" table in the wrong SKILL.md section | Not a fatal failure. The rule applies at Plan phase regardless of section placement. The SKILL.md only specifies a natural home. |
| Code phase discovers a fifth branch after the plan was written | Plan signature deviation logging rule (`.claude/rules/plan-commit-atomicity.md` "Plan Signature Deviations Must Be Logged") covers this — log the deviation, add a test for the new branch, continue. |
| No-waivers rule changes again in the future (e.g. targeted escape hatch reintroduced) | Extract-helper-refactor.md cross-references no-waivers.md. If no-waivers is relaxed, the extract-helper rule inherits the relaxation automatically via the cross-reference. |
| `skills/flow-plan/SKILL.md` is itself scanned by `tests/scope_enumeration.rs` — does adding the new subsection introduce a scope-enumeration violation? | The new subsection's prose uses "for every extraction task" (universal quantifier) + "task" or "helper" — none of these are in the scope-enumeration trigger vocabulary (which includes subcommand, runner, entry point, state mutator, mutator, CLI variant, CLI entry, callsite, caller, dispatch path, handler). "Task" and "helper" are intentional gaps. No violation. |
| The rule file's own prose may accidentally trigger the external-input-audit scanner if it uses the word "assert" or "panic" discussively | Add opt-out comments where needed. Low risk — the rule's subject matter is coverage, not assertions. |
| CLAUDE.md needs to mention the new rule | Per `.claude/rules/docs-with-behavior.md`, permanent on-main artifacts need a Key Files entry. The new `.claude/rules/extract-helper-refactor.md` is NOT a new permanent artifact in the Key Files sense — rule files are globbed by `.claude/rules/*.md` and the CLAUDE.md Conventions section already points at the rules directory. No CLAUDE.md update required, but a Conventions bullet would improve discoverability. |
| The motivating incident section in the rule file cites PR #1155 — will a tombstone audit flag it? | Rule file citations are NOT tombstone comments — the tombstone audit only scans `tests/*.rs` files (`bin/flow tombstone-audit`). Rule file content is unaffected. |
| **Verification risk: "Testable via subprocess" is actually testable** | Must verify during Plan: confirm `tests/main_dispatch.rs` exists and is the canonical pattern. Node 2 already confirmed this — it was added in PR #1156 Task 11. No outstanding risk. |

Quality: **9/10** — all contradictions resolved, all mitigations identified.

Key finding: The two risks that need explicit plan attention are (1) the new rule file's own prose must not accidentally trigger existing scanners (scope-enumeration, external-input-audit), and (2) any contract test must scope its search to avoid false positives from unrelated files. Both are cheap to verify during Plan.

---

## PHASE 2: AGGREGATE & REFINE

**Contradictions across nodes:**

1. **Issue body recommendation vs. no-waivers.md.** Resolved in Node 4 — drop the waiver category.
2. **Extend existing file vs. new file.** Resolved in Node 5 — create `.claude/rules/extract-helper-refactor.md` (structural sibling to `supersession.md`).
3. **Mechanical scanner vs. instructional-only.** Resolved in Nodes 5 and 7 — instructional-only in iteration 1, following the supersession.md precedent and the "Simplest Approach First" skill-authoring rule.

**Refinements accumulated:**
- The taxonomy has THREE positive classifications plus ONE "refactor further" escape that is not a waiver
- The table has FOUR columns (Branch / Condition / Classification / Test) — the Test column is the forcing function
- Iteration 1 lands: rule file + SKILL.md subsection + contract test asserting subsection presence
- No new `bin/flow` subcommand; no scanner; no CLI changes

---

## PHASE 3: SYNTHESIS

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS — Plan-Phase Extract-Helper Discipline
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

### Final Design

**1. New rule file:** `.claude/rules/extract-helper-refactor.md`

Structure (modeled on `.claude/rules/supersession.md`):

- **Title** — "Extract-Helper Branch Enumeration"
- **Why** — Cites PR #1155 incident. Under the superseded waiver regime, a Plan that counted tests against `run_impl_inner` (the seam) missed the 4 branches inside `production_ci_decider` (the extracted helper). Three branches were waived. The waiver loophole was then closed by commit 868d6989 and PR #1156's `.claude/rules/no-waivers.md`. The rule exists so the Plan phase enumerates helper branches up-front instead of discovering them mid-Code and being tempted to waive.
- **The Rule** — When a Plan task description says "extract <X> into a new <Y>" (or any equivalent refactor-for-testability phrasing), the plan's Exploration or Approach section must include a **Branch Enumeration Table** with columns: Branch / Condition / Classification / Test. Every row must carry one of the three positive classifications (`Testable via seam`, `Testable directly`, `Testable via subprocess`) or must be rewritten as a "refactor further / delete the branch" decision per `.claude/rules/no-waivers.md`.
- **The Three Classifications** — explained with reference patterns:
  - `Testable via seam` → `run_impl_inner(args, root, runner, ci_decider)` pattern (PR #1155 Task 2)
  - `Testable directly` → `production_ci_decider_tree_changed_returns_not_skipped` (PR #1155 Task 2)
  - `Testable via subprocess` → `check_phase_first_phase_exits_0` (PR #1156 Task 11, `tests/main_dispatch.rs`)
- **Forbidden Plan Prose** — lists the prohibited phrases (`untestable in unit scope`, `waive this branch`, `coverage waiver`, `test_coverage.md`). Cross-references `.claude/rules/no-waivers.md`.
- **Opt-Out Grammar** — opt-out comment on the trigger line, line directly above, or two lines above with one blank line in between. Mirrors `scope-enumeration.md` and `external-input-audit-gate.md` exactly.
- **How to Apply** — Plan-phase checklist: (1) identify extractions from the DAG / task list; (2) enumerate the new function's branches from the planned source shape; (3) classify each with a testing strategy; (4) name each test function; (5) order the tests before the implementation in the Tasks section.
- **Motivating Incident** — PR #1155 Task 2/3/4 narrative with commit references `59844b30`, `fcc9a69c`, and the `868d6989` loophole close.
- **Cross-References** — `no-waivers.md`, `docs-with-behavior.md` (Named Tests After Refactor), `supersession.md` (structural sibling), `skill-authoring.md` (Plan Task Ordering, Simplest Approach First).

**2. SKILL.md update:** `skills/flow-plan/SKILL.md` Step 3

Add a new subsection titled `### Extract-Helper Branch Enumeration` between the existing "External-Input Audit for Panic/Assert Tightenings" subsection (line 378) and the "Supersession Enumeration" subsection (line 415). 2-3 sentence purpose preamble per `skill-authoring.md`, trigger prose, required table, cross-reference to the new rule file. Existing Step 4 `bin/flow plan-check` block is unchanged.

**3. Contract test:** `tests/skill_contracts.rs`

New test `flow_plan_skill_has_extract_helper_branch_enumeration`:
- Reads `skills/flow-plan/SKILL.md`
- Asserts the string `### Extract-Helper Branch Enumeration` appears
- Asserts the heading falls between `### Step 3` and `### Step 4` (check offsets)
- Asserts the subsection body contains `extract-helper-refactor.md`, `Testable via seam`, `Testable directly`, `Testable via subprocess`
- Asserts the body does NOT contain `waiver` or `test_coverage.md` as positive instructions

**4. Corpus contract test:** Extend `tests/tombstones.rs` OR add a new file

Test `no_waiver_language_in_rule_corpus`:
- Globs `.claude/rules/*.md`, `CLAUDE.md`, `skills/**/SKILL.md`
- Asserts NO file contains the forbidden substrings (`untestable in unit scope`, `coverage waiver`, `file a test_coverage.md entry`, `test_coverage.md entry for`) — with a per-file exemption list of `.claude/rules/no-waivers.md` and `.claude/rules/extract-helper-refactor.md` (where the prohibitions are discussed, not instructed).
- The exemption list uses canonicalized path comparison like `tests/tombstones.rs::test_no_backward_facing_comments_in_rust_source`.

**5. No changes to:**
- `src/` (no new scanner, no new CLI subcommand)
- `bin/flow plan-check` (existing scanners unchanged)
- `src/plan_extract.rs` callsites (no new rule integration)
- CLAUDE.md (new rule file is discoverable via the Conventions section's rules directory glob — but add an optional bullet for discoverability)

### Ordered Plan Tasks (with TDD + atomic commit groups)

| # | Task | Type | Depends On | Atomic Group |
|---|---|---|---|---|
| 1 | Write contract test `flow_plan_skill_has_extract_helper_branch_enumeration` in `tests/skill_contracts.rs` (initially failing) | test | — | A |
| 2 | Add `### Extract-Helper Branch Enumeration` subsection to `skills/flow-plan/SKILL.md` Step 3 (makes task 1 pass) | implement | 1 | A |
| 3 | Write contract test `no_waiver_language_in_rule_corpus` in `tests/tombstones.rs` (initially failing against the exempt files not yet existing) | test | — | B |
| 4 | Create `.claude/rules/extract-helper-refactor.md` via `bin/flow write-rule` (makes task 3 pass after the exemption list is wired) | implement | 3 | B |
| 5 | Add optional Conventions bullet in `CLAUDE.md` pointing at `extract-helper-refactor.md` for discoverability | implement | 4 | C |
| 6 | Run full `bin/flow ci` — confirm plan-check gate, scope-enumeration contract test, and external-input-audit contract test all remain green against the new rule file prose | verify | 2, 4, 5 | — |

**Commit boundaries:**
- Atomic group A = test + SKILL.md subsection (must land together so contract test passes)
- Atomic group B = test + rule file (must land together so tombstone test passes with the exemption already wired)
- Group C is the CLAUDE.md bullet — independently shippable, could merge into B if desired
- Task 6 is a verification task, not a commit

**Risks to record in the plan:**
1. **Prose drift in the new rule file may trigger existing scanners.** The rule discusses assertions, panics, and universal-coverage language in passing. Verify during Code phase that `bin/flow plan-check` does not flag the plan file itself, and that `tests/scope_enumeration.rs` / `tests/external_input_audit.rs` pass against the committed rule file. If either scanner fires, add the appropriate opt-out comment or rephrase.
2. **"Extract" is a common word.** If a mechanical scanner is added later, the trigger vocabulary must be curated to avoid false positives against prose like "extract from the state file" or "extract the JSON key". Iteration 1 does not have a scanner so the risk is deferred to the scanner PR.
3. **The contract test's exemption list must not become a waiver loophole.** Only the two authoritative rule files (`no-waivers.md`, `extract-helper-refactor.md`) are exempt. Any third exemption request must go through code review with explicit justification, and the exemption list must be asserted short in the contract test itself.
4. **Must verify** during Plan: `tests/main_dispatch.rs` exists and documents the subprocess test pattern cited by the new rule. (Node 2 confirmed this from git history — verified.)
5. **Must verify** during Plan: `.claude/rules/no-waivers.md` is on main at the planned branch point (not just staged). (Node 2 confirmed from `git log main` — verified.)

### Supersession Check

**Does this plan supersede any existing code or rules?**

- `.claude/rules/docs-with-behavior.md` "Named Tests After Refactor" subsection partially overlaps — it addresses the case where a refactor makes named tests LOOK redundant. The new rule addresses the case where a refactor introduces NEW uncovered branches. These are complementary, not redundant. **No supersession.**
- `.claude/rules/supersession.md` is structurally analogous but covers a different Plan-phase discipline (deletion of redundant code). **No supersession.**
- `.claude/rules/no-waivers.md` is the ground rule this new rule applies to the extract-helper shape. The new rule DEPENDS on no-waivers but does not supersede it. **No supersession.**

Conclusion: no files are deleted. The new rule is purely additive.

### What a Vanilla Claude Response Would Have Missed

```
Confidence: 90%  |  Nodes: 9  |  Parallel branches: 2

vs. Vanilla Claude (what linear reasoning would have missed):
  - The waiver/no-waivers contradiction. The issue body proposes a waiver
    category; the no-waivers.md rule (added in PR #1156 Phase 5 Learn)
    forbids it. A linear reader of the issue alone would have shipped a
    plan that directly contradicts an authoritative rule. Node 1 caught
    this upfront by reading no-waivers.md before any design work.
  - The subprocess-test third category. Vanilla reasoning would have kept
    the issue's "Untestable in unit scope" label and either (a) shipped
    with waivers anyway, or (b) replaced it with something vague like
    "requires further refactor." Node 4 correctly identified that
    cargo-llvm-cov instruments subprocess calls when they spawn the same
    binary, which makes `tests/main_dispatch.rs` the canonical third
    option under no-waivers.
  - The placement decision. Vanilla reasoning would have extended
    docs-with-behavior.md because the issue body mentions it. Node 5's
    comparison against supersession.md's placement caught that this is
    structurally a single-topic Plan-phase rule, not a documentation-
    sync concern, and the file structure precedent supports a new file.
  - The "Test" column as a forcing function. Vanilla reasoning would
    have kept a three-column table (Branch/Condition/Classification) as
    the issue body suggests. Node 6 recognized that naming a specific
    test function in the row is what prevents the plan from staying
    abstract — if you can't name the test, you can't claim the
    classification.
  - The supersession check that found nothing. Vanilla reasoning would
    not have run one at all. Node 8's contradiction sweep proved the new
    rule is purely additive, which simplifies the task list (no deletion
    tasks, no atomic groups involving removals).
  - The risk that the new rule's own prose may trigger existing
    scope-enumeration or external-input-audit scanners. Vanilla reasoning
    would not have caught this until CI failed during Code phase.
    Node 8 surfaced it as a Plan-time risk with specific mitigations.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 19m |
| Code | 9h 29m |
| Code Review | <1m |
| Learn | 11m |
| Complete | 7m |
| **Total** | **10h 8m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/plan-phase-should-enumerate-new.json</summary>

```json
{
  "schema_version": 1,
  "branch": "plan-phase-should-enumerate-new",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1168,
  "pr_url": "https://github.com/benkruger/flow/pull/1168",
  "started_at": "2026-04-14T22:25:36-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/plan-phase-should-enumerate-new-plan.md",
    "dag": ".flow-states/plan-phase-should-enumerate-new-dag.md",
    "log": ".flow-states/plan-phase-should-enumerate-new.log",
    "state": ".flow-states/plan-phase-should-enumerate-new.json"
  },
  "session_tty": "/dev/ttys007",
  "session_id": "89f216cc-b9c7-4012-9e34-2177df4316d6",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/89f216cc-b9c7-4012-9e34-2177df4316d6.jsonl",
  "notes": [
    {
      "phase": "flow-code",
      "phase_name": "Code",
      "timestamp": "2026-04-15T07:10:49-07:00",
      "type": "correction",
      "note": "Every test must guard a real regression path with a named consumer, not a hypothetical future drift surface. Before adding a test, name the specific regression it guards and the code path that produces that regression. If neither exists, the test is speculation, not verification. Corpus-wide drift-guard scans over authoring surfaces are speculative unless there is a concrete pathway where the forbidden content would drift into those surfaces. Existing tombstones + rule prose + plan-check scanners already cover real drift; broader scans for hypothetical drift add test-code cost for zero real regressions."
    }
  ],
  "prompt": "work on issue #1160",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-14T22:25:36-07:00",
      "completed_at": "2026-04-14T22:26:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 29,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-14T22:26:15-07:00",
      "completed_at": "2026-04-14T22:45:31-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1156,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-14T22:46:57-07:00",
      "completed_at": "2026-04-15T08:16:08-07:00",
      "session_started_at": null,
      "cumulative_seconds": 34151,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-15T08:16:19-07:00",
      "completed_at": "2026-04-15T12:11:03-07:00",
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-15T12:11:17-07:00",
      "completed_at": "2026-04-15T12:22:37-07:00",
      "session_started_at": null,
      "cumulative_seconds": 680,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-15T12:22:54-07:00",
      "completed_at": "2026-04-15T12:30:39-07:00",
      "session_started_at": null,
      "cumulative_seconds": 465,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-14T22:26:15-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-14T22:46:57-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-15T08:16:19-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-15T12:11:17-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-15T12:22:54-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 6,
  "code_task_name": "Task 6: Add cross-reference bullet to docs-with-behavior.md Multi-Task Plans section",
  "code_task": 6,
  "diff_stats": {
    "files_changed": 5,
    "insertions": 368,
    "deletions": 0,
    "captured_at": "2026-04-15T08:16:08-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "findings": [
    {
      "finding": "Cross-reference in docs-with-behavior.md Multi-Task Plans section is semantically mismatched",
      "reason": "Multi-Task Plans already hosts the Named Tests After Refactor sub-rule which addresses coverage-adjacent refactor discipline. The new cross-reference is a thematic sibling, not a mismatch. CLAUDE.md Conventions is the canonical entry point; docs-with-behavior supplements it for readers arriving via that file.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T12:02:47-07:00"
    },
    {
      "finding": "Rule has no mechanical gate in plan-check — Plan phase will not block a missing Branch Enumeration Table",
      "reason": "Known design decision per skill-authoring.md Simplest Approach First. The plan explicitly lands iteration 1 as instructional-only to mirror supersession.md. A scanner is reserved for a follow-up PR if drift surfaces. Not a defect of this PR.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T12:02:54-07:00"
    },
    {
      "finding": "Opt-out grammar is vestigial because no scanner processes it",
      "reason": "The opt-out grammar is documented as part of the rule's stable API so when a scanner is added in a future iteration it inherits the placement rules verbatim. Today the grammar is inert by design. Same known-limitation class as P1.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T12:03:01-07:00"
    },
    {
      "finding": "SKILL.md subsection lacks a dedicated Why heading",
      "reason": "The subsection opens with a 2-3 sentence purpose preamble per skill-authoring.md Purpose Preamble for Behavioral Sections. That IS the Why; the rule file carries the longer narrative. No drift.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T12:03:07-07:00"
    },
    {
      "finding": "SKILL.md Branch Enumeration Table example had only one data row — misleading for multi-branch enumeration",
      "reason": "Expanded to three rows matching the rule file's canonical example so Plan authors see the multi-row purpose directly in the skill instead of having to follow the cross-reference.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T12:03:43-07:00"
    },
    {
      "finding": "Rule file cited src/complete_fast.rs lines 429-495 for production_ci_decider but the function is actually at lines 453-495",
      "reason": "Corrected the line range to 453-495 to match the actual function location.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T12:05:45-07:00"
    },
    {
      "finding": "Rule file lacked an Enforcement section documenting the iteration-1 prose-only stance",
      "reason": "Added an Enforcement section that names the four layers (rule file, SKILL.md subsection, reviewer agent, adversarial agent), marks the scanner as absent, and names the natural home for a future scanner (src/extract_helper_refactor.rs) so a reader does not spend turns searching for code that does not exist.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T12:05:52-07:00"
    },
    {
      "finding": "Rule file used seam, decider, sentinel, and CiDecider without defining them for readers unfamiliar with PR #1155",
      "reason": "Added a Vocabulary section near the top defining seam, decider, sentinel, and CiDecider with concrete file references so a newcomer can parse the rest of the rule without prior context.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T12:06:00-07:00"
    },
    {
      "finding": "Contract tests did not assert Branch Enumeration Table presence, opt-out token in SKILL.md, or rule-file section structure",
      "reason": "Tightened both contract tests: flow_plan_skill_has_extract_helper_branch_enumeration now asserts the four-column table header and the opt-out token appear in the SKILL.md subsection; extract_helper_refactor_rule_has_expected_structure now asserts the canonical section headings (Vocabulary, Why, The Rule, The Three Classifications, Enforcement, Opt-Out Grammar, How to Apply, Motivating Incident) and the Branch Enumeration Table header.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-15T12:06:37-07:00"
    },
    {
      "finding": "Rule compliance clean findings (4, 5, 6, 7) — Simplest Approach First applied, atomic groups honored, docs-with-behavior same-commit rule honored, Code Review triage properly fixed all real findings in the PR",
      "reason": "Clean compliance observations from learn-analyst. No artifact required — these confirm rules were followed, not that a fix is needed. Recorded for audit trail.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-15T12:14:24-07:00"
    },
    {
      "finding": "Tests must guard real regression paths with a named consumer, not speculative future drift",
      "reason": "User correction during Code phase flagged a corpus-wide scan test with no concrete regression path. Principle codified as a new rule file.",
      "outcome": "rule_written",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-15T12:15:35-07:00",
      "path": ".claude/rules/tests-guard-real-regressions.md"
    },
    {
      "finding": "New rule prose stands on its own without defensive cross-references to already-handled prohibitions",
      "reason": "Narrowly applicable principle covered implicitly by skill-authoring.md Simplest Approach First and stop-on-frustration.md. Mechanically hard to apply (what counts as defensive?) and the feedback loop with the user already catches it. Rule bloat not worth the marginal coverage.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-15T12:16:15-07:00"
    },
    {
      "finding": "Process gap — Plan/Code phase does not surface speculative-test tasks before they land; user had to catch it via review",
      "reason": "Filed as issue #1172 on benkruger/flow. The tests-guard-real-regressions.md rule added in this PR is the prose discipline; the issue tracks the mechanical escalation (plan-check scanner or SKILL.md step addition).",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-15T12:22:08-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1172"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "issues_filed": [
    {
      "label": "Flow",
      "title": "Plan phase should surface speculative-test tasks before they land",
      "url": "https://github.com/benkruger/flow/issues/1172",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-15T12:21:59-07:00"
    }
  ],
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "freshness_retries": 1,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/plan-phase-should-enumerate-new.log</summary>

```text
2026-04-14T22:25:35-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-14T22:25:35-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-14T22:25:35-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-14T22:25:36-07:00 [Phase 1] create .flow-states/plan-phase-should-enumerate-new.json (exit 0)
2026-04-14T22:25:36-07:00 [Phase 1] freeze .flow-states/plan-phase-should-enumerate-new-phases.json (exit 0)
2026-04-14T22:25:36-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-14T22:25:37-07:00 [Phase 1] start-init — label-issues (labeled: [1160], failed: [])
2026-04-14T22:25:43-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-14T22:25:43-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-14T22:25:44-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-14T22:25:53-07:00 [Phase 1] start-workspace — worktree .worktrees/plan-phase-should-enumerate-new (ok)
2026-04-14T22:25:57-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-14T22:25:57-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-14T22:25:57-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-14T22:26:05-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-14T22:26:05-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-14T22:26:47-07:00 [Phase 2] Step 2 — plan_step set to 2 (exit 0)
2026-04-14T22:34:48-07:00 [stop-continue] first stop, conditional continue: pending=decompose
2026-04-14T22:40:19-07:00 [Phase 2] Step 3 — standard exploration begin (exit 0)
2026-04-14T22:45:31-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-14T22:46:57-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-14T22:47:29-07:00 [Phase 3] Task 1 start — flow_plan_skill_has_extract_helper_branch_enumeration test
2026-04-14T22:50:23-07:00 [Phase 3] Task 1 — writing contract test (exit 0)
2026-04-15T07:06:27-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-15T07:06:31-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-15T07:10:31-07:00 [stop-continue] first stop, conditional continue: pending=commit
2026-04-15T07:23:44-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-15T07:23:48-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-15T07:29:00-07:00 [stop-continue] blocking: pending=commit
2026-04-15T07:34:26-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-15T07:34:30-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-15T07:41:16-07:00 [Phase 3] Rule drift: .claude/rules/testing-gotchas.md landed on main with Subsection-Local Assertions rule. Decision: no sweep needed. Reason: flow_plan_skill_has_extract_helper_branch_enumeration already uses bounded subsection slicing (find+offset from subsection heading to next \n### heading, functionally equivalent to the rule's preferred split_once pattern). extract_helper_refactor_rule_has_expected_structure asserts whole-file content, not inside-named-section content, so the rule does not apply.
2026-04-15T08:11:15-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-15T08:11:19-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-15T08:15:30-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-15T08:15:34-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-15T08:16:08-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-15T08:16:19-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-15T12:10:40-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-15T12:10:44-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-15T12:11:03-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-15T12:11:17-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-15T12:20:32-07:00 [Phase 5] finalize-commit — ci (ok)
2026-04-15T12:20:36-07:00 [Phase 5] finalize-commit — done ("ok")
2026-04-15T12:22:37-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-15T12:30:39-07:00 [Phase 6] complete-finalize — starting
2026-04-15T12:30:39-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-15T12:30:39-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Flow | Plan phase should surface speculative-test tasks before they land | Learn | #1172 |

<!-- end:Issues Filed -->