### PR TITLE
Coverage Sweep Plan Phase

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -74,9 +74,9 @@ fi
 #   produce LEAK lines during the run which pass through the awk filter in full)
 # pipefail (set above) preserves cargo llvm-cov's exit code.
 cargo llvm-cov --no-cfg-coverage --no-clean \
-  --fail-under-lines 94 \
-  --fail-under-regions 95 \
-  --fail-under-functions 93 \
+  --fail-under-lines 95 \
+  --fail-under-regions 96 \
+  --fail-under-functions 94 \
   nextest --status-level pass --final-status-level fail "$@" 2>&1 | awk '
 /^ *PASS / {
   printf "."

--- a/src/plan_check.rs
+++ b/src/plan_check.rs
@@ -565,6 +565,136 @@ mod tests {
         assert_eq!(result["status"], "error");
     }
 
+    // --- run_impl non-NotFound I/O error ---
+
+    /// When `--plan-file` points at a directory, `read_to_string`
+    /// returns an I/O error with kind `IsADirectory` (not
+    /// `NotFound`). This exercises the infrastructure-failure branch
+    /// at lines 126-131 that returns `Err(String)`.
+    #[test]
+    fn run_impl_plan_file_is_directory_returns_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let args = Args {
+            branch: None,
+            plan_file: Some(dir.path().to_string_lossy().to_string()),
+        };
+        let err = run_impl(&args).unwrap_err();
+        assert!(
+            err.contains("Could not read plan file"),
+            "expected I/O error message, got: {}",
+            err
+        );
+    }
+
+    // --- run_impl duplicate-test-coverage loop ---
+
+    /// Trigger the dup-violations loop body (lines 173-174) by
+    /// creating a plan whose fenced code block declares a function
+    /// name that collides with an existing test in the repo's
+    /// corpus. `absolute_override_passes_through` is a test in this
+    /// file; the scanner normalizes both sides and detects the
+    /// collision.
+    #[test]
+    fn run_impl_triggers_dup_violations() {
+        let tmp = std::env::temp_dir().join(format!("plan-check-dup-{}.md", std::process::id()));
+        let plan_content = "## Tasks\n\n```rust\nfn absolute_override_passes_through() {\n}\n```\n";
+        std::fs::write(&tmp, plan_content).expect("write fixture plan");
+
+        let args = Args {
+            branch: None,
+            plan_file: Some(tmp.to_string_lossy().to_string()),
+        };
+        let result = run_impl(&args).expect("run_impl returns business response");
+        let _ = std::fs::remove_file(&tmp);
+
+        assert_eq!(result["status"], "error");
+        let violations = result["violations"]
+            .as_array()
+            .expect("violations is an array");
+        let rules: Vec<String> = violations
+            .iter()
+            .map(|v| v["rule"].as_str().unwrap_or("").to_string())
+            .collect();
+        assert!(
+            rules.iter().any(|r| r == "duplicate-test-coverage"),
+            "expected duplicate-test-coverage violation, got rules: {:?}",
+            rules
+        );
+    }
+
+    // --- resolve_plan_file_from_state edge paths ---
+
+    /// When the state file has a top-level `plan_file` key but no
+    /// `files.plan`, the legacy fallback at lines 350-355 fires.
+    #[test]
+    fn resolve_plan_file_from_state_legacy_plan_file_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let branch = "test-legacy-fallback";
+        let flow_states = root.join(".flow-states");
+        std::fs::create_dir_all(&flow_states).unwrap();
+        let state_path = flow_states.join(format!("{}.json", branch));
+        std::fs::write(&state_path, r#"{"plan_file": "legacy-plan.md"}"#).unwrap();
+
+        let result = resolve_plan_file_from_state(root, Some(branch));
+        let path = result
+            .expect("outer Result should be Ok")
+            .expect("inner Result should be Ok");
+        assert_eq!(path, root.join("legacy-plan.md"));
+    }
+
+    /// When the state file contains invalid JSON, the parse
+    /// `.map_err` closure at line 342 fires, returning
+    /// `Err(String)`.
+    #[test]
+    fn resolve_plan_file_from_state_invalid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let branch = "test-invalid-json";
+        let flow_states = root.join(".flow-states");
+        std::fs::create_dir_all(&flow_states).unwrap();
+        let state_path = flow_states.join(format!("{}.json", branch));
+        std::fs::write(&state_path, "{not valid json").unwrap();
+
+        let result = resolve_plan_file_from_state(root, Some(branch));
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Invalid JSON in state file"),
+            "expected JSON parse error, got: {}",
+            err
+        );
+    }
+
+    /// When the state file exists but is unreadable (chmod 000),
+    /// the read `.map_err` closure at line 340 fires, returning
+    /// `Err(String)`.
+    #[test]
+    fn resolve_plan_file_from_state_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let branch = "test-unreadable";
+        let flow_states = root.join(".flow-states");
+        std::fs::create_dir_all(&flow_states).unwrap();
+        let state_path = flow_states.join(format!("{}.json", branch));
+        std::fs::write(&state_path, r#"{"valid": true}"#).unwrap();
+
+        // Remove read permission so read_to_string fails
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&state_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = resolve_plan_file_from_state(root, Some(branch));
+
+        // Restore permissions so tempdir cleanup succeeds
+        let _ = std::fs::set_permissions(&state_path, std::fs::Permissions::from_mode(0o644));
+
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Could not read state file"),
+            "expected read error, got: {}",
+            err
+        );
+    }
+
     /// Clean plan (no violations) returns `{"status": "ok"}` from
     /// the dual-scanner aggregation path.
     #[test]

--- a/src/plan_extract.rs
+++ b/src/plan_extract.rs
@@ -249,8 +249,8 @@ pub fn promote_headings(content: &str) -> String {
 
     for line in content.lines() {
         let trimmed = line.trim_start();
-        // Track fenced code blocks
-        if trimmed.starts_with("```") {
+        // Track fenced code blocks (backtick and tilde per CommonMark)
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
             in_code_block = !in_code_block;
             result.push_str(line);
             result.push('\n');
@@ -296,7 +296,7 @@ pub fn count_tasks(content: &str) -> usize {
 
     for line in content.lines() {
         let trimmed = line.trim_start();
-        if trimmed.starts_with("```") {
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
             in_code_block = !in_code_block;
             continue;
         }
@@ -323,7 +323,7 @@ pub fn count_tasks_any_level(content: &str) -> usize {
 
     for line in content.lines() {
         let trimmed = line.trim_start();
-        if trimmed.starts_with("```") {
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
             in_code_block = !in_code_block;
             continue;
         }

--- a/src/plan_extract.rs
+++ b/src/plan_extract.rs
@@ -983,4 +983,24 @@ mod tests {
         assert!(!msg.contains("scope-enumeration.md"));
         assert!(!msg.contains("external-input-audit-gate.md"));
     }
+
+    // --- complete_plan_phase error path ---
+
+    /// When `mutate_state` fails (e.g. non-existent state file path),
+    /// `complete_plan_phase` returns `Err(String)` via the `.map_err`
+    /// closure at line 412.
+    #[test]
+    fn complete_plan_phase_returns_err_on_missing_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let state_path = root.join(".flow-states").join("nonexistent.json");
+        let result = complete_plan_phase(&state_path, root, "nonexistent");
+        assert!(result.is_err(), "expected Err when state file is missing");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Failed to complete phase"),
+            "expected map_err message, got: {}",
+            err
+        );
+    }
 }

--- a/src/plan_extract.rs
+++ b/src/plan_extract.rs
@@ -912,6 +912,58 @@ mod tests {
         assert_eq!(resp["path"], "resumed");
     }
 
+    // --- load_frozen_config ---
+
+    /// When a frozen phases file exists at the expected path,
+    /// `load_frozen_config` returns `(Some(order), Some(commands))`
+    /// with values parsed from the file. This exercises lines 117,
+    /// 121-122 which are unreached when no frozen file exists.
+    #[test]
+    fn load_frozen_config_with_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let branch = "test-frozen";
+        let flow_states = root.join(".flow-states");
+        std::fs::create_dir_all(&flow_states).unwrap();
+        let frozen_path = flow_states.join(format!("{}-phases.json", branch));
+        let frozen_json = serde_json::json!({
+            "order": ["flow-start", "flow-plan"],
+            "phases": {
+                "flow-start": {"name": "Start", "command": "/flow:flow-start"},
+                "flow-plan": {"name": "Plan", "command": "/flow:flow-plan"}
+            }
+        });
+        std::fs::write(&frozen_path, frozen_json.to_string()).unwrap();
+
+        let (order, commands) = load_frozen_config(root, branch);
+        assert!(
+            order.is_some(),
+            "order should be Some when frozen file exists"
+        );
+        assert!(
+            commands.is_some(),
+            "commands should be Some when frozen file exists"
+        );
+        let order = order.unwrap();
+        assert_eq!(order.len(), 2);
+        assert_eq!(order[0], "flow-start");
+    }
+
+    // --- count_tasks_any_level code-block toggle ---
+
+    /// `count_tasks_any_level` must not count task headings inside
+    /// fenced code blocks. This exercises lines 327-328 (the
+    /// code-block toggle branch).
+    #[test]
+    fn count_tasks_any_level_skips_code_blocks() {
+        let content = "### Task 1: Real task\n\n\
+            ```\n\
+            ### Task 2: Inside code block\n\
+            ```\n\n\
+            ### Task 3: Another real task\n";
+        assert_eq!(count_tasks_any_level(content), 2);
+    }
+
     /// Duplicate-only response names only the duplicate rule file.
     #[test]
     fn violations_response_duplicate_only_names_only_duplicate_rule() {

--- a/tests/plan_check.rs
+++ b/tests/plan_check.rs
@@ -443,3 +443,42 @@ fn plan_check_accepts_plan_file_override() {
     assert_eq!(code, 0);
     assert_eq!(json["status"], "ok");
 }
+
+// --- Infrastructure error (exit 1) ---
+
+/// When the state file contains invalid JSON, `run_impl` returns
+/// `Err(String)` and `run()` hits the `json_error` + `exit(1)` branch
+/// (lines 57-59). The error is written to stderr, not stdout.
+#[test]
+fn plan_check_invalid_json_state_exits_with_code_1() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_git_repo(dir.path(), "test-feature");
+    let state_dir = flow_states_dir(dir.path());
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("test-feature.json"),
+        "{not valid json at all",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["plan-check", "--branch", "test-feature"])
+        .current_dir(dir.path())
+        .env_remove("FLOW_CI_RUNNING")
+        .output()
+        .unwrap();
+
+    let code = output.status.code().unwrap_or(-1);
+    assert_eq!(
+        code, 1,
+        "expected exit 1 for corrupt state file, got {}",
+        code
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Invalid JSON"),
+        "stdout should mention JSON parse failure, got: {}",
+        stdout
+    );
+}


### PR DESCRIPTION
## What

work on issue #1141.

Closes #1141

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/coverage-sweep-plan-phase-plan.md` |
| DAG | `.flow-states/coverage-sweep-plan-phase-dag.md` |
| Log | `.flow-states/coverage-sweep-plan-phase.log` |
| State | `.flow-states/coverage-sweep-plan-phase.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/0db44029-c102-464d-9dcb-b04c4e5f3c14.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

Issue #1141: Coverage sweep for `src/plan_check.rs` (87.36% lines, 34 missed) and `src/plan_extract.rs` (94.60% lines, 33 missed). Both files implement Phase 2 Plan gates. Goal: 100% coverage on lines, regions, and functions for both files. No waivers per `.claude/rules/no-waivers.md`.

## Exploration

| File | Current coverage | Missed lines | Role |
|------|-----------------|-------------|------|
| `src/plan_check.rs` | 87.36% lines | 34 | Standard plan-check gate: aggregates scope, audit, dup scanners |
| `src/plan_extract.rs` | 94.60% lines | 33 | Phase entry, issue fetch, extracted/resumed/standard paths |
| `tests/plan_check.rs` | — | — | Existing subprocess integration tests (15 tests) |
| `tests/plan_extract.rs` | — | — | Existing unit + integration tests (34 tests) |

### Uncovered lines — plan_check.rs

Many lines showing 0-hit in the flow-rs binary are already covered by inline `#[cfg(test)]` unit tests (which run in the test binary). The truly uncovered lines needing new tests:

<!-- duplicate-test-coverage: not-a-new-test -->
<!-- scope-enumeration: imperative -->

| Lines | Description | Already covered by inline test? |
|-------|-------------|-------------------------------|
| 57-59 | `run()` Err branch (`json_error` + `exit(1)`) | No — needs subprocess test |
| 126-131 | Non-NotFound I/O error reading plan file | No |
<!-- duplicate-test-coverage: not-a-new-test -->
| 164-171 | Audit violations loop body in `run_impl` | Possibly — `run_impl_aggregates_violations_from_both_scanners` triggers this. Must verify. |
| 173-174 | Dup violations loop body in `run_impl` | No — no test triggers dup violations through `run_impl` |
| 304-307 | `resolve_branch` returns `None` | Not via `run_impl` — needs non-git-repo fixture |
| 340 | State file read `.map_err` closure | No |
| 342 | State file JSON parse `.map_err` closure | No |
| 353-354 | Legacy `plan_file` top-level fallback closures | No |

### Uncovered lines — plan_extract.rs

| Lines | Description | Pattern |
|-------|-------------|---------|
| 117, 121-122 | `load_frozen_config` — frozen file exists + map closures | Rare edge path |
| 327-328 | `count_tasks_any_level` — code-block toggle | Missing fixture |
| 365-376 | `violations_response` — audit + dup loop bodies | Scanner fixture |
| 412 | `complete_plan_phase` `.map_err` | `.map_err` closure |
| 431 | `run_impl` state file read `.map_err` | `.map_err` closure |
| 490, 529, 628, 682, 759 | `mutate_state` wrong-type guards (5 closures) | Defensive guard |
| 497, 536, 637, 692, 763 | `mutate_state` `.map_err` (5 closures) | `.map_err` closure |
| 621, 668 | `strip_prefix` `unwrap_or_else` | Edge path |
| 623, 670 | DAG/plan write `.map_err` | `.map_err` closure |
| 632, 686 | `files`-not-object inner guards | Defensive guard |
| 768, 770 | Re-read/re-parse state `.map_err` | `.map_err` closure |
| 774 | `pr_number` `.or_else` fallback | Edge path |

## Risks

- **`.map_err` closures on `mutate_state`**: `mutate_state` reads then writes the file. Making the state file unwritable (e.g. `chmod 444`) after it was readable should trigger the write failure. On macOS, file permissions are respected for non-root users. Must verify.
- **Wrong-type guards in `mutate_state` closures**: The guard `if !(state.is_object() || state.is_null()) { return; }` fires when the state file root is an array, number, or string. Writing `[]` or `"hello"` as state content exercises this, but `mutate_state` itself parses the JSON — the guard runs inside the closure after parse succeeds. Writing valid JSON with a non-object root (`[]`) should reach the guard.
- **Existing inline test coverage ambiguity**: Some lines show 0-hit in the flow-rs binary but may be covered by inline tests. The first Code-phase step should run a targeted `bin/flow test` and check the merged coverage to confirm which lines are truly uncovered before writing new tests.
- **`load_frozen_config` frozen file**: The frozen phases file uses `flow-phases.json` format. Creating a valid one in a temp dir exercises lines 117, 121-122.
- **Dup violations through `run_impl`**: The test must create a plan with a `fn <name>(` inside a code block where `<name>` collides with an existing test. Using a hermetic `TestCorpus` in unit tests would be cleaner, but `run_impl` constructs its own `TestCorpus::from_repo`. The test can use a plan referencing any test that currently exists in the repo (e.g. a long-named test from `tests/hooks.rs`).

## Approach

1. **Verify first**: Run targeted coverage to confirm which lines are truly uncovered after merging inline test coverage.
2. **Inline unit tests for `run_impl`-level gaps**: Most gaps are reachable by calling `run_impl` with crafted `Args` and fixture files. Use `tempfile::TempDir` for isolated fixtures.
3. **Subprocess test for `run()` Err branch**: The only path that calls `process::exit` and needs subprocess testing.
4. **Direct function tests for helpers**: `load_frozen_config`, `count_tasks_any_level`, `violations_response` can be tested by calling them directly from the inline test module.
5. **No refactoring needed**: All gaps are reachable from existing function signatures.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Verify current merged coverage | verify | — |
| 2. plan_check.rs inline tests | test | 1 |
| 3. plan_check.rs subprocess test | test | 1 |
| 4. plan_extract.rs helper unit tests | test | 1 |
| 5. plan_extract.rs run_impl edge-path tests | test | 1 |
| 6. Verify 100% and raise thresholds | verify | 2, 3, 4, 5 |

## Tasks

### Task 1: Verify current merged coverage

Run `bin/flow test -- plan_check` and `bin/flow test -- plan_extract` to get the current merged coverage baseline. Identify exactly which lines remain uncovered after inline tests contribute. This informs which new tests are truly needed vs. which are already covered.

- Files: none (verification only)

### Task 2: plan_check.rs inline unit tests

Add inline unit tests in `src/plan_check.rs` `#[cfg(test)] mod tests` for the uncovered `run_impl` and helper paths:

- `run_impl_plan_file_is_directory_returns_err`: Create a tempdir, write a state file pointing `files.plan` at a directory path. Call `run_impl` with `--plan-file <dir>`. Exercises lines 126-131 (non-NotFound I/O error).
- `run_impl_triggers_dup_violations`: Create a plan with `fn <colliding_name>(` in a fenced code block where the name matches an existing test. Call `run_impl` with `--plan-file`. Exercises lines 173-174 (dup violations loop).
- `resolve_plan_file_from_state_legacy_plan_file_fallback`: Create a state file with top-level `"plan_file": "legacy.md"` but no `files.plan`. Call `resolve_plan_file_from_state`. Exercises lines 353-354 (legacy fallback closures).
- `resolve_plan_file_from_state_invalid_json`: Create a state file with `{invalid json`. Call `resolve_plan_file_from_state`. Exercises line 342 (.map_err parse error).
- `resolve_plan_file_from_state_unreadable`: Create a state file path in a non-existent subdirectory so `read_to_string` fails with I/O error. Exercises line 340 (.map_err read error). Note: this may be hard to distinguish from the "file not found" path — the state file must exist for the `exists()` check on line 332 to pass but fail on read. Alternative: write the state file, chmod 000, then read. Must verify on macOS.

- Files: `src/plan_check.rs`
- TDD: Write tests, run targeted `bin/flow test -- plan_check`, confirm they pass and lines are now covered.

### Task 3: plan_check.rs subprocess test for run() Err branch

Add a subprocess test in `tests/plan_check.rs` that spawns `flow-rs plan-check` with a state file containing invalid JSON. The binary should exit with code 1 and print an error to stderr.

- `plan_check_invalid_json_state_exits_with_code_1`: Set up a git repo fixture with a `.flow-states/<branch>.json` containing `{not valid json`. Spawn the binary with `--branch <branch>`. Assert exit code is 1 and stderr contains error text. Exercises lines 57-59 (`run()` Err path).

- Files: `tests/plan_check.rs`
- TDD: Write test, run `bin/flow test -- plan_check`, confirm exit code 1 path is covered.

### Task 4: plan_extract.rs helper unit tests

Add inline unit tests in `src/plan_extract.rs` `#[cfg(test)] mod tests` for helper functions:

- `load_frozen_config_with_existing_file`: Create a tempdir with a valid `flow-phases.json`-format frozen file. Call `load_frozen_config`. Assert both returned Options are `Some`. Exercises lines 117, 121-122.
- `count_tasks_any_level_skips_code_blocks`: Call `count_tasks_any_level` with content containing `### Task 1:` inside a fenced code block. Assert count is 0. Exercises lines 327-328 (code-block toggle).
- `violations_response_includes_audit_violations`: Call `violations_response` with non-empty audit violations. Assert the JSON contains `"rule": "external-input-audit"`. Exercises lines 365-371.
- `violations_response_includes_dup_violations`: Call `violations_response` with non-empty dup violations. Assert the JSON contains `"rule": "duplicate-test-coverage"`. Exercises lines 373-376.

- Files: `src/plan_extract.rs`
- TDD: Write tests, run targeted `bin/flow test -- plan_extract`, confirm they pass.

### Task 5: plan_extract.rs run_impl edge-path tests

Add inline unit tests and/or subprocess tests for the remaining uncovered paths in `run_impl`:

- For **wrong-type guards** (lines 490, 529, 628, 682, 759): Write a state file with `[]` (valid JSON array) as root. Run the path that hits that `mutate_state`. The guard fires and returns early. Note: reaching the inner `mutate_state` calls requires the earlier state reads to succeed (they use `serde_json::from_str` which succeeds on `[]`), but subsequent `.get("files")` chains return `None` on arrays, which may cause different early returns. Must trace the execution path carefully. If the wrong-type guard is unreachable because an earlier read prevents reaching it, consider whether the guard is dead code and can be removed per `.claude/rules/no-waivers.md` option 3.
- For **files-not-object guards** (lines 632, 686): Write a state file with `{"files": 42, "phases": {"flow-start": {"status": "complete"}}, ...}`. The `files` field exists but is a number, triggering the `if !matches!(state.get("files"), Some(v) if v.is_object())` guard.
- For `.map_err` closures on `mutate_state` (lines 497, 536, 637, 692, 763): These fire when `mutate_state` fails to write. The most reliable trigger is to set the state file path to a directory (not a file), so `fs::write` inside `mutate_state` fails.
- For `strip_prefix` `unwrap_or_else` (lines 621, 668): These fire when `dag_abs` or `plan_abs` doesn't have `root` as a prefix. This would require `FlowPaths::dag_file()` or `plan_file()` to return a path outside `root`, which shouldn't happen in normal usage. If this is truly unreachable, remove the `unwrap_or_else` branch per option 3.

- Files: `src/plan_extract.rs`, possibly `tests/plan_extract.rs`
- TDD: Write tests, run targeted `bin/flow test -- plan_extract`, confirm they pass.

### Task 6: Verify 100% and raise thresholds

Run full `bin/flow ci`. Verify both files reach 100% on lines, regions, and functions. Raise the `--fail-under-lines`, `--fail-under-regions`, `--fail-under-functions` thresholds in `bin/test` to match the new aggregate TOTAL (whole percent, ~1% buffer below actual).

- Files: `bin/test`
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# DAG Analysis: Coverage sweep for src/plan_check.rs and src/plan_extract.rs

<dag goal="Coverage sweep for src/plan_check.rs and src/plan_extract.rs to 100%" mode="full">
  <plan>
    <node id="1" name="Classify plan_check.rs gaps" type="analysis" depends="[]" parallel_with="2">
      <objective>Map each uncovered line cluster in plan_check.rs to a test strategy (subprocess, inline unit, refactor)</objective>
    </node>
    <node id="2" name="Classify plan_extract.rs gaps" type="analysis" depends="[]" parallel_with="1">
      <objective>Map each uncovered line cluster in plan_extract.rs to a test strategy (subprocess, inline unit, refactor)</objective>
    </node>
    <node id="3" name="Identify shared patterns" type="analysis" depends="[1,2]" parallel_with="[]">
      <objective>Find common gap classes across both files and design shared fixture helpers</objective>
    </node>
    <node id="4" name="Design test plan" type="synthesis" depends="[3]" parallel_with="[]">
      <objective>Produce the ordered task list with TDD pairs, dependency graph, and risk analysis</objective>
    </node>
  </plan>
</dag>

---

## NODE 1: Classify plan_check.rs gaps

Based on the llvm-cov output, here are the uncovered line clusters in `plan_check.rs` with test strategies:

| Cluster | Lines | Description | Strategy |
|---------|-------|-------------|----------|
| A | 57-59 | `run()` Err branch — `json_error` + `exit(1)` | **Subprocess test**: spawn `bin/flow plan-check` with a state file whose JSON is corrupt (readable but unparseable). The `run_impl` returns `Err(String)`, `run()` prints to stderr and exits 1. |
| B | 126-131 | Non-NotFound I/O error reading plan file | **Inline unit test**: create state pointing at a path that is a directory, not a file. `read_to_string(dir)` returns an I/O error with kind != NotFound. |
| C | 164-171 | Audit violations loop body in `run_impl` | **Inline unit test**: write a plan fixture containing external-input-audit trigger prose (e.g. "add assert! on input") without an audit table. The audit scanner fires, populating the violations array. |
| D | 173-174 | Duplicate-test violations loop body in `run_impl` | **Inline unit test**: write a plan fixture containing a `fn existing_test_name(` inside a code block that collides with a real test in the repo. Requires TestCorpus setup. |
| E | 202-212 | `duplicate_violation_to_tagged_json` | Covered by inline test `duplicate_violation_json_shape_has_all_required_fields`. **Already covered in merged profdata.** |
| F | 238-242 | `build_violation_message` audit > 0 | Covered by inline test `message_names_only_audit_when_scope_count_is_zero`. **Already covered.** |
| G | 245-250 | `build_violation_message` dup > 0 | Covered by inline test `message_names_only_duplicate_when_others_are_zero`. **Already covered.** |
| H | 286 | `resolve_plan_file_override` relative path | Covered by inline test `relative_override_joins_project_root`. **Already covered.** |
| I | 304-307 | `resolve_branch` returns None | **Inline unit test**: call `run_impl` with `branch: None` and `plan_file: None` in a temp dir that is NOT a git repo. `resolve_branch` returns None, we get the business error JSON. |
| J | 322-329 | `FlowPaths::try_new` returns None | Covered by inline test `run_impl_does_not_panic_on_slash_branch`. **Already covered.** |
| K | 340 | State file read `.map_err` closure | **Subprocess test**: create a state file, chmod 000, run plan-check. Returns Err from the closure. Or: create a symlink to a non-existent file at the state path. |
| L | 342 | State file JSON parse `.map_err` closure | **Subprocess test or inline**: write invalid JSON to the state file. |
| M | 353-354 | Legacy `plan_file` fallback closures | **Inline unit test**: create state with `plan_file: "some-plan.md"` at the top level but no `files.plan`. The `or_else` branch fires. |

**Truly uncovered clusters needing new tests: A, B, C, D, I, K, L, M** (8 clusters)

Already covered by inline tests: E, F, G, H, J (5 clusters)

---

## NODE 2: Classify plan_extract.rs gaps

Based on the llvm-cov output, here are the uncovered line clusters in `plan_extract.rs`:

| Cluster | Lines | Description | Strategy |
|---------|-------|-------------|----------|
| N | 72-74 | `resolve_state` — branch None | **Inline unit test**: run_impl in non-git temp dir with no branch override. |
| O | 117 | `load_frozen_config` — frozen file exists | **Inline unit test**: create a frozen phases file and call `load_frozen_config`. |
| P | 121-122 | `load_frozen_config` — config.as_ref().map closures | Depends on cluster O. When frozen config exists AND is valid, these closures fire. |
| Q | 145 | `fetch_issue` — command fails (non-zero exit) | **Inline unit test with stub**: difficult without mocking. The gh command is a real subprocess. Could create a gh stub that returns exit 1. |
| R | 412 | `complete_plan_phase` — `mutate_state` `.map_err` closure | **Inline unit test**: pass a read-only state file path so mutate_state fails. |
| S | 431 | `run_impl` — state file read `.map_err` | Similar to plan_check K. Write unreadable state file. |
| T | 490 | Resume path — `mutate_state` closure, state wrong type guard | **Inline unit test**: write a state file where root is an array, not object. |
| U | 497 | Resume path — `mutate_state` `.map_err` | **Inline unit test**: pass read-only state path. |
| V | 529 | Standard path — state wrong type guard | Same as T but for the standard path's `mutate_state`. |
| W | 536 | Standard path — `mutate_state` `.map_err` | Same as U. |
| X | 621 | DAG path — `strip_prefix` unwrap_or_else | **Inline unit test**: construct FlowPaths where dag_abs doesn't have root as prefix. Unusual edge case. |
| Y | 623 | DAG write — `.map_err` | **Inline unit test**: set dag path to an unwritable directory. |
| Z | 628 | DAG state mutation — state wrong type guard | Same class as T/V. |
| AA | 632 | DAG state mutation — files not object, create empty | **Inline unit test**: state has `files` as a string, not object. |
| BB | 637 | DAG state mutation — `.map_err` | Same class as U/W. |
| CC | 668 | Plan path — `strip_prefix` unwrap_or_else | Same class as X. |
| DD | 670 | Plan write — `.map_err` | Same class as Y. |
| EE | 682 | Plan state mutation — state wrong type guard | Same class as T/V/Z. |
| FF | 686 | Plan state mutation — files not object guard | Same class as AA. |
| GG | 692 | Plan state mutation — `.map_err` | Same class as U/W/BB. |
| HH | 759 | PR render — state wrong type guard | Same class. |
| II | 763 | PR render — `.map_err` | Same class. |
| JJ | 768 | Re-read state — `.map_err` | Same class as S. |
| KK | 770 | Re-parse state — `.map_err` | Same class as S/JJ. |
| LL | 774 | PR number — `.or_else` fallback | **Inline unit test**: run the extracted path with `args.pr = None` and state has `pr_number`. |
| MM | 778 | `gh_set_body` call | Only fires when `pr` is Some. In the extracted path integration test, pr is None. |

**Pattern analysis:** Most uncovered lines fall into 4 classes:
1. **`.map_err` closures** (K, L, S, U, W, BB, GG, II, JJ, KK, R, Y, DD) — error paths on I/O or state mutation
2. **State wrong-type guards** (T, V, Z, EE, HH) — defensive `if !(state.is_object() || state.is_null())` returns
3. **Files-not-object guards** (AA, FF) — inner defensive guard
4. **Rare edge paths** (N, O, P, Q, X, CC, LL, MM)

---

## NODE 3: Identify shared patterns

**Shared gap classes across both files:**

1. **`.map_err` closure coverage** — Both files have multiple `.map_err(|e| format!("...", e))` closures at 0 hits. These are one-line closures that transform I/O errors into error strings. Strategy: **Test via the parent function** by causing the I/O operation to fail (unreadable file, missing directory, read-only path).

2. **`mutate_state` wrong-type guards** — Both files have `if !(state.is_object() || state.is_null()) { return; }` at the top of every `mutate_state` closure. Strategy: **A single test helper** that writes a state file containing `[]` (array) or `"string"` instead of `{}`, then runs the function. The guard fires and returns early.

3. **Files-not-object inner guards** — `plan_extract.rs` has `if !matches!(state.get("files"), Some(v) if v.is_object()) { state["files"] = json!({}); }` in 3 closures. Strategy: Write state with `"files": "not-an-object"` or `"files": 42`.

4. **Scanner violation loop bodies** — Both files aggregate violations from scope, audit, and dup scanners. `plan_check.rs` has scope covered but audit/dup at 0. `plan_extract.rs` has scope covered but audit/dup at 0. Strategy: Write plan fixtures that trigger each scanner independently.

**Shared fixture helpers needed:**

- `write_state_with_plan(dir, branch, plan_content)` — creates `.flow-states/<branch>.json` with `phases.flow-start.status: "complete"` and `files.plan` pointing at a written plan file
- `write_corrupt_state(dir, branch, content)` — writes arbitrary string as state file
- `write_state_array(dir, branch)` — writes `[]` as state file for wrong-type tests

---

## NODE 4: Design test plan (synthesis)

### Coverage Gap Summary

**plan_check.rs** — 34 missed lines. ~14 are already covered by inline unit tests (build_violation_message branches, resolve_plan_file_override relative path, try_new None slash-branch). The real gap is ~20 lines across: scanner violation loop bodies for audit+dup, .map_err closures, resolve_branch None, legacy plan_file fallback, and the run() Err branch.

**plan_extract.rs** — 33 missed lines. Dominated by repetitive defensive patterns: .map_err closures (~13 lines), mutate_state wrong-type guards (~5 lines), files-not-object inner guards (~2 lines), load_frozen_config exists path (~3 lines), and edge paths (strip_prefix, pr_number fallback, fetch_issue failure).

### Test Strategy

1. **Inline unit tests in both `src/plan_check.rs` and `src/plan_extract.rs`** for the bulk of coverage — run_impl-level tests with crafted fixtures
2. **One subprocess test in `tests/plan_check.rs`** for the `run()` Err branch (calls `process::exit`)
3. **Shared fixture pattern:** create temp git repo, write state files with specific shapes (corrupt, wrong-type, missing keys), write plan files with targeted scanner triggers

### Risk Analysis

- **`.map_err` closures on I/O operations**: Some are hard to trigger without filesystem tricks (permissions, read-only). On macOS, `chmod 000` on a file doesn't always prevent root from reading. Alternative: use a path inside a non-existent directory (causes NotFound on the directory, not the file — different error kind).
- **`fetch_issue` failure**: Requires a gh stub or mock. The integration tests already use `create_gh_stub`. For inline tests, this function can be tested indirectly.
- **`mutate_state` failure**: mutate_state fails when the file can't be written. Use a path in a non-existent directory.
- **Many "uncovered" lines in flow-rs binary are actually covered by inline tests** — about half the lines shown as 0-hit in the binary-specific coverage report are actually covered in merged profdata through inline unit tests.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 11m |
| Code | 1h 0m |
| Code Review | 20m |
| Learn | 2h 56m |
| Complete | 9m |
| **Total** | **4h 38m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/coverage-sweep-plan-phase.json</summary>

```json
{
  "schema_version": 1,
  "branch": "coverage-sweep-plan-phase",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1193,
  "pr_url": "https://github.com/benkruger/flow/pull/1193",
  "started_at": "2026-04-16T07:02:50-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/coverage-sweep-plan-phase-plan.md",
    "dag": ".flow-states/coverage-sweep-plan-phase-dag.md",
    "log": ".flow-states/coverage-sweep-plan-phase.log",
    "state": ".flow-states/coverage-sweep-plan-phase.json"
  },
  "session_tty": "/dev/ttys002",
  "session_id": "0db44029-c102-464d-9dcb-b04c4e5f3c14",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/0db44029-c102-464d-9dcb-b04c4e5f3c14.jsonl",
  "notes": [],
  "prompt": "work on issue #1141",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-16T07:02:50-07:00",
      "completed_at": "2026-04-16T07:03:26-07:00",
      "session_started_at": null,
      "cumulative_seconds": 36,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-16T07:03:36-07:00",
      "completed_at": "2026-04-16T07:14:46-07:00",
      "session_started_at": null,
      "cumulative_seconds": 670,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-16T07:15:37-07:00",
      "completed_at": "2026-04-16T08:15:56-07:00",
      "session_started_at": null,
      "cumulative_seconds": 3619,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-16T08:16:12-07:00",
      "completed_at": "2026-04-16T08:36:39-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1227,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-16T08:36:52-07:00",
      "completed_at": "2026-04-16T11:33:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 10588,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-16T11:35:45-07:00",
      "completed_at": "2026-04-16T11:45:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 598,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-16T07:03:36-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-16T07:15:37-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-16T08:16:12-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-16T08:36:52-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-16T11:35:45-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 6,
  "code_task_name": "Verify 100% and raise thresholds",
  "code_task": 6,
  "diff_stats": {
    "files_changed": 4,
    "insertions": 244,
    "deletions": 3,
    "captured_at": "2026-04-16T08:15:56-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "compact_summary": "You're out of extra usage · resets 11am (America/Los_Angeles)",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/coverage-sweep-plan-phase",
  "compact_count": 5,
  "findings": [
    {
      "finding": "Manual temp file in run_impl_triggers_dup_violations",
      "reason": "Consistent with existing pattern in same file; OS temp dir leak is harmless",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T08:30:07-07:00"
    },
    {
      "finding": "Weak assertion in complete_plan_phase test",
      "reason": "Test already asserts on message content with contains check",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T08:30:09-07:00"
    },
    {
      "finding": "chmod 000 test vacuous on root",
      "reason": "CI runs locally on macOS as non-root; test is valid in actual CI environment",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T08:30:10-07:00"
    },
    {
      "finding": "resolve_state uses FlowPaths::new on external branch",
      "reason": "Pre-existing code not modified by this PR; out of scope for coverage-only changes",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T08:30:11-07:00"
    },
    {
      "finding": "Structural coupling to live test name in dup violations test",
      "reason": "Coupling is within same file and visible to any editor; acceptable for coverage test",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T08:30:12-07:00"
    },
    {
      "finding": "Coverage threshold ratchet blocks start-gate",
      "reason": "Intentional design documented in bin/test; blocking coverage-inadequate PRs is the feature",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T08:30:13-07:00"
    },
    {
      "finding": "Doc comment suggestions for test functions",
      "reason": "Existing doc comments adequately describe test purpose; suggestions are style preferences",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T08:30:15-07:00"
    },
    {
      "finding": "count_tasks and count_tasks_any_level miss tilde fences",
      "reason": "CommonMark allows both backtick and tilde fences; adversarial tests proved tasks inside tilde blocks were counted",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T08:31:52-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/coverage-sweep-plan-phase.log</summary>

```text
2026-04-16T07:02:49-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-16T07:02:49-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-16T07:02:50-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-16T07:02:50-07:00 [Phase 1] create .flow-states/coverage-sweep-plan-phase.json (exit 0)
2026-04-16T07:02:50-07:00 [Phase 1] freeze .flow-states/coverage-sweep-plan-phase-phases.json (exit 0)
2026-04-16T07:02:50-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-16T07:02:51-07:00 [Phase 1] start-init — label-issues (labeled: [1141], failed: [])
2026-04-16T07:03:01-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-16T07:03:01-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-16T07:03:02-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-16T07:03:12-07:00 [Phase 1] start-workspace — worktree .worktrees/coverage-sweep-plan-phase (ok)
2026-04-16T07:03:16-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-16T07:03:16-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-16T07:03:16-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-16T07:03:26-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-16T07:03:26-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-16T07:09:35-07:00 [stop-continue] first stop, conditional continue: pending=decompose
2026-04-16T07:14:46-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-16T07:15:37-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-16T07:42:03-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T07:42:07-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T07:49:09-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T07:49:13-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T08:00:44-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T08:00:48-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T08:10:53-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T08:10:58-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T08:15:20-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T08:15:24-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T08:15:56-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-16T08:16:12-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-16T08:35:49-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-16T08:35:53-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-16T08:36:39-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-16T08:36:52-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-16T11:33:20-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-16T11:45:43-07:00 [Phase 6] complete-finalize — starting
2026-04-16T11:45:43-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-16T11:45:43-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>