### PR TITLE
Coverage Sweep Orchestration

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -74,9 +74,9 @@ fi
 #   produce LEAK lines during the run which pass through the awk filter in full)
 # pipefail (set above) preserves cargo llvm-cov's exit code.
 cargo llvm-cov --no-cfg-coverage --no-clean \
-  --fail-under-lines 94 \
-  --fail-under-regions 95 \
-  --fail-under-functions 93 \
+  --fail-under-lines 96 \
+  --fail-under-regions 96 \
+  --fail-under-functions 94 \
   nextest --status-level pass --final-status-level fail "$@" 2>&1 | awk '
 /^ *PASS / {
   printf "."

--- a/src/orchestrate_report.rs
+++ b/src/orchestrate_report.rs
@@ -509,6 +509,139 @@ mod tests {
         assert!(content.contains("Add PDF export"));
     }
 
+    // --- missing-field edge branches ---
+    //
+    // Each test guards a specific `unwrap_or(default)` branch in
+    // `generate_report`. If a future edit removes the default or
+    // changes the rendered sentinel, these tests catch it.
+
+    #[test]
+    fn report_missing_issue_number_renders_question_mark() {
+        let state = make_report_state(
+            vec![json!({
+                "title": "No issue number",
+                "outcome": "completed",
+                "pr_url": "https://github.com/x/y/pull/1",
+            })],
+            "2026-03-20T22:00:00-07:00",
+            Some("2026-03-21T06:00:00-07:00"),
+        );
+        let result = generate_report(&state);
+        let summary = result["summary"].as_str().unwrap();
+        assert!(
+            summary.contains("| #? "),
+            "expected `| #? ` sentinel cell, got: {}",
+            summary
+        );
+    }
+
+    #[test]
+    fn report_missing_title_renders_empty_title() {
+        let state = make_report_state(
+            vec![json!({
+                "issue_number": 99,
+                "outcome": "completed",
+                "pr_url": "https://github.com/x/y/pull/1",
+            })],
+            "2026-03-20T22:00:00-07:00",
+            Some("2026-03-21T06:00:00-07:00"),
+        );
+        let result = generate_report(&state);
+        let summary = result["summary"].as_str().unwrap();
+        // `#99 ` followed by empty title then ` | completed` in the row.
+        assert!(
+            summary.contains("| #99  | completed |"),
+            "expected empty-title row, got: {}",
+            summary
+        );
+    }
+
+    #[test]
+    fn report_missing_outcome_renders_pending() {
+        let state = make_report_state(
+            vec![json!({
+                "issue_number": 99,
+                "title": "Pending item",
+            })],
+            "2026-03-20T22:00:00-07:00",
+            Some("2026-03-21T06:00:00-07:00"),
+        );
+        let result = generate_report(&state);
+        let summary = result["summary"].as_str().unwrap();
+        assert!(
+            summary.contains("| pending |"),
+            "expected `pending` outcome cell, got: {}",
+            summary
+        );
+        // An item with no `outcome` is neither completed nor failed — no
+        // sections should list it.
+        assert_eq!(result["completed"], 0);
+        assert_eq!(result["failed"], 0);
+    }
+
+    #[test]
+    fn report_missing_pr_url_renders_em_dash() {
+        let state = make_report_state(
+            vec![json!({
+                "issue_number": 99,
+                "title": "No PR yet",
+                "outcome": "completed",
+            })],
+            "2026-03-20T22:00:00-07:00",
+            Some("2026-03-21T06:00:00-07:00"),
+        );
+        let result = generate_report(&state);
+        let summary = result["summary"].as_str().unwrap();
+        assert!(
+            summary.contains("| \u{2014} |"),
+            "expected em-dash pr_url cell, got: {}",
+            summary
+        );
+    }
+
+    #[test]
+    fn report_failed_item_missing_reason_renders_unknown() {
+        let state = make_report_state(
+            vec![json!({
+                "issue_number": 42,
+                "title": "Broken item",
+                "outcome": "failed",
+            })],
+            "2026-03-20T22:00:00-07:00",
+            Some("2026-03-21T06:00:00-07:00"),
+        );
+        let result = generate_report(&state);
+        let summary = result["summary"].as_str().unwrap();
+        assert!(
+            summary.contains("\u{2014} Unknown"),
+            "expected `Unknown` reason in Failed section, got: {}",
+            summary
+        );
+    }
+
+    #[test]
+    fn generate_and_write_report_write_failure_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_report_state(
+            vec![completed_item(42, "Add PDF export", None)],
+            "2026-03-20T22:00:00-07:00",
+            Some("2026-03-21T06:00:00-07:00"),
+        );
+        let state_path = dir.path().join("orchestrate.json");
+        fs::write(&state_path, serde_json::to_string(&state).unwrap()).unwrap();
+
+        // Pre-create the summary path as a directory so fs::write returns EISDIR.
+        let summary_path = dir.path().join("orchestrate-summary.md");
+        fs::create_dir(&summary_path).unwrap();
+
+        let result = generate_and_write_report(&state_path, dir.path());
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Failed to write summary"));
+    }
+
     // --- CLI run_impl tests ---
 
     #[test]

--- a/src/orchestrate_report.rs
+++ b/src/orchestrate_report.rs
@@ -221,27 +221,17 @@ pub struct Args {
 
 /// Testable implementation — returns the JSON Value to print.
 ///
-/// Returns `Ok(value)` for both success and application-error
-/// responses so the CLI prints the result and exits 0 in either case;
-/// the morning-report flow keeps running even when one orchestration
-/// queue file is malformed. `Err(msg)` is reserved for infrastructure
-/// failures (unreadable plugin root, etc.) that should exit 1.
-pub fn run_impl(args: &Args) -> Result<Value, String> {
-    Ok(generate_and_write_report(
-        Path::new(&args.state_file),
-        Path::new(&args.output_dir),
-    ))
+/// The morning-report flow keeps running even when one orchestration
+/// queue file is malformed: missing state files and corrupt JSON are
+/// surfaced as `{"status":"error", ...}` values, not as failures.
+/// There is no infrastructure-error path to distinguish, so the
+/// return type is `Value`, not `Result`.
+pub fn run_impl(args: &Args) -> Value {
+    generate_and_write_report(Path::new(&args.state_file), Path::new(&args.output_dir))
 }
 
 pub fn run(args: Args) {
-    match run_impl(&args) {
-        Ok(value) => {
-            println!("{}", value);
-        }
-        Err(msg) => {
-            println!("{}", json!({"status": "error", "message": msg}));
-        }
-    }
+    println!("{}", run_impl(&args));
 }
 
 #[cfg(test)]
@@ -540,7 +530,7 @@ mod tests {
             output_dir: dir.path().to_string_lossy().to_string(),
         };
 
-        let result = run_impl(&args).unwrap();
+        let result = run_impl(&args);
         assert_eq!(result["status"], "ok");
         assert_eq!(result["completed"], 1);
         assert_eq!(result["failed"], 1);
@@ -559,7 +549,7 @@ mod tests {
             output_dir: dir.path().to_string_lossy().to_string(),
         };
 
-        let result = run_impl(&args).unwrap();
+        let result = run_impl(&args);
         assert_eq!(result["status"], "error");
         assert!(result["message"].as_str().unwrap().contains("not found"));
     }
@@ -575,7 +565,7 @@ mod tests {
             output_dir: dir.path().to_string_lossy().to_string(),
         };
 
-        let result = run_impl(&args).unwrap();
+        let result = run_impl(&args);
         assert_eq!(result["status"], "error");
     }
 }

--- a/src/orchestrate_state.rs
+++ b/src/orchestrate_state.rs
@@ -73,15 +73,12 @@ pub fn create_state(queue: &[Value], state_dir: &Path) -> Value {
         "current_index": null,
     });
 
-    match serde_json::to_string_pretty(&state) {
-        Ok(content) => {
-            if let Err(e) = std::fs::write(&state_path, content) {
-                return json!({"status": "error", "message": format!("Failed to write state: {}", e)});
-            }
-            json!({"status": "ok"})
-        }
-        Err(e) => json!({"status": "error", "message": format!("Failed to serialize: {}", e)}),
+    // serde_json::to_string_pretty on a `json!({...})` literal is infallible.
+    let content = serde_json::to_string_pretty(&state).expect("json! literal serializes");
+    if let Err(e) = std::fs::write(&state_path, content) {
+        return json!({"status": "error", "message": format!("Failed to write state: {}", e)});
     }
+    json!({"status": "ok"})
 }
 
 /// Mark queue item at index as in_progress.

--- a/src/orchestrate_state.rs
+++ b/src/orchestrate_state.rs
@@ -1204,4 +1204,351 @@ mod tests {
         let result = run_impl(&args).unwrap();
         assert_eq!(result["status"], "error");
     }
+
+    // --- build_queue_item ---
+
+    #[test]
+    fn build_queue_item_missing_issue_number_defaults_to_zero() {
+        let item = build_queue_item(&json!({"title": "No number"}));
+        assert_eq!(item["issue_number"], 0);
+        assert_eq!(item["title"], "No number");
+    }
+
+    #[test]
+    fn build_queue_item_missing_title_defaults_to_empty() {
+        let item = build_queue_item(&json!({"issue_number": 42}));
+        assert_eq!(item["issue_number"], 42);
+        assert_eq!(item["title"], "");
+    }
+
+    // --- start_issue edge branches ---
+
+    #[test]
+    fn start_issue_negative_index_returns_out_of_range() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        create_state(&sample_queue(), &state_dir);
+        let state_path = state_dir.join("orchestrate.json");
+
+        let result = start_issue(&state_path, -1);
+        assert_eq!(result["status"], "error");
+        assert!(result["message"].as_str().unwrap().contains("out of range"));
+    }
+
+    #[test]
+    fn start_issue_queue_item_non_object_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        fs::create_dir_all(&state_dir).unwrap();
+        let state_path = state_dir.join("orchestrate.json");
+        // Valid object root with a non-object queue entry — bypasses the
+        // root-level guard and hits the per-item guard at start_issue:120-124.
+        fs::write(
+            &state_path,
+            serde_json::to_string_pretty(&json!({
+                "started_at": "2026-03-20T22:00:00-07:00",
+                "completed_at": null,
+                "queue": [42],
+                "current_index": null,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let result = start_issue(&state_path, 0);
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Queue item is not a JSON object"));
+    }
+
+    #[test]
+    fn start_issue_mutate_state_io_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // state_path points to a directory — Path::exists() returns true
+        // (short-circuits the "not found" early-return), then mutate_state's
+        // OpenOptions::open fails with EISDIR.
+        let state_path = dir.path().join("orchestrate.json");
+        fs::create_dir(&state_path).unwrap();
+
+        let result = start_issue(&state_path, 0);
+        assert_eq!(result["status"], "error");
+        // mutate_state's Io variant formats as "I/O error: ...".
+        assert!(
+            result["message"].as_str().unwrap().contains("I/O error"),
+            "expected I/O error, got: {}",
+            result["message"]
+        );
+    }
+
+    // --- record_outcome edge branches ---
+
+    #[test]
+    fn record_outcome_negative_index_returns_out_of_range() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        create_state(&sample_queue(), &state_dir);
+        let state_path = state_dir.join("orchestrate.json");
+
+        let result = record_outcome(&state_path, -1, "completed", None, None, None);
+        assert_eq!(result["status"], "error");
+        assert!(result["message"].as_str().unwrap().contains("out of range"));
+    }
+
+    #[test]
+    fn record_outcome_queue_item_non_object_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        fs::create_dir_all(&state_dir).unwrap();
+        let state_path = state_dir.join("orchestrate.json");
+        fs::write(
+            &state_path,
+            serde_json::to_string_pretty(&json!({
+                "started_at": "2026-03-20T22:00:00-07:00",
+                "completed_at": null,
+                "queue": ["not-an-object"],
+                "current_index": null,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let result = record_outcome(&state_path, 0, "completed", None, None, None);
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Queue item is not a JSON object"));
+    }
+
+    #[test]
+    fn record_outcome_empty_pr_url_not_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        create_state(&sample_queue(), &state_dir);
+        let state_path = state_dir.join("orchestrate.json");
+
+        let result = record_outcome(&state_path, 0, "completed", Some(""), None, None);
+        assert_eq!(result["status"], "ok");
+
+        let content = fs::read_to_string(&state_path).unwrap();
+        let state: Value = serde_json::from_str(&content).unwrap();
+        // pr_url should still be null (the empty-string filter prevented the write).
+        assert!(state["queue"][0]["pr_url"].is_null());
+    }
+
+    #[test]
+    fn record_outcome_empty_branch_not_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        create_state(&sample_queue(), &state_dir);
+        let state_path = state_dir.join("orchestrate.json");
+
+        let result = record_outcome(&state_path, 0, "completed", None, Some(""), None);
+        assert_eq!(result["status"], "ok");
+
+        let content = fs::read_to_string(&state_path).unwrap();
+        let state: Value = serde_json::from_str(&content).unwrap();
+        assert!(state["queue"][0]["branch"].is_null());
+    }
+
+    #[test]
+    fn record_outcome_empty_reason_not_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        create_state(&sample_queue(), &state_dir);
+        let state_path = state_dir.join("orchestrate.json");
+
+        let result = record_outcome(&state_path, 0, "failed", None, None, Some(""));
+        assert_eq!(result["status"], "ok");
+
+        let content = fs::read_to_string(&state_path).unwrap();
+        let state: Value = serde_json::from_str(&content).unwrap();
+        assert!(state["queue"][0]["reason"].is_null());
+    }
+
+    // --- read_state edge branches ---
+
+    #[test]
+    fn read_state_corrupt_json_returns_invalid_json_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("orchestrate.json");
+        fs::write(&state_path, "{bad json").unwrap();
+
+        let result = read_state(&state_path);
+        assert_eq!(result["status"], "error");
+        assert!(result["message"].as_str().unwrap().contains("Invalid JSON"));
+    }
+
+    #[test]
+    fn read_state_fs_read_error_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // state_path points to a directory — fs::read_to_string returns Err.
+        let state_path = dir.path().join("orchestrate.json");
+        fs::create_dir(&state_path).unwrap();
+
+        let result = read_state(&state_path);
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Failed to read"));
+    }
+
+    // --- next_issue edge branches ---
+
+    #[test]
+    fn next_issue_corrupt_json_returns_invalid_json_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("orchestrate.json");
+        fs::write(&state_path, "{bad json").unwrap();
+
+        let result = next_issue(&state_path);
+        assert_eq!(result["status"], "error");
+        assert!(result["message"].as_str().unwrap().contains("Invalid JSON"));
+    }
+
+    #[test]
+    fn next_issue_no_queue_key_returns_done() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("orchestrate.json");
+        fs::write(&state_path, "{}").unwrap();
+
+        let result = next_issue(&state_path);
+        assert_eq!(result["status"], "done");
+    }
+
+    #[test]
+    fn next_issue_fs_read_error_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("orchestrate.json");
+        fs::create_dir(&state_path).unwrap();
+
+        let result = next_issue(&state_path);
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Failed to read"));
+    }
+
+    // --- create_state edge branches ---
+
+    #[test]
+    fn create_state_existing_corrupt_json_overwrites() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        fs::create_dir_all(&state_dir).unwrap();
+        // Existing but corrupt — the `if let Ok(existing) = ...` guard
+        // at create_state:56 is False, so the "already in progress" check
+        // is skipped and the file gets overwritten.
+        fs::write(state_dir.join("orchestrate.json"), "{bad json").unwrap();
+
+        let result = create_state(&sample_queue(), &state_dir);
+        assert_eq!(result["status"], "ok");
+
+        let content = fs::read_to_string(state_dir.join("orchestrate.json")).unwrap();
+        let state: Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(state["queue"].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn orchestrate_create_state_write_failure_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        fs::create_dir_all(&state_dir).unwrap();
+        // Pre-create the target path as a directory — fs::write EISDIRs.
+        fs::create_dir(state_dir.join("orchestrate.json")).unwrap();
+
+        let result = create_state(&sample_queue(), &state_dir);
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Failed to write state"));
+    }
+
+    #[test]
+    fn create_state_create_dir_all_failure_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // The "parent" for state_dir is a regular file — create_dir_all
+        // cannot descend into it, returning Err.
+        let blocker = dir.path().join("blocker");
+        fs::write(&blocker, "not a directory").unwrap();
+        let state_dir = blocker.join(".flow-states");
+
+        let result = create_state(&sample_queue(), &state_dir);
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Failed to create directory"));
+    }
+
+    // --- run_impl --create error branches ---
+
+    #[test]
+    fn run_impl_create_missing_queue_file_returns_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let args = Args {
+            create: true,
+            start_issue: None,
+            record_outcome: None,
+            complete: false,
+            read: false,
+            next: false,
+            queue_file: Some(
+                dir.path()
+                    .join("nonexistent.json")
+                    .to_string_lossy()
+                    .to_string(),
+            ),
+            state_dir: Some(dir.path().to_string_lossy().to_string()),
+            state_file: None,
+            outcome: None,
+            pr_url: None,
+            branch: None,
+            reason: None,
+        };
+
+        let result = run_impl(&args);
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Failed to read queue file"),
+            "expected read-failure err, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn run_impl_create_malformed_queue_json_returns_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let queue_file = dir.path().join("queue.json");
+        fs::write(&queue_file, "{bad json").unwrap();
+
+        let args = Args {
+            create: true,
+            start_issue: None,
+            record_outcome: None,
+            complete: false,
+            read: false,
+            next: false,
+            queue_file: Some(queue_file.to_string_lossy().to_string()),
+            state_dir: Some(dir.path().to_string_lossy().to_string()),
+            state_file: None,
+            outcome: None,
+            pr_url: None,
+            branch: None,
+            reason: None,
+        };
+
+        let result = run_impl(&args);
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Invalid queue JSON"),
+            "expected parse-failure err, got: {}",
+            err
+        );
+    }
 }

--- a/tests/orchestrate_subprocess.rs
+++ b/tests/orchestrate_subprocess.rs
@@ -76,3 +76,100 @@ fn orchestrate_report_run_happy_path_prints_ok_status() {
     // The summary file should exist as a side effect.
     assert!(root.join("orchestrate-summary.md").exists());
 }
+
+/// Happy-path spawn of `flow-rs orchestrate-state --read` — verifies
+/// the `run()` wrapper's `println!(Ok(value))` line by dispatching a
+/// read against a pre-written valid state file.
+#[test]
+fn orchestrate_state_run_read_happy_path_prints_ok_status() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+
+    let state = json!({
+        "started_at": "2026-03-20T22:00:00-07:00",
+        "completed_at": null,
+        "queue": [{
+            "issue_number": 42,
+            "title": "Sample issue",
+            "status": "pending",
+            "started_at": null,
+            "completed_at": null,
+            "outcome": null,
+            "pr_url": null,
+            "branch": null,
+            "reason": null,
+        }],
+        "current_index": null,
+    });
+    let state_path = root.join("orchestrate.json");
+    fs::write(&state_path, serde_json::to_string(&state).unwrap()).unwrap();
+
+    let output = Command::new(FLOW_RS)
+        .arg("orchestrate-state")
+        .arg("--read")
+        .arg("--state-file")
+        .arg(&state_path)
+        .env_remove("FLOW_CI_RUNNING")
+        .output()
+        .expect("failed to spawn flow-rs");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "expected exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"status\":\"ok\""),
+        "expected stdout to contain \"status\":\"ok\", got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("\"state\""),
+        "expected stdout to contain the state payload, got: {}",
+        stdout
+    );
+}
+
+/// Err-path spawn of `flow-rs orchestrate-state --create` — verifies
+/// the `run()` wrapper's `println!(Err(msg))` arm by pointing
+/// `--queue-file` at a nonexistent path so `run_impl` returns Err,
+/// forcing the wrapper into its error-printing branch.
+#[test]
+fn orchestrate_state_run_create_missing_queue_file_prints_error_status() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let missing_queue = root.join("nonexistent-queue.json");
+    let state_dir = root.join(".flow-states");
+
+    let output = Command::new(FLOW_RS)
+        .arg("orchestrate-state")
+        .arg("--create")
+        .arg("--queue-file")
+        .arg(&missing_queue)
+        .arg("--state-dir")
+        .arg(&state_dir)
+        .env_remove("FLOW_CI_RUNNING")
+        .output()
+        .expect("failed to spawn flow-rs");
+
+    // run_impl's Err is caught and printed by run(); exit stays 0.
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "expected exit 0 (run prints Err and exits 0), stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"status\":\"error\""),
+        "expected stdout to contain \"status\":\"error\", got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Failed to read queue file"),
+        "expected stdout to name the read-failure step, got: {}",
+        stdout
+    );
+}

--- a/tests/orchestrate_subprocess.rs
+++ b/tests/orchestrate_subprocess.rs
@@ -1,0 +1,78 @@
+//! Subprocess-level coverage for the `orchestrate-report` and
+//! `orchestrate-state` CLI wrappers.
+//!
+//! Spawning the compiled `flow-rs` binary with real args exercises the
+//! `run()` wrapper's `println!` lines, which in-process `run_impl` tests
+//! cannot reach. cargo-llvm-cov instruments subprocess calls to the
+//! same binary, so the branches land in the coverage report.
+//!
+//! Follows the `tests/main_dispatch.rs` spawn pattern
+//! (`env!("CARGO_BIN_EXE_flow-rs")`) and
+//! `.claude/rules/testing-gotchas.md` macOS Subprocess Path
+//! Canonicalization (tempdir root canonicalized before descendant path
+//! construction).
+
+use std::fs;
+use std::process::Command;
+
+use serde_json::json;
+
+const FLOW_RS: &str = env!("CARGO_BIN_EXE_flow-rs");
+
+/// Happy-path spawn of `flow-rs orchestrate-report` — verifies that the
+/// `run()` wrapper's `println!(run_impl(&args))` line prints the
+/// morning-report JSON with `"status":"ok"` and an exit code of 0.
+#[test]
+fn orchestrate_report_run_happy_path_prints_ok_status() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+
+    let state = json!({
+        "started_at": "2026-03-20T22:00:00-07:00",
+        "completed_at": "2026-03-21T06:00:00-07:00",
+        "queue": [{
+            "issue_number": 42,
+            "title": "Add PDF export",
+            "status": "completed",
+            "started_at": "2026-03-20T22:05:00-07:00",
+            "completed_at": "2026-03-20T23:00:00-07:00",
+            "outcome": "completed",
+            "pr_url": "https://github.com/test/test/pull/42",
+            "branch": "issue-42",
+            "reason": null,
+        }],
+        "current_index": null,
+    });
+    let state_path = root.join("orchestrate.json");
+    fs::write(&state_path, serde_json::to_string(&state).unwrap()).unwrap();
+
+    let output = Command::new(FLOW_RS)
+        .arg("orchestrate-report")
+        .arg("--state-file")
+        .arg(&state_path)
+        .arg("--output-dir")
+        .arg(&root)
+        .env_remove("FLOW_CI_RUNNING")
+        .output()
+        .expect("failed to spawn flow-rs");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "expected exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"status\":\"ok\""),
+        "expected stdout to contain \"status\":\"ok\", got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("\"completed\":1"),
+        "expected stdout to contain \"completed\":1, got: {}",
+        stdout
+    );
+    // The summary file should exist as a side effect.
+    assert!(root.join("orchestrate-summary.md").exists());
+}


### PR DESCRIPTION
## What

work on issue #1144.

Closes #1144

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/coverage-sweep-orchestration-plan.md` |
| DAG | `.flow-states/coverage-sweep-orchestration-dag.md` |
| Log | `.flow-states/coverage-sweep-orchestration.log` |
| State | `.flow-states/coverage-sweep-orchestration.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/140a752a-67f8-42c7-939c-f1d27755f747.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Implementation Plan — Coverage Sweep Orchestration (Issue #1144)

## Context

Issue #1144 — raise coverage on `src/orchestrate_report.rs` (94.88%
lines, 21 missed) and `src/orchestrate_state.rs` (96.63% lines, 30
missed) toward 100% on lines/regions/functions. No waivers per
`.claude/rules/no-waivers.md`. After coverage lands, bump `bin/test`
thresholds to the new floor so the ratchet captures the gain.

## Exploration

| File | Role | Status |
|---|---|---|
| `src/orchestrate_report.rs` | Morning-report generator (pure fns + `run_impl` + `run`) | 18 existing in-process tests target `run_impl` and helpers. `run` wrapper's `println!` lines on the Ok arm are uncovered. Several small edge branches (`unwrap_or("?")`, `unwrap_or("")`, `unwrap_or("pending")`, `unwrap_or("Unknown")`, `unwrap_or("\u{2014}")`) are uncovered. `fs::write` failure in `generate_and_write_report` uncovered. The `run()` wrapper's `Err(msg)` arm is unreachable today — `run_impl` returns `Ok(...)` unconditionally. |
| `src/orchestrate_state.rs` | Orchestrate-queue state CRUD (6 pure fns + `run_impl` + `run`) | 30 existing in-process tests target `run_impl` and helpers. `run` wrapper's `println!` lines on both Ok and Err arms are uncovered. `build_queue_item` default branches on missing `issue_number`/`title` uncovered. Several negative-index branches uncovered. Per-item "Queue item is not a JSON object" branches uncovered (existing tests hit the sibling root-level object guard). Empty-string filter branches on `pr_url`/`branch`/`reason` in `record_outcome` uncovered. `read_state` / `next_issue` corrupt-JSON and fs-read-error arms uncovered. `create_state` write-failure, create_dir_all-failure, and existing-but-corrupt-JSON arms uncovered. `create_state`'s `Err(e)` match arm on `serde_json::to_string_pretty(&state)` is unreachable — serializing a `json!({...})` `Value` cannot fail. | <!-- duplicate-test-coverage: not-a-new-test -->
| `tests/main_dispatch.rs` | Existing subprocess dispatch test (lines 103-104) | Covers `--help` for both subcommands. Does NOT run the `run()` wrapper, so the `println!` paths remain uncovered by the existing suite. |
| `tests/orchestrate_subprocess.rs` (new) | New integration test file | Will spawn `flow-rs orchestrate-report` and `flow-rs orchestrate-state` with real args to hit the `run()` wrapper's `println!` lines through the compiled binary surface. cargo-llvm-cov instruments subprocess spawns of the same binary. |
| `bin/test` (lines 77-79) | CI runner, current thresholds `lines=94 regions=95 functions=93` | Bump to `floor(new_total)` for each metric after all coverage tasks land. |
| `src/lock.rs::mutate_state` | State mutation helper (verified during exploration) | Does NOT auto-heal non-object roots — passes parsed JSON directly to `transform_fn`. Therefore `test_start_issue_non_object_state` (which writes `[1,2,3]` root) DOES reach the root-level "State file is not a JSON object" branch. The per-item "Queue item is not a JSON object" branches at `start_issue:120-124` and `record_outcome:174-178` are the uncovered ones — require a valid object root with a non-object queue entry. | <!-- duplicate-test-coverage: not-a-new-test -->

<!-- duplicate-test-coverage: not-a-new-test -->
**Superseded code** (per `.claude/rules/supersession.md`): two
unreachable branches are dead in the PR's wake and will be deleted in
Task 1 — the `Err(e)` match arm of `serde_json::to_string_pretty(&state)`
inside `create_state` (serialization of a `json!` literal cannot fail), <!-- duplicate-test-coverage: not-a-new-test -->
<!-- duplicate-test-coverage: not-a-new-test -->
and the `Err(msg)` arm of `orchestrate_report::run()` (which has no
reachable `Err` producer from `run_impl`). The `Err(msg)` arm of
`orchestrate_state::run()` IS reachable (via `--create --queue-file
/nonexistent`) and is kept + tested in Task 7.

## Risks

1. **Write-failure branch portability.** `chmod 0o555` is unreliable
   across macOS tempfile and CI. Mitigation: pre-create the target path
   as a directory so `fs::write` returns EISDIR. This is the pattern
   used for `orchestrate_create_state_write_failure_returns_error`,
   `generate_and_write_report_write_failure_returns_error`, and any
   mutate_state-backed write-failure case. Portable on macOS, Linux,
   and CI.

2. **`mutate_state` write-failure inside start_issue/record_outcome is
   hard to provoke.** `mutate_state` opens the file with `OpenOptions::new().read(true).write(true).open(state_path)` — if the
   state file is actually a directory, the `open` itself fails with
   EISDIR (I/O error), so the `mutate_state` I/O error arm is
   reachable. The per-arm test `start_issue_mutate_state_io_error`
   covers this.

3. **Host-environment leak.** Neither module calls `project_root()` or
   `current_branch()`; both take explicit `Path` args. No risk per
   `.claude/rules/testing-gotchas.md`.

4. **Rust parallel-test env-var races.** Neither module reads env
   vars. No risk.

5. **Threshold computation concurrency.** The threshold bump must land
   in the same PR as the coverage tasks so `start-gate`'s CI-on-main
   serialization (per CLAUDE.md "Start-Gate CI on Main as
   Serialization Point") catches a coverage regression on the first
   post-merge flow-start, not the second. Task 11 sequences after
   coverage measurement in Task 10.

6. **`start-gate` long-lived target-dir stale-covmap hazard.**
   Full-suite `bin/test` runs `cargo clean -p flow-rs --target-dir
   target/llvm-cov-target` at the top per `.claude/rules/tool-dispatch.md`.
   Invariant preserved — the threshold-capture run (Task 10) inherits
   this.

7. **Issue body's "gh/GitHub failure paths" claim is wrong for these
   two files.** Script Behavior Verification catch: neither
   `orchestrate_report.rs` nor `orchestrate_state.rs` spawns any gh
   subprocess. The issue body likely copy-pasted from a sibling
   coverage-sweep issue targeting `src/orchestrate.rs` (the
   orchestrator itself, not in this scope). Plan proceeds with the
   actual gaps from reading the code.

8. **No-waivers enforcement.** Per `.claude/rules/no-waivers.md`,
   every gap closes via a subprocess test, a refactor, or a
   delete-dead-branch. No `test_coverage.md` entries. This plan uses
   subprocess tests (Tasks 4, 7) and dead-branch deletion (Task 1);
   the remaining gaps are direct unit tests.

9. **Extract-helper rule does not apply.** No task proposes
   extracting a block into a new helper. The existing
   `run_impl(args) -> Result<Value, String>` seam handles every
   testable branch. No Branch Enumeration Table required per
   `.claude/rules/extract-helper-refactor.md`.

10. **New test names must not collide with existing tests.**
    Verified against the full test corpus of both modules: the 25
    new test function names proposed in Tasks 2, 4, 5, and 7 all
    normalize to distinct identifiers from every existing `test_*`
    function in `src/orchestrate_report.rs`,
    `src/orchestrate_state.rs`, and the rest of the repo.

## Approach

Close coverage gaps in two modules by:

1. **Deleting the two unreachable `Err` arms** identified during
   exploration (Task 1) — per `.claude/rules/no-waivers.md` response
   #3 and `.claude/rules/supersession.md`.
2. **Writing targeted unit tests** against the existing `run_impl`
   seam for every edge branch in both modules (Tasks 2, 5).
3. **Adding subprocess tests** for the `run()` wrappers' `println!`
   paths through the compiled binary (Tasks 4, 7). New test file
   `tests/orchestrate_subprocess.rs`.
4. **Measuring the new aggregate TOTAL** with a full-suite
   `bin/flow ci` run (Task 10) and bumping the `bin/test` thresholds
   (Task 11) to `floor(new_total)` for each of the three metrics
   (lines, regions, functions).
5. **Final verification** with a clean `bin/flow ci` (Task 12) to
   prove the new floors pass.

Architecture is unchanged. No new seams. No new files other than
`tests/orchestrate_subprocess.rs`. The existing
`run_impl(args) -> Result<Value, String>` pattern (per
`.claude/rules/rust-patterns.md` CLI Testability) is the canonical
seam and already in place.

**`bin/test` threshold convention.** The floor is the whole-percent
floor of the new aggregate TOTAL, no buffer — per the committed
`bin/test` doc comment: "the floor of the current aggregate TOTAL —
i.e., `floor(actual_whole_percent)`." The issue body's "~1% buffer
below actual" language predates the no-waivers ratchet discipline
on main; this plan follows the `bin/test` convention.

## Dependency Graph

| Task | Type | Depends On |
|---|---|---|
| 1. Delete unreachable `Err` arms (orchestrate_report::run, create_state serialize) | implement | — |
| 2. Unit tests for orchestrate_report.rs edge branches | test | 1 |
| 3. Any pure-branch fix needed by Task 2 (expected: none) | implement | 2 |
| 4. Subprocess test for orchestrate_report::run() happy path | test | 1 |
| 5. Unit tests for orchestrate_state.rs edge branches | test | — |
| 6. Any pure-branch fix needed by Task 5 (expected: none) | implement | 5 |
| 7. Subprocess tests for orchestrate_state::run() (Ok path + Err path) | test | — |
| 8. Run full-suite `bin/flow ci`, capture new aggregate TOTAL | verify | 1, 2, 3, 4, 5, 6, 7 |
| 9. Bump `bin/test` thresholds to floor of new TOTAL | implement | 8 |
| 10. Final `bin/flow ci` verification against new floors | verify | 9 |

## Tasks

Each task follows TDD (test precedes implementation) per
`.claude/rules/skill-authoring.md` Plan Task Ordering. Each task
increments `code_task` by 1 per `.claude/rules/code-task-counter.md`.
No atomic commit groups required — each task is independently
shippable and leaves `bin/flow ci` green.

### Task 1 — Delete unreachable `Err` arms

**Files:** `src/orchestrate_report.rs`, `src/orchestrate_state.rs`.

**What:**

- In `src/orchestrate_report.rs::run()`, delete the `Err(msg)` match
  arm and collapse the `match` into an unconditional
  `println!("{}", run_impl(&args).expect_ok())` — or a simpler form
  that fits the now-Ok-only return. `run_impl` returns `Ok(...)`
  unconditionally, so the `Err` arm is dead code per
  `.claude/rules/supersession.md`.
- In `src/orchestrate_state.rs::create_state()`, delete the `Err(e)`
  match arm on `serde_json::to_string_pretty(&state)` (lines 83-84).
  Serializing a `json!({...})` literal `Value` cannot fail. Collapse
  the match into an unwrap-or-direct-use. Keep the sibling `Err`
  arm in `run()` — that one IS reachable via `--create
  --queue-file /nonexistent`.

**Tests:** None new — existing tests cover the happy paths and will
still pass. The deletions are `Testable directly` under
`.claude/rules/no-waivers.md` response #3 (delete-dead-branch).

**Tombstone:** Not required per `.claude/rules/tombstone-tests.md`
"When to Add" — these are inline match arms, not named features or
config axes.

### Task 2 — Unit tests for orchestrate_report.rs edge branches

**File:** `src/orchestrate_report.rs` (extend the existing
`#[cfg(test)] mod tests` block).

**New tests (all direct unit tests against pure helpers):**

```rust
fn report_missing_issue_number_renders_question_mark() { /* queue item without issue_number → results-table cell contains "#?" */ }
fn report_missing_title_renders_empty_title() { /* queue item without title → results-table cell renders with empty title string */ }
fn report_missing_outcome_renders_pending() { /* queue item without outcome → results-table outcome cell renders "pending" */ }
fn report_missing_pr_url_renders_em_dash() { /* queue item without pr_url → results-table cell renders "\u{2014}" */ }
fn report_failed_item_missing_reason_renders_unknown() { /* failed item without reason → Failed section renders "Unknown" */ }
fn generate_and_write_report_write_failure_returns_error() { /* pre-create `<output_dir>/orchestrate-summary.md` as a directory → fs::write returns EISDIR → returns {"status":"error","message":"Failed to write summary: ..."} */ }
```

**TDD Notes:** Each test constructs a state fixture with one or
more missing optional fields in a queue item, calls
`generate_report(&state)` (or `generate_and_write_report` for the
write-failure test), and asserts on specific substrings in the
rendered summary. The write-failure test uses the
directory-at-target-path trick from Risks #1. Test-name regression
guards: each test guards the specific missing-field branch in
`generate_report` that would otherwise go uncovered.

### Task 3 — Pure-branch fix (if needed)

**Files:** `src/orchestrate_report.rs`.

**What:** No changes expected. If any of Task 2's tests reveal an
actual bug (not expected — fns are already correct), fix here.
Otherwise commit empty (the commit skill handles the empty-diff
"Nothing to commit" return path per CLAUDE.md Conventions).

### Task 4 — Subprocess test for orchestrate_report::run() happy path

**File:** `tests/orchestrate_subprocess.rs` (NEW).

**New test:**

```rust
fn orchestrate_report_run_happy_path_prints_ok_status() { /* spawn flow-rs orchestrate-report --state-file <tmp/orchestrate.json> --output-dir <tmp>, assert exit 0 and stdout contains "status":"ok" */ }
```

**TDD Notes:** Pre-write a valid orchestrate.json via
`serde_json::to_string` of a `json!({...})` fixture matching the
schema used in `orchestrate_report::tests::make_report_state`.
Use `env!("CARGO_BIN_EXE_flow-rs")` to locate the compiled binary,
per `tests/main_dispatch.rs` reference pattern. Follow
`.claude/rules/testing-gotchas.md` "macOS Subprocess Path
Canonicalization" — canonicalize the tempdir root. Exercises the
`run()` wrapper's `println!(value)` line — the only remaining
uncovered line in that module after Task 1.

### Task 5 — Unit tests for orchestrate_state.rs edge branches

**File:** `src/orchestrate_state.rs` (extend the existing
`#[cfg(test)] mod tests` block).

**New tests (all direct unit tests against pure helpers):**

```rust
fn build_queue_item_missing_issue_number_defaults_to_zero() { /* json!({"title":"x"}) → item["issue_number"] == 0 */ }
fn build_queue_item_missing_title_defaults_to_empty() { /* json!({"issue_number": 42}) → item["title"] == "" */ }
fn start_issue_negative_index_returns_out_of_range() { /* index = -1 → "out of range" error */ }
fn start_issue_queue_item_non_object_returns_error() { /* state with valid object root, "queue": [42] (number entry) → per-item "Queue item is not a JSON object" error */ }
fn start_issue_mutate_state_io_error() { /* state_path points to a directory → mutate_state returns I/O Err, wrapper returns {"status":"error","message":"I/O error: ..."} */ }
fn record_outcome_negative_index_returns_out_of_range() { /* index = -1 → "out of range" error */ }
fn record_outcome_queue_item_non_object_returns_error() { /* state with valid object root, "queue": ["string"] → per-item "Queue item is not a JSON object" error */ }
fn record_outcome_empty_pr_url_not_written() { /* pr_url=Some("") → state's pr_url field NOT set */ }
fn record_outcome_empty_branch_not_written() { /* branch=Some("") → state's branch field NOT set */ }
fn record_outcome_empty_reason_not_written() { /* reason=Some("") → state's reason field NOT set */ }
fn read_state_corrupt_json_returns_invalid_json_error() { /* pre-write "{bad json" → returns {"status":"error","message":"Invalid JSON: ..."} */ }
fn read_state_fs_read_error_returns_error() { /* state_path points to a directory → read returns Err, wrapper returns {"status":"error","message":"Failed to read: ..."} */ }
fn next_issue_corrupt_json_returns_invalid_json_error() { /* pre-write "{bad json" → returns Invalid JSON error */ }
fn next_issue_no_queue_key_returns_done() { /* state is {} (no queue) → returns {"status":"done"} */ }
fn next_issue_fs_read_error_returns_error() { /* state_path points to a directory → read returns Err */ }
fn create_state_existing_corrupt_json_overwrites() { /* state_dir contains orchestrate.json with "{bad json" → if-let-Ok(existing) is false → create_state falls through and overwrites */ }
fn orchestrate_create_state_write_failure_returns_error() { /* pre-create state_dir/orchestrate.json as a directory → fs::write returns EISDIR → error JSON */ }
fn create_state_create_dir_all_failure_returns_error() { /* state_dir parent is a FILE (not a directory) → create_dir_all returns Err → error JSON */ }
fn run_impl_create_missing_queue_file_returns_err() { /* run_impl with --create and non-existent queue_file → returns Err("Failed to read queue file: ...") — via Result arm, not Ok */ }
fn run_impl_create_malformed_queue_json_returns_err() { /* queue_file contains "{bad json" → returns Err("Invalid queue JSON: ...") */ }
```

**TDD Notes:** Each test guards a specific uncovered branch
identified during exploration. Write-failure tests use the
directory-at-target-path pattern from Risks #1. Test names do not
collide with any existing test in the corpus (verified in Risk #10).

### Task 6 — Pure-branch fix (if needed)

**Files:** `src/orchestrate_state.rs`.

**What:** No changes expected. If any of Task 5's tests reveal an
actual bug, fix here. Otherwise commit empty.

### Task 7 — Subprocess tests for orchestrate_state::run()

**File:** `tests/orchestrate_subprocess.rs` (extends the file
created in Task 4).

**New tests:**

```rust
fn orchestrate_state_run_read_happy_path_prints_ok_status() { /* spawn flow-rs orchestrate-state --read --state-file <tmp/orchestrate.json> with a pre-written valid state; assert exit 0, stdout contains "status":"ok" */ }
fn orchestrate_state_run_create_missing_queue_file_prints_error_status() { /* spawn flow-rs orchestrate-state --create --queue-file /nonexistent.json --state-dir <tmp>; run_impl returns Err, run() matches Err and prints error JSON; assert exit 0 (run() does not propagate Err as nonzero), stdout contains "status":"error" and "Failed to read queue file" */ }
```

**TDD Notes:** The second test exercises the `run()` wrapper's
`Err` arm — the only production caller of that arm. cargo-llvm-cov
instruments subprocess calls of the same binary, so both
`println!` paths become covered. Follow the
`tests/main_dispatch.rs` spawn pattern. Canonicalize tempdirs per
`.claude/rules/testing-gotchas.md`.

### Task 8 — Capture new aggregate TOTAL

**What:** Run full-suite `bin/flow ci` from the worktree. The
nextest/llvm-cov summary prints the three TOTAL percentages
(lines, regions, functions) at the bottom. Record each whole-percent
value via `bin/flow log`.

Use a 10-minute Bash tool timeout (`timeout: 600000`) — CI runs
can take 3–4 minutes and the default 2-minute timeout would
background the process, defeating the gate (per
`.claude/rules/ci-is-a-gate.md`).

### Task 9 — Bump `bin/test` thresholds

**File:** `bin/test` (lines 77-79).

**What:** Edit `--fail-under-lines`, `--fail-under-regions`,
`--fail-under-functions` to `floor(new_total)` for each metric
captured in Task 8. No buffer — this follows the committed
`bin/test` doc-comment convention ("the floor of the current
aggregate TOTAL — i.e., `floor(actual_whole_percent)`") and the
ratchet discipline documented in the same doc comment ("it tracks
every whole-percent improvement and never moves down"). If any
metric's current threshold is already higher than the new floor
(unlikely given this PR raises coverage, but theoretically
possible if an unrelated PR regressed while this one was in
flight), leave that threshold unchanged.

### Task 10 — Final `bin/flow ci` verification

**What:** Run full-suite `bin/flow ci` one more time to confirm
the new floors pass.

Use a 10-minute Bash tool timeout (`timeout: 600000`) — CI runs
can take 3–4 minutes and the default 2-minute timeout would
background the process, defeating the gate (per
`.claude/rules/ci-is-a-gate.md`).
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: Coverage sweep for orchestration modules (issue #1144)

```xml
<dag goal="Coverage sweep for orchestration modules (issue #1144) — close gaps in orchestrate_report.rs and orchestrate_state.rs toward 100% without waivers" mode="full">
  <plan>
    <node id="1" name="Module Surface Map" type="research" depends="[]" parallel_with="[]">
      <objective>Read both modules end-to-end. Catalog every public/private function, error path, and external dependency (gh, fs, env). Identify test seams that already exist.</objective>
    </node>
    <node id="2" name="Existing Test Inventory" type="research" depends="[1]" parallel_with="3">
      <objective>Enumerate every test that currently exercises these modules. Note which functions are covered via in-process tests, which via subprocess tests, which have no tests.</objective>
    </node>
    <node id="3" name="Uncovered-Line Inspection Plan" type="research" depends="[1]" parallel_with="2">
      <objective>Define the exact llvm-cov workflow the Code phase will run to enumerate uncovered (line, region, branch) locations in both files. Specify region-coverage-lt=100 invocation and the expected output shape.</objective>
    </node>
    <node id="4" name="orchestrate_report.rs Gap Classification" type="analysis" depends="[1,2]" parallel_with="5">
      <objective>For each likely uncovered region (gh failure paths, unusual issue shapes, formatting branches), classify under the three no-waiver responses: subprocess test, refactor for testability, or delete-dead-code. Name concrete fixtures where applicable.</objective>
    </node>
    <node id="5" name="orchestrate_state.rs Gap Classification" type="analysis" depends="[1,2]" parallel_with="4">
      <objective>For each likely uncovered region (state-file corruption, array-shaped variants, missing keys), classify under the three no-waiver responses. Identify refactor seams (e.g. path injection) needed.</objective>
    </node>
    <node id="6" name="Test Seam Architecture" type="decision" depends="[4,5]" parallel_with="[]">
      <objective>Decide which new seams (if any) must land BEFORE test tasks. Extract-helper branch enumeration check per .claude/rules/extract-helper-refactor.md. Every branch lands in one of the three classifications (direct / seam / subprocess).</objective>
    </node>
    <node id="7" name="Threshold Update Strategy" type="analysis" depends="[4,5]" parallel_with="8">
      <objective>Define how the Code phase computes new --fail-under-lines / --fail-under-regions / --fail-under-functions. Workflow: run full-suite bin/test, capture TOTAL, round DOWN to whole percent with ~1% buffer, update bin/test defaults. Note concurrency hazards.</objective>
    </node>
    <node id="8" name="Risk Surface" type="validation" depends="[4,5,6]" parallel_with="7">
      <objective>Enumerate risks: fixture isolation (gh subprocess vs mock), host-env leaks, main's long-lived target dir and llvm-cov stale-covmap hazard, parallel-test env-var races, dependency on gh being authenticated. Map each to a mitigation.</objective>
    </node>
    <node id="9" name="Task Ordering &amp; Commit Plan" type="synthesis" depends="[6,7,8]" parallel_with="[]">
      <objective>Produce the ordered task list with TDD pairing (test → implementation), atomic commit groups where needed, and dependency-graph-backed ordering. Ensure threshold-update task lands LAST after all coverage tasks.</objective>
    </node>
    <node id="10" name="Final Synthesis" type="synthesis" depends="[9]" parallel_with="[]">
      <objective>Emit a concrete implementation plan the Plan phase can paste: Exploration table, Risks list, Approach paragraph, Dependency Graph, and ordered Tasks with TDD notes.</objective>
    </node>
  </plan>
</dag>
```

Validation: no cycles, every depends ID exists, nodes 2+3 and 4+5 and 7+8 are genuinely parallel, node 10 is the terminal synthesis, scale is Standard (10 nodes) appropriate for a multi-file coverage sweep with refactor risk.

---

▶ NODE 1: Module Surface Map (depends on: [])

Read `src/orchestrate_report.rs` end-to-end (245 lines + 337 lines of tests = 582 total). Read `src/orchestrate_state.rs` end-to-end (411 lines + 800 lines of tests = 1211 total).

Key finding (Node 1, part 1): `orchestrate_report.rs` is already highly covered with 18 existing in-process tests. The module has four public fns: `compute_duration_seconds`, `generate_report`, `generate_and_write_report`, `run_impl`, plus `run`. `run` calls `println!` then returns — tests for `run_impl` cover the logic. Gaps are probably the CLI `run` wrapper's println path and a few unusual fallback branches (`unwrap_or("?")`, `unwrap_or("pending")`, `unwrap_or("Unknown")`, `unwrap_or("")` branches for edge fields).

Key finding (Node 1, part 2): Both modules follow the same architecture: pure logic fns → `run_impl(args) -> Result<Value, String>` (testable) → `run(args)` (println + swallow). The `run` wrapper is the main uncovered surface since tests target `run_impl`. Additional gaps: `create_state` directory creation failure, serialization failure, write failure; `build_queue_item` with missing/wrong-type fields; `record_outcome`/`start_issue` with queue item being non-object; `next_issue`/`read_state` with corrupt JSON.

Quality: 9/10 — both modules fully read with all existing tests enumerated.

---

▶ PARALLEL BRANCH A — NODE 2: Existing Test Inventory

main.rs dispatch points:
- `src/main.rs:41-42` — `use flow_rs::orchestrate_report; use flow_rs::orchestrate_state;`
- `src/main.rs:385, 389` — Commands enum variants
- `src/main.rs:664-665` — dispatch to `run(args)`

Existing tests for both modules (counted by reading the files):
- `orchestrate_report.rs` tests mod: 18 tests (compute_duration_seconds ×3, generate_report ×11, generate_and_write_report ×1, run_impl ×3).
- `orchestrate_state.rs` tests mod: 30 tests (create_state ×4, start_issue ×4, record_outcome ×5, complete ×3, read_state ×2, next_issue ×4, CLI run_impl ×8).

`tests/main_dispatch.rs` only covers the CLI dispatch *registration* of `orchestrate-report` and `orchestrate-state` subcommands via `--help` — it does NOT actually spawn the binary with those subcommands to run the `run()` wrapper's `println!` paths.

Quality: 9/10 — complete test inventory.

▶ PARALLEL BRANCH B — NODE 3: Uncovered-Line Inspection Plan

The canonical inspection command for enumerating uncovered regions is documented in the issue body:

```bash
/opt/homebrew/opt/llvm/bin/llvm-cov show \
  --instr-profile=target/llvm-cov-target/flow.profdata \
  target/llvm-cov-target/debug/flow-rs \
  --sources src/orchestrate_report.rs src/orchestrate_state.rs \
  --region-coverage-lt=100
```

Per `.claude/rules/worktree-commands.md`, the Code phase runs this through `bin/flow test` for the measurement. Direct cargo/llvm-cov invocations are forbidden from Bash tool.

`bin/test` is configured with `--fail-under-lines 94 --fail-under-regions 95 --fail-under-functions 93` (lines 77-79). These must be raised after coverage lands (per issue #1144 Definition of Done).

Quality: 8/10 — inspection plan is pragmatic; actual line/region numbers only obtainable during Code phase.

▶ MERGE (Nodes 1–3): Both modules use the `run_impl` / `run` split per `.claude/rules/no-waivers.md`. Existing tests cover `run_impl` — the `run` wrappers' `println!` lines and some edge branches remain. `main_dispatch.rs` only exercises `--help`. Current thresholds: `lines=94 regions=95 functions=93`. Quality: 9/10 — complete enumeration of both module surfaces and their existing test coverage.

---

▶ PARALLEL BRANCH A — NODE 4: orchestrate_report.rs Gap Classification

Likely uncovered surfaces with no-waiver-compliant classifications:

| Gap | Location | Classification | Test / Refactor |
|---|---|---|---|
| `run()` wrapper `println!(value)` on Ok | lines 237-239 | Testable via subprocess | Subprocess test spawning `flow-rs orchestrate-report --state-file <good> --output-dir <tmp>` and asserting stdout contains `"status":"ok"` |
| `run()` wrapper `println!(Err)` path | lines 240-244 | Testable directly via `run_impl` or delete | `run_impl` never returns Err today — the println!(Err) path is dead. Delete it per `.claude/rules/no-waivers.md` default response #3 |
| `generate_and_write_report` fs::write failure | lines 189-193 | Testable directly | Unit test passing a read-only output_dir (chmod 0o555) to force `fs::write` → Err |
| `issue_number` unwrap_or("?") branch | line 88 | Testable directly | New unit test `generate_report_missing_issue_number_shows_question_mark` with `queue_items` containing `{"title":"x"}` (no issue_number) |
| `title` unwrap_or("") branch in results table | line 89 | Testable directly | Unit test with queue item missing title |
| `outcome` unwrap_or("pending") branch | line 93 | Testable directly | Unit test with queue item missing outcome (pending status) → table renders "pending" |
| `pr_url` "\u{2014}" em-dash branch | line 95 | Testable directly | Unit test with queue item missing pr_url (failed item without url) → table renders em-dash |
| `reason` unwrap_or("Unknown") branch | line 137 | Testable directly | Unit test with failed item missing `reason` → Failed section renders "Unknown" |

**Dead branch note** — `run_impl` currently returns `Ok(...)` unconditionally. The `run()` wrapper's `Err` arm is unreachable. Per no-waivers rule response #3 (delete unreachable branches), delete the Err arm — or keep it and prove reachability by changing `run_impl` to return `Err` for infrastructure failures.

Quality: 8/10 — enumerated every gap with a test strategy.

▶ PARALLEL BRANCH B — NODE 5: orchestrate_state.rs Gap Classification

| Gap | Location | Classification | Test / Refactor |
|---|---|---|---|
| `run()` wrapper `println!(value)` on Ok | lines 403-405 | Testable via subprocess | Subprocess test spawning `flow-rs orchestrate-state --read --state-file <good>` |
| `run()` wrapper `println!(Err)` path | lines 407-409 | Testable via subprocess (infra err) | Subprocess test with `--create --queue-file /nonexistent.json --state-dir <tmp>` — `read_to_string` returns `Err`, `run_impl` maps to `Err(msg)`, `run` emits error JSON |
| `create_state` `create_dir_all` failure | lines 48-50 | Testable directly | Unit test with `state_dir` parented by a read-only dir |
| `create_state` serialize failure | lines 83 | UNREACHABLE with json! input | Delete the match arm — `serde_json::to_string_pretty` on `Value` cannot fail. Per no-waivers #3, remove the dead branch |
| `create_state` write failure | lines 78-80 | Testable directly | Unit test pre-creating `orchestrate.json` as a directory at the target path to force EISDIR |
| `build_queue_item` missing `issue_number` | line 28 `unwrap_or(0)` | Testable directly | Unit test with `json!({"title":"x"})` (no issue_number) |
| `build_queue_item` missing `title` | line 29 `unwrap_or("")` | Testable directly | Unit test with `json!({"issue_number": 42})` (no title) |
| `create_state` existing-but-corrupt-json branch | line 56 `if let Ok(existing) = ...` FALSE branch | Testable directly | Unit test with state_dir containing `orchestrate.json` with corrupt JSON → overwrites |
| `start_issue` negative index | line 112 `index < 0` | Testable directly | Unit test with `index = -1` |
| `start_issue` queue item not object | lines 120-124 | Testable directly | Unit test with state whose `queue` is `[42]` → "Queue item is not a JSON object" |
| `record_outcome` negative index | line 166 `index < 0` | Testable directly | Unit test with `index = -1` |
| `record_outcome` queue item not object | lines 174-178 | Testable directly | Unit test with state whose `queue` is `["not-an-object"]` |
| `record_outcome` empty-string pr_url filtered | line 182 `.filter(|s| !s.is_empty())` | Testable directly | Unit test passing `pr_url=Some("")` — asserts pr_url NOT set in state |
| `record_outcome` empty-string branch filtered | line 185 | Testable directly | Same for `branch=Some("")` |
| `record_outcome` empty-string reason filtered | line 188 | Testable directly | Same for `reason=Some("")` |
| `read_state` corrupt JSON | lines 232-234 | Testable directly | Unit test with pre-written corrupt JSON file |
| `read_state` fs read error | lines 235 | Testable directly | Unit test with state_path pointing to a directory |
| `next_issue` corrupt JSON | lines 269 | Testable directly | Unit test with corrupt JSON |
| `next_issue` fs read error | lines 271 | Testable directly | Unit test with state_path pointing to a directory |
| `next_issue` no `queue` key | line 254 (None branch) | Testable directly | Unit test with state `{}` (no queue) → done |
| `run_impl` — `create` branch `read_to_string` error | line 356 maps to `Err` | Testable directly | Unit test with non-existent queue_file → `run_impl` returns `Err` |
| `run_impl` — `create` branch `from_str` error | line 358 maps to `Err` | Testable directly | Unit test with malformed queue JSON → `run_impl` returns `Err` |

**Dead branch note** — `serde_json::to_string_pretty(&state)` on a `json!({...})` `Value` always succeeds. The match arm at line 76-84 has a dead `Err(e)` branch. Response #3: delete the unreachable `Err` arm in `create_state`.

Quality: 9/10 — each gap has a concrete test strategy; two dead branches identified for deletion under no-waivers rule.

▶ MERGE (Nodes 4–5): Both modules share the `run` wrapper uncovered pattern. Two unreachable `Err` branches found for deletion. All other gaps are direct unit tests or subprocess tests. No refactor needed (`run_impl` is already the seam).

---

▶ NODE 6: Test Seam Architecture

**Seam audit.** `run_impl` already exists in both modules. Tests call `run_impl` directly — this is the established seam. The `run()` wrapper's only uncovered lines are the `println!` calls. These are `Testable via subprocess` — spawning the compiled binary through integration tests.

**Extract-helper branch enumeration check.** This plan does NOT propose extracting a block into a new helper — it only proposes adding tests against existing seams plus deleting two dead branches. The extract-helper rule's trigger vocabulary does not apply. No Branch Enumeration Table required.

**Every branch lands in one of three classifications:**

- Most gaps → **Testable directly** (in-process unit tests against pure helpers)
- `run()` wrapper → **Testable via subprocess** (new integration tests in `tests/orchestrate_subprocess.rs`)
- Dead `Err` arms in `run()` + dead serialize `Err` in `create_state` → **Delete the branch** (no-waiver rule response #3)

No branch remains unclassified. Quality: 9/10.

---

▶ PARALLEL BRANCH A — NODE 7: Threshold Update Strategy

Current thresholds in `bin/test` lines 77-79:

```bash
--fail-under-lines 94 \
--fail-under-regions 95 \
--fail-under-functions 93 \
```

**Workflow:**

1. Run full-suite `bin/flow ci` once to capture aggregate TOTAL from the coverage summary output.
2. Read the three TOTAL percentages from nextest summary output.
3. For each metric: `new_threshold = floor(total_percent)`. The current `bin/test` convention is floor, no buffer. The issue body says "~1% buffer below actual" — this conflicts with bin/test. Decision: follow bin/test convention (floor, no buffer).
4. Update the three thresholds in a single commit.

**Concurrency hazard.** `start-gate` runs CI on main as a serialization point. The threshold update must land in the same PR as the coverage tasks so main's post-merge start-gate CI passes on the first flow-start.

**Stale-covmap hazard.** Full-suite `bin/test` cleans `flow-rs` package scope before measuring per `.claude/rules/tool-dispatch.md`. Invariant preserved.

Quality: 8/10 — flagged the issue-body-vs-bin/test convention mismatch.

▶ PARALLEL BRANCH B — NODE 8: Risk Surface

| Risk | Likelihood | Mitigation |
|---|---|---|
| `chmod 0o555` fixture for "read-only dir" does not work portably | Medium | Use "pre-create target as directory" (EISDIR) trick instead |
| `mutate_state` write-failure branch hard to provoke | Medium | Use directory-at-target-path trick to force EISDIR on mutate_state's write |
| Host-environment leak | Low | Neither module calls project_root()/current_branch(). No risk |
| Rust parallel-test env-var races | Low | Neither module reads env vars |
| `test_start_issue_non_object_state` may be vacuous | Medium | `mutate_state` may auto-heal array root to {}. Verify branch actually taken in Code phase; rewrite fixture if vacuous |
| `start-gate` long-lived target-dir | Low | `bin/test` full-suite already cleans flow-rs package |
| `test_coverage.md` waiver temptation | High | Rule explicit: forbidden. Delete dead branches instead |
| TOTAL rounding | Low | floor(x%) is unambiguous |
| "gh/GitHub failure paths" claim from issue body is wrong | Verified | Neither module spawns gh. Plan uses actual gaps from reading code |

**Issue-body-vs-reality mismatch.** The issue body says "gh/GitHub failure paths" but neither module spawns gh subprocesses — gh calls live in `orchestrate.rs` (not in scope). This is a Script Behavior Verification catch.

Quality: 9/10.

---

▶ NODE 9: Task Ordering & Commit Plan

Ordering:
- TDD: every test precedes its implementation.
- Dead-branch deletions are their own tasks.
- `bin/test` threshold bump lands LAST after all coverage tasks produce the new TOTAL.
- No atomic commit groups required.
- Each task increments `code_task` by 1.

1. Delete unreachable `Err` arms
2. Unit tests — orchestrate_report.rs pure branches
3. Implement any pure-branch fix (if tests reveal bugs; expected: none)
4. Subprocess test — orchestrate_report.rs `run()` wrapper
5. Unit tests — orchestrate_state.rs pure branches
6. Implement any pure-branch fix (if tests reveal bugs; expected: none)
7. Subprocess tests — orchestrate_state.rs `run()` wrapper (both Ok and Err)
8. Verify `test_start_issue_non_object_state` not vacuous
9. If task 8 reveals vacuous test, rewrite
10. Capture new TOTAL via `bin/flow ci`
11. Bump `bin/test` thresholds
12. Final `bin/flow ci` verification

Quality: 9/10.

---

▶ NODE 10: Final Synthesis

Deferred to the synthesis block below.

---

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

## Implementation Plan

### Context

Issue #1144 — raise coverage on `src/orchestrate_report.rs` (94.88% lines, 21 missed) and `src/orchestrate_state.rs` (96.63% lines, 30 missed) toward 100% on lines/regions/functions. No waivers per `.claude/rules/no-waivers.md`. After coverage lands, bump `bin/test` thresholds to the new floor.

### Exploration

| File | Role | Status |
|---|---|---|
| `src/orchestrate_report.rs` | Morning-report generator (pure fns + `run_impl` + `run`) | Existing 18 tests target `run_impl` and helpers. `run` wrapper's `println!` lines are uncovered. Edge branches (`unwrap_or("?")`, `unwrap_or("pending")`, `unwrap_or("Unknown")`, `unwrap_or("\u{2014}")`) partially covered. `fs::write` failure branch uncovered. |
| `src/orchestrate_state.rs` | Orchestrate-queue state CRUD (6 pure fns + `run_impl` + `run`) | Existing 30 tests target `run_impl` and helpers. `run` wrapper uncovered. `build_queue_item` default branches uncovered. Empty-string-filter branches uncovered. Negative-index branches uncovered. Several corrupt-JSON / fs-error branches uncovered. Two unreachable `Err` arms. |
| `tests/main_dispatch.rs` | Existing subprocess dispatch test | Covers `--help` for both subcommands. Does NOT run the `run()` wrapper. |
| `bin/test` | CI runner | Current thresholds `lines=94 regions=95 functions=93`. Bump to new floor as the final task. |

Files to be modified: `src/orchestrate_report.rs`, `src/orchestrate_state.rs`, `tests/orchestrate_subprocess.rs` (new), `bin/test`.

**Superseded code** (per `.claude/rules/supersession.md`): two unreachable `Err` match arms — the `Err(e)` arm of `serde_json::to_string_pretty(&state)` in `create_state` and the `Err(msg)` arm of `orchestrate_report::run()`. Deletion discussion in Approach.

### Risks

1. **Dead-branch deletion vs. `run_impl` future extension.** `orchestrate_state::run_impl` DOES return `Err(...)` on `read_to_string`/`from_str` failures in the `--create` branch. KEEP the `Err` arm in `orchestrate_state::run()` (reachable via `--create --queue-file /nonexistent`). `orchestrate_report::run_impl` returns `Ok(...)` unconditionally — DELETE its `Err` arm.

2. **Write-failure branch hard to provoke.** Pre-creating `orchestrate.json` as a directory (EISDIR) forces `fs::write` error portably across macOS and CI.

3. **Host-environment leak.** Neither module calls `project_root()` or `current_branch()`. Low risk per `.claude/rules/testing-gotchas.md`.

4. **Rust parallel-test env-var races.** Neither module reads env vars. Low risk.

5. **`mutate_state` object guard auto-heal may make the "array root" test vacuous.** `test_start_issue_non_object_state` writes `[1,2,3]` — `mutate_state` may auto-heal to `{}`, producing queue_len=0 and "out of range" rather than "not a JSON object". Verify in Code phase; if vacuous, rewrite fixture.

6. **Threshold computation concurrency.** The threshold bump must land in the same PR as coverage tasks so `start-gate`'s CI-on-main serialization catches regressions.

7. **`start-gate` long-lived target-dir stale-covmap hazard.** Full-suite `bin/test` cleans `flow-rs` per `.claude/rules/tool-dispatch.md`. Invariant preserved.

8. **Issue body's "gh/GitHub failure paths" claim is wrong for these two files.** Verified: neither module spawns gh subprocesses. Plan uses actual gaps from reading the code.

9. **No-waivers enforcement.** Per `.claude/rules/no-waivers.md`, every gap closes via subprocess test, refactor, or delete. No `test_coverage.md` entries.

10. **Extract-helper rule does not apply.** No task proposes extracting a block into a new helper. Existing `run_impl` seam handles every testable branch.

### Approach

Close coverage gaps in two modules by writing targeted unit tests against the existing `run_impl` seam, adding subprocess tests for the `run()` wrappers through the compiled binary, and deleting unreachable dead branches identified by reading the code. Verify `test_start_issue_non_object_state` is not vacuous. After all coverage tasks land, measure the new aggregate TOTAL and bump the `bin/test` thresholds.

Architecture is unchanged. No new seams. The existing `run_impl(args) -> Result<Value, String>` pattern is the canonical seam.

**Dead-branch deletions**:
- `orchestrate_state::run()`'s `Err` arm is reachable — KEEP and test.
- `orchestrate_report::run()`'s `Err` arm is unreachable — DELETE.
- `orchestrate_state::create_state`'s serialize `Err` arm is unreachable — DELETE.

### Dependency Graph

| Task | Type | Depends On |
|---|---|---|
| 1. Delete unreachable `Err` arms (orchestrate_report::run, create_state serialize) | implement | — |
| 2. Unit tests for orchestrate_report.rs pure branches | test | 1 |
| 3. Implement any pure-branch fix (expected: none) | implement | 2 |
| 4. Subprocess test for orchestrate_report::run() happy path | test | 1 |
| 5. Unit tests for orchestrate_state.rs pure branches | test | — |
| 6. Implement any pure-branch fix (expected: none) | implement | 5 |
| 7. Subprocess tests for orchestrate_state::run() (Ok + Err paths) | test | — |
| 8. Verify test_start_issue_non_object_state is not vacuous | verify | — |
| 9. If task 8 reveals vacuous test, rewrite | implement | 8 |
| 10. Run full-suite bin/flow ci, capture new TOTAL | verify | 1,2,3,4,5,6,7,9 |
| 11. Bump bin/test thresholds | implement | 10 |
| 12. Final bin/flow ci run to verify thresholds pass | verify | 11 |

### Tasks

TDD discipline per `.claude/rules/skill-authoring.md`. Each task increments `code_task` by 1 per `.claude/rules/code-task-counter.md`.

1. **Delete unreachable `Err` arms.** Files: `src/orchestrate_report.rs` (the `run` wrapper's Err arm), `src/orchestrate_state.rs` (the `create_state` serialize Err arm). Rationale: `orchestrate_report::run_impl` returns `Ok(...)` unconditionally; `serde_json::to_string_pretty(&Value)` on a json! literal cannot fail. Per `.claude/rules/no-waivers.md` response #3 and `.claude/rules/supersession.md`. No tombstone — inline match arms, not named features.

2. **Unit tests for orchestrate_report.rs pure branches.** TDD notes:
   - `report_missing_issue_number_renders_question_mark` — queue item without `issue_number` → table cell renders `#?`.
   - `report_missing_title_renders_empty` — queue item without `title` → empty cell.
   - `report_missing_outcome_renders_pending` — queue item without `outcome` → `pending`.
   - `report_missing_pr_url_renders_em_dash` — queue item without `pr_url` → `—`.
   - `report_failed_item_missing_reason_renders_unknown` — failed item without `reason` → `Unknown`.
   - `generate_and_write_report_write_failure_returns_error` — pre-create `orchestrate-summary.md` as a directory inside output_dir → fs::write returns Err → error JSON.

3. **Implement any pure-branch fix.** Expected: none.

4. **Subprocess test for orchestrate_report::run() happy path.** New test file `tests/orchestrate_subprocess.rs`. Spawn `flow-rs orchestrate-report --state-file <tmp/orchestrate.json> --output-dir <tmp>`. Assert exit 0 and stdout contains `"status":"ok"`. Exercises the `println!(value)` line.

5. **Unit tests for orchestrate_state.rs pure branches.** TDD notes:
   - `build_queue_item_missing_issue_number_defaults_to_zero`.
   - `build_queue_item_missing_title_defaults_to_empty`.
   - `start_issue_negative_index_returns_out_of_range`.
   - `start_issue_queue_item_non_object_returns_error`.
   - `record_outcome_negative_index_returns_out_of_range`.
   - `record_outcome_queue_item_non_object_returns_error`.
   - `record_outcome_empty_pr_url_not_written`.
   - `record_outcome_empty_branch_not_written`.
   - `record_outcome_empty_reason_not_written`.
   - `read_state_corrupt_json_returns_invalid_json_error`.
   - `read_state_fs_read_error_returns_error`.
   - `next_issue_corrupt_json_returns_invalid_json_error`.
   - `next_issue_no_queue_key_returns_done`.
   - `next_issue_fs_read_error_returns_error`.
   - `create_state_existing_corrupt_json_overwrites`.
   - `create_state_write_failure_returns_error`.
   - `create_state_create_dir_all_failure_returns_error`.
   - `run_impl_create_missing_queue_file_returns_err`.
   - `run_impl_create_malformed_queue_json_returns_err`.

6. **Implement any pure-branch fix.** Expected: none.

7. **Subprocess tests for orchestrate_state::run().** Two tests in `tests/orchestrate_subprocess.rs`:
   - `orchestrate_state_read_happy_path_prints_ok` — `flow-rs orchestrate-state --read --state-file <tmp/orchestrate.json>`.
   - `orchestrate_state_create_missing_queue_file_prints_err` — `flow-rs orchestrate-state --create --queue-file /nonexistent.json --state-dir <tmp>`. Exercises the `run()` wrapper's `Err` arm.

8. **Verify `test_start_issue_non_object_state` is not vacuous.** Read the test, trace `mutate_state` behavior. If auto-heal converts `[1,2,3]` to `{}`, the assertion hits "out of range" not "not a JSON object".

9. **If task 8 reveals vacuous test, rewrite.** Change fixture to valid object root with `"queue": [42]` so the per-item object guard fires. Rename test if needed.

10. **Run full-suite bin/flow ci, capture new TOTAL.** Use a 10-minute Bash tool timeout (`timeout: 600000`) — CI runs can take 3–4 minutes and the default 2-minute timeout would background the process, defeating the gate (per `.claude/rules/ci-is-a-gate.md`). Record percentages via `bin/flow log`.

11. **Bump bin/test thresholds.** Edit `bin/test` lines 77-79 to `floor(new_total)` for lines/regions/functions. No buffer — follows bin/test's existing convention.

12. **Final bin/flow ci verification.** Use a 10-minute Bash tool timeout (`timeout: 600000`) — CI runs can take 3–4 minutes and the default 2-minute timeout would background the process, defeating the gate (per `.claude/rules/ci-is-a-gate.md`).

Confidence: 90% | Nodes: 10 | Parallel branches: 3

vs. Vanilla Claude (what linear reasoning would have missed):
  • Linear planning would have accepted the issue body's "gh/GitHub failure paths" claim verbatim and designed gh-mock fixtures for modules that never spawn gh.
  • Linear planning would have proposed `test_coverage.md` waivers for the two unreachable `Err` arms instead of deleting them.
  • Linear planning would have merged the two files' analyses and missed the branch-level distinction: `orchestrate_state::run()`'s `Err` arm is reachable (keep + test) while `orchestrate_report::run()`'s `Err` arm is unreachable (delete).

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 5m |
| Plan | 20m |
| Code | 57m |
| Code Review | 8m |
| Learn | 3m |
| Complete | 21m |
| **Total** | **1h 57m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/coverage-sweep-orchestration.json</summary>

```json
{
  "schema_version": 1,
  "branch": "coverage-sweep-orchestration",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1194,
  "pr_url": "https://github.com/benkruger/flow/pull/1194",
  "started_at": "2026-04-16T11:29:27-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/coverage-sweep-orchestration-plan.md",
    "dag": ".flow-states/coverage-sweep-orchestration-dag.md",
    "log": ".flow-states/coverage-sweep-orchestration.log",
    "state": ".flow-states/coverage-sweep-orchestration.json"
  },
  "session_tty": "/dev/ttys009",
  "session_id": "140a752a-67f8-42c7-939c-f1d27755f747",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/140a752a-67f8-42c7-939c-f1d27755f747.jsonl",
  "notes": [],
  "prompt": "work on issue #1144",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-16T11:29:27-07:00",
      "completed_at": "2026-04-16T11:35:00-07:00",
      "session_started_at": null,
      "cumulative_seconds": 333,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-16T11:35:26-07:00",
      "completed_at": "2026-04-16T11:56:13-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1247,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-16T11:56:57-07:00",
      "completed_at": "2026-04-16T12:54:17-07:00",
      "session_started_at": null,
      "cumulative_seconds": 3440,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-16T12:54:33-07:00",
      "completed_at": "2026-04-16T13:02:46-07:00",
      "session_started_at": null,
      "cumulative_seconds": 493,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-16T13:02:58-07:00",
      "completed_at": "2026-04-16T13:06:42-07:00",
      "session_started_at": null,
      "cumulative_seconds": 224,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-16T13:06:55-07:00",
      "completed_at": "2026-04-16T13:28:23-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1288,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-16T11:35:26-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-16T11:56:57-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-16T12:54:33-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-16T13:02:58-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-16T13:06:55-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 10,
  "code_task_name": "Final bin/flow ci verification",
  "code_task": 10,
  "diff_stats": {
    "files_changed": 4,
    "insertions": 674,
    "deletions": 32,
    "captured_at": "2026-04-16T12:54:17-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "compact_summary": "<analysis>\nThe user's request is to perform a compliance audit of PR #1194 (Coverage Sweep Orchestration) using the Learn phase analysis framework. This is NOT a normal code development task - I am being asked to analyze a completed feature against FLOW process rules, code patterns, and project conventions.\n\nThe conversation structure is:\n1. A long preamble explaining my role as a \"Learn-phase analyst\" with three tenants (process gaps, rule compliance, missing rules)\n2. Inline context containing: DIFF, PLAN, STATE FILE DATA, LOG FILE, PROJECT CLAUDE.MD, and extensive .CLAUDE/RULES files\n3. The user's CRITICAL instruction at the end: \"TEXT ONLY, DO NOT CALL ANY TOOLS\"\n\nI have the following inputs provided inline:\n- Full git diff of the changes\n- Plan file showing 10 tasks (coverage sweep for two files)\n- State file with phase timings and visit counts\n- Log file showing execution history\n- CLAUDE.md project instructions\n- 40+ rule files covering everything from testing discipline to hook state timing\n\nMy job is to:\n1. Audit the PR against three tenants\n2. Find process gaps (workflow issues)\n3. Check rule compliance (violations with enforcement levels)\n4. Identify missing rules (patterns not documented)\n5. Report findings in structured format with Premise/Trace/Conclude reasoning\n\nThe user is NOT asking me to continue coding or develop anything. They are asking me to analyze work that was already completed and provide compliance findings. This is a read-only, analysis-only task with no tool calls permitted.\n\nLooking at the inline context provided:\n- Plan describes 10 tasks to raise coverage from 94.88% and 96.63% to 100% by adding tests and deleting unreachable code\n- State file shows: code_task=10 (completed), all phases complete, 3 findings dismissed as false positives\n- Log shows 5 commits with `finalize-commit ci` and `finalize-commit done` sequences\n- Diff shows changes to 4 files: bin/test (threshold changes), src/orchestrate_report.rs (tests added), src/orchestrate_state.rs (tests added), tests/orchestrate_subprocess.rs (new test file)\n\nThe user's CRITICAL instruction is clear: TEXT ONLY, NO TOOLS. This is the entire task - analyze and report based on what's already provided.\n\nKey rules to check against:\n- code-task-counter.md: counter increments once per task\n- plan-commit-atomicity.md: when tasks are split across commits\n- plan-deviation.rs: checking if plan-named test fixtures match code\n- docs-with-behavior.md: whether docs were updated for behavior changes\n- no-waivers.md: whether 100% coverage was achieved without waivers\n- tests-guard-real-regressions.md: whether tests guard real regression paths\n- skip-instructions from inline: explicitly check these things\n\nI should analyze:\n1. Did the Code phase increment code_task properly (should be 10 if all 10 tasks were done)?\n2. Did commits match the plan's task boundaries?\n3. Are the added tests guarding real regressions?\n4. Were documentation updates made for the signature change (run_impl Result→Value)?\n5. Did the plan follow no-waivers discipline?\n6. Are there any process friction signals (visit_count > 1)?\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   Perform a compliance audit of PR #1194 (Coverage Sweep Orchestration) as a Learn-phase analyst. The task is to analyze a completed feature against FLOW process workflow, rule compliance, and project conventions. The analysis must identify: (1) process gaps in the FLOW plugin workflow, (2) rule compliance violations with enforcement levels (Unclear vs Ignored), and (3) missing rules that should be documented. The audit operates under three tenants: workflow effectiveness, rule adherence, and gap identification. The analysis is retrospective and advisory - examining completed work with no knowledge of the conversation that produced the changes.\n\n2. Key Technical Concepts:\n   - FLOW 6-phase development lifecycle (Start, Plan, Code, Code Review, Learn, Complete)\n   - Code coverage testing (cargo-llvm-cov, lines/regions/functions metrics)\n   - Return type refactoring (Result<Value, String> to Value simplification)\n   - Test architecture patterns (unit tests, subprocess tests, integration tests)\n   - State file mutation and phase tracking\n   - Rule enforcement mechanisms (hooks, gates, scanners, tombstones)\n   - Cognitive isolation for code review agents\n   - Concurrency model for N×N×N parallel flows\n\n3. Files and Code Sections:\n   - bin/test: Modified to bump coverage thresholds from 94/95/93 to 96/96/94 (lines/regions/functions) - important because threshold changes need justification and documentation in plan\n   - src/orchestrate_report.rs: Added 6 unit tests (report_missing_issue_number_renders_question_mark, report_missing_title_renders_empty_title, etc.) and 1 subprocess test for run() wrapper - tests guard edge branches in `unwrap_or` patterns and file-write failures using EISDIR technique\n   - src/orchestrate_state.rs: Added 20 unit tests covering missing fields (build_queue_item_missing_issue_number), negative indices, corrupt JSON, fs errors, and state creation failures - comprehensive coverage of error paths\n   - tests/orchestrate_subprocess.rs: New file created with 3 subprocess tests (orchestrate_report_run_happy_path_prints_ok_status, orchestrate_state_run_read_happy_path_prints_ok_status, orchestrate_state_run_create_missing_queue_file_prints_error_status) - exercises run() wrappers through compiled binary interface\n\n4. Errors and fixes:\n   No errors were reported in the state file. The Code Review phase dismissed all 3 findings as false positives, meaning the delivered code passed all agent reviews without corrections needed.\n\n5. Problem Solving:\n   Code phase completed all 10 tasks sequentially across 5 commits with CI passing after each commit (visible from log: finalize-commit ci/done cycles). State file shows code_task=10 final value, indicating all tasks were tracked. No visit_count > 1 on any phase (all were visit_count: 1), showing no phase was revisited - strong signal of smooth execution without rework.\n\n6. All user messages:\n   The user provided a single instruction block: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.\" This instruction explicitly forbids the use of Read, Bash, Grep, Glob, Edit, Write, or any other tools. The user emphasized that tool calls would be rejected and waste the only turn, causing failure of the task. The user stated that all context needed is already provided in the conversation.\n\n7. Pending Tasks:\n   No pending tasks remain from the conversation. The PR is complete (code_task=10, all phases complete). The audit itself is the current and only task.\n\n8. Current Work:\n   The current work is analyzing PR #1194 against FLOW compliance standards. The analysis requires examining:\n   - State file data showing phase visit counts and timings (all phases visited exactly once)\n   - Plan file detailing 10 tasks: delete unreachable Err arms, add unit tests for report edge branches, add subprocess test for report run(), add unit tests for state edge branches, add subprocess tests for state run() (read and create paths), capture coverage totals, bump thresholds, verify new thresholds\n   - Log file showing 5 commits with proper CI gates\n   - Diff showing additions of 6+20+3=29 new tests and threshold changes from 94/95/93 to 96/96/94\n   - Checking against rules: code-task-counter.md (increment once per task), plan-deviation.rs (check test fixture matching), docs-with-behavior.md (behavior changes require doc updates), no-waivers.md (100% coverage without waivers), tests-guard-real-regressions.md (each test guards a named regression)\n\n9. Optional Next Step:\n   The analysis is complete with all context provided inline. No next step is required as the user provided all necessary artifacts in the initial prompt and explicitly forbade tool use. The task is to produce findings using only the provided context regarding: (1) whether the plan was executed correctly matching task boundaries, (2) whether code_task was incremented once per task (should be 10), (3) whether the return type signature change from Result to Value had corresponding documentation updates, (4) whether all tests guard real regression paths per no-waivers.md discipline, and (5) whether any process friction signals exist in visit counts or timing anomalies. These findings should follow the \"Premise → Trace → Conclude\" reasoning discipline specified in the semi-formal-reasoning rule.\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/coverage-sweep-orchestration",
  "compact_count": 5,
  "findings": [
    {
      "finding": "Coverage threshold bump (94/95/93 → 96/96/94) could surprise concurrent PRs at finalize-commit time",
      "reason": "Ratchet working as designed per bin/test doc comment and .claude/rules/no-waivers.md; concurrent PRs that regress below the new floor SHOULD fail CI — that is the ratchet's purpose. Proposed 'pin threshold values' test directly contradicts the ratchet discipline.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T13:02:33-07:00"
    },
    {
      "finding": "tests/orchestrate_subprocess.rs missing from CLAUDE.md Key Files",
      "reason": "Key Files enumerates architecturally load-bearing source modules; individual test files are documented via the separate Test Architecture section's Key test files list, which is reserved for structural-contract enforcers (structural, skill_contracts, permissions, docs_sync, concurrency). Per-module coverage tests are not listed by convention — none of ~60 tests/*.rs files appear there. Adding orchestrate_subprocess.rs would mislead readers about which tests enforce contracts.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T13:02:34-07:00"
    },
    {
      "finding": "Coverage threshold bump to 96/96/94 not documented beyond bin/test",
      "reason": "bin/test doc comment lines 58-65 already documents the ratchet convention (floors track whole-percent TOTAL, bump on whole-percent improvements, never move down). Specific numeric values drift on every coverage-raising PR — they are inherently unsuitable for cross-file documentation. The agent cited flow-state-schema.md but that rule is about state field ranges, not shell tool thresholds; analogy does not transfer.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T13:02:36-07:00"
    },
    {
      "finding": "bin/test threshold bump should be documented in CLAUDE.md",
      "reason": "bin/test doc comment already self-documents ratchet convention; specific threshold values drift every coverage sweep so cross-file documentation creates churn that fights ratchet discipline",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T13:05:54-07:00"
    },
    {
      "finding": "Return type simplification needs caller enumeration in plan",
      "reason": "Plan's Risks #1 already traced reachability for both modules' run_impl Err arms; Task 1 listed 3 test call-site updates explicitly. Analyst missed existing content.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T13:05:58-07:00"
    },
    {
      "finding": "Subprocess tests need explicit regression statements in plan",
      "reason": "Plan TDD Notes for Tasks 4 and 7 already stated the named regression each subprocess test guards (run() wrapper println!value line; run() wrapper Err arm). Analyst missed existing content.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T13:06:02-07:00"
    },
    {
      "finding": "Plan should document measured coverage values before threshold bump",
      "reason": "Task 8 captured TOTAL via bin/flow log (lines=96.01%, regions=96.38%, functions=94.14%). Task 9 commit message documents measured deltas. Pre-threshold validation happened and was documented — just not inline in the plan file.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T13:06:06-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "",
  "_continue_pending": "",
  "_stop_instructed": true,
  "freshness_retries": 1,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/coverage-sweep-orchestration.log</summary>

```text
2026-04-16T11:29:24-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-16T11:29:24-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-16T11:29:27-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-16T11:29:27-07:00 [Phase 1] create .flow-states/coverage-sweep-orchestration.json (exit 0)
2026-04-16T11:29:27-07:00 [Phase 1] freeze .flow-states/coverage-sweep-orchestration-phases.json (exit 0)
2026-04-16T11:29:27-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-16T11:29:37-07:00 [Phase 1] start-init — label-issues (labeled: [1144], failed: [])
2026-04-16T11:30:11-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-16T11:33:56-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-16T11:34:01-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-16T11:34:17-07:00 [Phase 1] start-workspace — worktree .worktrees/coverage-sweep-orchestration (ok)
2026-04-16T11:34:27-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-16T11:34:27-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-16T11:34:27-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-16T11:35:00-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-16T11:35:00-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-16T11:36:14-07:00 [Phase 2] Step 2 — plan_step=2 set (exit 0)
2026-04-16T11:39:22-07:00 [Phase 2] Step 3 — DAG node 1-2 exploration complete (exit 0)
2026-04-16T11:44:32-07:00 [stop-continue] first stop, conditional continue: pending=decompose
2026-04-16T11:56:13-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-16T11:56:57-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-16T12:05:55-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T12:06:01-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T12:12:16-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T12:12:22-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T12:20:32-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T12:20:38-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T12:29:21-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T12:29:27-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T12:34:58-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T12:35:04-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T12:35:34-07:00 [Phase 3] Task 8 — TOTAL captured after Tasks 1-7: lines=96.01%, regions=96.38%, functions=94.14% → floors lines=96, regions=96, functions=94
2026-04-16T12:41:21-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T12:41:29-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T12:42:18-07:00 [Phase 3] Task 10 — final CI verification: sentinel skip (new floors 96/96/94 confirmed green from Task 9 full-suite run)
2026-04-16T12:54:17-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-16T12:54:33-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-16T13:02:46-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-16T13:02:58-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-16T13:06:42-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-16T13:09:03-07:00 [stop-continue] first stop, conditional continue: pending=commit
2026-04-16T13:23:29-07:00 [Phase 6] finalize-commit — ci (ok)
2026-04-16T13:23:32-07:00 [Phase 6] finalize-commit — done ("ok")
2026-04-16T13:28:23-07:00 [Phase 6] complete-finalize — starting
2026-04-16T13:28:23-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-16T13:28:23-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>