### PR TITLE
Coverage Gap

### DIFF
--- a/src/hooks/validate_claude_paths.rs
+++ b/src/hooks/validate_claude_paths.rs
@@ -110,10 +110,6 @@ pub fn run_impl_main(
     hook_input: Option<serde_json::Value>,
     cwd: Option<&Path>,
 ) -> (i32, Option<String>) {
-    let cwd = match cwd {
-        Some(p) => p,
-        None => return (0, None),
-    };
     let hook_input = match hook_input {
         Some(v) => v,
         None => return (0, None),
@@ -132,11 +128,13 @@ pub fn run_impl_main(
         return (0, None);
     }
 
-    let project_root = find_project_root_in(cwd);
-    let branch = if project_root.is_some() {
-        detect_branch_from_path(cwd)
-    } else {
-        None
+    // Unresolvable cwd (None) flows through the same branch as
+    // "no .flow-states/ ancestor" — project_root ends up None and
+    // flow_active stays false, so the hook silently allows the action.
+    let project_root = cwd.and_then(find_project_root_in);
+    let branch = match (project_root.as_ref(), cwd) {
+        (Some(_), Some(c)) => detect_branch_from_path(c),
+        _ => None,
     };
     let flow_active = match (&branch, &project_root) {
         (Some(b), Some(r)) => is_flow_active(b, &resolve_main_root(r)),

--- a/src/hooks/validate_claude_paths.rs
+++ b/src/hooks/validate_claude_paths.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 
-use super::{detect_branch_from_cwd, is_flow_active, read_hook_input, resolve_main_root};
+use super::{detect_branch_from_path, is_flow_active, read_hook_input, resolve_main_root};
 use crate::flow_paths::FlowStatesDir;
 
 /// Check if a file path targets a protected .claude/ location.
@@ -73,10 +73,13 @@ pub fn validate(file_path: &str, flow_active: bool) -> (bool, String) {
     )
 }
 
-/// Find the project root by walking up from CWD for `.flow-states/` directory.
-fn find_project_root() -> Option<std::path::PathBuf> {
-    let cwd = std::env::current_dir().ok()?;
-    let mut current = cwd.as_path().to_path_buf();
+/// Find the project root by walking up from `cwd` for a `.flow-states/`
+/// directory. Pure helper — accepts `cwd` as a parameter so unit tests
+/// can drive every branch with a `TempDir` fixture. Mirrors the sibling
+/// cwd-injection pattern in `src/hooks/mod.rs`
+/// (`find_settings_and_root_from`, `detect_branch_from_path`).
+fn find_project_root_in(cwd: &Path) -> Option<std::path::PathBuf> {
+    let mut current = cwd.to_path_buf();
     loop {
         if FlowStatesDir::new(&current).path().is_dir() {
             return Some(current);
@@ -88,11 +91,21 @@ fn find_project_root() -> Option<std::path::PathBuf> {
     None
 }
 
-/// Run the validate-claude-paths hook (entry point from CLI).
-pub fn run() {
-    let hook_input = match read_hook_input() {
-        Some(input) => input,
-        None => std::process::exit(0),
+/// Pure core of the validate-claude-paths hook.
+///
+/// Accepts the parsed stdin payload and the resolved cwd as injected
+/// dependencies so every branch is reachable from unit tests with a
+/// `TempDir` fixture. Follows the `run_impl_main` pattern in
+/// `.claude/rules/rust-patterns.md` — `process::exit` and stderr I/O
+/// live in the thin `run()` wrapper below.
+///
+/// Return contract:
+/// - `(0, None)` → allow silently (wrapper exits 0, no stderr)
+/// - `(2, Some(message))` → block (wrapper prints message to stderr, exits 2)
+pub fn run_impl_main(hook_input: Option<serde_json::Value>, cwd: &Path) -> (i32, Option<String>) {
+    let hook_input = match hook_input {
+        Some(v) => v,
+        None => return (0, None),
     };
 
     let tool_input = hook_input
@@ -105,12 +118,12 @@ pub fn run() {
         .and_then(|v| v.as_str())
         .unwrap_or("");
     if file_path.is_empty() {
-        std::process::exit(0);
+        return (0, None);
     }
 
-    let project_root = find_project_root();
+    let project_root = find_project_root_in(cwd);
     let branch = if project_root.is_some() {
-        detect_branch_from_cwd()
+        detect_branch_from_path(cwd)
     } else {
         None
     };
@@ -121,11 +134,25 @@ pub fn run() {
 
     let (allowed, message) = validate(file_path, flow_active);
     if !allowed {
-        eprintln!("{}", message);
-        std::process::exit(2);
+        return (2, Some(message));
     }
 
-    std::process::exit(0);
+    (0, None)
+}
+
+/// Run the validate-claude-paths hook (entry point from CLI).
+///
+/// Thin wrapper: reads stdin, resolves `std::env::current_dir()`,
+/// calls `run_impl_main`, writes any block message to stderr, and
+/// exits with the returned code.
+pub fn run() {
+    let input = read_hook_input();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
+    let (code, message) = run_impl_main(input, &cwd);
+    if let Some(m) = message {
+        eprintln!("{}", m);
+    }
+    std::process::exit(code);
 }
 
 #[cfg(test)]
@@ -317,5 +344,138 @@ mod tests {
         assert!(msg.contains("write-rule"));
         assert!(msg.contains("--path"));
         assert!(msg.contains("--content-file"));
+    }
+
+    // --- find_project_root_in ---
+
+    #[test]
+    fn find_project_root_in_returns_cwd_when_flow_states_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        std::fs::create_dir_all(root.join(".flow-states")).unwrap();
+        assert_eq!(find_project_root_in(&root), Some(root));
+    }
+
+    #[test]
+    fn find_project_root_in_returns_ancestor_when_flow_states_in_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        std::fs::create_dir_all(root.join(".flow-states")).unwrap();
+        let deep = root.join("sub").join("deep");
+        std::fs::create_dir_all(&deep).unwrap();
+        assert_eq!(find_project_root_in(&deep), Some(root));
+    }
+
+    #[test]
+    fn find_project_root_in_returns_none_when_no_flow_states() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        // No .flow-states/ at root or any ancestor created by this test.
+        // If a real .flow-states/ exists at a parent of the tempdir on
+        // the developer machine, this test would fail — signaling that
+        // the isolation assumption is wrong. CI runs in a fresh env
+        // without such ancestors.
+        assert_eq!(find_project_root_in(&root), None);
+    }
+
+    // --- run_impl_main ---
+
+    /// Seed a fixture laid out as `<root>/.flow-states/<branch>.json`
+    /// plus `<root>/.worktrees/<branch>/.git` marker so the worktree
+    /// cwd `<root>/.worktrees/<branch>` resolves project_root via
+    /// `find_project_root_in` and branch via `detect_branch_from_path`.
+    fn seed_active_flow_fixture(root: &Path, branch: &str) -> std::path::PathBuf {
+        std::fs::create_dir_all(root.join(".flow-states")).unwrap();
+        std::fs::write(
+            root.join(".flow-states").join(format!("{}.json", branch)),
+            "{}",
+        )
+        .unwrap();
+        let worktree = root.join(".worktrees").join(branch);
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(worktree.join(".git"), "gitdir: fake\n").unwrap();
+        worktree
+    }
+
+    #[test]
+    fn run_impl_main_returns_zero_when_hook_input_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let (code, msg) = run_impl_main(None, &root);
+        assert_eq!(code, 0);
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn run_impl_main_returns_zero_when_file_path_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let input = serde_json::json!({"tool_input": {}});
+        let (code, msg) = run_impl_main(Some(input), &root);
+        assert_eq!(code, 0);
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn run_impl_main_returns_zero_when_no_project_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        // No .flow-states/ anywhere — find_project_root_in returns None,
+        // flow_active is false, so even a protected file_path is allowed.
+        let input = serde_json::json!({
+            "tool_input": {"file_path": "/anything/.claude/rules/foo.md"}
+        });
+        let (code, msg) = run_impl_main(Some(input), &root);
+        assert_eq!(code, 0);
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn run_impl_main_returns_block_when_flow_active_and_protected_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let worktree = seed_active_flow_fixture(&root, "feat");
+        let target = worktree.join(".claude/rules/foo.md");
+        let input = serde_json::json!({
+            "tool_input": {"file_path": target.to_string_lossy()}
+        });
+        let (code, msg) = run_impl_main(Some(input), &worktree);
+        assert_eq!(code, 2);
+        let msg = msg.expect("block returns Some(message)");
+        assert!(msg.contains("BLOCKED"), "message: {}", msg);
+    }
+
+    #[test]
+    fn run_impl_main_returns_zero_when_flow_active_and_unprotected_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let worktree = seed_active_flow_fixture(&root, "feat");
+        let target = worktree.join("src/lib.rs");
+        let input = serde_json::json!({
+            "tool_input": {"file_path": target.to_string_lossy()}
+        });
+        let (code, msg) = run_impl_main(Some(input), &worktree);
+        assert_eq!(code, 0);
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn run_impl_main_returns_zero_when_branch_none() {
+        // project_root resolves (`.flow-states/` present) but cwd is
+        // outside any `.worktrees/<branch>/` layout, so
+        // `detect_branch_from_path` falls back to `git branch
+        // --show-current` in cwd. TempDir has no git repo → None.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        std::fs::create_dir_all(root.join(".flow-states")).unwrap();
+        // cwd is a sub-directory under root, not under .worktrees/.
+        let sub = root.join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        let input = serde_json::json!({
+            "tool_input": {"file_path": "/anything/.claude/rules/foo.md"}
+        });
+        let (code, msg) = run_impl_main(Some(input), &sub);
+        assert_eq!(code, 0);
+        assert!(msg.is_none());
     }
 }

--- a/src/hooks/validate_claude_paths.rs
+++ b/src/hooks/validate_claude_paths.rs
@@ -95,14 +95,25 @@ fn find_project_root_in(cwd: &Path) -> Option<std::path::PathBuf> {
 ///
 /// Accepts the parsed stdin payload and the resolved cwd as injected
 /// dependencies so every branch is reachable from unit tests with a
-/// `TempDir` fixture. Follows the `run_impl_main` pattern in
-/// `.claude/rules/rust-patterns.md` — `process::exit` and stderr I/O
-/// live in the thin `run()` wrapper below.
+/// `TempDir` fixture. `cwd` is optional so the wrapper can pass
+/// `std::env::current_dir().ok()` without an untestable fallback
+/// closure — an unresolvable cwd means no project_root can be
+/// detected, so the hook silently allows the action. Follows the
+/// `run_impl_main` pattern in `.claude/rules/rust-patterns.md` —
+/// `process::exit` and stderr I/O live in the thin `run()` wrapper
+/// below.
 ///
 /// Return contract:
 /// - `(0, None)` → allow silently (wrapper exits 0, no stderr)
 /// - `(2, Some(message))` → block (wrapper prints message to stderr, exits 2)
-pub fn run_impl_main(hook_input: Option<serde_json::Value>, cwd: &Path) -> (i32, Option<String>) {
+pub fn run_impl_main(
+    hook_input: Option<serde_json::Value>,
+    cwd: Option<&Path>,
+) -> (i32, Option<String>) {
+    let cwd = match cwd {
+        Some(p) => p,
+        None => return (0, None),
+    };
     let hook_input = match hook_input {
         Some(v) => v,
         None => return (0, None),
@@ -147,8 +158,8 @@ pub fn run_impl_main(hook_input: Option<serde_json::Value>, cwd: &Path) -> (i32,
 /// exits with the returned code.
 pub fn run() {
     let input = read_hook_input();
-    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
-    let (code, message) = run_impl_main(input, &cwd);
+    let cwd = std::env::current_dir().ok();
+    let (code, message) = run_impl_main(input, cwd.as_deref());
     if let Some(m) = message {
         eprintln!("{}", m);
     }
@@ -398,10 +409,25 @@ mod tests {
     }
 
     #[test]
+    fn run_impl_main_returns_zero_when_cwd_none() {
+        // Wrapper couldn't resolve std::env::current_dir() — no way to
+        // detect a FLOW phase, so the hook silently allows the action.
+        let cwd: Option<&Path> = None;
+        let (code, msg) = run_impl_main(
+            Some(serde_json::json!({
+                "tool_input": {"file_path": "/anything/.claude/rules/foo.md"}
+            })),
+            cwd,
+        );
+        assert_eq!(code, 0);
+        assert!(msg.is_none());
+    }
+
+    #[test]
     fn run_impl_main_returns_zero_when_hook_input_missing() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().canonicalize().unwrap();
-        let (code, msg) = run_impl_main(None, &root);
+        let (code, msg) = run_impl_main(None, Some(&root));
         assert_eq!(code, 0);
         assert!(msg.is_none());
     }
@@ -411,7 +437,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().canonicalize().unwrap();
         let input = serde_json::json!({"tool_input": {}});
-        let (code, msg) = run_impl_main(Some(input), &root);
+        let (code, msg) = run_impl_main(Some(input), Some(&root));
         assert_eq!(code, 0);
         assert!(msg.is_none());
     }
@@ -425,7 +451,7 @@ mod tests {
         let input = serde_json::json!({
             "tool_input": {"file_path": "/anything/.claude/rules/foo.md"}
         });
-        let (code, msg) = run_impl_main(Some(input), &root);
+        let (code, msg) = run_impl_main(Some(input), Some(&root));
         assert_eq!(code, 0);
         assert!(msg.is_none());
     }
@@ -439,7 +465,7 @@ mod tests {
         let input = serde_json::json!({
             "tool_input": {"file_path": target.to_string_lossy()}
         });
-        let (code, msg) = run_impl_main(Some(input), &worktree);
+        let (code, msg) = run_impl_main(Some(input), Some(&worktree));
         assert_eq!(code, 2);
         let msg = msg.expect("block returns Some(message)");
         assert!(msg.contains("BLOCKED"), "message: {}", msg);
@@ -454,7 +480,7 @@ mod tests {
         let input = serde_json::json!({
             "tool_input": {"file_path": target.to_string_lossy()}
         });
-        let (code, msg) = run_impl_main(Some(input), &worktree);
+        let (code, msg) = run_impl_main(Some(input), Some(&worktree));
         assert_eq!(code, 0);
         assert!(msg.is_none());
     }
@@ -474,7 +500,7 @@ mod tests {
         let input = serde_json::json!({
             "tool_input": {"file_path": "/anything/.claude/rules/foo.md"}
         });
-        let (code, msg) = run_impl_main(Some(input), &sub);
+        let (code, msg) = run_impl_main(Some(input), Some(&sub));
         assert_eq!(code, 0);
         assert!(msg.is_none());
     }

--- a/src/hooks/validate_claude_paths.rs
+++ b/src/hooks/validate_claude_paths.rs
@@ -16,6 +16,12 @@ use crate::flow_paths::FlowStatesDir;
 /// Protected: .claude/rules/ (any depth), .claude/skills/ (any depth),
 /// CLAUDE.md (any level).
 /// Not protected: .claude/settings.json, .claude/settings.local.json.
+///
+/// Matching is ASCII-case-insensitive for `.claude`, `rules`, `skills`,
+/// and `CLAUDE.md` so a caller on a case-insensitive filesystem
+/// (macOS APFS/HFS+ by default) cannot bypass the gate by writing to
+/// `.CLAUDE/rules/foo.md` or `Claude.md` — which resolve to the same
+/// inode as the protected names.
 pub fn is_protected_path(file_path: &str) -> bool {
     if file_path.is_empty() {
         return false;
@@ -27,19 +33,19 @@ pub fn is_protected_path(file_path: &str) -> bool {
         .map(|c| c.as_os_str().to_str().unwrap_or(""))
         .collect();
 
-    // Check for .claude/rules/ or .claude/skills/ at any depth
+    // Check for .claude/rules/ or .claude/skills/ at any depth.
     for (i, comp) in components.iter().enumerate() {
-        if *comp == ".claude" && i + 1 < components.len() {
+        if comp.eq_ignore_ascii_case(".claude") && i + 1 < components.len() {
             let next = components[i + 1];
-            if next == "rules" || next == "skills" {
+            if next.eq_ignore_ascii_case("rules") || next.eq_ignore_ascii_case("skills") {
                 return true;
             }
         }
     }
 
-    // Check for CLAUDE.md at any level
+    // Check for CLAUDE.md at any level.
     if let Some(filename) = components.last() {
-        if *filename == "CLAUDE.md" {
+        if filename.eq_ignore_ascii_case("CLAUDE.md") {
             return true;
         }
     }
@@ -231,6 +237,31 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn test_is_protected_path_mixed_case_claude_md() {
+        // On case-insensitive filesystems (macOS APFS/HFS+ default),
+        // `Claude.md`, `claude.md`, and `CLAUDE.md` all resolve to the
+        // same inode. The gate must reject every variant.
+        assert!(is_protected_path("/project/Claude.md"));
+        assert!(is_protected_path("/project/claude.md"));
+    }
+
+    #[test]
+    fn test_is_protected_path_mixed_case_claude_dir() {
+        // `.CLAUDE/rules/foo.md` and `.Claude/rules/foo.md` must be
+        // blocked on case-insensitive filesystems.
+        assert!(is_protected_path("/project/.CLAUDE/rules/foo.md"));
+        assert!(is_protected_path("/project/.Claude/rules/foo.md"));
+    }
+
+    #[test]
+    fn test_is_protected_path_mixed_case_rules_and_skills() {
+        // The `rules` / `skills` component must also case-fold so a
+        // caller can't write to `.claude/Rules/foo.md` to bypass.
+        assert!(is_protected_path("/project/.claude/Rules/foo.md"));
+        assert!(is_protected_path("/project/.claude/SKILLS/foo/SKILL.md"));
+    }
+
     // --- validate tests ---
 
     #[test]
@@ -355,7 +386,7 @@ mod tests {
         assert!(msg.contains("--content-file"));
     }
 
-    // --- find_project_root_in ---
+    // --- find_project_root_in tests ---
 
     #[test]
     fn find_project_root_in_returns_cwd_when_flow_states_present() {
@@ -387,12 +418,16 @@ mod tests {
         assert_eq!(find_project_root_in(&root), None);
     }
 
-    // --- run_impl_main ---
+    // --- run_impl_main tests ---
 
     /// Seed a fixture laid out as `<root>/.flow-states/<branch>.json`
     /// plus `<root>/.worktrees/<branch>/.git` marker so the worktree
     /// cwd `<root>/.worktrees/<branch>` resolves project_root via
     /// `find_project_root_in` and branch via `detect_branch_from_path`.
+    ///
+    /// Returns the path to `<root>/.worktrees/<branch>` — the worktree
+    /// directory callers pass to `run_impl_main` as `cwd` and use as
+    /// the parent for target `file_path` values.
     fn seed_active_flow_fixture(root: &Path, branch: &str) -> std::path::PathBuf {
         std::fs::create_dir_all(root.join(".flow-states")).unwrap();
         std::fs::write(


### PR DESCRIPTION
## What

work on issue #1095.

Closes #1095

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/coverage-gap-plan.md` |
| DAG | `.flow-states/coverage-gap-dag.md` |
| Log | `.flow-states/coverage-gap.log` |
| State | `.flow-states/coverage-gap.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/e02b514a-476a-4290-a37f-620f259ed440.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan: 100% Coverage on `src/hooks/validate_claude_paths.rs`

## Context

Issue #1095 asks for 100% coverage on `src/hooks/validate_claude_paths.rs`. Current: 80.00% regions, 80.19% lines, 91.18% functions (67 regions, 41 lines, 3 functions missed). Per `.claude/rules/no-waivers.md`, the only valid responses are (1) subprocess tests, (2) refactor to a testable seam, or (3) design change deleting unreachable branches. `test_coverage.md` entries are forbidden — the issue body mentions waivers but that suggestion is overridden by the rule.

## Exploration

**Target file.** `src/hooks/validate_claude_paths.rs` (131 production lines + 190 test lines). Four top-level items:

- `is_protected_path(file_path: &str) -> bool` (public) — covered by existing inline unit tests.
- `validate(file_path: &str, flow_active: bool) -> (bool, String)` (public) — covered by existing inline unit tests.
- `find_project_root() -> Option<PathBuf>` (private) — **uncovered**. Reads `std::env::current_dir()` and walks ancestors checking for `.flow-states/`.
- `run()` (public) — **uncovered by inline tests**. CLI entry point; reads stdin, resolves branch + project_root, invokes `validate`, `eprintln!` + `process::exit(2)` on block or `process::exit(0)` on allow.

**Existing subprocess coverage.** `tests/hooks.rs` lines 891–1083 contain seven subprocess tests that spawn `flow-rs hook validate-claude-paths` with piped stdin and exercise the full `run()` path end-to-end — malformed stdin, empty file_path, no-.flow-states allow, protected blocks (rules/skills/CLAUDE.md/worktree variants), settings.json allow, src/lib.rs allow, and flow-state-file-missing allow. Despite these, `run()` shows uncovered regions in cargo-llvm-cov — likely closures inside `.and_then`/`.unwrap_or` chains that never evaluate their default-expression arm, plus private helper `find_project_root()` which is unreachable from any inline unit test because it reads `std::env::current_dir()` directly.

**Reference patterns:**

- `.claude/rules/rust-patterns.md` — `run_impl_main(params, root[, cwd]) -> (ReturnType, i32)` seam for main-arm dispatch that hoists `process::exit` out of the tested surface. Concrete precedent: `check_phase::run_impl_main`, `phase_transition::run_impl_main`, `tui_data::run_impl_main`, `format_status::run_impl_main`.
- `src/hooks/mod.rs` — companion pattern already used in this module's siblings: `find_settings_and_root()` wraps `find_settings_and_root_from(start: &Path)`; `detect_branch_from_cwd()` wraps `detect_branch_from_path(cwd: &Path)`. The cwd-injection seam is the established shape for this module.
- `tests/hooks.rs::setup_worktree_fixture` / `run_hook_in` — reference fixture helpers with documented contracts (`.git` marker, `with_state_file` branch, stdin piping via `Stdio::piped`).
- `tests/common/mod.rs::create_git_repo_with_remote` — shared fixture builder for git-aware tests.
- `bin/test` lines 58–79 — threshold ratchet: `--fail-under-lines 96`, `--fail-under-regions 96`, `--fail-under-functions 94`. Convention is "floor of actual whole percent" — raise when coverage crosses into a new whole-percent range, never move down.

**Affected files:**

- `src/hooks/validate_claude_paths.rs` — refactor target: extract `find_project_root_in(cwd)` and `run_impl_main(hook_input, cwd)` seams, convert `find_project_root` and `run` to thin wrappers, add inline unit tests.
- `bin/test` — raise thresholds after coverage lands.

**No subprocess test surface added.** The existing seven subprocess tests in `tests/hooks.rs` will continue to cover the post-refactor `run()` wrapper end-to-end through the same stdin→exit path; no new `tests/main_dispatch.rs` test is needed.

## Risks

1. **Test fixtures must canonicalize the TempDir root** per `.claude/rules/testing-gotchas.md` "macOS Subprocess Path Canonicalization" — otherwise `starts_with` checks against project_root or ancestor-walk comparisons silently fail on macOS's `/var → /private/var` symlink. Every new inline test that constructs a cwd or expected-result path calls `dir.path().canonicalize().unwrap()` at the top of the test body.
2. **Threshold bump ordering** — the threshold bump task must run AFTER all coverage lands. Running it earlier captures stale numbers. Enforced via task dependency order (Task 5 depends on Tasks 1–4).
3. **Threshold drift from concurrent PRs** — main's aggregate TOTAL moves as sibling PRs merge. Mitigation: use the floor-of-whole-percent ratchet convention from `bin/test` lines 58–65 — raise thresholds to the floor of the observed post-implementation whole-percent value, not to the exact number.
4. **`run_impl_main` reads real filesystem state** via `super::detect_branch_from_cwd`, `super::is_flow_active`, and `super::resolve_main_root`. Inline tests must seed a TempDir with both a `.worktrees/<branch>/.git` marker (for branch detection) and `.flow-states/<branch>.json` (for flow-active detection) — matching the existing `tests/hooks.rs::setup_worktree_fixture` contract.
5. **Supersession** — the old `find_project_root` body is superseded by `find_project_root_in`; the one-line wrapper remains and delegates. Similarly the old `run()` body is superseded by `run_impl_main`; the wrapper remains as the CLI entry point. Both supersessions land in the same commit as the extraction, not as separate cleanup.
6. **Plan-deviation gate** — the plan names specific test functions. The Code phase must implement each test with a body whose added-lines contain the string literals this plan commits to (primarily `"BLOCKED"` in the block test). The gate in `src/finalize_commit.rs` cross-references `(test_name, fixture_key, plan_value)` triples from fenced code blocks; plan prose below intentionally uses no fenced code blocks that commit to fixture values beyond the one canonical assertion documented in `.claude/rules/plan-commit-atomicity.md` examples.

## Approach

Extract two pure helpers that accept injected dependencies, then test each branch with TempDir fixtures:

1. **`find_project_root_in(cwd: &Path) -> Option<PathBuf>`** — the existing traversal logic with `cwd` as a parameter. The existing `find_project_root()` becomes a one-line wrapper that reads `std::env::current_dir()` and delegates. This follows the established sibling pattern in `src/hooks/mod.rs` (`find_settings_and_root_from`, `detect_branch_from_path`).
2. **`run_impl_main(hook_input: Option<Value>, cwd: &Path) -> (i32, Option<String>)`** — the existing `run()` body with stdin (as `Option<Value>`) and cwd hoisted out. Returns `(0, None)` for allow, `(2, Some(msg))` for block. The existing `run()` becomes a thin wrapper: calls `super::read_hook_input()`, resolves `std::env::current_dir()`, calls `run_impl_main`, dispatches to `eprintln!` + `process::exit`.

All three branches of `find_project_root_in` and all six runtime branches of `run_impl_main` are exercised by inline unit tests. The `run()` wrapper's 5-line dispatch is covered by the existing subprocess tests in `tests/hooks.rs` (seven tests spanning malformed stdin, empty file_path, no-project-root, block variants, allow variants). After the coverage lands, measure the new aggregate TOTAL via `bin/flow ci` and raise `bin/test`'s `--fail-under-lines`, `--fail-under-regions`, `--fail-under-functions` thresholds to the floor of the observed whole-percent values.

### Branch Enumeration Table — `find_project_root_in(cwd: &Path)`

| Branch | Condition | Classification | Test |
|---|---|---|---|
| A | cwd directly contains `.flow-states/` | Testable directly | `find_project_root_in_returns_cwd_when_flow_states_present` |
| B | ancestor of cwd contains `.flow-states/` | Testable directly | `find_project_root_in_returns_ancestor_when_flow_states_in_parent` |
| C | no ancestor contains `.flow-states/` | Testable directly | `find_project_root_in_returns_none_when_no_flow_states` |

### Branch Enumeration Table — `run_impl_main(hook_input: Option<Value>, cwd: &Path)`

| Branch | Condition | Classification | Test |
|---|---|---|---|
| a | `hook_input` is None | Testable directly | `run_impl_main_returns_zero_when_hook_input_missing` |
| b | `tool_input.file_path` missing, null, or empty | Testable directly | `run_impl_main_returns_zero_when_file_path_empty` |
| c | `find_project_root_in` returns None → `flow_active = false` | Testable directly | `run_impl_main_returns_zero_when_no_project_root` |
| d | flow_active true, protected path → block | Testable directly | `run_impl_main_returns_block_when_flow_active_and_protected_path` |
| e | flow_active true, unprotected path → allow | Testable directly | `run_impl_main_returns_zero_when_flow_active_and_unprotected_path` |
| f | project_root Some but branch None (no `.git` marker) → flow_active false → allow even a protected path | Testable directly | `run_impl_main_returns_zero_when_branch_none` |

Every branch lands under Testable directly — no seam or subprocess classification required beyond the two extracted helpers themselves.

## Dependency Graph

| Task | Type | Depends On | Atomic Group |
|---|---|---|---|
| 1. Write inline tests for `find_project_root_in` (3 branches) | test | — | G1 |
| 2. Extract `find_project_root_in` + wrap `find_project_root` | implement | 1 | G1 |
| 3. Write inline tests for `run_impl_main` (6 branches) | test | 2 | G2 |
| 4. Extract `run_impl_main` + wrap `run` | implement | 3 | G2 |
| 5. Measure new aggregate TOTAL via `bin/flow ci`; raise thresholds in `bin/test` to the floor of the observed whole-percent values | measure+implement | 4 | G3 |

**Atomic groups rationale** per `.claude/rules/plan-commit-atomicity.md`:

- **G1 (Tasks 1+2)** — atomic because Task 1's tests reference `find_project_root_in` which does not exist until Task 2. The intermediate state between Task 1 and Task 2 has failing tests (unresolved symbol). Splitting violates Condition 1 of the atomic-split rule.
- **G2 (Tasks 3+4)** — same rationale: Task 3's tests reference `run_impl_main` which does not exist until Task 4.
- **G3 (Task 5)** — lands alone. Task 5 is measurement-only; it runs `bin/flow ci` (which the previous commits already passed) and then raises thresholds. Routes through `/flow:flow-commit` per CLAUDE.md "Measurement-only tasks still route through `/flow:flow-commit`."

## Tasks

### Task 1 — Write inline unit tests for `find_project_root_in`

**Files:** `src/hooks/validate_claude_paths.rs` (tests module only)

Add three tests in the existing `#[cfg(test)] mod tests` block, each using `tempfile::TempDir` with `dir.path().canonicalize().unwrap()` at the top of the test body for macOS symlink safety:

- `find_project_root_in_returns_cwd_when_flow_states_present` — create `<tmp>/.flow-states/` directly in the TempDir, call `find_project_root_in(&tmp)`, assert `Some(tmp)`.
- `find_project_root_in_returns_ancestor_when_flow_states_in_parent` — create `<tmp>/.flow-states/`, then a subdirectory `<tmp>/sub/deep/`; call `find_project_root_in(&<tmp>/sub/deep)`, assert `Some(tmp)`.
- `find_project_root_in_returns_none_when_no_flow_states` — create a fresh TempDir with no `.flow-states/`. To avoid walking up into a real FLOW checkout on the developer machine, set `GIT_CEILING_DIRECTORIES` (not applicable here — `find_project_root_in` only consults `.flow-states/`, which does not respect ceiling dirs). Instead, construct a TempDir in an isolated location (the canonicalized path is used as-is) and rely on the absence of `.flow-states/` at every ancestor up to `/`. The assertion is `result.is_none()` — if `.flow-states/` happens to exist at a real ancestor, the test would fail locally, which is the correct signal. The Code phase verifies the test passes in CI's fresh environment.

Tests will fail to compile initially (the function does not yet exist). That is the expected TDD state, cleared by Task 2.

**Atomic with Task 2** (G1).

**Regression this guards:** A refactor of the ancestor-walk loop could return the wrong ancestor (e.g., first instead of nearest) or fail to terminate at filesystem root. The three branches lock the contract.

### Task 2 — Extract `find_project_root_in` and convert `find_project_root` to a wrapper

**Files:** `src/hooks/validate_claude_paths.rs`

Split the body of `find_project_root` into a pure helper and a thin wrapper:

- Add `fn find_project_root_in(cwd: &Path) -> Option<PathBuf>` containing the existing walk-up loop, but taking `cwd` as a parameter instead of calling `std::env::current_dir()`.
- Rewrite `find_project_root()` as a one-line delegator: `std::env::current_dir().ok().and_then(|cwd| find_project_root_in(&cwd))`.

Update the module doc comment to describe the cwd-injection seam, matching the sibling style in `src/hooks/mod.rs` for `find_settings_and_root_from` and `detect_branch_from_path`.

Tests from Task 1 now pass. The existing subprocess tests in `tests/hooks.rs` continue to pass — they exercise `find_project_root` via the `run()` entry point.

**Supersession:** the old inline loop body inside `find_project_root` is superseded by the extracted `find_project_root_in`. The one-line wrapper remains as the public-from-within-the-file entry point.

### Task 3 — Write inline unit tests for `run_impl_main`

**Files:** `src/hooks/validate_claude_paths.rs` (tests module only)

Add six tests, each using `tempfile::TempDir` canonicalized at the top for macOS safety, then seeded with a `.worktrees/<branch>/.git` marker (for branch detection) and `.flow-states/<branch>.json` (for flow-active detection) mirroring the `tests/hooks.rs::setup_worktree_fixture` contract where needed:

- `run_impl_main_returns_zero_when_hook_input_missing` — call with `None`, assert return `(0, None)`.
- `run_impl_main_returns_zero_when_file_path_empty` — call with `Some(json!({"tool_input": {}}))`, assert `(0, None)`.
- `run_impl_main_returns_zero_when_no_project_root` — call with a TempDir cwd that has no `.flow-states/` at any ancestor; assert `(0, None)` even if `file_path` points at `.claude/rules/foo.md`.
- `run_impl_main_returns_block_when_flow_active_and_protected_path` — seed worktree fixture with state file, call with file_path `<worktree>/.claude/rules/foo.md`; assert `(2, Some(msg))` with `msg.contains("BLOCKED")`.
- `run_impl_main_returns_zero_when_flow_active_and_unprotected_path` — same fixture, file_path `<worktree>/src/lib.rs`; assert `(0, None)`.
- `run_impl_main_returns_zero_when_branch_none` — seed project with `.flow-states/` but no `.worktrees/<branch>/.git` marker so `detect_branch_from_cwd` returns None; assert `(0, None)` even with a protected file_path.

Tests fail to compile initially. Cleared by Task 4.

**Atomic with Task 4** (G2).

**Regression this guards:** A refactor that silently changes a branch's exit code (e.g., returns `(0, Some(msg))` on block) passes type check but defeats the gate. The six named tests lock every branch's contract.

### Task 4 — Extract `run_impl_main` and convert `run` to a wrapper

**Files:** `src/hooks/validate_claude_paths.rs`

Extract the body of `run` into a pure helper that accepts `hook_input: Option<serde_json::Value>` and `cwd: &Path` as injected dependencies and returns `(i32, Option<String>)`. Internally the helper calls `super::detect_branch_from_cwd()`, `super::is_flow_active`, and `super::resolve_main_root` — these already have their own tests in `src/hooks/mod.rs` and do not need re-injection per Variant A of the Node 3 refactor design.

Return-value contract: `(0, None)` for allow (silent exit 0); `(2, Some(msg))` for block (exit 2 with stderr message).

Rewrite `run()` as a thin wrapper:

- Call `super::read_hook_input()` to obtain `Option<Value>`.
- Resolve `std::env::current_dir()` with a safe fallback (`PathBuf::from("/")`) so cwd resolution cannot panic.
- Call `run_impl_main(input, &cwd)`.
- On `Some(msg)` print to stderr via `eprintln!`.
- Call `std::process::exit(code)`.

Update the module doc comment to describe the `run_impl_main` seam. Tests from Task 3 now pass. The existing subprocess tests in `tests/hooks.rs` continue to pass — they exercise the wrapper's stdin-read + cwd-resolve + dispatch chain end-to-end.

**Supersession:** the old inline body of `run()` is superseded by `run_impl_main`. The wrapper remains as the CLI entry point.

### Task 5 — Measure new aggregate TOTAL and raise `bin/test` thresholds

**Files:** `bin/test`

Measurement-only: run `bin/flow ci` with a 10-minute Bash tool timeout (`timeout: 600000`) — CI runs can take 3–4 minutes and the default 2-minute timeout would background the process, defeating the gate (per `.claude/rules/ci-is-a-gate.md`). Capture the post-implementation aggregate TOTAL percentages for lines, regions, and functions from the cargo-llvm-cov output. Update `bin/test`'s `--fail-under-lines`, `--fail-under-regions`, `--fail-under-functions` flags (lines 77–79) to the **floor of each observed whole-percent value**, per the ratchet convention in `bin/test` lines 58–65. Re-run `bin/flow ci` to confirm the new thresholds pass. Route the commit through `/flow:flow-commit` per CLAUDE.md Conventions.

**Regression this guards:** Without raising thresholds, a future regression that drops any of the three metrics below the new aggregate TOTAL passes CI silently. Raising the floor locks in the improvement and protects the whole-repo coverage surface going forward.

## Hard Rules Compliance Summary

- **`.claude/rules/no-waivers.md`** — Every uncovered branch has a named test. Zero waiver prose. No `test_coverage.md` entries.
- **`.claude/rules/extract-helper-refactor.md`** — Branch Enumeration Tables present for both extracted helpers (3 + 6 branches), every branch Testable directly.
- **`.claude/rules/supersession.md`** — Both old function bodies are superseded by the extracted helpers; deletions land in the same commit as the extractions (Tasks 2 and 4).
- **`.claude/rules/plan-commit-atomicity.md`** — G1 and G2 marked atomic with rationale (tests reference symbols that do not exist until paired implementation lands). G3 is explicitly a separate commit.
- **`.claude/rules/skill-authoring.md`** Plan Task Ordering — Tests precede implementation within each group (TDD).
- **`.claude/rules/rust-patterns.md`** `run_impl_main` pattern — new seam follows reference shape `(ReturnType, i32)` adapted to `(i32, Option<String>)`.
- **`.claude/rules/testing-gotchas.md`** macOS canonicalization — every inline test calls `.canonicalize()` on its TempDir root before deriving paths.
- **`.claude/rules/ci-is-a-gate.md`** — Task 5 uses `timeout: 600000` for its `bin/flow ci` invocation.
- **`.claude/rules/external-input-audit-gate.md`** — Not applicable. <!-- external-input-audit: not-a-tightening --> No new panic/assert/invariant checks are added; the refactor is pure extraction and the existing `is_flow_active` rejection guards (empty branch, slash, backslash) already exist on main and are not modified.
- **`.claude/rules/tombstone-tests.md`** — Not applicable. No named feature is removed; extractions leave the public API (`run`, `find_project_root`) in place as wrappers.
- **`.claude/rules/external-input-validation.md`** — Not applicable. No new branch-valued or git-sourced inputs are added; `run_impl_main` reads the same sources as before via the existing `super::` helpers.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: 100% coverage on src/hooks/validate_claude_paths.rs

```xml
<dag goal="100% coverage on src/hooks/validate_claude_paths.rs" mode="full">
  <plan>
    <node id="1" name="Uncovered Branch Inventory" type="research" depends="[]" parallel_with="[]">
      <objective>Enumerate every uncovered line/region/function in validate_claude_paths.rs and map to branch conditions.</objective>
    </node>
    <node id="2" name="find_project_root Refactor Design" type="analysis" depends="[1]" parallel_with="3">
      <objective>Design the cwd-injection seam so each branch of find_project_root is Testable directly with a TempDir fixture.</objective>
    </node>
    <node id="3" name="run() Refactor Design" type="analysis" depends="[1]" parallel_with="2">
      <objective>Design the run_impl_main seam returning (exit_code, stderr_msg) so process::exit is hoisted out of the tested surface.</objective>
    </node>
    <node id="4" name="Test Strategy Selection" type="decision" depends="[2,3]" parallel_with="5">
      <objective>Pick inline unit tests vs tests/main_dispatch.rs subprocess for each branch; cover allow and block paths end-to-end.</objective>
    </node>
    <node id="5" name="Threshold Bump Strategy" type="analysis" depends="[1]" parallel_with="4">
      <objective>Determine how bin/test --fail-under-lines/regions/functions is currently computed and how to raise it to match new aggregate TOTAL.</objective>
    </node>
    <node id="6" name="Risk Audit" type="validation" depends="[2,3,4]" parallel_with="[]">
      <objective>Apply extract-helper enumeration, external-input audit, no-waivers, state-dependent gate ordering, and supersession checks.</objective>
    </node>
    <node id="7" name="Task Ordering + Dependency Graph" type="analysis" depends="[4,5,6]" parallel_with="[]">
      <objective>Order tasks TDD-first (tombstone? → test → refactor → threshold raise), mark atomic groups, and build dependency graph.</objective>
    </node>
    <node id="8" name="Synthesis — Plan Structure" type="synthesis" depends="[7]" parallel_with="[]">
      <objective>Produce Context, Exploration, Risks, Approach, Dependency Graph, Tasks sections for .flow-states/coverage-gap-plan.md.</objective>
    </node>
  </plan>
</dag>
```

---

▶ NODE 1: Uncovered Branch Inventory

Four functions in the file:

- `is_protected_path(file_path: &str) -> bool` — fully covered by existing unit tests (empty, rules, skills, CLAUDE.md, settings.json, nested, worktree variants).
- `validate(file_path: &str, flow_active: bool) -> (bool, String)` — fully covered (empty, no-flow allow, protected block, unrelated allow, worktree variants).
- `find_project_root() -> Option<PathBuf>` — **uncovered**. Three branches: (A) cwd contains `.flow-states/` → return Some; (B) ancestor contains `.flow-states/` → return Some after loop; (C) walked to filesystem root, no match → return None. Reads `std::env::current_dir()` — untestable without an env seam.
- `run()` — **uncovered** CLI entry. Branches: (a) `read_hook_input` returns None → exit 0; (b) `tool_input.file_path` empty → exit 0; (c) `find_project_root` None → `flow_active = false` → allow exit 0; (d) both Some, `is_flow_active = true`, protected path → `eprintln!` + exit 2; (e) allow path → exit 0. Calls `process::exit` inline — untestable without a seam that returns instead of exits.
- Closures inside `run()` (`.cloned().unwrap_or()`, `.and_then(|v| v.as_str())`) account for the "3 functions missed" count.

Quality: 9/10 — branch set complete and maps directly to refactor surfaces.
Key finding: All uncovered surface collapses into two refactor seams — `find_project_root(cwd: &Path)` and `run_impl_main(input, cwd) -> (i32, Option<String>)`.

---

▶ PARALLEL BRANCH A — NODE 2: `find_project_root` Refactor Design

Rename/split to `find_project_root_in(cwd: &Path) -> Option<PathBuf>` as the pure helper. The existing `find_project_root()` becomes a thin wrapper that calls `std::env::current_dir().ok().and_then(|cwd| find_project_root_in(&cwd))`. The wrapper is covered incidentally when `run()` is exercised by subprocess tests; the pure helper covers all three branches directly.

Branch Enumeration Table for `find_project_root_in`:

| Branch | Condition | Classification | Test |
|---|---|---|---|
| A | cwd itself contains `.flow-states/` | Testable directly | `find_project_root_in_returns_cwd_when_flow_states_present` |
| B | ancestor of cwd contains `.flow-states/` | Testable directly | `find_project_root_in_returns_ancestor_when_flow_states_in_parent` |
| C | no ancestor contains `.flow-states/` | Testable directly | `find_project_root_in_returns_none_when_no_flow_states` |

Quality: 9/10 — the three branches all land under Testable directly; no seam beyond cwd injection required.
Key finding: cwd is the only non-deterministic input; isolating it gives full coverage via TempDir fixtures.

▶ PARALLEL BRANCH B — NODE 3: `run()` Refactor Design

Extract `run_impl_main(hook_input: Option<Value>, cwd: &Path) -> (i32, Option<String>)` following the `run_impl_main` pattern in `.claude/rules/rust-patterns.md`. Return tuple interpretation:

- `(0, None)` → allow silently (exit 0, no stderr)
- `(2, Some(msg))` → block (exit 2, eprintln message)

Parameters are injected rather than read from stdin/env internally, so the pure core is exercised without subprocess overhead. The `run()` wrapper becomes: read stdin via `read_hook_input`, resolve cwd via `std::env::current_dir`, call `run_impl_main`, dispatch via stderr/exit.

Two viable variants — pick the simpler:

- Variant A: `run_impl_main` takes `hook_input: Option<Value>` and `cwd: &Path`. Inline tests pass crafted JSON values to hit every branch. `run()` is a 5-line wrapper — covered via one subprocess test in `tests/main_dispatch.rs` that pipes a minimal payload and asserts exit 0.
- Variant B: Full dependency injection (also inject `branch_resolver` and `flow_active_checker`). Rejected — the helpers live in `super::` and already have their own tests; re-injecting them is added machinery without test surface gain.

Selected: Variant A. The three `super::` helper calls (`read_hook_input`, `detect_branch_from_cwd`, `is_flow_active`, `resolve_main_root`) remain inline inside `run_impl_main`, and `run_impl_main` is tested for each branch using prepared `Value` inputs plus a TempDir cwd.

`detect_branch_from_cwd` and `is_flow_active` read real filesystem state (git dir, state files). Testing them end-to-end inside `run_impl_main` requires a full fixture (git repo + .flow-states file). The fixture already exists in `tests/common/mod.rs::create_git_repo_with_remote`, and `tests/hooks.rs` has `setup_worktree_fixture` for exactly this shape. Inline tests can reuse the same helpers.

Branch Enumeration Table for `run_impl_main`:

| Branch | Condition | Classification | Test |
|---|---|---|---|
| a | `hook_input` is None | Testable directly | `run_impl_main_returns_zero_when_hook_input_missing` |
| b | `tool_input.file_path` missing or empty | Testable directly | `run_impl_main_returns_zero_when_file_path_empty` |
| c | `find_project_root_in` returns None → `flow_active = false` | Testable directly | `run_impl_main_returns_zero_when_no_project_root` |
| d | flow_active && protected path | Testable directly | `run_impl_main_returns_block_when_flow_active_and_protected_path` |
| e | flow_active && unprotected path | Testable directly | `run_impl_main_returns_zero_when_flow_active_and_unprotected_path` |
| f | project_root found but branch None (git not initialized) | Testable directly | `run_impl_main_returns_zero_when_branch_none` |

Quality: 9/10 — every branch under Testable directly via `tests/hooks.rs`-style fixtures.
Key finding: Variant A avoids over-parameterization; the TempDir fixture covers all five runtime branches.

▶ MERGE: Nodes 2 + 3 together collapse the uncovered surface to two helpers (`find_project_root_in`, `run_impl_main`) — both fully unit-testable with TempDir. `run()` wrapper remains covered via a single subprocess test in `tests/main_dispatch.rs` to exercise the stdin→exit path through the real binary.

---

▶ NODE 4: Test Strategy Selection

Two test surfaces:

1. **Inline unit tests** in `src/hooks/validate_claude_paths.rs` `#[cfg(test)] mod tests` — exercise `find_project_root_in` (3 branches) and `run_impl_main` (6 branches). TempDir + JSON `Value` construction; reuse `tests/hooks.rs` helpers where practical.
2. **Subprocess test** in `tests/main_dispatch.rs` — one test that spawns `flow-rs hook validate-claude-paths` with a piped JSON stdin, asserts exit code 0. Covers the `run()` wrapper's stdin-read + cwd-resolution + exit dispatch lines.

Inline tests cover all refactored branches (Testable directly). The subprocess test covers the wrapper's 5-line tie-in to `std::env::current_dir()` and `process::exit`. Per `.claude/rules/no-waivers.md`, every line has a named coverage path — no waiver candidates.

Quality: 9/10 — coverage strategy is complete, cheap, and follows the reference patterns from rust-patterns.md.
Key finding: Inline tests for the seam + one subprocess test for the wrapper = full coverage with minimal new surface.

---

▶ NODE 5: Threshold Bump Strategy

`bin/test` applies `--fail-under-lines`, `--fail-under-regions`, `--fail-under-functions` flags (per issue body's Definition of Done). The new aggregate TOTAL after coverage lands needs measurement: run `bin/flow ci` post-implementation, capture the new TOTAL percentages from cargo-llvm-cov output, and raise the flag values to **whole-percent values with a ~1% buffer below the actual**. The buffer absorbs minor drift from sibling PRs without false-failing CI.

Implementation shape: a measurement-only task that re-runs `bin/flow ci` and proposes the new threshold values based on observed TOTAL, then edits `bin/test`. Per CLAUDE.md Conventions: "Measurement-only tasks still route through `/flow:flow-commit`."

Quality: 8/10 — depends on observed coverage, so the task is "capture and bump" rather than "bump to specific value." Safe.
Key finding: Threshold bump is the final task, runs after all coverage lands.

---

▶ NODE 6: Risk Audit

| Rule | Applies? | Handling |
|---|---|---|
| `.claude/rules/no-waivers.md` | Yes | All uncovered branches have a concrete test. Zero waiver prose in the plan. |
| `.claude/rules/extract-helper-refactor.md` | Yes | Branch Enumeration Tables present for `find_project_root_in` (3 branches) and `run_impl_main` (6 branches), all Testable directly. |
| `.claude/rules/external-input-audit-gate.md` | No | No new `panic!`/`assert!`/invariant checks added. Refactor is pure extraction. |
| `.claude/rules/external-input-validation.md` | No | No new branch-valued or git-sourced inputs. `run_impl_main` reads the same sources as before via `super::` helpers. |
| `.claude/rules/tombstone-tests.md` | No | No intentional removal of a named feature — just extraction + injection. |
| `.claude/rules/supersession.md` | Partial | The old `find_project_root` body is superseded by `find_project_root_in`; the wrapper's one-line delegation remains. Included as delete-and-re-add inside the same commit. |
| `.claude/rules/skill-authoring.md` — Plan Task Ordering | Yes | Tests come before implementation per TDD order. |
| `.claude/rules/plan-commit-atomicity.md` | Yes | Test + implementation pairs marked atomic. Threshold-bump is a separate commit (runs after all coverage lands). |
| `.claude/rules/rust-patterns.md` — `run_impl_main` pattern | Yes | New seam follows the reference shape `(i32, Option<String>)`. |
| `.claude/rules/rust-patterns.md` — Symlink-safe checks | No | No new `Path::exists()` → write patterns. `FlowStatesDir::new(&current).path().is_dir()` is read-only. |
| `.claude/rules/panic-safe-cleanup.md` | No | No new resource acquisition. |
| `.claude/rules/testing-gotchas.md` — macOS path canonicalization | Yes | Tests that construct TempDir paths must call `.canonicalize()` before passing to `run_impl_main` or asserting against its results. |
| `.claude/rules/hook-state-timing.md` | Partial | `run_impl_main` reads state via `is_flow_active`. The helper already exists and has documented read-window semantics — no new read ordering introduced. |

Quality: 9/10 — rule coverage complete; only open item is canonicalization discipline in tests, which is a well-known pattern.
Key finding: Zero waivers, no panic additions, one superseded code block routed through same-commit replacement.

---

▶ NODE 7: Task Ordering + Dependency Graph

Tasks in TDD order:

| Task | Type | Depends On | Atomic Group |
|---|---|---|---|
| 1. Write inline unit tests for `find_project_root_in` (3 branches) | test | — | G1 |
| 2. Extract `find_project_root_in(cwd: &Path)` and convert `find_project_root` to wrapper | implement | 1 | G1 |
| 3. Write inline unit tests for `run_impl_main` (6 branches) | test | 2 | G2 |
| 4. Extract `run_impl_main(hook_input, cwd) -> (i32, Option<String>)` and convert `run` to wrapper | implement | 3 | G2 |
| 5. Write subprocess test in `tests/main_dispatch.rs` for the `run` wrapper | test | 4 | G3 |
| 6. Run `bin/flow ci`, capture new aggregate TOTAL, raise thresholds in `bin/test` | measure+implement | 5 | G4 |

Atomic groups (per plan-commit-atomicity.md):

- **G1** — Tasks 1+2 land together (tests guard the new helper; intermediate state without the helper has failing tests).
- **G2** — Tasks 3+4 land together (same rationale).
- **G3** — Task 5 lands alone (wrapper already exists from G2; this is additive coverage).
- **G4** — Task 6 lands alone (measurement-only; raises thresholds).

Quality: 9/10 — every task has a named test, every group has an atomicity rationale.
Key finding: Four commits total; each independently shippable and CI-green.

---

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS — Node 8
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

## Context

Issue #1095 asks for 100% coverage on `src/hooks/validate_claude_paths.rs`. Current: 80.00% regions, 80.19% lines, 91.18% functions (67 regions, 41 lines, 3 functions missed). Per `.claude/rules/no-waivers.md`, the only valid responses are subprocess tests, refactor to a testable seam, or design change deleting unreachable branches. `test_coverage.md` entries are forbidden.

## Exploration

**File:** `src/hooks/validate_claude_paths.rs` (131 production lines + 190 test lines). Four top-level items:

- `is_protected_path` (public) — covered.
- `validate` (public) — covered.
- `find_project_root` (private) — uncovered. Reads `std::env::current_dir()` and walks ancestors checking for `.flow-states/`.
- `run` (public) — uncovered. CLI entry point; reads stdin, resolves branch+project_root, invokes `validate`, `eprintln!` + `process::exit(2)` on block or `process::exit(0)` on allow.

**Reference patterns:**

- `.claude/rules/rust-patterns.md` — `run_impl_main(params, root[, cwd]) -> (ReturnType, i32)` seam for main-arm dispatch that hoists `process::exit` out of the tested surface.
- `tests/main_dispatch.rs` — reference subprocess test surface for CLI entry points; cargo-llvm-cov instruments subprocess calls on the same binary.
- `tests/hooks.rs::setup_worktree_fixture` / `setup_pretool_fixture` — reference fixture helpers with documented contracts (`.git` marker, `with_state_file` branch, `allow_patterns` format).
- `tests/common/mod.rs::create_git_repo_with_remote` — shared fixture builder.

**Affected files:**

- `src/hooks/validate_claude_paths.rs` — refactor target.
- `tests/main_dispatch.rs` — add one subprocess test.
- `bin/test` — raise `--fail-under-lines`, `--fail-under-regions`, `--fail-under-functions` thresholds.

## Risks

1. **Test fixtures must canonicalize the TempDir root** per `.claude/rules/testing-gotchas.md` "macOS Subprocess Path Canonicalization" — otherwise `starts_with` checks against project_root silently fail on macOS's `/var → /private/var` symlink. Every test that constructs a cwd or file_path calls `dir.path().canonicalize().unwrap()` at the top of the test body.
2. **Threshold bump ordering** — Task 6 must run AFTER all coverage lands (Tasks 1–5). Running it earlier captures stale numbers and sets thresholds too low. Enforced via task dependency order.
3. **Aggregate TOTAL may change on other files between measurement and commit** — if concurrent PRs land on main during this PR's Code phase, the observed TOTAL after `bin/flow ci` may not match the threshold we set. Mitigation: use a ~1% buffer below observed actual (per issue body).
4. **`run()` wrapper coverage via subprocess test** — cargo-llvm-cov must instrument subprocess calls for the wrapper's `std::env::current_dir()`, `read_hook_input`, and dispatch lines to appear covered. The reference `tests/main_dispatch.rs::check_phase_first_phase_exits_0` demonstrates this works for `flow-rs`.
5. **`run_impl_main` tests touch git subprocess** — `detect_branch_from_cwd` and `is_flow_active` read the fixture's `.git` dir and `.flow-states/`. Fixture must seed both with `create_git_repo_with_remote` + a valid state file. Test naming convention: `run_impl_main_*`.
6. **Extraction branch enumeration enforced by `.claude/rules/extract-helper-refactor.md`** — Branch Enumeration Tables for both new helpers are included in this plan. Every branch lands under Testable directly; no `Testable via seam` or `Testable via subprocess` classifications are needed.

## Approach

Extract two pure helpers that accept injected dependencies, then test each branch with TempDir fixtures:

1. **`find_project_root_in(cwd: &Path) -> Option<PathBuf>`** — the existing traversal logic with `cwd` as a parameter. The existing `find_project_root()` becomes a one-line wrapper that reads `std::env::current_dir()` and delegates.
2. **`run_impl_main(hook_input: Option<Value>, cwd: &Path) -> (i32, Option<String>)`** — the existing `run()` body with stdin and cwd hoisted out. Returns `(0, None)` for allow, `(2, Some(msg))` for block. The existing `run()` becomes a thin wrapper: reads stdin, resolves cwd, calls `run_impl_main`, dispatches to stderr/exit.

All six runtime branches of `run_impl_main` and all three branches of `find_project_root_in` are exercised by inline unit tests. The `run()` wrapper's 5-line dispatch is covered by one subprocess test in `tests/main_dispatch.rs` that pipes a minimal allow-path JSON and asserts exit 0. After all coverage lands, measure the new aggregate TOTAL and raise `bin/test` thresholds to whole-percent values ~1% below observed actual.

## Dependency Graph

| Task | Type | Depends On | Atomic Group |
|---|---|---|---|
| 1. Write inline tests for `find_project_root_in` (3 branches) | test | — | G1 |
| 2. Extract `find_project_root_in` + wrap `find_project_root` | implement | 1 | G1 |
| 3. Write inline tests for `run_impl_main` (6 branches) | test | 2 | G2 |
| 4. Extract `run_impl_main` + wrap `run` | implement | 3 | G2 |
| 5. Write subprocess test in `tests/main_dispatch.rs` for the `run` wrapper | test | 4 | G3 |
| 6. Measure new aggregate TOTAL via `bin/flow ci`; raise thresholds in `bin/test` | measure+implement | 5 | G4 |

---

Confidence: 90% | Nodes: 8 | Parallel branches: 2

vs. Vanilla Claude (what linear reasoning would have missed):
- The branch enumeration requirement from `.claude/rules/extract-helper-refactor.md` — linear plans typically list "write tests" without enumerating each extracted helper's internal branches with a testability classification.
- The supersession check from `.claude/rules/supersession.md` — a linear plan would leave the old `find_project_root` body in place as "still needed" instead of routing it through same-commit replacement.
- The `no-waivers.md` discipline — the issue body itself references `test_coverage.md` waivers, which linear reasoning would have carried forward. The DAG's Risk Audit node catches the conflict between issue-body suggestion and the no-waivers rule and routes every branch to a concrete test.
- The macOS canonicalization requirement for every TempDir test — a linear plan would skip this and the tests would pass vacuously on macOS.
- The threshold-bump ordering constraint — Task 6 must run after Tasks 1–5, not in parallel; linear planning would frequently collapse the sequence.
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 10m |
| Code | 36m |
| Code Review | 25m |
| Learn | 6m |
| Complete | <1m |
| **Total** | **1h 19m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/coverage-gap.json</summary>

```json
{
  "schema_version": 1,
  "branch": "coverage-gap",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1204,
  "pr_url": "https://github.com/benkruger/flow/pull/1204",
  "started_at": "2026-04-16T13:58:48-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/coverage-gap-plan.md",
    "dag": ".flow-states/coverage-gap-dag.md",
    "log": ".flow-states/coverage-gap.log",
    "state": ".flow-states/coverage-gap.json"
  },
  "session_tty": "/dev/ttys000",
  "session_id": "e02b514a-476a-4290-a37f-620f259ed440",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/e02b514a-476a-4290-a37f-620f259ed440.jsonl",
  "notes": [],
  "prompt": "work on issue #1095",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-16T13:58:48-07:00",
      "completed_at": "2026-04-16T13:59:19-07:00",
      "session_started_at": null,
      "cumulative_seconds": 31,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-16T13:59:32-07:00",
      "completed_at": "2026-04-16T14:09:56-07:00",
      "session_started_at": null,
      "cumulative_seconds": 624,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-16T14:11:03-07:00",
      "completed_at": "2026-04-16T14:47:28-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2185,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-16T14:47:39-07:00",
      "completed_at": "2026-04-16T15:13:09-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1530,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-16T15:13:28-07:00",
      "completed_at": "2026-04-16T15:19:38-07:00",
      "session_started_at": null,
      "cumulative_seconds": 370,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-16T15:19:56-07:00",
      "completed_at": "2026-04-16T15:20:25-07:00",
      "session_started_at": null,
      "cumulative_seconds": 29,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-16T13:59:32-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-16T14:11:03-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-16T14:47:39-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-16T15:13:28-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-16T15:19:56-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 5,
  "code_task_name": "Measure aggregate TOTAL and raise bin/test thresholds to floor of whole-percent",
  "code_task": 5,
  "diff_stats": {
    "files_changed": 1,
    "insertions": 203,
    "deletions": 19,
    "captured_at": "2026-04-16T14:47:28-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "compact_summary": "<analysis>\nThe user has requested a learning analysis of a completed FLOW feature branch, specifically auditing compliance with three tenants: process gaps (Tenant 1), rule compliance (Tenant 2), and missing rules (Tenant 3). I am an auditor with no knowledge of the original conversation that produced these changes.\n\nLooking at the conversation:\n\n1. The user provided comprehensive context inline in the system prompt:\n   - A full diff of git changes (src/hooks/validate_claude_paths.rs, 243 insertions, 24 deletions)\n   - State file data (phase timings, visit counts, findings)\n   - Plan file (coverage-gap-plan.md)\n   - Project CLAUDE.md\n   - 48 rules files from .claude/rules/\n   - State file log (36 entries)\n\n2. I made several tool calls:\n   - Read request for plan file failed due to worktree path issue\n   - Glob to list rules files (successful)\n   - Read for CLAUDE.md (successful)\n   - Read for log file (successful)\n   - Multiple system-reminder blocks with rule files content (all read successfully)\n   - Bash command attempt failed due to compound command restriction\n\n3. The user then issued a CRITICAL instruction to stop using tools and provide text-only analysis with <analysis> and <summary> blocks, explicitly stating \"Tool calls will be REJECTED and will waste your only turn.\"\n\nI need to analyze what I've learned from the inline context provided:\n\n**Key observations from the artifacts:**\n\nThe feature is PR #1204, coverage-gap branch, working on issue #1095 for 100% coverage on `src/hooks/validate_claude_paths.rs`.\n\n**State file data shows:**\n- All phases completed: Start (31s), Plan (624s), Code (2185s), Code Review (1530s), Learn in progress\n- All visit_counts = 1 (no back-navigation)\n- All phases: commit=auto, continue=auto (autonomous flow)\n- 5 code tasks total, all marked complete (code_task: 5)\n- 9 findings: 6 dismissed (3 pre-mortem, 2 adversarial, 1 documentation), 3 fixed in Code Review (2 reviewer polish, 1 adversarial case-folding)\n\n**Plan shows:**\n- Two atomic groups G1+G2 combined into one commit\n- Plan named specific test functions with specific fixture values\n- Branch enumeration tables present for extraction refactors\n- Task count: 5 tasks total\n- Risks section noted: macOS canonicalization, threshold bump ordering, concurrent PR drift, filesystem state seeding, supersession handling, plan-deviation gate\n\n**Log file shows specific deviations logged:**\n- Line 20: \"atomic groups G1 (Tasks 1+2) and G2 (Tasks 3+4) combined into one commit\"\n- Line 23: \"run_impl_main cwd parameter widened from &Path to Option<&Path>\"\n- Line 26: \"aggregate TOTAL 96.70% regions / 96.42% lines / 94.56% functions\"\n- Line 27: \"Post-refactor simplification: replaced cwd=None early-return match with cwd.and_then\"\n\n**Diff summary from prompt:**\n- One file changed: src/hooks/validate_claude_paths.rs\n- 243 insertions, 24 deletions\n- Refactored hook into two pure helpers (find_project_root_in, run_impl_main) with cwd injection\n- Deleted old find_project_root wrapper as superseded\n- Added 9 new inline unit tests for find_project_root_in (3) and run_impl_main (6)\n- Code Review added case-insensitive matching in is_protected_path plus 3 mixed-case tests\n- Two polish fixes: section-marker style, seed_active_flow_fixture doc comment\n\n**Key rules that appear relevant from review:**\n- `.claude/rules/no-waivers.md` - no waivers, 100% coverage required\n- `.claude/rules/extract-helper-refactor.md` - branch enumeration required for extractions\n- `.claude/rules/plan-commit-atomicity.md` - atomic groups rules and plan-deviation logging\n- `.claude/rules/rust-patterns.md` - run_impl_main pattern, testing patterns\n- `.claude/rules/testing-gotchas.md` - macOS path canonicalization\n- `.claude/rules/supersession.md` - delete superseded code in same PR\n- `.claude/rules/code-review-scope.md` - all real findings fixed in PR, none filed\n\n**Notable observations for auditing:**\n\nTenant 1 (Process gaps): \n- Plan explicitly noted risks including macOS canonicalization, coverage threshold drift\n- State file logged deviations (atomic group combination, cwd parameter widening)\n- Code Review added case-insensitive matching as a finding\n\nTenant 2 (Rule compliance):\n- Plan deviation gate was used and logged (explicit entries in log)\n- Supersession appears to have been handled (wrapper functions retained, extraction in same commit)\n- No back-navigation needed (visit_counts all 1)\n- All code tasks completed (code_task: 5 / code_tasks_total: 5)\n- Code Review findings fixed, none filed\n\nTenant 3 (Missing rules):\n- The log shows a coverage-chasing pattern where coverage attempts included simplifications and refactors mid-phase\n- The pattern of \"run filtered tests, coverage shows low, refactor helper, simplify logic\" appears multiple times in the log\n- No existing rule covers when to stop iterating on coverage improvements\n\nThe user wants me to analyze this as a compliance auditor with three specific tenants to check.\n</analysis>\n\n<summary>\n\n1. Primary Request and Intent:\n   The user requested a compliance audit of a completed FLOW feature branch (PR #1204, issue #1095) as a learning analysis. The audit must assess three specific tenants: (1) whether FLOW's process/tooling broke or created friction, (2) whether Claude followed project rules in CLAUDE.md and .claude/rules/, and (3) what new rules should exist but don't. The auditor explicitly has no knowledge of the original conversation and bases analysis only on diff, state file, plan, CLAUDE.md, and rules files.\n\n2. Key Technical Concepts:\n   - FLOW's 6-phase development lifecycle: Start, Plan, Code, Code Review, Learn, Complete\n   - Extraction-helper refactoring pattern with cwd injection seams (run_impl_main, find_project_root_in)\n   - Plan-deviation gate in src/finalize_commit.rs that blocks commits when plan-named test fixtures drift\n   - Atomic commit groups (G1, G2, G3) where tests reference symbols that don't exist until paired implementation\n   - Coverage ratcheting convention: raise thresholds to \"floor of observed whole-percent\" not exact numbers\n   - macOS subprocess path canonicalization (tempdir symlinks /var → /private/var)\n   - FLOW concurrency model: branch-scoped state files, per-worktree artifacts, main-shared coordination via start lock\n   - Three valid coverage responses per no-waivers.md: subprocess tests, refactor seams, design changes\n\n3. Files and Code Sections:\n   - `src/hooks/validate_claude_paths.rs` (131 production lines + 190 test lines)\n      - Extracted find_project_root_in(cwd: &Path) -> Option<PathBuf> pure helper\n      - Extracted run_impl_main(hook_input: Option<Value>, cwd: &Path) -> (i32, Option<String>) pure helper\n      - Refactored find_project_root() to one-line wrapper delegating to find_project_root_in\n      - Refactored run() to thin wrapper that reads stdin, resolves cwd, calls run_impl_main, dispatches to exit\n      - Added 9 new inline unit tests: 3 for find_project_root_in (cwd has .flow-states, ancestor has .flow-states, none has .flow-states), 6 for run_impl_main (missing input, empty file_path, no project_root, protected+flow_active, unprotected+flow_active, branch_none)\n      - Code Review added is_protected_path case-insensitive matching, 3 mixed-case tests\n      - Polish: section-marker style fix, seed_active_flow_fixture doc comment\n   - `bin/test` (lines 77-79)\n      - Updated --fail-under-lines, --fail-under-regions, --fail-under-functions thresholds to floor of observed whole-percent values (not exact)\n   - `.flow-states/coverage-gap-plan.md`\n      - Plan file with full task breakdown (Tasks 1-5)\n      - Branch enumeration tables for both extracted helpers (3 + 6 branches, all \"Testable directly\")\n      - Atomic groups G1 (Tasks 1+2) and G2 (Tasks 3+4) with rationale: tests reference symbols that don't exist until paired implementation\n      - Explicit plan-deviation gate warning about fixture_key and plan_value triples\n   - `.flow-states/coverage-gap.log` (36 entries)\n      - Entry 20: Logged plan deviation for atomic group G1+G2 combination\n      - Entry 23: Logged plan deviation for run_impl_main cwd parameter widening from &Path to Option<&Path>\n      - Entry 26: Captured aggregate TOTAL 96.70% regions / 96.42% lines / 94.56% functions\n      - Entry 27: Logged post-refactor simplification replacing cwd=None match with and_then\n\n4. Errors and fixes:\n   - Tool call 1 (Read for plan file): Failed due to worktree path issue. Read request used /Users/ben/code/flow/.worktrees/coverage-gap-plan.md but should use /Users/ben/code/flow/.flow-states/coverage-gap-plan.md (state files are not in worktrees). Fixed by subsequent successful read of correct path.\n   - Tool call 5 (Bash with compound command): Failed with \"Compound commands (&&) are not allowed outside quoted arguments.\" Attempted to chain git diff with head -200. This is a permission/hook validation error, not a logic error.\n   - No user feedback on errors—the user immediately issued critical instruction to stop using tools.\n\n5. Problem Solving:\n   - Identified that state file data shows zero re-visits across all phases (visit_count: 1 everywhere), suggesting the process worked without friction requiring back-navigation.\n   - Identified that Code Review findings (6 dismissed, 3 fixed) correspond to expected review scope: 2 reviewer polish nits (minor), 1 adversarial finding (case-folding bypass).\n   - Identified that plan deviation gate was explicitly used and logged in state file, showing proper discipline.\n   - Identified that supersession rule was followed: old function bodies extracted and marked as superseded, wrappers retained, both in same commit.\n   - Identified coverage-chasing pattern in log entries 20-29 showing multiple refactors and simplifications during Code phase, suggesting possible missing rule about iteration discipline.\n\n6. All user messages:\n   - \"You are auditing rule compliance and identifying process gaps for a FLOW feature branch. You have no memory of the conversation that produced this work — only the artifacts below.\" (system context)\n   - \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools. [repeated emphasis] Tool calls will be REJECTED and will waste your only turn — you will fail the task.\" (final instruction)\n\n7. Pending Tasks:\n   - Create learning analysis audit identifying findings in three tenant categories: Process gaps, Rule compliance, Missing rules\n   - Each finding must be structured with Category, Enforcement (for rule compliance), Evidence, Where, Recommendation\n   - Complete audit by turn limit with no further tool calls\n\n8. Current Work:\n   Attempting to gather and analyze context for the three-tenant learning analysis. Successfully read:\n   - CLAUDE.md (232 lines, project architecture and conventions)\n   - Glob of .claude/rules/ (48 rule files listed)\n   - State file log (36 entries showing phase progression and deviations)\n   - Plan file contents (181 lines with tasks, risks, branch enumerations)\n   - Multiple rule files inline via system-reminder blocks (docs-with-behavior.md, repo-level-only.md, worktree-commands.md, and 45 others totaling comprehensive rule set)\n   \n   Had attempted tool calls to read plan file and run git diff but user issued hard stop instruction.\n\n9. Optional Next Step:\n   Complete the three-tenant learning analysis audit as a text-only response. The user has explicitly requested \"an <analysis> block followed by a <summary> block\" with findings in the structure: \"Finding N: [Short title]\" with Category, Enforcement, Evidence, Where, Recommendation fields. No further tool invocations are permitted. The audit should assess: (1) whether FLOW process tooling broke (gaps in plugins, hooks, skills, phase gates, visit counts, coverage issues), (2) whether Claude followed all stated rules (plan-commit-atomicity, extract-helper-refactor, no-waivers, supersession, code-review-scope, testing-gotchas), and (3) what new rules should exist (coverage iteration discipline appears to be one candidate based on log pattern of repeated refactors).\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/coverage-gap",
  "compact_count": 6,
  "findings": [
    {
      "finding": "Pre-mortem: silent hook bypass when cwd is None",
      "reason": "Intentional and pre-existing. Old code used unwrap_or_else(|_| PathBuf::from('/')) which also silently allowed. Refactor preserved identical behavior via cwd.and_then(find_project_root_in).",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T15:04:55-07:00"
    },
    {
      "finding": "Pre-mortem: no subprocess test for run() wrapper",
      "reason": "Seven existing subprocess tests in tests/hooks.rs (lines 891-1083) already exercise run() end-to-end: malformed stdin, empty file_path, no-flow-states allow, worktree block variants (rules/skills/CLAUDE.md), settings.json allow, src/lib.rs allow, flow-state-file-missing allow.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T15:05:06-07:00"
    },
    {
      "finding": "Pre-mortem: find_project_root_in_returns_none_when_no_flow_states relies on no .flow-states/ ancestor",
      "reason": "Theoretical risk only. TempDir on macOS is under /var/folders/... which has no .flow-states/ ancestor. On Linux, /tmp/ is the tempdir root with no .flow-states/ ancestor. The test's comment already acknowledges the assumption; CI environments are isolated from ~/.flow-states/.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T15:05:17-07:00"
    },
    {
      "finding": "Adversarial: NUL-byte truncation in file_path bypasses is_protected_path",
      "reason": "Not exploitable. Rust's Path and filesystem write functions reject embedded NUL bytes in paths (invalid input to syscalls). The hook allowing the path decision is moot because the actual Edit/Write operation cannot succeed with a NUL-containing path.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T15:05:28-07:00"
    },
    {
      "finding": "Adversarial: nested .worktrees layout defeats branch detection",
      "reason": "Nested .worktrees/ is not a supported FLOW layout. CLAUDE.md and .claude/rules/concurrency-model.md assume a single .worktrees/<branch>/ at project root; detect_branch_from_path's first-occurrence match aligns with that documented contract. No realistic user path produces this layout.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T15:05:39-07:00"
    },
    {
      "finding": "Documentation: Permission Invariant section missing validate_claude_paths phase-aware behavior",
      "reason": "Agent misread the diff. The hook was already phase-aware on main (via is_flow_active check on state file existence); my refactor preserved that behavior via cwd.and_then(find_project_root_in). No doc drift introduced.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T15:05:49-07:00"
    },
    {
      "finding": "Reviewer: test section markers used name-only form instead of '<name> tests' convention",
      "reason": "Changed '// --- find_project_root_in ---' and '// --- run_impl_main ---' to '// --- find_project_root_in tests ---' and '// --- run_impl_main tests ---' to match the pre-existing 'is_protected_path tests' / 'validate tests' style in the same file. Per rust-patterns.md Test Module Section Markers.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T15:10:45-07:00"
    },
    {
      "finding": "Reviewer: seed_active_flow_fixture doc comment omitted return value description",
      "reason": "Added two-sentence return-value description to the doc comment naming the PathBuf returned (worktree directory) and how callers use it. Per testing-gotchas.md Document Test Fixture Helpers.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T15:10:55-07:00"
    },
    {
      "finding": "Adversarial: is_protected_path bypass via mixed-case (.CLAUDE/rules, Claude.md, .claude/Rules) on case-insensitive filesystems",
      "reason": "Added eq_ignore_ascii_case comparisons for .claude, rules, skills, and CLAUDE.md components. Added three contract tests covering mixed-case variants (test_is_protected_path_mixed_case_claude_md, test_is_protected_path_mixed_case_claude_dir, test_is_protected_path_mixed_case_rules_and_skills). Pre-existing security gap; tightening aligns with no-waivers.md security discipline and is adjacent to already-modified code per code-review-scope.md.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T15:11:08-07:00"
    },
    {
      "finding": "Learn: Atomic-group log format prefix conflates plan deviations with atomic-group decisions",
      "reason": "Observational nitpick, not a rule gap. plan-commit-atomicity.md documents both Plan Deviations and Atomic Group decisions under a single rule file; the 'Plan deviation:' log prefix I used covers both, and the rule does not mandate separate log prefixes. Log message content (three conditions verified) was sufficient. A rule prescribing specific log prefixes would be noise.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T15:18:09-07:00"
    },
    {
      "finding": "Learn: plan-deviation log entry timing (after vs before commit)",
      "reason": "Analyst misread the ordering. Each plan deviation was logged via bin/flow log BEFORE running /flow:flow-commit, matching the rule requirement that the log entry exist before finalize-commit's plan-deviation gate runs. The analyst's concern that entry 27 was 'logged after the commit' doesn't match the actual sequence captured in the session log.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T15:18:19-07:00"
    },
    {
      "finding": "Learn: Coverage iteration discipline missing — Code phase spent ~28% of logged activity on coverage ratcheting",
      "reason": "Observation is accurate but a prescriptive rule (e.g., 'max N iterations') would be arbitrary. The existing bin/test floor-of-whole-percent ratchet already encodes the practical discipline: trust the aggregate TOTAL gate, don't chase marginal improvements. Future sessions should read bin/test lines 58-65 comments for the ratchet contract. A new rule would duplicate existing guidance.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T15:18:30-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/coverage-gap.log</summary>

```text
2026-04-16T13:58:48-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-16T13:58:48-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-16T13:58:48-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-16T13:58:48-07:00 [Phase 1] create .flow-states/coverage-gap.json (exit 0)
2026-04-16T13:58:48-07:00 [Phase 1] freeze .flow-states/coverage-gap-phases.json (exit 0)
2026-04-16T13:58:48-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-16T13:58:50-07:00 [Phase 1] start-init — label-issues (labeled: [1095], failed: [])
2026-04-16T13:58:57-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-16T13:58:57-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-16T13:58:58-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-16T13:59:05-07:00 [Phase 1] start-workspace — worktree .worktrees/coverage-gap (ok)
2026-04-16T13:59:09-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-16T13:59:09-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-16T13:59:09-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-16T13:59:19-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-16T13:59:19-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-16T14:03:32-07:00 [stop-continue] first stop, conditional continue: pending=decompose
2026-04-16T14:09:56-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-16T14:11:03-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-16T14:18:18-07:00 [Phase 3] Plan deviation: atomic groups G1 (Tasks 1+2) and G2 (Tasks 3+4) combined into one commit. Both groups are independently shippable but combining is simpler — the refactor is one coherent unit and the dead find_project_root() wrapper is superseded in the same commit as run_impl_main's extraction. No test assertion spans the boundary.
2026-04-16T14:23:11-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T14:23:15-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T14:24:50-07:00 [Phase 3] Plan signature deviation: run_impl_main cwd parameter widened from &Path to Option<&Path> to remove the unwrap_or_else closure in run(), which was the last uncovered defensive branch. Tests updated to wrap existing calls in Some(&root); one new test run_impl_main_returns_zero_when_cwd_none covers the None branch.
2026-04-16T14:38:55-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T14:38:59-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T14:39:39-07:00 [Phase 3] Task 5 measurement: aggregate TOTAL 96.70% regions / 96.42% lines / 94.56% functions. Floor-of-whole-percent = 96/96/94 matches current bin/test thresholds (--fail-under-lines 96, --fail-under-regions 96, --fail-under-functions 94). No threshold bump needed — the file-level improvement on validate_claude_paths.rs (80 to 99.83) did not move the aggregate across a whole-percent boundary.
2026-04-16T14:46:21-07:00 [Phase 3] Post-refactor simplification: replaced cwd=None early-return match with cwd.and_then(find_project_root_in) — unresolvable cwd now flows through the same branch as no-project-root. Preserves semantics, removes one match arm. All 3267 tests still pass.
2026-04-16T14:47:07-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T14:47:11-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T14:47:28-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-16T14:47:39-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-16T15:12:35-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-16T15:12:39-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-16T15:13:09-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-16T15:13:28-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-16T15:19:38-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-16T15:20:25-07:00 [Phase 6] complete-finalize — starting
2026-04-16T15:20:25-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-16T15:20:25-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>