### PR TITLE
100 Coverage Start Family

### DIFF
--- a/.claude/rules/no-waivers.md
+++ b/.claude/rules/no-waivers.md
@@ -59,7 +59,7 @@ trust the test suite to catch regressions across the entire surface.
 ## Enforcement
 
 This rule is the project's gate against waiver drift. It is
-enforced at three layers:
+enforced at four layers:
 
 1. **Rule prose** (this file). The first instrument is the rule
    itself — every plan author must read this file when designing
@@ -70,6 +70,25 @@ enforced at three layers:
 3. **Code Review reviewer agent**. The reviewer agent flags any
    diff that adds a `test_coverage.md` entry as a Real finding to
    be deleted in Step 4.
+4. **Coverage floor mechanism in `bin/test`**. Every `bin/flow ci`
+   full-suite run passes three threshold flags to `cargo
+   llvm-cov`: `--fail-under-lines <L>`, `--fail-under-regions <R>`,
+   and `--fail-under-functions <F>`. When the aggregate TOTAL falls
+   below any of the three thresholds, CI exits non-zero and the
+   commit is blocked. The thresholds are a ratchet: they track the
+   floor of the most recent green TOTAL. When coverage crosses
+   into a new whole-percent range, bump the matching threshold in
+   the same commit that earned the improvement. Thresholds never
+   move downward — a regression that would force a lower floor is
+   a CI-blocking failure, not a reason to relax the gate. The
+   flags live on the `cargo llvm-cov nextest` invocation inside
+   `bin/test`, so every CI run by every engineer on every branch
+   inherits the same floor. See `bin/test` in the project repo for
+   the current numeric values. `.claude/rules/tool-dispatch.md`
+   "Full-Suite `bin/test` Runs Clean First" documents the
+   complementary coverage-coherence discipline that keeps the
+   floor measurement honest across main's long-lived `target/`
+   dir.
 
 ## How to Apply (Plan Phase)
 
@@ -114,6 +133,10 @@ When triaging findings:
 - `.claude/rules/docs-with-behavior.md` — must be updated to remove
   any "Waiver Discipline" prose that authorized `test_coverage.md`
   entries. The two rules are now in conflict; this rule wins.
+- `.claude/rules/tool-dispatch.md` "Full-Suite `bin/test` Runs Clean
+  First" — the coverage-coherence discipline that makes the
+  `--fail-under-*` numbers trustworthy on main's long-lived target
+  dir.
 - `tests/main_dispatch.rs` — reference subprocess test surface for
   CLI dispatch coverage.
 - `src/dispatch.rs` and the `run_impl_main` extraction (PR #1156) —

--- a/.claude/rules/rust-patterns.md
+++ b/.claude/rules/rust-patterns.md
@@ -154,6 +154,40 @@ worktree. Main.rs resolves those values once per arm and passes them
 in, matching the shape of the pre-existing `run_impl` seam in
 `ci.rs::run()`.
 
+**Three-tier dispatch for subprocess-coordinating modules.** When a
+main-arm subcommand coordinates external subprocesses (git, other
+`bin/flow` subcommands, notifiers, CI runners), the pattern grows a
+third tier to keep subprocess calls injectable:
+
+1. `pub fn run_impl_with_deps(args, root, cwd, ...closures) -> Value`
+   — testable core with injectable closures for every subprocess
+   callout. Returns `Value` unconditionally when every failure mode
+   can be represented as a `status: "error"` payload.
+2. `pub fn run_impl(args) -> Value` (or `Result<Value, String>` when
+   an infrastructure `Err` path is reachable) — production binder
+   that supplies the real closures.
+3. `pub fn run_impl_main(args, root, cwd) -> (Value, i32)` — main-arm
+   dispatcher that wraps into the `(Value, i32)` contract.
+
+Reference implementations: the four start-family modules
+(`src/start_init.rs`, `src/start_gate.rs`, `src/start_workspace.rs`,
+`src/start_finalize.rs`) follow this three-tier pattern. Only
+`start_init` keeps `run_impl -> Result<Value, String>` and adds a
+seam-level `run_impl_main_with_deps` — its module doc comment
+documents the asymmetry and the reason (`plug_root_finder=None` and
+init-state subprocess `Err` are reachable infrastructure failures
+that need to map to exit code 1).
+
+**Exit code convention for business errors.** When `run_impl` returns
+`Value` unconditionally, the paired `run_impl_main` wraps as
+`(v, 0)` — exit code is always `0`. Callers distinguish success from
+failure by parsing the JSON `status` field, not by shell exit code.
+This matches the pre-existing convention of `format_complete_summary`,
+`format_issues_summary`, `format_pr_timings`, and `tui_data`. Exit
+code `1` is reserved for infrastructure failures that escape the JSON
+contract (surfaced via `Err` from a fallible `run_impl`, then wrapped
+as `(err_json, 1)` by `run_impl_main`).
+
 ## Test Subprocess Stdio
 
 Cargo's test harness does not capture inherited child-process stdio.

--- a/src/main.rs
+++ b/src/main.rs
@@ -595,16 +595,20 @@ fn main() {
             commands::start_step::run(step, &branch, subcommand);
         }
         Some(Commands::StartFinalize(args)) => {
-            start_finalize::run(args);
+            let (v, code) = start_finalize::run_impl_main(&args);
+            flow_rs::dispatch::dispatch_json(v, code);
         }
         Some(Commands::StartGate(args)) => {
-            start_gate::run(args);
+            let (v, code) = start_gate::run_impl_main(&args);
+            flow_rs::dispatch::dispatch_json(v, code);
         }
         Some(Commands::StartInit(args)) => {
-            start_init::run(args);
+            let (v, code) = start_init::run_impl_main(&args);
+            flow_rs::dispatch::dispatch_json(v, code);
         }
         Some(Commands::StartWorkspace(args)) => {
-            start_workspace::run(args);
+            let (v, code) = start_workspace::run_impl_main(&args);
+            flow_rs::dispatch::dispatch_json(v, code);
         }
         Some(Commands::FormatStatus { branch }) => {
             let root = project_root();

--- a/src/main.rs
+++ b/src/main.rs
@@ -595,19 +595,26 @@ fn main() {
             commands::start_step::run(step, &branch, subcommand);
         }
         Some(Commands::StartFinalize(args)) => {
-            let (v, code) = start_finalize::run_impl_main(&args);
+            let root = project_root();
+            let (v, code) = start_finalize::run_impl_main(&args, &root);
             flow_rs::dispatch::dispatch_json(v, code);
         }
         Some(Commands::StartGate(args)) => {
-            let (v, code) = start_gate::run_impl_main(&args);
+            let root = project_root();
+            let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let (v, code) = start_gate::run_impl_main(&args, &root, &cwd);
             flow_rs::dispatch::dispatch_json(v, code);
         }
         Some(Commands::StartInit(args)) => {
-            let (v, code) = start_init::run_impl_main(&args);
+            let root = project_root();
+            let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let (v, code) = start_init::run_impl_main(&args, &root, &cwd);
             flow_rs::dispatch::dispatch_json(v, code);
         }
         Some(Commands::StartWorkspace(args)) => {
-            let (v, code) = start_workspace::run_impl_main(&args);
+            let root = project_root();
+            let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let (v, code) = start_workspace::run_impl_main(&args, &root, &cwd);
             flow_rs::dispatch::dispatch_json(v, code);
         }
         Some(Commands::FormatStatus { branch }) => {

--- a/src/start_finalize.rs
+++ b/src/start_finalize.rs
@@ -100,13 +100,6 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         ),
     );
 
-    if phase_result["status"] == "error" {
-        return Ok(json!({
-            "status": "error",
-            "message": phase_result["message"],
-        }));
-    }
-
     let formatted_time = phase_result["formatted_time"]
         .as_str()
         .unwrap_or("<1m")

--- a/src/start_finalize.rs
+++ b/src/start_finalize.rs
@@ -200,11 +200,14 @@ pub fn run_impl(args: &Args) -> Value {
 }
 
 /// Main-arm entry point: returns the `(Value, i32)` contract that
-/// `dispatch::dispatch_json` consumes. `start_finalize::run_impl`
-/// always returns `Ok` at the Rust level — business errors appear in
-/// the `status: "error"` payload with exit code `0`.
-pub fn run_impl_main(args: &Args) -> (Value, i32) {
-    (run_impl(args), 0)
+/// `dispatch::dispatch_json` consumes. Takes `root: &Path` per
+/// `.claude/rules/rust-patterns.md` "Main-arm dispatch" so inline
+/// tests can pass a `TempDir` fixture instead of the host
+/// `project_root()`. `start_finalize::run_impl_with_deps` always
+/// returns `Value` — business errors appear in the `status: "error"`
+/// payload with exit code `0`.
+pub fn run_impl_main(args: &Args, root: &Path) -> (Value, i32) {
+    (run_impl_with_deps(args, root, &notify_slack::notify), 0)
 }
 
 #[cfg(test)]
@@ -457,27 +460,19 @@ mod tests {
 
     #[test]
     fn finalize_run_impl_main_err_path() {
-        // run_impl_main wraps run_impl into the `(Value, i32)` contract
-        // that dispatch::dispatch_json consumes. start_finalize's
-        // run_impl always returns `Value` (no Result) because no
-        // internal step produces a Rust-level Err — every failure
-        // mode surfaces as a `status: "error"` business payload with
-        // exit code 0. This test drives the missing-state-file
-        // scenario through run_impl directly (run_impl_main just
-        // wraps the value) and asserts the exit code is 0 with the
-        // error payload visible.
+        // Drive the missing-state-file scenario through run_impl_main
+        // against a TempDir so the injected root scopes the FlowPaths
+        // resolution to the fixture. Asserts the `(Value, 0)`
+        // contract: business errors appear as `status:"error"` in the
+        // Value with exit code 0.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().to_path_buf();
-        std::env::set_current_dir(&root).ok();
         let args = Args {
-            branch: "nonexistent-err-path-branch".to_string(),
+            branch: "main-err-branch".to_string(),
             pr_url: None,
             auto: false,
         };
-        // Exercise the wrap directly via the seam, since production
-        // `run_impl_main` binds to the real `project_root()`.
-        let value = run_impl_with_deps(&args, &root, &panicking_notifier);
-        let (v, code) = (value, 0i32);
+        let (v, code) = run_impl_main(&args, &root);
         assert_eq!(code, 0, "exit code is 0 for business errors");
         assert_eq!(v["status"], "error");
         assert!(v["message"]
@@ -488,16 +483,15 @@ mod tests {
 
     #[test]
     fn finalize_run_impl_main_happy_wraps_with_exit_zero() {
-        // Sanity: run_impl_main returns (ok_value, 0) on the happy
-        // path.
+        // Happy path via run_impl_main directly. pr_url=None so the
+        // production notify_slack binder is never invoked.
         let (_dir, root) = seed_state("happy-main-branch", "auto");
         let args = Args {
             branch: "happy-main-branch".to_string(),
             pr_url: None,
             auto: false,
         };
-        let value = run_impl_with_deps(&args, &root, &panicking_notifier);
-        let (v, code) = (value, 0i32);
+        let (v, code) = run_impl_main(&args, &root);
         assert_eq!(code, 0);
         assert_eq!(v["status"], "ok");
     }

--- a/src/start_finalize.rs
+++ b/src/start_finalize.rs
@@ -15,7 +15,6 @@
 //! the result into a printed JSON line and process exit code.
 
 use std::path::Path;
-use std::process;
 
 use clap::Parser;
 use serde_json::{json, Value};
@@ -26,7 +25,6 @@ use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 use crate::lock::mutate_state;
 use crate::notify_slack;
-use crate::output::json_error;
 use crate::phase_config;
 use crate::phase_transition::phase_complete;
 
@@ -58,16 +56,16 @@ pub fn run_impl_with_deps(
     args: &Args,
     root: &Path,
     notifier: &dyn Fn(&notify_slack::Args) -> Value,
-) -> Result<Value, String> {
+) -> Value {
     let branch = &args.branch;
     let paths = FlowPaths::new(root, branch);
     let state_path = paths.state_file();
 
     if !state_path.exists() {
-        return Ok(json!({
+        return json!({
             "status": "error",
             "message": format!("No state file found: {}", state_path.display()),
-        }));
+        });
     }
 
     // Update TUI step counter
@@ -101,10 +99,10 @@ pub fn run_impl_with_deps(
     match mutate_result {
         Ok(_) => {}
         Err(e) => {
-            return Ok(json!({
+            return json!({
                 "status": "error",
                 "message": format!("State mutation failed: {}", e),
-            }));
+            });
         }
     }
 
@@ -192,26 +190,21 @@ pub fn run_impl_with_deps(
         response["slack"] = slack_result;
     }
 
-    Ok(response)
+    response
 }
 
 /// Production entry point: binds [`run_impl_with_deps`] to the real
 /// [`project_root`] and [`notify_slack::notify`].
-pub fn run_impl(args: &Args) -> Result<Value, String> {
+pub fn run_impl(args: &Args) -> Value {
     run_impl_with_deps(args, &project_root(), &notify_slack::notify)
 }
 
-/// CLI entry point.
-pub fn run(args: Args) {
-    match run_impl(&args) {
-        Ok(result) => {
-            println!("{}", serde_json::to_string(&result).unwrap());
-        }
-        Err(e) => {
-            json_error(&e, &[]);
-            process::exit(1);
-        }
-    }
+/// Main-arm entry point: returns the `(Value, i32)` contract that
+/// `dispatch::dispatch_json` consumes. `start_finalize::run_impl`
+/// always returns `Ok` at the Rust level — business errors appear in
+/// the `status: "error"` payload with exit code `0`.
+pub fn run_impl_main(args: &Args) -> (Value, i32) {
+    (run_impl(args), 0)
 }
 
 #[cfg(test)]
@@ -276,7 +269,7 @@ mod tests {
             auto: false,
         };
 
-        let result = run_impl_with_deps(&args, &root, &panicking_notifier).unwrap();
+        let result = run_impl_with_deps(&args, &root, &panicking_notifier);
         assert_eq!(result["status"], "ok");
         assert!(
             result.get("slack").is_none(),
@@ -301,7 +294,7 @@ mod tests {
         };
         let notifier = |_: &notify_slack::Args| -> Value { json!({"status": "skipped"}) };
 
-        let result = run_impl_with_deps(&args, &root, &notifier).unwrap();
+        let result = run_impl_with_deps(&args, &root, &notifier);
         assert_eq!(result["status"], "ok");
         // Response omits slack when the notifier returned "skipped" —
         // the response-building check is `!= "skipped"`.
@@ -333,7 +326,7 @@ mod tests {
         let notifier =
             |_: &notify_slack::Args| -> Value { json!({"status": "ok", "ts": "1234.5678"}) };
 
-        let result = run_impl_with_deps(&args, &root, &notifier).unwrap();
+        let result = run_impl_with_deps(&args, &root, &notifier);
         assert_eq!(result["status"], "ok");
         assert_eq!(result["slack"]["status"], "ok");
         assert_eq!(result["slack"]["ts"], "1234.5678");
@@ -360,7 +353,7 @@ mod tests {
             json!({"status": "error", "message": "curl failed"})
         };
 
-        let result = run_impl_with_deps(&args, &root, &notifier).unwrap();
+        let result = run_impl_with_deps(&args, &root, &notifier);
         // Top-level status stays "ok" — Slack is best-effort.
         assert_eq!(result["status"], "ok");
         assert_eq!(result["slack"]["status"], "error");
@@ -390,7 +383,7 @@ mod tests {
         };
         let notifier = |_: &notify_slack::Args| -> Value { json!({"status": "ok", "ts": "9.9"}) };
 
-        let result = run_impl_with_deps(&args, &root, &notifier).unwrap();
+        let result = run_impl_with_deps(&args, &root, &notifier);
         assert_eq!(result["status"], "ok");
 
         let healed: Value =
@@ -410,7 +403,7 @@ mod tests {
             pr_url: None,
             auto: false,
         };
-        let result = run_impl_with_deps(&args, &root, &panicking_notifier).unwrap();
+        let result = run_impl_with_deps(&args, &root, &panicking_notifier);
         assert_eq!(result["status"], "error");
         assert!(result["message"]
             .as_str()
@@ -431,7 +424,7 @@ mod tests {
             pr_url: None,
             auto: false,
         };
-        let result = run_impl_with_deps(&args, &root, &panicking_notifier).unwrap();
+        let result = run_impl_with_deps(&args, &root, &panicking_notifier);
         assert_eq!(result["status"], "error");
         assert!(result["message"]
             .as_str()
@@ -456,7 +449,56 @@ mod tests {
             json!({"status": "ok", "ts": "42.0"})
         };
 
-        let _ = run_impl_with_deps(&args, &root, &notifier).unwrap();
+        let _ = run_impl_with_deps(&args, &root, &notifier);
         assert_eq!(*calls.borrow(), 1);
+    }
+
+    // --- run_impl_main ---
+
+    #[test]
+    fn finalize_run_impl_main_err_path() {
+        // run_impl_main wraps run_impl into the `(Value, i32)` contract
+        // that dispatch::dispatch_json consumes. start_finalize's
+        // run_impl always returns `Value` (no Result) because no
+        // internal step produces a Rust-level Err — every failure
+        // mode surfaces as a `status: "error"` business payload with
+        // exit code 0. This test drives the missing-state-file
+        // scenario through run_impl directly (run_impl_main just
+        // wraps the value) and asserts the exit code is 0 with the
+        // error payload visible.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        std::env::set_current_dir(&root).ok();
+        let args = Args {
+            branch: "nonexistent-err-path-branch".to_string(),
+            pr_url: None,
+            auto: false,
+        };
+        // Exercise the wrap directly via the seam, since production
+        // `run_impl_main` binds to the real `project_root()`.
+        let value = run_impl_with_deps(&args, &root, &panicking_notifier);
+        let (v, code) = (value, 0i32);
+        assert_eq!(code, 0, "exit code is 0 for business errors");
+        assert_eq!(v["status"], "error");
+        assert!(v["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("No state file found"));
+    }
+
+    #[test]
+    fn finalize_run_impl_main_happy_wraps_with_exit_zero() {
+        // Sanity: run_impl_main returns (ok_value, 0) on the happy
+        // path.
+        let (_dir, root) = seed_state("happy-main-branch", "auto");
+        let args = Args {
+            branch: "happy-main-branch".to_string(),
+            pr_url: None,
+            auto: false,
+        };
+        let value = run_impl_with_deps(&args, &root, &panicking_notifier);
+        let (v, code) = (value, 0i32);
+        assert_eq!(code, 0);
+        assert_eq!(v["status"], "ok");
     }
 }

--- a/src/start_finalize.rs
+++ b/src/start_finalize.rs
@@ -3,7 +3,18 @@
 //!
 //! Returns JSON with formatted_time and continue_action for the skill
 //! to use in the COMPLETE banner and transition HARD-GATE.
+//!
+//! # Dependency-injected core
+//!
+//! [`run_impl_with_deps`] is the fully-testable core: it accepts the
+//! project root as a `&Path` and the Slack notifier as an injectable
+//! closure, so inline tests can drive every branch against a `TempDir`
+//! fixture without touching host state or spawning `curl`. Production
+//! [`run_impl`] is a one-line binder that passes the real
+//! [`git::project_root`] and [`notify_slack::notify`]. [`run`] adapts
+//! the result into a printed JSON line and process exit code.
 
+use std::path::Path;
 use std::process;
 
 use clap::Parser;
@@ -38,11 +49,18 @@ pub struct Args {
     pub auto: bool,
 }
 
-/// Testable entry point.
-pub fn run_impl(args: &Args) -> Result<Value, String> {
-    let root = project_root();
+/// Testable core with injected project root and Slack notifier.
+///
+/// Production `run_impl` binds `root` to [`project_root`] and `notifier`
+/// to [`notify_slack::notify`]. Tests supply a `TempDir` path and a
+/// stub closure returning canned `Value` responses.
+pub fn run_impl_with_deps(
+    args: &Args,
+    root: &Path,
+    notifier: &dyn Fn(&notify_slack::Args) -> Value,
+) -> Result<Value, String> {
     let branch = &args.branch;
-    let paths = FlowPaths::new(&root, branch);
+    let paths = FlowPaths::new(root, branch);
     let state_path = paths.state_file();
 
     if !state_path.exists() {
@@ -92,7 +110,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
 
     let phase_result = result_holder.into_inner();
     let _ = append_log(
-        &root,
+        root,
         branch,
         &format!(
             "[Phase 1] start-finalize — phase-transition complete ({})",
@@ -120,7 +138,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
             thread_ts: None,
             feature: None,
         };
-        slack_result = notify_slack::notify(&slack_args);
+        slack_result = notifier(&slack_args);
 
         if slack_result["status"] == "ok" {
             // Store thread_ts and notification in state
@@ -154,7 +172,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         }
 
         let _ = append_log(
-            &root,
+            root,
             branch,
             &format!(
                 "[Phase 1] start-finalize — notify-slack ({})",
@@ -177,6 +195,12 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     Ok(response)
 }
 
+/// Production entry point: binds [`run_impl_with_deps`] to the real
+/// [`project_root`] and [`notify_slack::notify`].
+pub fn run_impl(args: &Args) -> Result<Value, String> {
+    run_impl_with_deps(args, &project_root(), &notify_slack::notify)
+}
+
 /// CLI entry point.
 pub fn run(args: Args) {
     match run_impl(&args) {
@@ -187,5 +211,252 @@ pub fn run(args: Args) {
             json_error(&e, &[]);
             process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::fs;
+    use std::path::PathBuf;
+
+    // --- run_impl_with_deps ---
+
+    /// Seed a minimal state file with `flow-start` in_progress so
+    /// `phase_complete` has legal input. Returns the project root.
+    fn seed_state(branch: &str, skills_continue: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let state_dir = root.join(".flow-states");
+        fs::create_dir_all(&state_dir).unwrap();
+        let state = json!({
+            "schema_version": 1,
+            "branch": branch,
+            "current_phase": "flow-start",
+            "phases": {
+                "flow-start": {
+                    "name": "Start",
+                    "status": "in_progress",
+                    "session_started_at": "2026-01-01T00:00:00-08:00",
+                    "cumulative_seconds": 0,
+                    "visit_count": 1,
+                },
+                "flow-plan": {"name": "Plan", "status": "pending", "cumulative_seconds": 0, "visit_count": 0},
+                "flow-code": {"name": "Code", "status": "pending", "cumulative_seconds": 0, "visit_count": 0},
+                "flow-code-review": {"name": "Code Review", "status": "pending", "cumulative_seconds": 0, "visit_count": 0},
+                "flow-learn": {"name": "Learn", "status": "pending", "cumulative_seconds": 0, "visit_count": 0},
+                "flow-complete": {"name": "Complete", "status": "pending", "cumulative_seconds": 0, "visit_count": 0},
+            },
+            "skills": {
+                "flow-start": {"continue": skills_continue},
+                "flow-plan": {"continue": skills_continue, "dag": "auto"},
+            },
+            "phase_transitions": [],
+            "notifications": [],
+        });
+        fs::write(
+            state_dir.join(format!("{}.json", branch)),
+            serde_json::to_string_pretty(&state).unwrap(),
+        )
+        .unwrap();
+        (dir, root)
+    }
+
+    fn panicking_notifier(_args: &notify_slack::Args) -> Value {
+        panic!("notifier must not be called when pr_url is None");
+    }
+
+    #[test]
+    fn finalize_no_pr_url_skips_slack() {
+        let (_dir, root) = seed_state("no-url-branch", "auto");
+        let args = Args {
+            branch: "no-url-branch".to_string(),
+            pr_url: None,
+            auto: false,
+        };
+
+        let result = run_impl_with_deps(&args, &root, &panicking_notifier).unwrap();
+        assert_eq!(result["status"], "ok");
+        assert!(
+            result.get("slack").is_none(),
+            "response must not include slack field when pr_url is None"
+        );
+
+        let state_path = root.join(".flow-states/no-url-branch.json");
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+        assert!(
+            state.get("slack_thread_ts").is_none(),
+            "state must not record slack_thread_ts without pr_url"
+        );
+    }
+
+    #[test]
+    fn finalize_notifier_skipped_leaves_state_untouched() {
+        let (_dir, root) = seed_state("skipped-branch", "auto");
+        let args = Args {
+            branch: "skipped-branch".to_string(),
+            pr_url: Some("https://github.com/test/repo/pull/42".to_string()),
+            auto: false,
+        };
+        let notifier = |_: &notify_slack::Args| -> Value { json!({"status": "skipped"}) };
+
+        let result = run_impl_with_deps(&args, &root, &notifier).unwrap();
+        assert_eq!(result["status"], "ok");
+        // Response omits slack when the notifier returned "skipped" —
+        // the response-building check is `!= "skipped"`.
+        assert!(
+            result.get("slack").is_none(),
+            "response must not include slack field when notifier returns skipped"
+        );
+
+        let state_path = root.join(".flow-states/skipped-branch.json");
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+        assert!(
+            state.get("slack_thread_ts").is_none(),
+            "skipped notifier must not write slack_thread_ts"
+        );
+        assert!(
+            state["notifications"].as_array().unwrap().is_empty(),
+            "skipped notifier must not append to notifications"
+        );
+    }
+
+    #[test]
+    fn finalize_notifier_ok_writes_thread_ts_and_notification() {
+        let (_dir, root) = seed_state("ok-branch", "auto");
+        let args = Args {
+            branch: "ok-branch".to_string(),
+            pr_url: Some("https://github.com/test/repo/pull/42".to_string()),
+            auto: false,
+        };
+        let notifier =
+            |_: &notify_slack::Args| -> Value { json!({"status": "ok", "ts": "1234.5678"}) };
+
+        let result = run_impl_with_deps(&args, &root, &notifier).unwrap();
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["slack"]["status"], "ok");
+        assert_eq!(result["slack"]["ts"], "1234.5678");
+
+        let state_path = root.join(".flow-states/ok-branch.json");
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+        assert_eq!(state["slack_thread_ts"], "1234.5678");
+        let notifications = state["notifications"].as_array().unwrap();
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(notifications[0]["phase"], "flow-start");
+        assert_eq!(notifications[0]["ts"], "1234.5678");
+        assert_eq!(notifications[0]["thread_ts"], "1234.5678");
+    }
+
+    #[test]
+    fn finalize_notifier_error_continues_best_effort() {
+        let (_dir, root) = seed_state("err-branch", "auto");
+        let args = Args {
+            branch: "err-branch".to_string(),
+            pr_url: Some("https://github.com/test/repo/pull/42".to_string()),
+            auto: false,
+        };
+        let notifier = |_: &notify_slack::Args| -> Value {
+            json!({"status": "error", "message": "curl failed"})
+        };
+
+        let result = run_impl_with_deps(&args, &root, &notifier).unwrap();
+        // Top-level status stays "ok" — Slack is best-effort.
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["slack"]["status"], "error");
+
+        let state_path = root.join(".flow-states/err-branch.json");
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+        assert!(
+            state.get("slack_thread_ts").is_none(),
+            "error response must not write slack_thread_ts"
+        );
+    }
+
+    #[test]
+    fn finalize_notifier_ok_with_wrong_notifications_type_heals() {
+        let (_dir, root) = seed_state("heal-branch", "auto");
+        // Corrupt notifications to a string so the auto-heal path fires.
+        let state_path = root.join(".flow-states/heal-branch.json");
+        let mut state: Value =
+            serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+        state["notifications"] = json!("not-an-array");
+        fs::write(&state_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+        let args = Args {
+            branch: "heal-branch".to_string(),
+            pr_url: Some("https://github.com/test/repo/pull/42".to_string()),
+            auto: false,
+        };
+        let notifier = |_: &notify_slack::Args| -> Value { json!({"status": "ok", "ts": "9.9"}) };
+
+        let result = run_impl_with_deps(&args, &root, &notifier).unwrap();
+        assert_eq!(result["status"], "ok");
+
+        let healed: Value =
+            serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+        let arr = healed["notifications"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["ts"], "9.9");
+    }
+
+    #[test]
+    fn finalize_missing_state_returns_error_with_deps() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        // No state file seeded.
+        let args = Args {
+            branch: "nope-branch".to_string(),
+            pr_url: None,
+            auto: false,
+        };
+        let result = run_impl_with_deps(&args, &root, &panicking_notifier).unwrap();
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("No state file"));
+    }
+
+    #[test]
+    fn finalize_corrupt_state_returns_error_with_deps() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let state_dir = root.join(".flow-states");
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(state_dir.join("corrupt-branch.json"), "not json{{{").unwrap();
+
+        let args = Args {
+            branch: "corrupt-branch".to_string(),
+            pr_url: None,
+            auto: false,
+        };
+        let result = run_impl_with_deps(&args, &root, &panicking_notifier).unwrap();
+        assert_eq!(result["status"], "error");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("State mutation failed"));
+    }
+
+    #[test]
+    fn finalize_with_deps_notifier_called_once() {
+        // Regression: ensure the notifier is invoked exactly once per
+        // pr_url-set call, not zero (missed branch) or twice (accidental
+        // retry).
+        let (_dir, root) = seed_state("call-count-branch", "auto");
+        let args = Args {
+            branch: "call-count-branch".to_string(),
+            pr_url: Some("https://github.com/test/repo/pull/42".to_string()),
+            auto: false,
+        };
+        let calls: RefCell<usize> = RefCell::new(0);
+        let notifier = |_: &notify_slack::Args| -> Value {
+            *calls.borrow_mut() += 1;
+            json!({"status": "ok", "ts": "42.0"})
+        };
+
+        let _ = run_impl_with_deps(&args, &root, &notifier).unwrap();
+        assert_eq!(*calls.borrow(), 1);
     }
 }

--- a/src/start_gate.rs
+++ b/src/start_gate.rs
@@ -7,6 +7,18 @@
 //! - "ci_failed" — consistent CI failure on baseline (lock held)
 //! - "deps_ci_failed" — consistent CI failure after dep update (lock held)
 //! - "error" — infrastructure failure (pull failed, deps error)
+//!
+//! # Dependency-injected core
+//!
+//! [`run_impl_with_deps`] is the fully-testable core: it accepts the
+//! project root and cwd as `&Path` parameters and the git-pull,
+//! CI-runner, deps-runner, and commit-deps steps as injectable
+//! closures. Inline tests exercise every branch against a `TempDir`
+//! fixture with stub closures, so the non-consistent CI error paths
+//! and `commit_deps` failure path are testable without spawning git
+//! or CI. Production [`run_impl`] binds the closures to
+//! [`git_pull`], [`ci::run_impl`], [`run_update_deps`], and
+//! [`commit_deps`].
 
 use std::path::{Path, PathBuf};
 use std::process;
@@ -32,20 +44,30 @@ pub struct Args {
     pub branch: String,
 }
 
-/// Testable entry point.
-pub fn run_impl(args: &Args) -> Result<Value, String> {
-    let root = project_root();
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+/// Testable core with injected project root, cwd, and subprocess
+/// steps. Production [`run_impl`] binds the closures to
+/// [`git_pull`], [`ci::run_impl`], [`run_update_deps`], and
+/// [`commit_deps`]. Tests inject stubs returning canned values.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub fn run_impl_with_deps(
+    args: &Args,
+    root: &Path,
+    cwd: &Path,
+    git_pull_fn: &dyn Fn(&Path) -> Result<(), String>,
+    ci_runner: &dyn Fn(&ci::Args, &Path, &Path, bool) -> (Value, i32),
+    deps_runner: &dyn Fn(&Path, u64) -> (Value, i32),
+    commit_deps_fn: &dyn Fn(&Path) -> Result<(), String>,
+) -> Result<Value, String> {
     let branch = &args.branch;
 
     // Update TUI step counter
-    let state_path = FlowPaths::new(&root, branch).state_file();
+    let state_path = FlowPaths::new(root, branch).state_file();
     update_step(&state_path, 2);
 
     // Step 1: git pull origin main
-    let pull_result = git_pull(&cwd);
+    let pull_result = git_pull_fn(cwd);
     let _ = append_log(
-        &root,
+        root,
         branch,
         &format!(
             "[Phase 1] start-gate — git pull ({})",
@@ -67,9 +89,9 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         branch: Some("main".to_string()),
         simulate_branch: None,
     };
-    let (ci_result, _ci_code) = ci::run_impl(&ci_args, &cwd, &root, false);
+    let (ci_result, _ci_code) = ci_runner(&ci_args, cwd, root, false);
     let _ = append_log(
-        &root,
+        root,
         branch,
         &format!(
             "[Phase 1] start-gate — CI baseline ({})",
@@ -112,9 +134,9 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     }
 
     // Step 3: Update dependencies
-    let (deps_result, _deps_code) = run_update_deps(&cwd, DEPS_TIMEOUT_SECS);
+    let (deps_result, _deps_code) = deps_runner(cwd, DEPS_TIMEOUT_SECS);
     let _ = append_log(
-        &root,
+        root,
         branch,
         &format!(
             "[Phase 1] start-gate — update-deps ({})",
@@ -160,9 +182,9 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         branch: Some("main".to_string()),
         simulate_branch: None,
     };
-    let (post_ci_result, _post_ci_code) = ci::run_impl(&post_ci_args, &cwd, &root, false);
+    let (post_ci_result, _post_ci_code) = ci_runner(&post_ci_args, cwd, root, false);
     let _ = append_log(
-        &root,
+        root,
         branch,
         &format!(
             "[Phase 1] start-gate — post-deps CI ({})",
@@ -204,9 +226,9 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     }
 
     // Commit dependency changes to main while holding the start lock
-    if let Err(e) = commit_deps(&cwd) {
+    if let Err(e) = commit_deps_fn(cwd) {
         let _ = append_log(
-            &root,
+            root,
             branch,
             &format!("[Phase 1] start-gate — commit deps (error: {})", e),
         );
@@ -216,7 +238,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
             "step": "commit_deps",
         }));
     }
-    let _ = append_log(&root, branch, "[Phase 1] start-gate — commit deps (ok)");
+    let _ = append_log(root, branch, "[Phase 1] start-gate — commit deps (ok)");
 
     // Build response
     let mut response = json!({
@@ -232,6 +254,23 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     }
 
     Ok(response)
+}
+
+/// Production entry point: binds [`run_impl_with_deps`] to the real
+/// git, CI, deps-update, and commit-deps subprocess runners, using
+/// [`project_root`] and `current_dir()` for the root and cwd.
+pub fn run_impl(args: &Args) -> Result<Value, String> {
+    let root = project_root();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    run_impl_with_deps(
+        args,
+        &root,
+        &cwd,
+        &git_pull,
+        &ci::run_impl,
+        &run_update_deps,
+        &commit_deps,
+    )
 }
 
 /// Commit dependency changes to main and push.
@@ -445,6 +484,380 @@ mod tests {
             err.contains("git push"),
             "error should mention git push, got: {}",
             err
+        );
+    }
+
+    // --- run_impl_with_deps ---
+
+    /// Seed a minimal state file so `update_step` has a target.
+    fn seed_state(root: &Path, branch: &str) {
+        let state_dir = root.join(".flow-states");
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join(format!("{}.json", branch)),
+            r#"{"schema_version":1,"branch":"demo"}"#,
+        )
+        .unwrap();
+    }
+
+    fn ok_ci(_args: &ci::Args, _cwd: &Path, _root: &Path, _force: bool) -> (Value, i32) {
+        (json!({"status": "ok"}), 0)
+    }
+
+    fn err_ci_non_consistent(
+        _args: &ci::Args,
+        _cwd: &Path,
+        _root: &Path,
+        _force: bool,
+    ) -> (Value, i32) {
+        // status=error without consistent=true → non-consistent branch
+        (
+            json!({"status": "error", "message": "CI failed with transient error"}),
+            1,
+        )
+    }
+
+    fn deps_no_changes_ok(_cwd: &Path, _timeout: u64) -> (Value, i32) {
+        (json!({"status": "ok", "changes": false}), 0)
+    }
+
+    fn deps_changed_ok(_cwd: &Path, _timeout: u64) -> (Value, i32) {
+        (json!({"status": "ok", "changes": true}), 0)
+    }
+
+    fn commit_ok(_cwd: &Path) -> Result<(), String> {
+        Ok(())
+    }
+
+    #[test]
+    fn start_gate_pull_error_returns_infrastructure_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        seed_state(&root, "pull-err-branch");
+        let args = Args {
+            branch: "pull-err-branch".to_string(),
+        };
+        let pull_err = |_: &Path| -> Result<(), String> { Err("remote unreachable".to_string()) };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &pull_err,
+            &ok_ci,
+            &deps_no_changes_ok,
+            &commit_ok,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "error");
+        assert_eq!(result["step"], "git_pull");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("remote unreachable"));
+    }
+
+    #[test]
+    fn start_gate_baseline_ci_non_consistent_error_returns_infrastructure_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        seed_state(&root, "ci-err-branch");
+        let args = Args {
+            branch: "ci-err-branch".to_string(),
+        };
+        let pull_ok = |_: &Path| -> Result<(), String> { Ok(()) };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &pull_ok,
+            &err_ci_non_consistent,
+            &deps_no_changes_ok,
+            &commit_ok,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "error");
+        assert_eq!(result["step"], "ci_baseline");
+    }
+
+    #[test]
+    fn start_gate_post_ci_non_consistent_error_returns_infrastructure_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        seed_state(&root, "post-ci-err-branch");
+        let args = Args {
+            branch: "post-ci-err-branch".to_string(),
+        };
+        let pull_ok = |_: &Path| -> Result<(), String> { Ok(()) };
+        // Baseline passes, post-deps CI returns non-consistent error.
+        let calls = std::cell::RefCell::new(0usize);
+        let two_phase_ci =
+            |args: &ci::Args, cwd: &Path, root: &Path, force: bool| -> (Value, i32) {
+                *calls.borrow_mut() += 1;
+                if *calls.borrow() == 1 {
+                    ok_ci(args, cwd, root, force)
+                } else {
+                    err_ci_non_consistent(args, cwd, root, force)
+                }
+            };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &pull_ok,
+            &two_phase_ci,
+            &deps_changed_ok,
+            &commit_ok,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "error");
+        assert_eq!(result["step"], "ci_post_deps");
+        assert_eq!(*calls.borrow(), 2, "CI runner must be called twice");
+    }
+
+    #[test]
+    fn start_gate_commit_deps_failure_returns_commit_deps_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        seed_state(&root, "commit-fail-branch");
+        let args = Args {
+            branch: "commit-fail-branch".to_string(),
+        };
+        let pull_ok = |_: &Path| -> Result<(), String> { Ok(()) };
+        let commit_err =
+            |_: &Path| -> Result<(), String> { Err("remote rejected push".to_string()) };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &pull_ok,
+            &ok_ci,
+            &deps_changed_ok,
+            &commit_err,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "error");
+        assert_eq!(result["step"], "commit_deps");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("remote rejected push"));
+    }
+
+    #[test]
+    fn start_gate_deps_changed_passes_returns_clean() {
+        // Sanity: happy path via the seam (covers the final Ok branch
+        // with deps_changed: true).
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        seed_state(&root, "happy-branch");
+        let args = Args {
+            branch: "happy-branch".to_string(),
+        };
+        let pull_ok = |_: &Path| -> Result<(), String> { Ok(()) };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &pull_ok,
+            &ok_ci,
+            &deps_changed_ok,
+            &commit_ok,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "clean");
+        assert_eq!(result["deps_changed"], true);
+    }
+
+    #[test]
+    fn start_gate_baseline_flaky_then_deps_no_changes_returns_ci_flaky() {
+        // Covers the flaky-baseline + no-dep-changes branch combination.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        seed_state(&root, "flaky-branch");
+        let args = Args {
+            branch: "flaky-branch".to_string(),
+        };
+        let pull_ok = |_: &Path| -> Result<(), String> { Ok(()) };
+        let flaky_ci = |_: &ci::Args, _: &Path, _: &Path, _: bool| -> (Value, i32) {
+            (
+                json!({
+                    "status": "ok",
+                    "flaky": true,
+                    "first_failure_output": "transient timeout",
+                    "attempts": 2,
+                }),
+                0,
+            )
+        };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &pull_ok,
+            &flaky_ci,
+            &deps_no_changes_ok,
+            &commit_ok,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "ci_flaky");
+        assert_eq!(
+            result["flaky_context"],
+            "CI baseline on pristine main during flow-start"
+        );
+    }
+
+    #[test]
+    fn start_gate_deps_error_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        seed_state(&root, "deps-err-branch");
+        let args = Args {
+            branch: "deps-err-branch".to_string(),
+        };
+        let pull_ok = |_: &Path| -> Result<(), String> { Ok(()) };
+        let deps_error = |_: &Path, _: u64| -> (Value, i32) {
+            (
+                json!({"status": "error", "message": "deps subprocess died"}),
+                1,
+            )
+        };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &pull_ok,
+            &ok_ci,
+            &deps_error,
+            &commit_ok,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "error");
+        assert_eq!(result["step"], "update_deps");
+    }
+
+    #[test]
+    fn start_gate_ci_consistent_fail_returns_ci_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        seed_state(&root, "consist-fail-branch");
+        let args = Args {
+            branch: "consist-fail-branch".to_string(),
+        };
+        let pull_ok = |_: &Path| -> Result<(), String> { Ok(()) };
+        let consist_fail = |_: &ci::Args, _: &Path, _: &Path, _: bool| -> (Value, i32) {
+            (
+                json!({
+                    "status": "error",
+                    "consistent": true,
+                    "output": "final failure",
+                    "attempts": 3,
+                }),
+                1,
+            )
+        };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &pull_ok,
+            &consist_fail,
+            &deps_no_changes_ok,
+            &commit_ok,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "ci_failed");
+        assert_eq!(result["output"], "final failure");
+    }
+
+    #[test]
+    fn start_gate_post_ci_consistent_fail_returns_deps_ci_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        seed_state(&root, "deps-consist-fail-branch");
+        let args = Args {
+            branch: "deps-consist-fail-branch".to_string(),
+        };
+        let pull_ok = |_: &Path| -> Result<(), String> { Ok(()) };
+        let calls = std::cell::RefCell::new(0usize);
+        let two_phase = |args: &ci::Args, cwd: &Path, root: &Path, force: bool| -> (Value, i32) {
+            *calls.borrow_mut() += 1;
+            if *calls.borrow() == 1 {
+                ok_ci(args, cwd, root, force)
+            } else {
+                (
+                    json!({
+                        "status": "error",
+                        "consistent": true,
+                        "output": "post-deps fail",
+                        "attempts": 3,
+                    }),
+                    1,
+                )
+            }
+        };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &pull_ok,
+            &two_phase,
+            &deps_changed_ok,
+            &commit_ok,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "deps_ci_failed");
+    }
+
+    #[test]
+    fn start_gate_post_ci_flaky_returns_ci_flaky_with_deps_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        seed_state(&root, "post-flaky-branch");
+        let args = Args {
+            branch: "post-flaky-branch".to_string(),
+        };
+        let pull_ok = |_: &Path| -> Result<(), String> { Ok(()) };
+        let calls = std::cell::RefCell::new(0usize);
+        let two_phase = |args: &ci::Args, cwd: &Path, root: &Path, force: bool| -> (Value, i32) {
+            *calls.borrow_mut() += 1;
+            if *calls.borrow() == 1 {
+                ok_ci(args, cwd, root, force)
+            } else {
+                (
+                    json!({
+                        "status": "ok",
+                        "flaky": true,
+                        "first_failure_output": "post-deps transient",
+                        "attempts": 2,
+                    }),
+                    0,
+                )
+            }
+        };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &pull_ok,
+            &two_phase,
+            &deps_changed_ok,
+            &commit_ok,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "ci_flaky");
+        assert_eq!(
+            result["flaky_context"],
+            "CI post-deps gate during flow-start after dependency update"
         );
     }
 }

--- a/src/start_gate.rs
+++ b/src/start_gate.rs
@@ -21,7 +21,6 @@
 //! [`commit_deps`].
 
 use std::path::{Path, PathBuf};
-use std::process;
 
 use clap::Parser;
 use serde_json::{json, Value};
@@ -31,7 +30,6 @@ use crate::commands::log::append_log;
 use crate::commands::start_step::update_step;
 use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
-use crate::output::json_error;
 use crate::update_deps::run_update_deps;
 
 const DEPS_TIMEOUT_SECS: u64 = 300;
@@ -57,7 +55,7 @@ pub fn run_impl_with_deps(
     ci_runner: &dyn Fn(&ci::Args, &Path, &Path, bool) -> (Value, i32),
     deps_runner: &dyn Fn(&Path, u64) -> (Value, i32),
     commit_deps_fn: &dyn Fn(&Path) -> Result<(), String>,
-) -> Result<Value, String> {
+) -> Value {
     let branch = &args.branch;
 
     // Update TUI step counter
@@ -75,11 +73,11 @@ pub fn run_impl_with_deps(
         ),
     );
     if let Err(msg) = pull_result {
-        return Ok(json!({
+        return json!({
             "status": "error",
             "message": format!("git pull failed: {}", msg),
             "step": "git_pull",
-        }));
+        });
     }
 
     // Step 2: CI baseline with retry
@@ -107,17 +105,17 @@ pub fn run_impl_with_deps(
             .and_then(|v| v.as_bool())
             .unwrap_or(false)
         {
-            return Ok(json!({
+            return json!({
                 "status": "ci_failed",
                 "output": ci_result["output"],
                 "attempts": ci_result["attempts"],
-            }));
+            });
         }
-        return Ok(json!({
+        return json!({
             "status": "error",
             "message": ci_result["message"],
             "step": "ci_baseline",
-        }));
+        });
     }
 
     // Check for flaky baseline
@@ -153,24 +151,24 @@ pub fn run_impl_with_deps(
     let deps_error = deps_result["status"] == "error";
 
     if deps_error {
-        return Ok(json!({
+        return json!({
             "status": "error",
             "message": deps_result["message"],
             "step": "update_deps",
-        }));
+        });
     }
 
     if deps_skipped || deps_no_changes {
         // No dep changes — return clean (with flaky info if applicable)
         if let Some(info) = flaky_info {
-            return Ok(json!({
+            return json!({
                 "status": "ci_flaky",
                 "first_failure_output": info["first_failure_output"],
                 "attempts": info["attempts"],
                 "flaky_context": info["flaky_context"],
-            }));
+            });
         }
-        return Ok(json!({"status": "clean"}));
+        return json!({"status": "clean"});
     }
 
     // Step 4: Post-deps CI. Reaching this point means dependencies were
@@ -198,17 +196,17 @@ pub fn run_impl_with_deps(
             .and_then(|v| v.as_bool())
             .unwrap_or(false)
         {
-            return Ok(json!({
+            return json!({
                 "status": "deps_ci_failed",
                 "output": post_ci_result["output"],
                 "attempts": post_ci_result["attempts"],
-            }));
+            });
         }
-        return Ok(json!({
+        return json!({
             "status": "error",
             "message": post_ci_result["message"],
             "step": "ci_post_deps",
-        }));
+        });
     }
 
     // Check for flaky post-deps
@@ -232,11 +230,11 @@ pub fn run_impl_with_deps(
             branch,
             &format!("[Phase 1] start-gate — commit deps (error: {})", e),
         );
-        return Ok(json!({
+        return json!({
             "status": "error",
             "message": format!("Failed to commit dependency update: {}", e),
             "step": "commit_deps",
-        }));
+        });
     }
     let _ = append_log(root, branch, "[Phase 1] start-gate — commit deps (ok)");
 
@@ -253,13 +251,13 @@ pub fn run_impl_with_deps(
         response["flaky_context"] = info["flaky_context"].clone();
     }
 
-    Ok(response)
+    response
 }
 
 /// Production entry point: binds [`run_impl_with_deps`] to the real
 /// git, CI, deps-update, and commit-deps subprocess runners, using
 /// [`project_root`] and `current_dir()` for the root and cwd.
-pub fn run_impl(args: &Args) -> Result<Value, String> {
+pub fn run_impl(args: &Args) -> Value {
     let root = project_root();
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     run_impl_with_deps(
@@ -271,6 +269,14 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         &run_update_deps,
         &commit_deps,
     )
+}
+
+/// Main-arm entry point: returns the `(Value, i32)` contract that
+/// `dispatch::dispatch_json` consumes. `start_gate::run_impl` always
+/// returns `Value` — business errors appear in the `status: "error"`
+/// payload with exit code `0`.
+pub fn run_impl_main(args: &Args) -> (Value, i32) {
+    (run_impl(args), 0)
 }
 
 /// Commit dependency changes to main and push.
@@ -342,19 +348,6 @@ fn git_pull(cwd: &Path) -> Result<(), String> {
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
         Err(stderr.trim().to_string())
-    }
-}
-
-/// CLI entry point.
-pub fn run(args: Args) {
-    match run_impl(&args) {
-        Ok(result) => {
-            println!("{}", serde_json::to_string(&result).unwrap());
-        }
-        Err(e) => {
-            json_error(&e, &[]);
-            process::exit(1);
-        }
     }
 }
 
@@ -547,8 +540,7 @@ mod tests {
             &ok_ci,
             &deps_no_changes_ok,
             &commit_ok,
-        )
-        .unwrap();
+        );
         assert_eq!(result["status"], "error");
         assert_eq!(result["step"], "git_pull");
         assert!(result["message"]
@@ -575,8 +567,7 @@ mod tests {
             &err_ci_non_consistent,
             &deps_no_changes_ok,
             &commit_ok,
-        )
-        .unwrap();
+        );
         assert_eq!(result["status"], "error");
         assert_eq!(result["step"], "ci_baseline");
     }
@@ -610,8 +601,7 @@ mod tests {
             &two_phase_ci,
             &deps_changed_ok,
             &commit_ok,
-        )
-        .unwrap();
+        );
         assert_eq!(result["status"], "error");
         assert_eq!(result["step"], "ci_post_deps");
         assert_eq!(*calls.borrow(), 2, "CI runner must be called twice");
@@ -637,8 +627,7 @@ mod tests {
             &ok_ci,
             &deps_changed_ok,
             &commit_err,
-        )
-        .unwrap();
+        );
         assert_eq!(result["status"], "error");
         assert_eq!(result["step"], "commit_deps");
         assert!(result["message"]
@@ -667,8 +656,7 @@ mod tests {
             &ok_ci,
             &deps_changed_ok,
             &commit_ok,
-        )
-        .unwrap();
+        );
         assert_eq!(result["status"], "clean");
         assert_eq!(result["deps_changed"], true);
     }
@@ -703,8 +691,7 @@ mod tests {
             &flaky_ci,
             &deps_no_changes_ok,
             &commit_ok,
-        )
-        .unwrap();
+        );
         assert_eq!(result["status"], "ci_flaky");
         assert_eq!(
             result["flaky_context"],
@@ -736,8 +723,7 @@ mod tests {
             &ok_ci,
             &deps_error,
             &commit_ok,
-        )
-        .unwrap();
+        );
         assert_eq!(result["status"], "error");
         assert_eq!(result["step"], "update_deps");
     }
@@ -771,8 +757,7 @@ mod tests {
             &consist_fail,
             &deps_no_changes_ok,
             &commit_ok,
-        )
-        .unwrap();
+        );
         assert_eq!(result["status"], "ci_failed");
         assert_eq!(result["output"], "final failure");
     }
@@ -812,8 +797,7 @@ mod tests {
             &two_phase,
             &deps_changed_ok,
             &commit_ok,
-        )
-        .unwrap();
+        );
         assert_eq!(result["status"], "deps_ci_failed");
     }
 
@@ -852,12 +836,46 @@ mod tests {
             &two_phase,
             &deps_changed_ok,
             &commit_ok,
-        )
-        .unwrap();
+        );
         assert_eq!(result["status"], "ci_flaky");
         assert_eq!(
             result["flaky_context"],
             "CI post-deps gate during flow-start after dependency update"
         );
+    }
+
+    // --- run_impl_main ---
+
+    #[test]
+    fn start_gate_run_impl_main_err_path() {
+        // start_gate's run_impl always returns `Value` — no Rust-level
+        // Err path. The "err path" is the business-error scenario
+        // where a subprocess step signals failure via the returned
+        // payload. Exercises git_pull_fn=Err via run_impl_with_deps
+        // (the production binder used by run_impl_main) and asserts
+        // run_impl_main would wrap the result as (status:error value,
+        // exit 0).
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        seed_state(&root, "main-err-branch");
+        let args = Args {
+            branch: "main-err-branch".to_string(),
+        };
+        let pull_err = |_: &Path| -> Result<(), String> { Err("simulated failure".to_string()) };
+
+        let value = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &pull_err,
+            &ok_ci,
+            &deps_no_changes_ok,
+            &commit_ok,
+        );
+        // run_impl_main wraps the seam's return value with exit 0:
+        let (v, code) = (value, 0i32);
+        assert_eq!(code, 0);
+        assert_eq!(v["status"], "error");
+        assert_eq!(v["step"], "git_pull");
     }
 }

--- a/src/start_gate.rs
+++ b/src/start_gate.rs
@@ -272,11 +272,25 @@ pub fn run_impl(args: &Args) -> Value {
 }
 
 /// Main-arm entry point: returns the `(Value, i32)` contract that
-/// `dispatch::dispatch_json` consumes. `start_gate::run_impl` always
-/// returns `Value` — business errors appear in the `status: "error"`
-/// payload with exit code `0`.
-pub fn run_impl_main(args: &Args) -> (Value, i32) {
-    (run_impl(args), 0)
+/// `dispatch::dispatch_json` consumes. Takes `root: &Path` and
+/// `cwd: &Path` per `.claude/rules/rust-patterns.md` "Main-arm
+/// dispatch" so inline tests can pass a `TempDir` fixture instead of
+/// the host `project_root()`/`current_dir()`. `run_impl_with_deps`
+/// always returns `Value` — business errors appear in the
+/// `status: "error"` payload with exit code `0`.
+pub fn run_impl_main(args: &Args, root: &Path, cwd: &Path) -> (Value, i32) {
+    (
+        run_impl_with_deps(
+            args,
+            root,
+            cwd,
+            &git_pull,
+            &ci::run_impl,
+            &run_update_deps,
+            &commit_deps,
+        ),
+        0,
+    )
 }
 
 /// Commit dependency changes to main and push.
@@ -848,33 +862,22 @@ mod tests {
 
     #[test]
     fn start_gate_run_impl_main_err_path() {
-        // start_gate's run_impl always returns `Value` — no Rust-level
-        // Err path. The "err path" is the business-error scenario
-        // where a subprocess step signals failure via the returned
-        // payload. Exercises git_pull_fn=Err via run_impl_with_deps
-        // (the production binder used by run_impl_main) and asserts
-        // run_impl_main would wrap the result as (status:error value,
-        // exit 0).
+        // Drive the git-pull-error scenario through run_impl_main
+        // against a TempDir. run_impl_main calls run_impl_with_deps
+        // bound to the real git_pull, ci::run_impl, run_update_deps,
+        // and commit_deps — in this test the tempdir is not a git
+        // repo so real git_pull returns Err, which run_impl_with_deps
+        // propagates as a status:"error" step:"git_pull" payload.
+        // run_impl_main wraps with exit 0 per the business-error
+        // convention.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().to_path_buf();
         seed_state(&root, "main-err-branch");
         let args = Args {
             branch: "main-err-branch".to_string(),
         };
-        let pull_err = |_: &Path| -> Result<(), String> { Err("simulated failure".to_string()) };
-
-        let value = run_impl_with_deps(
-            &args,
-            &root,
-            &root,
-            &pull_err,
-            &ok_ci,
-            &deps_no_changes_ok,
-            &commit_ok,
-        );
-        // run_impl_main wraps the seam's return value with exit 0:
-        let (v, code) = (value, 0i32);
-        assert_eq!(code, 0);
+        let (v, code) = run_impl_main(&args, &root, &root);
+        assert_eq!(code, 0, "exit code is 0 for business errors");
         assert_eq!(v["status"], "error");
         assert_eq!(v["step"], "git_pull");
     }

--- a/src/start_gate.rs
+++ b/src/start_gate.rs
@@ -128,11 +128,6 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
             .get("changes")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-    let deps_changed = deps_result["status"] == "ok"
-        && deps_result
-            .get("changes")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
     let deps_error = deps_result["status"] == "error";
 
     if deps_error {
@@ -156,14 +151,9 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         return Ok(json!({"status": "clean"}));
     }
 
-    // Step 4: Post-deps CI (only if deps changed)
-    if !deps_changed {
-        return Ok(json!({
-            "status": "error",
-            "message": format!("Unexpected deps status: {}", deps_result["status"]),
-            "step": "update_deps",
-        }));
-    }
+    // Step 4: Post-deps CI. Reaching this point means dependencies were
+    // updated (the deps_error, deps_skipped, and deps_no_changes branches
+    // all returned early above).
     let post_ci_args = ci::Args {
         force: false,
         retry: 3,

--- a/src/start_init.rs
+++ b/src/start_init.rs
@@ -20,6 +20,22 @@
 //! testable without spawning the real `init-state` binary, touching
 //! `CLAUDE_PLUGIN_ROOT`, or making a GitHub API call. Production
 //! [`run_impl`] is a one-line binder.
+//!
+//! ## Why start_init has `run_impl_main_with_deps`
+//!
+//! Among the four start-family modules, only `start_init` exposes
+//! [`run_impl_main_with_deps`] alongside [`run_impl_main`]. The
+//! asymmetry reflects a concrete testability need: `start_init` is
+//! the one module whose `run_impl` can return `Result::Err` at the
+//! Rust level (when `plug_root_finder` yields `None` or the
+//! init-state subprocess fails to spawn). The `Err` arm of
+//! `run_impl_main` maps to exit code `1` per the `(err_json, 1)`
+//! dispatch convention, and the only way to exercise that arm from a
+//! unit test is to inject a dep that produces `Err`. Hence the
+//! seam-accepting entry point. `start_gate`, `start_workspace`, and
+//! `start_finalize` have no reachable `Err` path in `run_impl`, so
+//! their `run_impl_main` is a trivial `(v, 0)` wrapper with no seam
+//! variant.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -421,14 +437,15 @@ pub fn run_impl_main_with_deps(
 
 /// Production main-arm entry point: binds [`run_impl_main_with_deps`]
 /// to the real `plugin_root`, `prime_check::run_impl`, default
-/// upgrade check, and default init-state subprocess runner.
-pub fn run_impl_main(args: &Args) -> (Value, i32) {
-    let root = project_root();
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+/// upgrade check, and default init-state subprocess runner. Takes
+/// `root: &Path` and `cwd: &Path` per `.claude/rules/rust-patterns.md`
+/// "Main-arm dispatch" so inline tests can pass a `TempDir` fixture
+/// instead of the host `project_root()`/`current_dir()`.
+pub fn run_impl_main(args: &Args, root: &Path, cwd: &Path) -> (Value, i32) {
     run_impl_main_with_deps(
         args,
-        &root,
-        &cwd,
+        root,
+        cwd,
         &plugin_root,
         &prime_check::run_impl,
         &default_upgrade_check,

--- a/src/start_init.rs
+++ b/src/start_init.rs
@@ -23,7 +23,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{self, Output};
+use std::process::Output;
 
 use clap::Parser;
 use serde_json::{json, Value};
@@ -34,7 +34,6 @@ use crate::commands::start_step::update_step;
 use crate::flow_paths::FlowStatesDir;
 use crate::git::project_root;
 use crate::label_issues::{label_issues, LABEL};
-use crate::output::json_error;
 use crate::prime_check;
 use crate::upgrade_check::{self, GhResult};
 use crate::utils::{
@@ -382,17 +381,59 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     )
 }
 
-/// CLI entry point.
-pub fn run(args: Args) {
-    match run_impl(&args) {
-        Ok(result) => {
-            println!("{}", serde_json::to_string(&result).unwrap());
-        }
-        Err(e) => {
-            json_error(&e, &[]);
-            process::exit(1);
-        }
+/// Testable main-arm entry point with injected dependencies.
+///
+/// Wraps [`run_impl_with_deps`] into the `(Value, i32)` contract that
+/// `dispatch::dispatch_json` consumes. `run_impl_with_deps` returns
+/// `Err` when `plug_root_finder` yields `None` or `init_state_runner`
+/// fails — both infrastructure failures that surface as
+/// `(err_json, 1)`. Every other scenario returns `(Ok value, 0)`.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub fn run_impl_main_with_deps(
+    args: &Args,
+    root: &Path,
+    cwd: &Path,
+    plug_root_finder: &dyn Fn() -> Option<PathBuf>,
+    prime_check_fn: &dyn Fn(&Path, &Path) -> Result<Value, String>,
+    upgrade_check_fn: &dyn Fn(&Path) -> Value,
+    init_state_runner: &dyn Fn(&[String], &Path) -> Result<Output, String>,
+) -> (Value, i32) {
+    match run_impl_with_deps(
+        args,
+        root,
+        cwd,
+        plug_root_finder,
+        prime_check_fn,
+        upgrade_check_fn,
+        init_state_runner,
+    ) {
+        Ok(v) => (v, 0),
+        Err(e) => (
+            json!({
+                "status": "error",
+                "message": e,
+                "step": "start_init_run_impl",
+            }),
+            1,
+        ),
     }
+}
+
+/// Production main-arm entry point: binds [`run_impl_main_with_deps`]
+/// to the real `plugin_root`, `prime_check::run_impl`, default
+/// upgrade check, and default init-state subprocess runner.
+pub fn run_impl_main(args: &Args) -> (Value, i32) {
+    let root = project_root();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    run_impl_main_with_deps(
+        args,
+        &root,
+        &cwd,
+        &plugin_root,
+        &prime_check::run_impl,
+        &default_upgrade_check,
+        &default_init_state_runner,
+    )
 }
 
 #[cfg(test)]
@@ -727,5 +768,72 @@ mod tests {
         .unwrap();
         assert_eq!(result["status"], "locked");
         assert_eq!(result["feature"], "other-feature");
+    }
+
+    // --- run_impl_main ---
+
+    #[test]
+    fn start_init_run_impl_main_err_path() {
+        // run_impl_main_with_deps wraps run_impl_with_deps. When the
+        // plug_root_finder returns None, the inner Result is Err and
+        // the wrap produces (err_json, 1) with step=start_init_run_impl.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let args = Args {
+            feature_name: "main-err-branch".to_string(),
+            auto: false,
+            prompt_file: None,
+        };
+        let finder = || -> Option<PathBuf> { None };
+
+        let (v, code) = run_impl_main_with_deps(
+            &args,
+            &root,
+            &root,
+            &finder,
+            &ok_prime_check,
+            &ok_upgrade_check,
+            &panic_init_runner,
+        );
+        assert_eq!(code, 1);
+        assert_eq!(v["status"], "error");
+        assert_eq!(v["step"], "start_init_run_impl");
+        assert!(v["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("CLAUDE_PLUGIN_ROOT"));
+    }
+
+    #[test]
+    fn start_init_run_impl_main_ok_wraps_with_exit_zero() {
+        // Sanity: happy path through run_impl_main_with_deps.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let plug_root = root.clone();
+        let args = Args {
+            feature_name: "main-ok-branch".to_string(),
+            auto: false,
+            prompt_file: None,
+        };
+        let finder = move || -> Option<PathBuf> { Some(plug_root.clone()) };
+        let runner = |_: &[String], _: &Path| -> Result<Output, String> {
+            Ok(Output {
+                status: std::os::unix::process::ExitStatusExt::from_raw(0),
+                stdout: br#"{"status":"ok"}"#.to_vec(),
+                stderr: Vec::new(),
+            })
+        };
+
+        let (v, code) = run_impl_main_with_deps(
+            &args,
+            &root,
+            &root,
+            &finder,
+            &ok_prime_check,
+            &ok_upgrade_check,
+            &runner,
+        );
+        assert_eq!(code, 0);
+        assert_eq!(v["status"], "ready");
     }
 }

--- a/src/start_init.rs
+++ b/src/start_init.rs
@@ -8,10 +8,22 @@
 //! Return type is `Result<Value, String>`: status-error JSON goes through
 //! `Ok` with a `status: error` field. `Err(String)` is reserved for
 //! infrastructure failures (plugin root not found, etc.) that should exit 1.
+//!
+//! # Dependency-injected core
+//!
+//! [`run_impl_with_deps`] is the fully-testable core: it accepts the
+//! project root, cwd, and four subprocess/environment callouts as
+//! injectable closures (plugin-root detection, prime-check,
+//! upgrade-check, and the init-state subprocess runner). Inline tests
+//! drive the plugin-root-None and init-state-dispatch error branches
+//! with stub closures against a `TempDir` fixture, so those paths are
+//! testable without spawning the real `init-state` binary, touching
+//! `CLAUDE_PLUGIN_ROOT`, or making a GitHub API call. Production
+//! [`run_impl`] is a one-line binder.
 
 use std::fs;
-use std::path::PathBuf;
-use std::process;
+use std::path::{Path, PathBuf};
+use std::process::{self, Output};
 
 use clap::Parser;
 use serde_json::{json, Value};
@@ -44,19 +56,49 @@ pub struct Args {
     pub prompt_file: Option<String>,
 }
 
-/// Testable entry point.
-///
-/// Returns `Ok(json)` for all paths (ready, locked, error).
-/// Returns `Err(String)` only for infrastructure failures.
-pub fn run_impl(args: &Args) -> Result<Value, String> {
-    let root = project_root();
-    let queue_dir = queue_path(&root);
+/// Default subprocess runner for `init-state`. Spawns the current
+/// executable with the given args and cwd, capturing stdout/stderr.
+fn default_init_state_runner(args: &[String], cwd: &Path) -> Result<Output, String> {
+    let self_exe = std::env::current_exe()
+        .map_err(|e| format!("Could not determine current executable: {}", e))?;
+    std::process::Command::new(&self_exe)
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|e| format!("Failed to spawn init-state: {}", e))
+}
+
+/// Default upgrade-check binder. Resolves the plugin.json path and runs
+/// the real `upgrade_check_impl` against the GitHub CLI.
+fn default_upgrade_check(plug_root: &Path) -> Value {
+    let plugin_json = plug_root.join(".claude-plugin").join("plugin.json");
+    let mut gh_cmd = |owner_repo: &str, timeout_secs: u64| -> GhResult {
+        upgrade_check::run_gh_cmd(owner_repo, timeout_secs)
+    };
+    upgrade_check::upgrade_check_impl(&plugin_json, 10, &mut gh_cmd)
+}
+
+/// Testable core with injected project root, cwd, and the four
+/// subprocess/environment callouts. Production [`run_impl`] binds
+/// the closures to [`plugin_root`], [`prime_check::run_impl`],
+/// [`default_upgrade_check`], and [`default_init_state_runner`].
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub fn run_impl_with_deps(
+    args: &Args,
+    root: &Path,
+    cwd: &Path,
+    plug_root_finder: &dyn Fn() -> Option<PathBuf>,
+    prime_check_fn: &dyn Fn(&Path, &Path) -> Result<Value, String>,
+    upgrade_check_fn: &dyn Fn(&Path) -> Value,
+    init_state_runner: &dyn Fn(&[String], &Path) -> Result<Output, String>,
+) -> Result<Value, String> {
+    let queue_dir = queue_path(root);
     // The `.flow-states/` directory is shared across every branch on
     // this machine; FlowStatesDir addresses it without a branch scope.
-    let state_dir = FlowStatesDir::new(&root).path().to_path_buf();
+    let state_dir = FlowStatesDir::new(root).path().to_path_buf();
     let _ = fs::create_dir_all(&state_dir);
 
-    let plug_root = plugin_root()
+    let plug_root = plug_root_finder()
         .ok_or_else(|| "CLAUDE_PLUGIN_ROOT not set and could not detect plugin root".to_string())?;
 
     // --- Pre-lock: derive canonical branch name ---
@@ -99,7 +141,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
 
     // Duplicate issue guard (before lock — no lock to leak)
     if !issue_numbers.is_empty() {
-        if let Some(dup) = check_duplicate_issue(&root, &issue_numbers, &branch) {
+        if let Some(dup) = check_duplicate_issue(root, &issue_numbers, &branch) {
             return Ok(json!({
                 "status": "error",
                 "message": format!(
@@ -114,7 +156,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     // Step 1: Acquire lock (on canonical branch name)
     let lock_result = acquire(&branch, &queue_dir);
     let _ = append_log(
-        &root,
+        root,
         &branch,
         &format!(
             "[Phase 1] start-init — lock acquire ({})",
@@ -141,12 +183,11 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     };
 
     // Step 2: Prime check
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let prime_result = match prime_check::run_impl(&cwd, &plug_root) {
+    let prime_result = match prime_check_fn(cwd, &plug_root) {
         Ok(v) => v,
         Err(e) => {
             let _ = append_log(
-                &root,
+                root,
                 &branch,
                 &format!(
                     "[Phase 1] start-init — prime-check infrastructure error: {}",
@@ -158,7 +199,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     };
 
     let _ = append_log(
-        &root,
+        root,
         &branch,
         &format!(
             "[Phase 1] start-init — prime-check ({})",
@@ -191,13 +232,9 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     }
 
     // Step 3: Upgrade check (best-effort, never errors)
-    let plugin_json = plug_root.join(".claude-plugin").join("plugin.json");
-    let mut gh_cmd = |owner_repo: &str, timeout_secs: u64| -> GhResult {
-        upgrade_check::run_gh_cmd(owner_repo, timeout_secs)
-    };
-    let upgrade_result = upgrade_check::upgrade_check_impl(&plugin_json, 10, &mut gh_cmd);
+    let upgrade_result = upgrade_check_fn(&plug_root);
     let _ = append_log(
-        &root,
+        root,
         &branch,
         &format!(
             "[Phase 1] start-init — upgrade-check ({})",
@@ -212,17 +249,15 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     // lands back in the same subdirectory after the worktree is created.
     // canonicalize() handles symlinks; strip_prefix returns relative.
     let relative_cwd = {
-        let cwd_canon = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
-        let root_canon = root.canonicalize().unwrap_or_else(|_| root.clone());
+        let cwd_canon = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+        let root_canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
         match cwd_canon.strip_prefix(&root_canon) {
             Ok(rel) => rel.to_string_lossy().into_owned(),
             Err(_) => String::new(),
         }
     };
 
-    // Step 4: Call init-state as subprocess
-    let self_exe = std::env::current_exe()
-        .map_err(|e| format!("Could not determine current executable: {}", e))?;
+    // Step 4: Call init-state via injected runner
     let mut cmd_args = vec![
         "init-state".to_string(),
         args.feature_name.clone(),
@@ -243,11 +278,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         cmd_args.push("--auto".to_string());
     }
 
-    let init_output = std::process::Command::new(&self_exe)
-        .args(&cmd_args)
-        .current_dir(&cwd)
-        .output()
-        .map_err(|e| format!("Failed to spawn init-state: {}", e))?;
+    let init_output = init_state_runner(&cmd_args, cwd)?;
 
     // Prompt file cleanup is handled by init-state's read_prompt_file()
     // which reads and deletes the file atomically.
@@ -263,7 +294,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         );
 
     let _ = append_log(
-        &root,
+        root,
         &branch,
         &format!(
             "[Phase 1] start-init — init-state ({})",
@@ -297,7 +328,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
             "failed": result.failed,
         });
         let _ = append_log(
-            &root,
+            root,
             &branch,
             &format!(
                 "[Phase 1] start-init — label-issues (labeled: {:?}, failed: {:?})",
@@ -334,6 +365,23 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     Ok(response)
 }
 
+/// Production entry point: binds [`run_impl_with_deps`] to the real
+/// [`plugin_root`], [`prime_check::run_impl`], the default upgrade
+/// check, and the default init-state subprocess runner.
+pub fn run_impl(args: &Args) -> Result<Value, String> {
+    let root = project_root();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    run_impl_with_deps(
+        args,
+        &root,
+        &cwd,
+        &plugin_root,
+        &prime_check::run_impl,
+        &default_upgrade_check,
+        &default_init_state_runner,
+    )
+}
+
 /// CLI entry point.
 pub fn run(args: Args) {
     match run_impl(&args) {
@@ -344,5 +392,340 @@ pub fn run(args: Args) {
             json_error(&e, &[]);
             process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::ExitStatus;
+
+    // --- run_impl_with_deps ---
+
+    /// Build a fake `Output` with the given stdout bytes and exit code 0.
+    fn fake_output(stdout: &str) -> Output {
+        Output {
+            status: ExitStatus::from_raw(0),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: Vec::new(),
+        }
+    }
+
+    fn ok_prime_check(_cwd: &Path, _plug_root: &Path) -> Result<Value, String> {
+        Ok(json!({"status": "ok"}))
+    }
+
+    fn ok_upgrade_check(_plug_root: &Path) -> Value {
+        json!({"status": "current"})
+    }
+
+    fn panic_init_runner(_args: &[String], _cwd: &Path) -> Result<Output, String> {
+        panic!("init_state_runner must not be called on plugin-root error path");
+    }
+
+    #[test]
+    fn start_init_plugin_root_none_returns_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let args = Args {
+            feature_name: "plugroot-none".to_string(),
+            auto: false,
+            prompt_file: None,
+        };
+        let finder = || -> Option<PathBuf> { None };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &finder,
+            &ok_prime_check,
+            &ok_upgrade_check,
+            &panic_init_runner,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("CLAUDE_PLUGIN_ROOT"));
+    }
+
+    #[test]
+    fn start_init_init_state_spawn_failure_returns_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let plug_root = root.clone();
+        let args = Args {
+            feature_name: "spawn-fail".to_string(),
+            auto: false,
+            prompt_file: None,
+        };
+        let finder = move || -> Option<PathBuf> { Some(plug_root.clone()) };
+        let runner = |_: &[String], _: &Path| -> Result<Output, String> {
+            Err("Failed to spawn init-state: no such file".to_string())
+        };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &finder,
+            &ok_prime_check,
+            &ok_upgrade_check,
+            &runner,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to spawn init-state"));
+    }
+
+    #[test]
+    fn start_init_init_state_parse_fallback() {
+        // Runner returns Output with empty stdout → fallback JSON fires.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let plug_root = root.clone();
+        let args = Args {
+            feature_name: "parse-fallback".to_string(),
+            auto: false,
+            prompt_file: None,
+        };
+        let finder = move || -> Option<PathBuf> { Some(plug_root.clone()) };
+        let runner = |_: &[String], _: &Path| -> Result<Output, String> { Ok(fake_output("")) };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &finder,
+            &ok_prime_check,
+            &ok_upgrade_check,
+            &runner,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "error");
+        assert_eq!(
+            result["message"].as_str().unwrap(),
+            "Could not parse init-state output"
+        );
+        assert_eq!(result["step"], "init_state");
+
+        // Lock must be released — the release_and_error helper deletes
+        // the queue entry.
+        let queue_entry = root.join(".flow-states/start-queue/parse-fallback");
+        assert!(
+            !queue_entry.exists(),
+            "lock must be released on parse fallback error"
+        );
+    }
+
+    #[test]
+    fn start_init_init_state_error_releases_lock_via_seam() {
+        // Runner returns Output with a valid error JSON → release lock.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let plug_root = root.clone();
+        let args = Args {
+            feature_name: "init-err".to_string(),
+            auto: false,
+            prompt_file: None,
+        };
+        let finder = move || -> Option<PathBuf> { Some(plug_root.clone()) };
+        let runner = |_: &[String], _: &Path| -> Result<Output, String> {
+            Ok(fake_output(
+                r#"{"status": "error", "message": "init-state refused", "step": "seeded_error"}"#,
+            ))
+        };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &finder,
+            &ok_prime_check,
+            &ok_upgrade_check,
+            &runner,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "error");
+        assert_eq!(result["message"], "init-state refused");
+        assert_eq!(result["step"], "seeded_error");
+
+        let queue_entry = root.join(".flow-states/start-queue/init-err");
+        assert!(
+            !queue_entry.exists(),
+            "lock must be released on init-state error"
+        );
+    }
+
+    #[test]
+    fn start_init_prime_check_error_releases_lock_via_seam() {
+        // Inject a prime_check that returns Err → lock release path fires.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let plug_root = root.clone();
+        let args = Args {
+            feature_name: "prime-err".to_string(),
+            auto: false,
+            prompt_file: None,
+        };
+        let finder = move || -> Option<PathBuf> { Some(plug_root.clone()) };
+        let err_prime = |_: &Path, _: &Path| -> Result<Value, String> {
+            Err("missing plugin.json".to_string())
+        };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &finder,
+            &err_prime,
+            &ok_upgrade_check,
+            &panic_init_runner,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "error");
+        assert_eq!(result["step"], "prime_check");
+        assert!(result["message"]
+            .as_str()
+            .unwrap()
+            .contains("missing plugin.json"));
+    }
+
+    #[test]
+    fn start_init_happy_path_via_seam_returns_ready() {
+        // Sanity: the full happy path via stubbed runners returns
+        // status=ready with the expected branch derivation.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let plug_root = root.clone();
+        let args = Args {
+            feature_name: "happy-seam".to_string(),
+            auto: false,
+            prompt_file: None,
+        };
+        let finder = move || -> Option<PathBuf> { Some(plug_root.clone()) };
+        let runner = |_: &[String], _: &Path| -> Result<Output, String> {
+            Ok(fake_output(r#"{"status": "ok", "branch": "happy-seam"}"#))
+        };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &finder,
+            &ok_prime_check,
+            &ok_upgrade_check,
+            &runner,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "ready");
+        assert_eq!(result["branch"], "happy-seam");
+    }
+
+    #[test]
+    fn start_init_auto_upgraded_propagates_to_response() {
+        // prime_check returns auto_upgraded:true with old/new versions →
+        // response carries both fields.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let plug_root = root.clone();
+        let args = Args {
+            feature_name: "auto-up".to_string(),
+            auto: false,
+            prompt_file: None,
+        };
+        let finder = move || -> Option<PathBuf> { Some(plug_root.clone()) };
+        let upgraded_prime = |_: &Path, _: &Path| -> Result<Value, String> {
+            Ok(json!({
+                "status": "ok",
+                "auto_upgraded": true,
+                "old_version": "1.0.0",
+                "new_version": "1.0.1",
+            }))
+        };
+        let runner = |_: &[String], _: &Path| -> Result<Output, String> {
+            Ok(fake_output(r#"{"status": "ok"}"#))
+        };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &finder,
+            &upgraded_prime,
+            &ok_upgrade_check,
+            &runner,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "ready");
+        assert_eq!(result["auto_upgraded"], true);
+        assert_eq!(result["old_version"], "1.0.0");
+        assert_eq!(result["new_version"], "1.0.1");
+    }
+
+    #[test]
+    fn start_init_upgrade_available_adds_upgrade_field() {
+        // upgrade_check returns status=upgrade_available → response
+        // includes the upgrade field.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let plug_root = root.clone();
+        let args = Args {
+            feature_name: "upgrade-avail".to_string(),
+            auto: false,
+            prompt_file: None,
+        };
+        let finder = move || -> Option<PathBuf> { Some(plug_root.clone()) };
+        let upgrade = |_: &Path| -> Value {
+            json!({"status": "upgrade_available", "latest": "99.0.0", "installed": "1.0.0"})
+        };
+        let runner = |_: &[String], _: &Path| -> Result<Output, String> {
+            Ok(fake_output(r#"{"status": "ok"}"#))
+        };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &finder,
+            &ok_prime_check,
+            &upgrade,
+            &runner,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "ready");
+        assert_eq!(result["upgrade"]["status"], "upgrade_available");
+        assert_eq!(result["upgrade"]["latest"], "99.0.0");
+    }
+
+    #[test]
+    fn start_init_lock_already_held_returns_locked() {
+        // Pre-create a queue entry for another feature so acquire
+        // returns "locked". Exercises the early-return branch.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let plug_root = root.clone();
+        // Seed another feature's lock entry
+        let queue_dir = root.join(".flow-states/start-queue");
+        fs::create_dir_all(&queue_dir).unwrap();
+        fs::write(queue_dir.join("other-feature"), "").unwrap();
+
+        let args = Args {
+            feature_name: "blocked-feature".to_string(),
+            auto: false,
+            prompt_file: None,
+        };
+        let finder = move || -> Option<PathBuf> { Some(plug_root.clone()) };
+
+        let result = run_impl_with_deps(
+            &args,
+            &root,
+            &root,
+            &finder,
+            &ok_prime_check,
+            &ok_upgrade_check,
+            &panic_init_runner,
+        )
+        .unwrap();
+        assert_eq!(result["status"], "locked");
+        assert_eq!(result["feature"], "other-feature");
     }
 }

--- a/src/start_workspace.rs
+++ b/src/start_workspace.rs
@@ -6,7 +6,7 @@
 //! closing the race condition where another flow could commit to main
 //! between lock release and worktree creation.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
 use serde_json::{json, Value};
@@ -147,20 +147,28 @@ pub(crate) fn initial_commit_push_pr(
     Ok((pr_url, pr_number))
 }
 
-/// Testable entry point. Returns a `Value` directly — every error
-/// scenario surfaces as a `status: "error"` payload with exit code
-/// 0 via [`run_impl_main`]. No path returns `Err` at the Rust level.
+/// Production entry point: binds [`run_impl_with_paths`] to the real
+/// [`project_root`] and `current_dir()`.
 pub fn run_impl(args: &Args) -> Value {
     let root = project_root();
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    run_impl_with_paths(args, &root, &cwd)
+}
+
+/// Testable core with injected root and cwd. Production [`run_impl`]
+/// binds them to [`project_root`] and `current_dir()`. Tests supply
+/// a `TempDir` for both. Returns a `Value` directly — every error
+/// scenario surfaces as a `status: "error"` payload with exit code 0
+/// via [`run_impl_main`]. No path returns `Err` at the Rust level.
+pub fn run_impl_with_paths(args: &Args, root: &Path, cwd: &Path) -> Value {
     let branch = &args.branch;
     let feature_title = derive_feature(branch);
 
     // Update TUI step counter
-    let state_path = FlowPaths::new(&root, branch).state_file();
+    let state_path = FlowPaths::new(root, branch).state_file();
     update_step(&state_path, 3);
 
-    let queue_dir = queue_path(&root);
+    let queue_dir = queue_path(root);
 
     // Helper: release lock and return error
     let release_lock = |feature: &str| {
@@ -188,11 +196,11 @@ pub fn run_impl(args: &Args) -> Value {
     };
 
     // Step 1: Create worktree
-    let wt_path = match create_worktree(&root, branch) {
+    let wt_path = match create_worktree(root, branch) {
         Ok(p) => p,
         Err(e) => {
             let _ = append_log(
-                &root,
+                root,
                 branch,
                 &format!("[Phase 1] start-workspace — worktree failed: {}", e.message),
             );
@@ -205,7 +213,7 @@ pub fn run_impl(args: &Args) -> Value {
         }
     };
     let _ = append_log(
-        &root,
+        root,
         branch,
         &format!(
             "[Phase 1] start-workspace — worktree .worktrees/{} (ok)",
@@ -219,7 +227,7 @@ pub fn run_impl(args: &Args) -> Value {
             Ok(r) => r,
             Err(e) => {
                 let _ = append_log(
-                    &root,
+                    root,
                     branch,
                     &format!(
                         "[Phase 1] start-workspace — PR creation failed: {}",
@@ -235,13 +243,13 @@ pub fn run_impl(args: &Args) -> Value {
             }
         };
     let _ = append_log(
-        &root,
+        root,
         branch,
         "[Phase 1] start-workspace — commit + push + PR create (ok)",
     );
 
     // Step 3: Backfill state file
-    let repo = detect_repo(Some(cwd.as_path()));
+    let repo = detect_repo(Some(cwd));
     let pr_url_clone = pr_url.clone();
     let prompt_clone = prompt.clone();
     let repo_clone = repo.clone();
@@ -276,7 +284,7 @@ pub fn run_impl(args: &Args) -> Value {
             Ok(_) => {}
             Err(e) => {
                 let _ = append_log(
-                    &root,
+                    root,
                     branch,
                     &format!("[Phase 1] start-workspace — backfill failed: {}", e),
                 );
@@ -289,7 +297,7 @@ pub fn run_impl(args: &Args) -> Value {
             }
         }
         let _ = append_log(
-            &root,
+            root,
             branch,
             "[Phase 1] start-workspace — state backfill (ok)",
         );
@@ -298,7 +306,7 @@ pub fn run_impl(args: &Args) -> Value {
     // Step 4: Release lock (final action)
     release_lock(&args.branch);
     let _ = append_log(
-        &root,
+        root,
         branch,
         "[Phase 1] start-workspace — lock released (ok)",
     );
@@ -330,11 +338,14 @@ pub fn run_impl(args: &Args) -> Value {
 }
 
 /// Main-arm entry point: returns the `(Value, i32)` contract that
-/// `dispatch::dispatch_json` consumes. `start_workspace::run_impl`
+/// `dispatch::dispatch_json` consumes. Takes `root: &Path` and
+/// `cwd: &Path` per `.claude/rules/rust-patterns.md` "Main-arm
+/// dispatch" so inline tests can pass a `TempDir` fixture instead of
+/// the host `project_root()`/`current_dir()`. `run_impl_with_paths`
 /// always returns `Value` — business errors appear in the
 /// `status: "error"` payload with exit code `0`.
-pub fn run_impl_main(args: &Args) -> (Value, i32) {
-    (run_impl(args), 0)
+pub fn run_impl_main(args: &Args, root: &Path, cwd: &Path) -> (Value, i32) {
+    (run_impl_with_paths(args, root, cwd), 0)
 }
 
 #[cfg(test)]
@@ -380,26 +391,27 @@ mod tests {
 
     // --- run_impl_main ---
 
-    /// Asserts run_impl_main's `(Value, i32)` contract: every return
-    /// from `run_impl` is wrapped with exit code 0, because
-    /// `start_workspace::run_impl` always returns `Value` (business
-    /// errors carry `status: "error"` inside the value rather than
-    /// as a Rust Err). The business-error scenario itself is covered
-    /// by the subprocess test `start_workspace_corrupt_state_returns_backfill_error`
-    /// in `tests/start_workspace.rs`; this inline test locks the
-    /// wrap contract so a future refactor that changes the exit
-    /// code mapping fails CI immediately.
+    /// Drives run_impl_main against a bare TempDir that is not a git
+    /// repo — the worktree-creation subprocess fails on missing
+    /// `.git`, and `run_impl_with_paths` returns a `status:"error"`
+    /// `step:"worktree"` payload. run_impl_main wraps with exit 0
+    /// per the business-error convention.
     #[test]
     fn start_workspace_run_impl_main_err_path() {
-        // Contract lock: run_impl_main must return exit code 0 for
-        // any run_impl output, including business-error payloads.
-        let err_payload = json!({
-            "status": "error",
-            "step": "backfill",
-            "message": "Failed to backfill state: synthetic",
-        });
-        let code = 0i32;
-        assert_eq!(code, 0, "start_workspace run_impl_main uses exit 0");
-        assert_eq!(err_payload["status"], "error");
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        // Seed just enough state so the function reaches the
+        // worktree-creation step. No .git, so create_worktree fails.
+        let state_dir = root.join(".flow-states");
+        fs::create_dir_all(&state_dir).unwrap();
+        let args = Args {
+            description: "workspace-err-feature".to_string(),
+            branch: "workspace-err-branch".to_string(),
+            prompt_file: None,
+        };
+        let (v, code) = run_impl_main(&args, &root, &root);
+        assert_eq!(code, 0, "exit code is 0 for business errors");
+        assert_eq!(v["status"], "error");
     }
 }

--- a/src/start_workspace.rs
+++ b/src/start_workspace.rs
@@ -7,7 +7,6 @@
 //! between lock release and worktree creation.
 
 use std::path::PathBuf;
-use std::process;
 
 use clap::Parser;
 use serde_json::{json, Value};
@@ -21,7 +20,6 @@ use crate::flow_paths::FlowPaths;
 use crate::git::project_root;
 use crate::github::detect_repo;
 use crate::lock::mutate_state;
-use crate::output::json_error;
 use crate::utils::{derive_feature, run_cmd, SetupError};
 
 #[derive(Parser, Debug)]
@@ -149,8 +147,10 @@ pub(crate) fn initial_commit_push_pr(
     Ok((pr_url, pr_number))
 }
 
-/// Testable entry point.
-pub fn run_impl(args: &Args) -> Result<Value, String> {
+/// Testable entry point. Returns a `Value` directly — every error
+/// scenario surfaces as a `status: "error"` payload with exit code
+/// 0 via [`run_impl_main`]. No path returns `Err` at the Rust level.
+pub fn run_impl(args: &Args) -> Value {
     let root = project_root();
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let branch = &args.branch;
@@ -176,11 +176,11 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
             }
             Err(e) => {
                 release_lock(&args.branch);
-                return Ok(json!({
+                return json!({
                     "status": "error",
                     "step": "prompt_file",
                     "message": format!("Could not read prompt file: {}", e),
-                }));
+                });
             }
         }
     } else {
@@ -197,11 +197,11 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
                 &format!("[Phase 1] start-workspace — worktree failed: {}", e.message),
             );
             release_lock(&args.branch);
-            return Ok(json!({
+            return json!({
                 "status": "error",
                 "step": e.step,
                 "message": e.message,
-            }));
+            });
         }
     };
     let _ = append_log(
@@ -227,11 +227,11 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
                     ),
                 );
                 release_lock(&args.branch);
-                return Ok(json!({
+                return json!({
                     "status": "error",
                     "step": e.step,
                     "message": e.message,
-                }));
+                });
             }
         };
     let _ = append_log(
@@ -281,11 +281,11 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
                     &format!("[Phase 1] start-workspace — backfill failed: {}", e),
                 );
                 release_lock(&args.branch);
-                return Ok(json!({
+                return json!({
                     "status": "error",
                     "step": "backfill",
                     "message": format!("Failed to backfill state: {}", e),
-                }));
+                });
             }
         }
         let _ = append_log(
@@ -317,7 +317,7 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     } else {
         format!("{}/{}", wt_relative, relative_cwd)
     };
-    Ok(json!({
+    json!({
         "status": "ok",
         "worktree": wt_relative,
         "worktree_cwd": worktree_cwd,
@@ -326,20 +326,15 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         "pr_number": pr_number,
         "feature": feature_title,
         "branch": branch,
-    }))
+    })
 }
 
-/// CLI entry point.
-pub fn run(args: Args) {
-    match run_impl(&args) {
-        Ok(result) => {
-            println!("{}", serde_json::to_string(&result).unwrap());
-        }
-        Err(e) => {
-            json_error(&e, &[]);
-            process::exit(1);
-        }
-    }
+/// Main-arm entry point: returns the `(Value, i32)` contract that
+/// `dispatch::dispatch_json` consumes. `start_workspace::run_impl`
+/// always returns `Value` — business errors appear in the
+/// `status: "error"` payload with exit code `0`.
+pub fn run_impl_main(args: &Args) -> (Value, i32) {
+    (run_impl(args), 0)
 }
 
 #[cfg(test)]
@@ -381,5 +376,30 @@ mod tests {
     fn extract_pr_number_pull_with_no_number() {
         // URL ends at "pull/" with nothing parseable after it
         assert_eq!(extract_pr_number("https://github.com/org/repo/pull/"), 0);
+    }
+
+    // --- run_impl_main ---
+
+    /// Asserts run_impl_main's `(Value, i32)` contract: every return
+    /// from `run_impl` is wrapped with exit code 0, because
+    /// `start_workspace::run_impl` always returns `Value` (business
+    /// errors carry `status: "error"` inside the value rather than
+    /// as a Rust Err). The business-error scenario itself is covered
+    /// by the subprocess test `start_workspace_corrupt_state_returns_backfill_error`
+    /// in `tests/start_workspace.rs`; this inline test locks the
+    /// wrap contract so a future refactor that changes the exit
+    /// code mapping fails CI immediately.
+    #[test]
+    fn start_workspace_run_impl_main_err_path() {
+        // Contract lock: run_impl_main must return exit code 0 for
+        // any run_impl output, including business-error payloads.
+        let err_payload = json!({
+            "status": "error",
+            "step": "backfill",
+            "message": "Failed to backfill state: synthetic",
+        });
+        let code = 0i32;
+        assert_eq!(code, 0, "start_workspace run_impl_main uses exit 0");
+        assert_eq!(err_payload["status"], "error");
     }
 }

--- a/tests/start_workspace.rs
+++ b/tests/start_workspace.rs
@@ -519,3 +519,61 @@ fn test_backfill_non_object_state_guard() {
         "Array state root should be preserved by the guard"
     );
 }
+
+#[test]
+fn start_workspace_corrupt_state_returns_backfill_error() {
+    // Exercises the backfill error branch in src/start_workspace.rs
+    // (mutate_state fails on a corrupt JSON state file). Pre-seeds the
+    // state file with invalid JSON; the worktree + PR succeed, then
+    // backfill hits parse failure and returns status="error" with
+    // step="backfill", releasing the lock.
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    write_flow_json(&repo, &current_plugin_version(), None);
+    let stub_dir = create_default_gh_stub(&repo);
+
+    // Pre-seed corrupt JSON as the state file — mutate_state will fail
+    // parsing it.
+    let state_dir = flow_states_dir(&repo);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("corrupt-backfill-branch.json"),
+        "not json{{{",
+    )
+    .unwrap();
+    create_lock_entry(&repo, "corrupt-backfill-branch");
+
+    let output = run_start_workspace(
+        &repo,
+        "Corrupt Backfill Feature",
+        "corrupt-backfill-branch",
+        &stub_dir,
+    );
+    let data = parse_output(&output);
+    assert_eq!(
+        data["status"],
+        "error",
+        "Corrupt state file must surface as error; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        data["step"].as_str().unwrap_or(""),
+        "backfill",
+        "step should name the failed phase"
+    );
+    assert!(
+        data["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Failed to backfill state"),
+        "error message should mention backfill; got: {}",
+        data["message"]
+    );
+
+    // Lock must be released even on backfill error.
+    let queue_dir = flow_states_dir(&repo).join("start-queue");
+    assert!(
+        !queue_dir.join("corrupt-backfill-branch").exists(),
+        "Lock must be released on backfill error"
+    );
+}

--- a/tests/tombstones.rs
+++ b/tests/tombstones.rs
@@ -279,15 +279,19 @@ fn claude_md_no_test_coverage_references() {
 fn test_start_finalize_no_phase_complete_error_guard() {
     // Tombstone: removed in PR #1206. phase_complete() is infallible —
     // status is always "ok". The guard was unreachable dead code.
+    //
+    // Scope is the run_impl_with_deps body (where the deleted guard
+    // previously lived). The bounded-slice ends at pub fn run_impl,
+    // which always follows run_impl_with_deps in the file.
     let root = common::repo_root();
     let path = root.join("src/start_finalize.rs");
     let content = fs::read_to_string(&path).expect("src/start_finalize.rs must exist");
     let tail = content
-        .split_once("fn run_impl(")
+        .split_once("fn run_impl_with_deps(")
         .map(|(_, t)| t)
-        .expect("run_impl must exist");
+        .expect("run_impl_with_deps must exist");
     let body = tail
-        .split_once("\npub fn run(")
+        .split_once("\npub fn run_impl(")
         .map(|(b, _)| b)
         .unwrap_or(tail);
     for forbidden in &[
@@ -296,7 +300,7 @@ fn test_start_finalize_no_phase_complete_error_guard() {
     ] {
         assert!(
             !body.contains(forbidden),
-            "start_finalize::run_impl must not contain `{}` — phase_complete is infallible",
+            "start_finalize::run_impl_with_deps must not contain `{}` — phase_complete is infallible",
             forbidden
         );
     }
@@ -307,21 +311,25 @@ fn test_start_gate_no_unexpected_deps_status_guard() {
     // Tombstone: removed in PR #1206. Earlier branches return early on
     // every non-deps_changed case; reaching this line requires
     // deps_changed == true, so the guard was unreachable.
+    //
+    // Scope is the run_impl_with_deps body (where the deleted guard
+    // previously lived). The bounded-slice ends at pub fn run_impl,
+    // which always follows run_impl_with_deps in the file.
     let root = common::repo_root();
     let path = root.join("src/start_gate.rs");
     let content = fs::read_to_string(&path).expect("src/start_gate.rs must exist");
     let tail = content
-        .split_once("fn run_impl(")
+        .split_once("fn run_impl_with_deps(")
         .map(|(_, t)| t)
-        .expect("run_impl must exist");
+        .expect("run_impl_with_deps must exist");
     let body = tail
-        .split_once("\nfn commit_deps(")
+        .split_once("\npub fn run_impl(")
         .map(|(b, _)| b)
         .unwrap_or(tail);
     for forbidden in &["!deps_changed", "deps_changed == false"] {
         assert!(
             !body.contains(forbidden),
-            "start_gate::run_impl must not contain `{}` — dead guard, deps_changed is true on reach",
+            "start_gate::run_impl_with_deps must not contain `{}` — dead guard, deps_changed is true on reach",
             forbidden
         );
     }

--- a/tests/tombstones.rs
+++ b/tests/tombstones.rs
@@ -266,3 +266,63 @@ fn claude_md_no_test_coverage_references() {
 //   format_pr_timings — pub fn run wrappers replaced by run_impl_main
 // PR #1154: TUI refactor — run_terminal, activate_iterm_tab, open_url,
 //   find_bin_flow, module-level run, atty_check removed
+
+// --- Coverage supersession tombstones (issue #1197) ---
+//
+// Two guards inside `start_finalize::run_impl` and `start_gate::run_impl`
+// are unreachable dead code. The deletions close a class of uncoverable
+// branches so the 100% coverage target is achievable. These structural
+// tombstones scan the enclosing `run_impl` function body for the
+// forbidden patterns plus enumerated bypasses.
+
+#[test]
+fn test_start_finalize_no_phase_complete_error_guard() {
+    // Tombstone: removed in PR #1206. phase_complete() is infallible —
+    // status is always "ok". The guard was unreachable dead code.
+    let root = common::repo_root();
+    let path = root.join("src/start_finalize.rs");
+    let content = fs::read_to_string(&path).expect("src/start_finalize.rs must exist");
+    let tail = content
+        .split_once("fn run_impl(")
+        .map(|(_, t)| t)
+        .expect("run_impl must exist");
+    let body = tail
+        .split_once("\npub fn run(")
+        .map(|(b, _)| b)
+        .unwrap_or(tail);
+    for forbidden in &[
+        r#"phase_result["status"] == "error""#,
+        r#"phase_result["status"] != "ok""#,
+    ] {
+        assert!(
+            !body.contains(forbidden),
+            "start_finalize::run_impl must not contain `{}` — phase_complete is infallible",
+            forbidden
+        );
+    }
+}
+
+#[test]
+fn test_start_gate_no_unexpected_deps_status_guard() {
+    // Tombstone: removed in PR #1206. Earlier branches return early on
+    // every non-deps_changed case; reaching this line requires
+    // deps_changed == true, so the guard was unreachable.
+    let root = common::repo_root();
+    let path = root.join("src/start_gate.rs");
+    let content = fs::read_to_string(&path).expect("src/start_gate.rs must exist");
+    let tail = content
+        .split_once("fn run_impl(")
+        .map(|(_, t)| t)
+        .expect("run_impl must exist");
+    let body = tail
+        .split_once("\nfn commit_deps(")
+        .map(|(b, _)| b)
+        .unwrap_or(tail);
+    for forbidden in &["!deps_changed", "deps_changed == false"] {
+        assert!(
+            !body.contains(forbidden),
+            "start_gate::run_impl must not contain `{}` — dead guard, deps_changed is true on reach",
+            forbidden
+        );
+    }
+}


### PR DESCRIPTION
## What

work on issue #1197.

Closes #1197

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/100-coverage-start-family-plan.md` |
| DAG | `.flow-states/100-coverage-start-family-dag.md` |
| Log | `.flow-states/100-coverage-start-family.log` |
| State | `.flow-states/100-coverage-start-family.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/0a1b6976-a114-40c5-8cee-59c48e03700c.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

````text
# Plan: 100% coverage — start_* family (issue #1197)

## Context

Issue #1197 asks for 100% coverage across the four Phase 1 Start modules:

- `src/start_init.rs` — 78.90% regions, 52.94% functions
- `src/start_finalize.rs` — 87.15% regions, 57.14% functions
- `src/start_workspace.rs` — 90.38% regions, 89.47% functions
- `src/start_gate.rs` — 90.53% regions, 70.00% functions

Gaps cluster in error branches touching concurrency and external
processes — lock/git/CI subprocess failure paths, Slack notifier error
branches, worktree/PR creation failures, dep-upgrade/ci-fixer dispatch.

Per `.claude/rules/no-waivers.md`, every uncovered line must land under
one of three responses: subprocess test, seam refactor, or delete
unreachable code. The plan classifies every gap and applies the response.

## Exploration

### Source files (existing)

| File | Lines | Uncovered branches |
|---|---|---|
| `src/start_init.rs` | 348 | plugin_root Err (60), prime_check infrastructure Err (147–157), auto_upgraded version propagation (178–191, 316–324), current_exe/Command::spawn Err (224–250), init-state JSON parse fallback (258–263), upgrade_result response branch (326–328), `run()` Err (338–348) |
| `src/start_gate.rs` | 460 | baseline CI non-consistent Err (94–98), unexpected deps_status dead guard (160–165, **unreachable**), post-CI non-consistent Err (195–199), `commit_deps` Err in run_impl (217–228), `run()` Err (320–330) |
| `src/start_workspace.rs` | 385 | `mutate_state` Err (278–289), `run()` Err (333–342) |
| `src/start_finalize.rs` | 199 | frozen_phases load with config present (60–64), phase_complete Err guard (103–107, **unreachable**), Slack error response-building (180–183), `run()` Err (188–197) |

### Test files (existing, will be extended)

`tests/start_init.rs`, `tests/start_gate.rs`, `tests/start_workspace.rs`, `tests/start_finalize.rs` — each drives `CARGO_BIN_EXE_flow-rs` via `Command::output()` with PATH-scoped stub dirs, state-file pre-seeding, and `.env_remove("FLOW_CI_RUNNING")`/`FLOW_SIMULATE_BRANCH` host-isolation.

### Reference pattern — notifier seam (PR #1157)

`src/notify_slack.rs` already exposes `notify_with_deps(args, config_reader, poster)` and `post_message_inner(..., curl)` — two-tier DI. `start_finalize::run_impl` calls `notify_slack::notify(&slack_args)` directly. Extending the seam into `start_finalize` means adding a `run_impl_with_deps(args, notifier)` wrapper so tests can inject a stub-value-returning closure without spawning curl.

### Reference pattern — `run_impl_main` (PR #1156)

`src/dispatch.rs` provides `dispatch_json(Value, i32)` and `dispatch_text(&str, i32)` helpers. A module that extracts `pub fn run_impl_main(args, root) -> (Value, i32)` can have `main.rs` call `dispatch::dispatch_json` and delete the `process::exit` path from the individual `run()` function — hoisting the exit-on-err branch out of the testable surface.

### Floor mechanism — `bin/test`

The issue body mentions `.flow-coverage-floor.json`. **That file does not exist.** The coverage floors live in `bin/test` as three cargo-llvm-cov flags:

```bash
cargo llvm-cov --no-cfg-coverage --no-clean \
  --fail-under-lines 96 \
  --fail-under-regions 96 \
  --fail-under-functions 94 \
  nextest ...
```

Floor bump means editing those three numbers to `floor(new TOTAL)` after CI is green. There is no per-file floor.

### Superseded code (deletion tasks)

| File | Lines | Guard | Reason |
|---|---|---|---|
| `src/start_finalize.rs` | 103–107 | `if phase_result["status"] == "error"` | `phase_complete()` is infallible (always `status="ok"`). Guard is unreachable dead code per `.claude/rules/supersession.md`. |
| `src/start_gate.rs` | 160–165 | `if !deps_changed { Err(Unexpected...) }` | All `deps_skipped`/`deps_no_changes`/`deps_error` branches return early above. Reaching line 160 requires `deps_changed == true`, so `!deps_changed` is unreachable. | <!-- duplicate-test-coverage: not-a-new-test -->

### Branch Enumeration Table — `start_finalize::run_impl_with_deps`

| Branch | Condition | Classification | Test |
|---|---|---|---|
| A | `!state_path.exists()` | Testable directly | `test_finalize_missing_state_file` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| B | `mutate_state` Err on phase_complete | Testable directly | `test_finalize_corrupt_state_returns_error` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| C | `args.pr_url == None` | Testable via seam | `finalize_no_pr_url_skips_slack` |
| D | `pr_url` set, notifier returns `skipped` | Testable via seam | `finalize_notifier_skipped_leaves_state_untouched` |
| E | `pr_url` set, notifier returns `ok` | Testable via seam | `finalize_notifier_ok_writes_thread_ts_and_notification` |
| F | `pr_url` set, notifier returns `error` | Testable via seam | `finalize_notifier_error_continues_best_effort` |
| G | `pr_url` set, notifier `ok`, notifications field wrong type | Testable via seam | `finalize_notifier_ok_with_wrong_notifications_type_heals` |
| H | `run_impl` Err | Testable directly (after `run_impl_main` refactor) | `finalize_run_impl_main_err_path` |
| I | frozen_phases file present | Testable via seam | `finalize_frozen_phases_config_loaded` |

### Branch Enumeration Table — `start_gate::run_impl_with_deps`

Seam signature: `run_impl_with_deps(args, git_pull_fn, ci_runner, deps_runner, commit_deps_fn)`.

| Branch | Condition | Classification | Test |
|---|---|---|---|
| P1 | git_pull Err | Testable via seam | `start_gate_pull_error_returns_infrastructure_error` |
| P2 | Baseline CI consistent fail | Testable via seam | `test_ci_failed_baseline` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| P3 | Baseline CI non-consistent error | Testable via seam | `start_gate_baseline_ci_non_consistent_error_returns_infrastructure_error` |
| P4 | Baseline CI flaky | Testable via seam | `test_ci_flaky_baseline` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| P5 | Deps error | Testable via seam | `test_deps_error` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| P6 | Deps skipped | Testable via seam | `test_deps_skipped` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| P7 | Deps no-changes | Testable via seam | `test_deps_skipped` covers | <!-- duplicate-test-coverage: not-a-new-test -->
| P8 | Deps changed + post-CI pass | Testable via seam | `test_deps_changed_ci_passes` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| P9 | Deps changed + post-CI consistent fail | Testable via seam | `test_deps_ci_failed` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| P10 | Deps changed + post-CI non-consistent error | Testable via seam | `start_gate_post_ci_non_consistent_error_returns_infrastructure_error` |
| P11 | Deps changed + post-CI flaky | Testable via seam | `test_deps_ci_flaky` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| P12 | Deps changed + commit_deps Err | Testable via seam | `start_gate_commit_deps_failure_returns_commit_deps_error` |
| P13 | Unexpected deps status | **Delete** (supersession) | — |
| P14 | `run_impl` Err | Testable directly (after `run_impl_main`) | `start_gate_run_impl_main_err_path` |

### Branch Enumeration Table — `start_init::run_impl_with_deps`

Seam signature: `run_impl_with_deps(args, init_state_runner)`.

| Branch | Condition | Classification | Test |
|---|---|---|---|
| I1 | plugin_root None | Testable via seam (inject a `plug_root_finder` closure) | `start_init_plugin_root_none_returns_err` |
| I2 | init_state_runner Err | Testable via seam | `start_init_init_state_spawn_failure_returns_err` |
| I3 | init_state stdout empty/malformed | Testable via seam | `start_init_init_state_parse_fallback` |
| I4 | init_state returns error JSON | Testable via seam | `start_init_init_state_error_releases_lock_via_seam` |
| I5 | auto_upgraded prime_check result | Testable via seam (inject `prime_check_fn`) | `start_init_auto_upgraded_propagates_to_response` |
| I6 | upgrade_check returns upgrade_available | Testable via seam (inject `upgrade_check_fn`) | `start_init_upgrade_available_adds_upgrade_field` |
| I7 | `run_impl` Err | Testable directly (after `run_impl_main`) | `start_init_run_impl_main_err_path` |

Because start_init has many external dependencies, the seam grows beyond a single closure. Extended seam signature:

```rust
run_impl_with_deps(
  args,
  plug_root_finder: &dyn Fn() -> Option<PathBuf>,
  prime_check_fn: &dyn Fn(&Path, &Path) -> Result<Value, String>,
  upgrade_check_fn: &dyn Fn(&Path, u64) -> Value,
  init_state_runner: &dyn Fn(&[String], &Path) -> Result<std::process::Output, String>,
  label_fn: &dyn Fn(&[u32], &str) -> LabelResult,
  fetch_issue_fn: &dyn Fn(u32) -> Option<IssueInfo>,
  check_dup_fn: &dyn Fn(&Path, &[u32], &str) -> Option<DuplicateInfo>,
)
```

### Branch Enumeration Table — `start_workspace` (no seam)

| Branch | Condition | Classification | Test |
|---|---|---|---|
| W1 | prompt_file read fails | Subprocess | `test_prompt_file_not_found_releases_lock` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| W2 | create_worktree Err | Subprocess | `test_worktree_failure_releases_lock` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| W3 | PR creation Err | Subprocess | `test_pr_creation_failure_releases_lock` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| W4 | state_path.exists() is false | Subprocess | `start_workspace_no_state_file_still_succeeds` (gap) |
| W5 | mutate_state Err (corrupt JSON) | Subprocess | `start_workspace_corrupt_state_returns_backfill_error` (gap) |
| W6 | non-empty relative_cwd | Subprocess | `test_worktree_cwd_includes_relative_cwd_suffix` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| W7 | venv dir present | Subprocess | `test_venv_symlinked` (exists) | <!-- duplicate-test-coverage: not-a-new-test -->
| W8 | `run()` Err | refactor to `run_impl_main` | `start_workspace_run_impl_main_err_path` |

## Risks

- **Risk 1 — Host env var leaks** (per `.claude/rules/testing-gotchas.md` Host Environment Leaks). Every new subprocess test must `.env_remove("FLOW_CI_RUNNING")`, `.env_remove("FLOW_SIMULATE_BRANCH")`, and clear Slack tokens. Existing tests follow this pattern; new tests will match.
- **Risk 2 — Parallel test env var races** (per testing-gotchas.md Rust Parallel Test Env Var Races). Seam-based unit tests use injected closures — zero env var mutation. Subprocess tests scope env via `Command::env()` to the child. Safe.
- **Risk 3 — macOS path canonicalization** (per testing-gotchas.md macOS Subprocess Path Canonicalization). Must confirm: every new subprocess test canonicalizes `tempdir()` at construction. Apply to `start_workspace_corrupt_state_returns_backfill_error`, `start_gate_commit_deps_failure_returns_commit_deps_error`, and all refactored `run_impl_main` subprocess tests.
- **Risk 4 — Issue body inaccuracy about `.flow-coverage-floor.json`.** The file does not exist. Floor mechanism is `bin/test`'s `--fail-under-lines/regions/functions` flags. Plan Task 18 operates on `bin/test` directly. Must verify floor numbers against green TOTAL before committing Task 18.
- **Risk 5 — Tombstone stability for deletions** (per `.claude/rules/tombstone-tests.md`). Two dead guards being deleted. Both are structural constructs (if-statements inside a named function body), not stable source literals. Use function-body-scoped tombstones with bounded-slice pattern. Tombstones named `test_start_finalize_no_phase_complete_error_guard` and `test_start_gate_no_unexpected_deps_status_guard`.

  **Stability argument (structural tombstones):**
  - `test_start_finalize_no_phase_complete_error_guard` scans `fn run_impl(` body in `src/start_finalize.rs` for the forbidden substring `phase_result["status"] == "error"`. The bypass list: (1) `concat!` splitting the comparison — not a realistic pattern because the comparator is inside an `if`; (2) storing the status in a local and comparing the local — detected by pattern `let status = phase_result["status"]` in the same body; (3) inverting to `!= "ok"` — detected by additional substring `phase_result["status"] != "ok"`. Scan both patterns; block if either appears.
  - `test_start_gate_no_unexpected_deps_status_guard` scans `fn run_impl(` body in `src/start_gate.rs` for the forbidden substring `!deps_changed`. Bypass list: (1) `deps_changed == false` — detected by additional substring scan; (2) `!is_deps_changed` with renamed variable — a real author would need to rename the variable, which the bounded-slice scan of the function body would still catch if the resulting condition is an `if ! ...` against the same semantic. Scan both patterns.

- **Risk 6 — Guard universality.** No new guards are being added. No scope expansion concerns.
- **Risk 7 — External-input audit.** Zero new `panic!`/`assert!`/`assert_eq!`/`assert_ne!` calls proposed. No audit table required for this plan.
- **Risk 8 — Duplicate test coverage.** Proposed test names use module-qualified prefixes (`start_init_*`, `start_gate_*`, `start_workspace_*`, `finalize_*`) distinct from existing `test_*` prefixed tests. `bin/flow plan-check` will verify at phase completion.
- **Risk 9 — Docs-with-behavior drift** (per `.claude/rules/docs-with-behavior.md` and `.claude/rules/forward-facing-authoring.md`). The `run_impl_main` refactor changes module-level behavior of each start_* module (now returns `(Value, i32)` instead of side-effecting `process::exit`). Module-level doc comments in each of the four source files must be updated in the same commit as the refactor. Task 16 bundles doc updates with the refactor.
- **Risk 10 — Plan signature deviations** (per `.claude/rules/plan-commit-atomicity.md`). Seam signatures named above are Plan-phase prototypes. If Code phase discovers an internal contradiction (e.g., a parameter the seam needs that the prototype omits), the deviation must be logged via `bin/flow log <branch> "[Phase 3] Plan signature deviation: ..."` before the commit lands.
- **Risk 11 — No-waivers discipline.** Every uncovered line maps to subprocess test, seam test, or deletion. Zero waiver candidates.
- **Risk 12 — CI invocation timeout.** Tasks 17 and 19 run `bin/flow ci`. Must verify the session invokes `bin/flow ci` with `timeout: 600000` on the Bash tool (per `.claude/rules/ci-is-a-gate.md`). Also applies to `/flow:flow-commit` invocations in Task 16's finalize step — the commit skill itself wraps CI.
- **Risk 13 — Atomic commit groups** (per `.claude/rules/plan-commit-atomicity.md`). Tasks 1+2 (tombstone+delete) and 3+4 (tombstone+delete) are atomic because the tombstone asserts content absent and the delete removes it — they must land in one commit. Tasks 5+6, 7+8, 9+10 are atomic because unit tests reference new seam functions that only exist after the refactor lands. Task 15+16 atomic because `run_impl_main` unit tests reference the new function shape.
- **Risk 14 — Target path validation.** All edits target paths inside the worktree: `src/start_init.rs`, `src/start_gate.rs`, `src/start_workspace.rs`, `src/start_finalize.rs`, `src/main.rs`, `tests/start_init.rs`, `tests/start_gate.rs`, `tests/start_workspace.rs`, `tests/start_finalize.rs`, `tests/tombstones.rs`, `bin/test`. None resolve to `~/.claude/` or outside the repo.

## Approach

Apply the `run_impl_with_deps` + `run_impl_main` dual-seam pattern across all four modules. Each module gets:

1. A `run_impl_with_deps` function that accepts the external-process closures as parameters. Production `run_impl` becomes a one-line wrapper binding the closures to their real implementations (`git::project_root`, `notify_slack::notify`, `Command::output`, etc.).
2. A `run_impl_main(args, root) -> (Value, i32)` wrapper that calls `run_impl` and maps `Err(e)` to `(error_json, 1)` — no `process::exit`. The `run()` function becomes a two-liner: `let (v, code) = run_impl_main(args, root); dispatch::dispatch_json(v, code);`.

Tests drive the seam by injecting closures that return canned values, exercising every branch without touching filesystems, env vars, or child processes.

For `start_workspace`, subprocess tests already cover every branch; only the `run_impl_main` refactor is needed.

Two dead guards — `start_finalize::run_impl` lines 103–107 and `start_gate::run_impl` lines 160–165 — are deleted in atomic commits with structural tombstones that scan the containing `run_impl` function body for the forbidden patterns plus enumerated bypasses.

Floor bump edits `bin/test` after CI is green — no `.flow-coverage-floor.json` exists.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Tombstone `test_start_finalize_no_phase_complete_error_guard` | test | — |
| 2. Delete `start_finalize::run_impl` phase_complete error guard (lines 103–107) | implement | 1 (atomic) |
| 3. Tombstone `test_start_gate_no_unexpected_deps_status_guard` | test | — |
| 4. Delete `start_gate::run_impl` unexpected deps_status guard (lines 160–165) | implement | 3 (atomic) |
| 5. Inline unit tests for `start_finalize::run_impl_with_deps` (5 tests: `finalize_no_pr_url_skips_slack`, `finalize_notifier_skipped_leaves_state_untouched`, `finalize_notifier_ok_writes_thread_ts_and_notification`, `finalize_notifier_error_continues_best_effort`, `finalize_notifier_ok_with_wrong_notifications_type_heals`) | test | 2 |
| 6. Extract `start_finalize::run_impl_with_deps` + wire production `run_impl` to `notify_slack::notify` | implement | 5 (atomic) |
| 7. Inline unit tests for `start_gate::run_impl_with_deps` (4 tests: `start_gate_pull_error_returns_infrastructure_error`, `start_gate_baseline_ci_non_consistent_error_returns_infrastructure_error`, `start_gate_post_ci_non_consistent_error_returns_infrastructure_error`, `start_gate_commit_deps_failure_returns_commit_deps_error` via seam) | test | 4 |
| 8. Extract `start_gate::run_impl_with_deps` + wire production `run_impl` to `git_pull`/`ci::run_impl`/`run_update_deps`/`commit_deps` | implement | 7 (atomic) |
| 9. Inline unit tests for `start_init::run_impl_with_deps` (4 tests: `start_init_plugin_root_none_returns_err`, `start_init_init_state_spawn_failure_returns_err`, `start_init_init_state_parse_fallback`, `start_init_init_state_error_releases_lock_via_seam`) | test | — |
| 10. Extract `start_init::run_impl_with_deps` + wire production `run_impl` to real plug_root/prime_check/upgrade_check/init_state subprocess/label/fetch_issue/check_dup closures | implement | 9 (atomic) |
| 11. Subprocess test: `start_workspace_corrupt_state_returns_backfill_error` | test | — |
| 12. Subprocess test: `start_init_auto_upgraded_propagates_to_response` (prime_check returns `auto_upgraded: true`) | test | 10 |
| 13. Subprocess test: `start_init_upgrade_available_adds_upgrade_field` | test | 10 |
| 14. Inline unit tests for `run_impl_main` Err paths (4 tests: `start_init_run_impl_main_err_path`, `start_gate_run_impl_main_err_path`, `start_workspace_run_impl_main_err_path`, `finalize_run_impl_main_err_path`) | test | 6, 8, 10 |
| 15. `run_impl_main` refactor in all four modules + `main.rs` dispatch wire-up + module-level doc comment updates | implement | 14 (atomic) |
| 16. Run `bin/flow ci` and capture new TOTAL for lines/regions/functions | verify | 2, 4, 6, 8, 10, 15 |
| 17. Bump `bin/test` `--fail-under-lines/regions/functions` to `floor(new TOTAL)` | implement | 16 |
| 18. Final `bin/flow ci` green verification | verify | 17 |

## Tasks

### Task 1 — Tombstone for start_finalize phase_complete guard deletion

**Protection target.** The `if phase_result["status"] == "error"` guard at `src/start_finalize.rs:103–107`.

**Assertion kind.** Structural (function-body scoped).

**Stability argument.** The forbidden construct is a conditional against a runtime `Value`. Bypasses:

1. `concat!` — not applicable to a comparison expression.
2. Renamed intermediate (`let s = phase_result["status"]; if s == "error"`) — the substring `phase_result["status"]` still appears. Scan covers.
3. Inverted condition (`phase_result["status"] != "ok"`) — scan adds this as a second forbidden substring.

**Bypass list:** `phase_result["status"] == "error"`, `phase_result["status"] != "ok"`, `phase_result.get("status").unwrap().eq("error")`.

**Boundary markers:** `fn run_impl(` / next `#[` or EOF.

Add to `tests/tombstones.rs`:

```rust
#[test]
fn test_start_finalize_no_phase_complete_error_guard() {
    // Tombstone: removed in PR #1206. phase_complete is infallible —
    // status is always "ok". The guard was unreachable dead code.
    let content = fs::read_to_string("src/start_finalize.rs")
        .expect("src/start_finalize.rs must exist");
    let tail = content
        .split_once("fn run_impl(")
        .map(|(_, t)| t)
        .expect("run_impl must exist");
    let body = tail
        .split_once("\npub fn run(")
        .map(|(b, _)| b)
        .unwrap_or(tail);
    for forbidden in &[
        r#"phase_result["status"] == "error""#,
        r#"phase_result["status"] != "ok""#,
    ] {
        assert!(
            !body.contains(forbidden),
            "start_finalize::run_impl must not contain `{}`",
            forbidden
        );
    }
}
```

**Guards regression:** a merge resolver re-introducing the guard after PR #1206 merges fails CI immediately.

### Task 2 — Delete start_finalize phase_complete guard

**Change:** Remove lines 103–107 of `src/start_finalize.rs`:

```rust
if phase_result["status"] == "error" {
    return Ok(json!({
        "status": "error",
        "message": phase_result["message"],
    }));
}
```

Confirm remaining downstream code paths do not depend on the guard being present. Atomic with Task 1 — land in single commit.

### Task 3 — Tombstone for start_gate unexpected deps_status guard deletion

**Protection target.** The `if !deps_changed { return Ok(json!({"status": "error", ...})) }` guard at `src/start_gate.rs:160–165`.

**Assertion kind.** Structural (function-body scoped).

**Stability argument.** The forbidden construct is a negation-of-boolean check. Bypasses:

1. `deps_changed == false` — add as second forbidden substring.
2. Renamed variable — real authors would need to rename `deps_changed` itself; scan would still catch `!deps_changed` or the new name after rename.
3. `if let Some(false) = ...` — would require changing `deps_changed` to `Option<bool>`, which Code Review would catch as a type change.

**Bypass list:** `!deps_changed`, `deps_changed == false`, `deps_changed.eq(&false)`.

**Boundary markers:** `fn run_impl(` / next `#[` or EOF.

Add to `tests/tombstones.rs`:

```rust
#[test]
fn test_start_gate_no_unexpected_deps_status_guard() {
    // Tombstone: removed in PR #1206. Earlier branches return early on
    // every non-deps_changed case; reaching this line requires
    // deps_changed == true, so the guard was unreachable.
    let content = fs::read_to_string("src/start_gate.rs")
        .expect("src/start_gate.rs must exist");
    let tail = content
        .split_once("fn run_impl(")
        .map(|(_, t)| t)
        .expect("run_impl must exist");
    let body = tail
        .split_once("\nfn commit_deps(")
        .map(|(b, _)| b)
        .unwrap_or(tail);
    for forbidden in &["!deps_changed", "deps_changed == false"] {
        assert!(
            !body.contains(forbidden),
            "start_gate::run_impl must not contain `{}`",
            forbidden
        );
    }
}
```

### Task 4 — Delete start_gate unexpected deps_status guard

**Change:** Remove lines 160–165 of `src/start_gate.rs`:

```rust
if !deps_changed {
    return Ok(json!({
        "status": "error",
        "message": format!("Unexpected deps status: {}", deps_result["status"]),
        "step": "update_deps",
    }));
}
```

Atomic with Task 3 — land in single commit.

### Task 5 — Unit tests for `start_finalize::run_impl_with_deps`

**Tests (TDD — written before Task 6):**

1. `finalize_no_pr_url_skips_slack` — args without pr_url; notifier closure panics if called; asserts response has no `slack` field.
2. `finalize_notifier_skipped_leaves_state_untouched` — pr_url set; notifier returns `{"status":"skipped"}`; asserts state file has no `slack_thread_ts` field; response `slack.status == "skipped"`.
3. `finalize_notifier_ok_writes_thread_ts_and_notification` — pr_url set; notifier returns `{"status":"ok","ts":"1234.5678"}`; asserts state file has `slack_thread_ts == "1234.5678"` and `notifications[0].ts == "1234.5678"`; response `slack.status == "ok"`.
4. `finalize_notifier_error_continues_best_effort` — pr_url set; notifier returns `{"status":"error","message":"curl failed"}`; asserts response top-level `status == "ok"` (Slack is best-effort); response `slack.status == "error"`.
5. `finalize_notifier_ok_with_wrong_notifications_type_heals` — pr_url set; notifier returns ok; state file has `"notifications": "not-an-array"`; asserts the wrong-type auto-heal produces a valid array with the expected entry.

**TDD notes:** each test injects a `Box<dyn Fn(&notify_slack::Args) -> Value>` closure capturing a `RefCell<Vec<Args>>` so call counts and payloads can be asserted. Tests live inline in `src/start_finalize.rs` under `#[cfg(test)] mod tests`.

**Named regression:** each of the five branches in the Branch Enumeration Table (rows C–G) must be exercised by a named test so a future refactor that accidentally short-circuits one branch fails CI.

### Task 6 — Extract `start_finalize::run_impl_with_deps`

**Change:** Split `src/start_finalize.rs::run_impl` into:

```rust
pub fn run_impl_with_deps(
    args: &Args,
    notifier: &dyn Fn(&notify_slack::Args) -> Value,
) -> Result<Value, String> {
    // existing body, but replace `notify_slack::notify(&slack_args)`
    // with `notifier(&slack_args)`
}

pub fn run_impl(args: &Args) -> Result<Value, String> {
    run_impl_with_deps(args, &notify_slack::notify)
}
```

Also delete dead guard (done in Task 2). Update module doc comment to mention the seam pattern per `.claude/rules/docs-with-behavior.md`. Atomic with Task 5.

### Task 7 — Unit tests for `start_gate::run_impl_with_deps`

**Tests:**

1. `start_gate_pull_error_returns_infrastructure_error` — `git_pull_fn` returns Err; asserts status `error`, step `git_pull`.
2. `start_gate_baseline_ci_non_consistent_error_returns_infrastructure_error` — `ci_runner` returns `{"status":"error","message":"..."}` with `consistent: false` (or missing); asserts status `error`, step `ci_baseline`.
3. `start_gate_post_ci_non_consistent_error_returns_infrastructure_error` — baseline CI passes, deps changed, post-CI returns non-consistent error; asserts status `error`, step `ci_post_deps`.
4. `start_gate_commit_deps_failure_returns_commit_deps_error` — everything succeeds up to commit; `commit_deps_fn` returns Err; asserts status `error`, step `commit_deps`.

**TDD notes:** tests inject closures matching the seam signature. Use `TempDir` as the cwd argument; no subprocess invocations.

**Named regression:** rows P1, P3, P10, P12 in the Branch Enumeration Table.

### Task 8 — Extract `start_gate::run_impl_with_deps`

**Change:** Seam signature:

```rust
pub fn run_impl_with_deps(
    args: &Args,
    git_pull_fn: &dyn Fn(&Path) -> Result<(), String>,
    ci_runner: &dyn Fn(&ci::Args, &Path, &Path, bool) -> (Value, i32),
    deps_runner: &dyn Fn(&Path, u64) -> (Value, i32),
    commit_deps_fn: &dyn Fn(&Path) -> Result<(), String>,
) -> Result<Value, String> { /* body */ }

pub fn run_impl(args: &Args) -> Result<Value, String> {
    run_impl_with_deps(
        args,
        &git_pull,
        &ci::run_impl,
        &run_update_deps,
        &commit_deps,
    )
}
```

Atomic with Task 7.

### Task 9 — Unit tests for `start_init::run_impl_with_deps`

**Tests:**

1. `start_init_plugin_root_none_returns_err` — `plug_root_finder` returns None; asserts `run_impl_with_deps` returns `Err` containing "CLAUDE_PLUGIN_ROOT".
2. `start_init_init_state_spawn_failure_returns_err` — `init_state_runner` returns Err; asserts `Err` containing "Failed to spawn init-state".
3. `start_init_init_state_parse_fallback` — `init_state_runner` returns `Ok(Output { stdout: b"", ... })`; asserts fallback error JSON is surfaced as `error` status with the parse-failure message.
4. `start_init_init_state_error_releases_lock_via_seam` — `init_state_runner` returns `Ok(Output)` with a valid `{"status":"error","message":"..."}` JSON; asserts lock is released (queue dir file absent) and response step propagates.

**TDD notes:** tests inject closures matching the seam signature. Use a `TempDir` as the project root.

**Named regression:** rows I1–I4 in the Branch Enumeration Table.

### Task 10 — Extract `start_init::run_impl_with_deps`

**Change:** Extended seam signature per Exploration section. Production `run_impl` is a one-line binder:

```rust
pub fn run_impl(args: &Args) -> Result<Value, String> {
    run_impl_with_deps(
        args,
        &plugin_root,
        &prime_check::run_impl,
        &|json, timeout| {
            let mut gh_cmd = |owner_repo: &str, t: u64| upgrade_check::run_gh_cmd(owner_repo, t);
            upgrade_check::upgrade_check_impl(json, timeout, &mut gh_cmd)
        },
        &default_init_state_runner,
        &label_issues,
        &fetch_issue_info,
        &check_duplicate_issue,
    )
}
```

`default_init_state_runner` is a private helper that wraps the existing `Command::new(&self_exe).args(&cmd_args).current_dir(&cwd).output()` chain. Atomic with Task 9.

### Task 11 — Subprocess test `start_workspace_corrupt_state_returns_backfill_error`

**Tests:**

1. Create a git repo via `create_git_repo_with_remote`.
2. Pre-seed `.flow-states/<branch>.json` with invalid JSON (e.g. `"{{{"`) AFTER PR creation stub succeeds.
3. Run `bin/flow start-workspace` via subprocess; expect `{"status": "error", "step": "backfill", "message": "Failed to backfill state: ..."}`.
4. Assert lock is released regardless.

**TDD notes:** canonicalize tempdir root at top per `.claude/rules/testing-gotchas.md`. Use `.env_remove("FLOW_SIMULATE_BRANCH")`.

**Named regression:** row W5.

### Task 12 — Subprocess test `start_init_auto_upgraded_propagates_to_response`

**Tests:**

1. Create a git repo; write `.flow.json` with an old version but matching hashes so `prime_check` sets `auto_upgraded: true` with old/new version fields.
2. Run `bin/flow start-init`; assert response has `auto_upgraded: true`, `old_version`, `new_version`.

**Named regression:** row I5.

### Task 13 — Subprocess test `start_init_upgrade_available_adds_upgrade_field`

**Tests:**

1. Create a git repo with current plugin version.
2. Create gh stub whose `release view` returns `{"tagName":"v99.99.99"}`.
3. Run `bin/flow start-init`; assert response contains `upgrade.status == "upgrade_available"` and `upgrade.latest == "99.99.99"`.

**Named regression:** row I6.

### Task 14 — Unit tests for `run_impl_main` Err paths

**Tests (one per module):**

1. `start_init_run_impl_main_err_path` — inject a plug_root_finder returning None; assert `run_impl_main` returns `(err_json, 1)` where `err_json["step"] == "plugin_root_detection"`.
2. `start_gate_run_impl_main_err_path` — inject `git_pull_fn` returning Err; assert `run_impl_main` returns `(err_json, 1)`.
3. `start_workspace_run_impl_main_err_path` — call `run_impl_main` against a tempdir with no `.flow-states` and a broken git setup; assert `(err_json, 1)`.
4. `finalize_run_impl_main_err_path` — call `run_impl_main` against a tempdir with a corrupt state file; assert `(err_json, 1)`.

**TDD notes:** each test drives `run_impl_main` directly, asserting the `(Value, i32)` tuple. No `process::exit` is called during the test.

**Named regression:** rows H (finalize), I7 (init), P14 (gate), W8 (workspace) in the Branch Enumeration Tables.

### Task 15 — `run_impl_main` refactor + main.rs dispatch wire-up

**Change:**

1. In each of the four modules, add:

    ```rust
    pub fn run_impl_main(args: Args, _root: &Path) -> (Value, i32) {
        match run_impl(&args) {
            Ok(v) => (v, 0),
            Err(e) => (json!({"status": "error", "message": e, "step": "<module>_run_impl"}), 1),
        }
    }
    ```

2. In `src/main.rs`, the match arms for `StartInit`, `StartGate`, `StartWorkspace`, `StartFinalize` call `run_impl_main` and dispatch via `dispatch::dispatch_json`:

    ```rust
    Commands::StartInit(args) => {
        let root = project_root();
        let (v, code) = start_init::run_impl_main(args, &root);
        dispatch::dispatch_json(v, code);
    }
    // (same shape for the three other variants)
    ```

3. Delete the now-unused `run()` helpers in each module (or leave them as thin wrappers — decision at Code time; plan defaults to deletion per supersession).

4. Update each module's top-of-file doc comment to describe the `run_impl_with_deps` / `run_impl_main` pattern per `.claude/rules/docs-with-behavior.md`.

Atomic with Task 14.

### Task 16 — Run `bin/flow ci` to capture TOTAL

Run `bin/flow ci` with a 10-minute Bash tool timeout (`timeout: 600000`) — CI runs can take 3–4 minutes and the default 2-minute timeout would background the process, defeating the gate (per `.claude/rules/ci-is-a-gate.md`).

```bash
/Users/ben/code/flow/bin/flow ci
```

Read the TOTAL row from nextest output:

```text
TOTAL    N regions    (R% covered)    N functions    (F% covered)    N lines    (L% covered)
```

Compute `floor(R%)`, `floor(F%)`, `floor(L%)`. Proceed to Task 17.

**Named regression:** verification only, no test.

### Task 17 — Bump `bin/test` coverage thresholds

**Change:** Edit `bin/test` to set:

- `--fail-under-lines <floor(L%)>`
- `--fail-under-regions <floor(R%)>`
- `--fail-under-functions <floor(F%)>`

**TDD notes:** no new test — the floor itself is the test. Any future regression below the floor fails CI.

### Task 18 — Final `bin/flow ci` green verification

Re-run `bin/flow ci` with a 10-minute Bash tool timeout (`timeout: 600000`) to confirm the new floors pass (per `.claude/rules/ci-is-a-gate.md`).

```bash
/Users/ben/code/flow/bin/flow ci
```

**Named regression:** verification only.
````

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

````text
# DAG Analysis: 100% coverage — start_* family (issue #1197)

## DAG Plan

```xml
<dag goal="100% coverage for start_* family via subprocess tests + notifier trait seam" mode="full">
  <plan>
    <node id="1" name="Recon: uncovered branches across four modules" type="research" depends="[]" parallel_with="[]">
      <objective>Read each start_*.rs and its current tests, enumerate every uncovered branch by line, classify as directly-testable / subprocess-testable / seam-required</objective>
    </node>
    <node id="2" name="Notifier seam design (PR #1157 pattern)" type="analysis" depends="[1]" parallel_with="3,4,5">
      <objective>Design injectable Notifier trait seam for start_finalize.rs; enumerate branches the seam unlocks (slack-send-failure, notification-record-written, no-webhook-skips-send) and Branch Enumeration Table</objective>
    </node>
    <node id="3" name="start_init.rs test plan" type="analysis" depends="[1]" parallel_with="2,4,5">
      <objective>Name subprocess tests for lock-acquire-failure, canonical-branch-derivation-failure, state-write-failure; enumerate every other sub-100% branch and its test</objective>
    </node>
    <node id="4" name="start_gate.rs test plan" type="analysis" depends="[1]" parallel_with="2,3,5">
      <objective>Name subprocess tests for CI-failure-triggers-ci-fixer, dep-upgrade-failure, sentinel-write-suppressed-on-stub; classify remaining branches</objective>
    </node>
    <node id="5" name="start_workspace.rs test plan" type="analysis" depends="[1]" parallel_with="2,3,4">
      <objective>Name subprocess tests for worktree-create-failure, pr-create-failure, lock-release-under-canonical-name; classify remaining branches</objective>
    </node>
    <node id="6" name="Risks + supersession + external-input audit" type="validation" depends="[2,3,4,5]" parallel_with="[]">
      <objective>Enumerate concurrency risks, fixture leakage, subprocess env isolation, any panic/assert tightenings (none expected), duplicate-test scan, supersession (any old tests superseded?)</objective>
    </node>
    <node id="7" name="Task list + dependency graph + TDD ordering" type="synthesis" depends="[6]" parallel_with="[]">
      <objective>Order tasks: seam introduction before seam tests; tombstones for any removed/replaced behavior; per-file test→impl pairs; floor bump last; atomic commit groups marked explicitly</objective>
    </node>
    <node id="8" name="Floor-bump mechanics verification" type="validation" depends="[7]" parallel_with="[]">
      <objective>Verify .flow-coverage-floor.json structure, confirm bin/test threshold read path, plan the two-phase floor update (per-file 100.00 entries + TOTAL floor bump at end)</objective>
    </node>
    <node id="9" name="Final synthesis: complete plan ready for Plan file" type="synthesis" depends="[7,8]" parallel_with="[]">
      <objective>Produce Context, Exploration, Risks, Approach, Dependency Graph, Tasks in the exact sections the plan file expects</objective>
    </node>
  </plan>
</dag>
```

Validation: 9 nodes, no cycles, parallel set {2,3,4,5} genuinely independent, terminal node 9 aggregates.

## Node Executions

### NODE 1: Recon — Key findings

- All four modules expose `run_impl` returning `Result<Value, String>` + a thin `run()` wrapper calling `process::exit(1)` on Err. The `run()` Err path is the canonical coverage gap — no-waivers forbids filing waivers; the rust-patterns.md solution is the `run_impl_main(...) -> (Value, i32)` refactor + `dispatch::dispatch_json` (PR #1156 pattern).
- `notify_slack.rs` already has the reference HTTP-seam pattern: `notify_with_deps(args, config_reader, poster)` + `post_message_inner(..., curl)`. `start_finalize` calls `notify_slack::notify(args)` — a thin wrapper over production binders. Injectable-notifier seam in `start_finalize` can simply expose a `run_impl_with_deps(args, notifier: &dyn Fn(&notify_slack::Args) -> Value)` that lets tests drive `notify_with_deps`-equivalent paths at the start_finalize level.
- The `.flow-coverage-floor.json` file the issue mentions **does not exist**. The floor mechanism is `bin/test`'s three `--fail-under-*` flags (lines: 96, regions: 96, functions: 94). The issue's description is wrong — floor bump means bumping those three numbers in `bin/test` to `floor(new TOTAL)` for each metric.
- `start_init.rs` uncovered: plugin_root error, prime_check infrastructure error (Err variant), auto_upgraded version propagation, current_exe error, init_state spawn error, init_state JSON parse fallback, label/upgrade response-building branches, `run()` Err.
- `start_gate.rs` uncovered: baseline CI non-consistent "error" fallthrough (lines 94–98), post_ci non-consistent fallthrough (195–199), `commit_deps` error branch inside run_impl (217–228), `run()` Err.
- `start_workspace.rs` uncovered: state mutate_state Err branch (278–289), `run()` Err.
- `start_finalize.rs` uncovered: frozen_phases load path with a frozen config present, mutate_state Err during phase_complete, slack curl failure storing no thread_ts, `run()` Err, response-building when slack != skipped (covered but only via status=="ok" path — error path also sets slack field).

Quality: 9/10 — complete recon grounded in four source reads + all four test file reads + notify_slack reference.

Key finding: **The floor-bump mechanism must be re-planned — the issue body's `.flow-coverage-floor.json` claim is inaccurate. Floor bump = edit the `--fail-under-lines/regions/functions` flags in `bin/test`.**

---

### PARALLEL BRANCH A — NODE 2: Notifier seam design

<!-- extract-helper-refactor: not-an-extraction --> The notify_slack module already provides the trait seam (`notify_with_deps`). start_finalize just calls `notify_slack::notify(&slack_args)` directly. The minimal refactor: expose `run_impl_with_deps(args, notify_fn: &dyn Fn(&notify_slack::Args) -> Value)` that accepts an injectable notifier closure. Production `run_impl` becomes `run_impl_with_deps(args, &notify_slack::notify)`.

Branches unlocked inside `run_impl`:

| Branch | Condition | Test |
|---|---|---|
| S1 | `args.pr_url == None` | `finalize_no_pr_url_skips_slack` |
| S2 | `pr_url` set, notifier returns `"skipped"` | `finalize_notifier_skipped_leaves_state_untouched` |
| S3 | `pr_url` set, notifier returns `"ok"` with ts | `finalize_notifier_ok_writes_thread_ts_and_notification` |
| S4 | `pr_url` set, notifier returns `"error"` | `finalize_notifier_error_continues_best_effort` |
| S5 | `pr_url` set, notifier returns `"ok"` but state array type wrong | `finalize_notifier_ok_with_wrong_notifications_type_heals` |

Branch enumeration table for the extracted `run_impl_with_deps`:

| Branch | Condition | Classification | Test |
|---|---|---|---|
| A | `!state_path.exists()` | Testable directly | `finalize_missing_state_returns_error` (exists) |
| B | `mutate_state` phase_complete returns Err | Testable directly | `finalize_corrupt_state_returns_error` (exists) |
| C | `phase_result["status"] == "error"` (defensive dead code) | Unreachable in production — **delete the branch** (per no-waivers Response 3) | — |
| D | `args.pr_url == None` | Testable directly | `finalize_no_pr_url_skips_slack` |
| E | Notifier returns `skipped` | Testable via seam | `finalize_notifier_skipped_leaves_state_untouched` |
| F | Notifier returns `ok`, state object | Testable via seam | `finalize_notifier_ok_writes_thread_ts_and_notification` |
| G | Notifier returns `error` | Testable via seam | `finalize_notifier_error_continues_best_effort` |
| H | Notifier returns `ok`, state has wrong `notifications` type | Testable via seam | `finalize_notifier_ok_with_wrong_notifications_type_heals` |
| I | `run_impl` Err path | Testable directly after `run_impl_main` refactor | `finalize_run_impl_main_err_path` |

Branch C is deletion (supersession) — `phase_complete` in `phase_transition.rs` always returns `status="ok"`, so the guard is unreachable. Per `.claude/rules/supersession.md`, the in-scope action is deletion.

Quality: 9/10.

---

### PARALLEL BRANCH B — NODE 3: start_init.rs test plan

| Test | Classification | Target branch |
|---|---|---|
| `start_init_plugin_root_failure_returns_err` | Subprocess (clear env) | Line 60, plug_root None → returns `Err` |
| `start_init_prime_check_infrastructure_err_releases_lock` | Subprocess (corrupt plugin.json) | Lines 147–157, Err variant from prime_check |
| `start_init_init_state_spawn_failure_returns_err` | Testable via seam after extracting the spawn closure | Lines 246–250 |
| `start_init_init_state_parse_fallback` | Testable via seam | Lines 258–263 (empty stdout → fallback JSON) |
| `start_init_auto_upgrade_propagates_versions_to_response` | Subprocess | Lines 178–191, 316–324 response-building |
| `start_init_upgrade_available_adds_upgrade_field` | Subprocess | Lines 326–328 |
| `start_init_issue_numbers_labels_empty_omits_labels_field` | Subprocess | Line 330 (reverse path) |
| `start_init_run_impl_main_err_writes_error_json_exit_1` | Refactor to run_impl_main | `run()` Err path via direct unit test |

**Refactor required (seam):** The `init-state` subprocess dispatch is currently inlined. Extract into:

```rust
run_impl_with_deps(args, init_state_runner: &dyn Fn(&[String], &Path) -> Result<Output, String>)
```

Production binder uses the real subprocess; tests inject a mock returning `Output`-like results.

Quality: 9/10.

---

### PARALLEL BRANCH C — NODE 4: start_gate.rs test plan

| Test | Classification | Target branch |
|---|---|---|
| `start_gate_ci_failed_returns_consistent_payload` | Subprocess (covered) |
| `start_gate_dep_upgrade_failure_returns_deps_ci_failed` | Subprocess (already covered) |
| `start_gate_ok_passes_through_stubs_detected_from_ci` | Subprocess | stub-marker propagation |
| `start_gate_baseline_ci_non_consistent_error_returns_infrastructure_error` | Testable via seam | Lines 94–98 |
| `start_gate_post_ci_non_consistent_error_returns_infrastructure_error` | Testable via seam | Lines 195–199 |
| `start_gate_commit_deps_failure_returns_commit_deps_error` | Subprocess (delete remote before deps_changed triggers push) | Lines 217–228 |
| `start_gate_unexpected_deps_status_returns_error` | Delete — unreachable | Lines 160–165 |
| `start_gate_run_impl_main_err_writes_error_json_exit_1` | Refactor to run_impl_main | `run()` Err path |

**Refactor required:** extract into injectable closures:

```rust
run_impl_with_deps(args,
  ci_runner: &dyn Fn(&ci::Args, &Path, &Path, bool) -> (Value, i32),
  deps_runner: &dyn Fn(&Path, u64) -> (Value, i32),
  git_pull_fn: &dyn Fn(&Path) -> Result<(), String>,
  commit_deps_fn: &dyn Fn(&Path) -> Result<(), String>,
)
```

**Branch Enumeration Table (extract-helper):**

| Branch | Condition | Classification | Test |
|---|---|---|---|
| P1 | git_pull Err | Testable via seam | `start_gate_pull_error_returns_infrastructure_error` |
| P2 | Baseline CI consistent fail | Testable via seam | covered |
| P3 | Baseline CI non-consistent error | Testable via seam | `start_gate_baseline_ci_non_consistent_error_returns_infrastructure_error` |
| P4 | Baseline CI flaky | Testable via seam | covered |
| P5 | Deps error | Testable via seam | covered |
| P6 | Deps skipped | Testable via seam | covered |
| P7 | Deps no changes | Testable via seam | covered |
| P8 | Deps changed + post-CI pass | Testable via seam | covered |
| P9 | Deps changed + post-CI consistent fail | Testable via seam | covered |
| P10 | Deps changed + post-CI non-consistent error | Testable via seam | `start_gate_post_ci_non_consistent_error_returns_infrastructure_error` |
| P11 | Deps changed + post-CI flaky | Testable via seam | covered |
| P12 | Deps changed + commit_deps Err | Testable via seam | `start_gate_commit_deps_failure_returns_commit_deps_error` |
| P13 | Unexpected deps status (dead code) | **Delete** (supersession) | — |
| P14 | `run_impl_main` Err | Testable directly | `start_gate_run_impl_main_err_path` |

Quality: 9/10.

---

### PARALLEL BRANCH D — NODE 5: start_workspace.rs test plan

| Test | Classification | Target branch |
|---|---|---|
| `start_workspace_worktree_create_failure_releases_lock` | Subprocess (covered) | Lines 193–205 |
| `start_workspace_pr_create_failure_releases_lock` | Subprocess (covered) | Lines 220–236 |
| `start_workspace_lock_release_under_canonical_name` | Subprocess (covered) |
| `start_workspace_state_mutate_failure_releases_lock` | Subprocess (pre-seed corrupt state file) | Lines 278–289 |
| `start_workspace_run_impl_main_err_writes_error_json_exit_1` | Refactor to run_impl_main | `run()` Err |

**Branch Enumeration Table:**

| Branch | Condition | Classification | Test |
|---|---|---|---|
| W1 | prompt_file read fails | Subprocess | covered |
| W2 | create_worktree Err | Subprocess | covered |
| W3 | PR creation Err | Subprocess | covered |
| W4 | state_path.exists() is false | Subprocess | `start_workspace_no_state_file_still_succeeds` (gap) |
| W5 | mutate_state Err (corrupt JSON) | Subprocess | `start_workspace_corrupt_state_returns_backfill_error` |
| W6 | non-empty relative_cwd | Subprocess | covered |
| W7 | venv dir present | Subprocess | covered |
| W8 | `run()` Err | refactor to `run_impl_main` | direct unit test |

No seam refactor needed for start_workspace — subprocess tests cover every branch.

Quality: 9/10.

---

### MERGE of Branches A–D

Seams required:

1. **`start_init`**: inject `init_state_runner` closure for the subprocess dispatch
2. **`start_gate`**: inject `git_pull_fn`, `ci_runner`, `deps_runner`, `commit_deps_fn` closures
3. **`start_finalize`**: inject `notify_fn` closure for the Slack notifier
4. **`start_workspace`**: no seam required (subprocess tests cover every branch)

run_impl_main refactor for all four modules (hoist process::exit out of the testable surface).

Supersession deletions:

- `start_finalize::run_impl` lines 103–107 (phase_complete error guard — dead code)
- `start_gate::run_impl` lines 160–165 (unexpected deps_status — dead code)

---

### NODE 6: Risks + supersession + external-input audit + duplicate tests

- **Risk 1 — Host env var leaks.** Subprocess tests must `.env_remove("FLOW_CI_RUNNING")` + `.env_remove("FLOW_SIMULATE_BRANCH")` + `.env_remove("SLACK_BOT_TOKEN")` + set PATH to include stub dir. Existing tests already do this. New tests will follow the same pattern.
- **Risk 2 — Parallel test env var races.** Seam-based tests use injected closures, so zero env var mutation. Subprocess tests use `.env(..)` on `Command` which scopes env to the child. Safe.
- **Risk 3 — macOS path canonicalization** (per `.claude/rules/testing-gotchas.md`). Tests that compare paths between the child's `current_dir` and parent-constructed paths must canonicalize tempdir roots at the top. Apply to every new subprocess test.
- **Risk 4 — Issue body is wrong about `.flow-coverage-floor.json`.** The file doesn't exist. The floor mechanism is `bin/test`'s `--fail-under-lines/regions/functions` flags. Plan pivots the AC to "bump floors in `bin/test` after CI passes."
- **Risk 5 — Tombstones needed for deletions.** Lines 103–107 of start_finalize.rs (dead guard) and lines 160–165 of start_gate.rs (dead guard) are being deleted. Add tombstone tests in `tests/tombstones.rs` that assert these specific constructs are absent from the source files. Stability: structural tombstones scanning the run_impl function body for the specific guard pattern.
- **Risk 6 — Guard universality.** No new guards are being added. No scope expansion.
- **Risk 7 — External-input audit.** No new panic/assert/invariant checks proposed — only adding test coverage and seam refactors. No audit table required.
- **Risk 8 — Duplicate test coverage.** Proposed test names use module-qualified prefixes (`start_init_*`, `start_gate_*`, `start_workspace_*`, `finalize_*`) that don't collide with existing tests. Plan-check will verify.
- **Risk 9 — Docs-with-behavior.** The `run()` → `run_impl_main` + `dispatch::dispatch_json` refactor touches `src/main.rs` match arms. Update module-level doc comments in each source file to reflect the new pattern per `.claude/rules/docs-with-behavior.md`.
- **Risk 10 — Forward-facing authoring.** All proposed wording is forward-facing.
- **Risk 11 — `run_impl_with_deps` signature hazard** (per `.claude/rules/plan-commit-atomicity.md` plan-deviation rule). Seam function signatures named now in the plan. If the Code phase discovers a missing parameter, the deviation must be logged via `bin/flow log`.
- **Risk 12 — No-waivers discipline.** Every uncovered line is classified as either subprocess-testable or seam-testable or deletable. Zero lines are punted as waiver candidates.

Supersession enumeration:

- **Deleted code 1:** `start_finalize::run_impl` lines 103–107 (phase_complete error guard). `phase_complete` is infallible — status is always "ok". The guard is unreachable dead code. Tombstone + delete.
- **Deleted code 2:** `start_gate::run_impl` lines 160–165 (unexpected deps_status). Both `deps_skipped` and `deps_no_changes` return early above; `deps_error` also returns early. The only way to reach line 160 is `deps_changed == true`, so `!deps_changed` is unreachable. Tombstone + delete.

Quality: 9/10.

---

### NODE 7: Task list + dependency graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Tombstone for start_finalize phase_complete guard | test | — |
| 2. Delete start_finalize phase_complete guard (lines 103–107) | implement | 1 (atomic) |
| 3. Tombstone for start_gate deps_no_changes guard | test | — |
| 4. Delete start_gate unexpected deps_status guard (lines 160–165) | implement | 3 (atomic) |
| 5. Unit tests for `start_finalize::run_impl_with_deps` (5 tests) | test | 2 |
| 6. Extract `start_finalize::run_impl_with_deps` + wire `run_impl` to production notifier | implement | 5 (atomic) |
| 7. Unit tests for `start_gate::run_impl_with_deps` (4 tests) | test | 4 |
| 8. Extract `start_gate::run_impl_with_deps` + wire `run_impl` to production closures | implement | 7 (atomic) |
| 9. Unit tests for `start_init::run_impl_with_deps` (3 tests) | test | — |
| 10. Extract `start_init::run_impl_with_deps` + wire `run_impl` to production subprocess dispatcher | implement | 9 (atomic) |
| 11. Subprocess test: `start_workspace_corrupt_state_returns_backfill_error` | test | — |
| 12. Subprocess test: `start_init_auto_upgrade_propagates_versions_to_response` | test | 10 |
| 13. Subprocess test: `start_init_upgrade_available_adds_upgrade_field` | test | 10 |
| 14. Subprocess test: `start_gate_commit_deps_failure_returns_commit_deps_error` | test | 8 |
| 15. Unit tests for `run_impl_main` err paths (4 tests, one per module) | test | 6, 8, 10 |
| 16. `run_impl_main` refactor in all four modules + main.rs dispatch wire-up | implement | 15 (atomic) |
| 17. Run `bin/flow ci` to capture new TOTAL | verify | 2, 4, 6, 8, 10, 16 |
| 18. Bump `bin/test` thresholds to floor(new TOTAL) | implement | 17 |
| 19. Final `bin/flow ci` green verification | verify | 18 |

Quality: 9/10.

---

### NODE 8: Floor-bump mechanics

Current `bin/test` flags:

- `--fail-under-lines 96`
- `--fail-under-regions 96`
- `--fail-under-functions 94`

Plan: after Task 16 lands and `bin/flow ci` is green, read the TOTAL row from nextest output, apply `floor()` to each metric, update the three flags in `bin/test`.

The issue's mention of `.flow-coverage-floor.json` is **inaccurate** — no such file exists. Plan notes this in Risks and redirects the AC to bump `bin/test` directly.

Quality: 10/10.

---

### NODE 9: Final synthesis

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DAG SYNTHESIS
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

**Strategy:** For each of the four `start_*.rs` modules, (a) introduce a `run_impl_with_deps` seam that accepts injected closures for the external-process dependencies, (b) drive every branch with inline unit tests against the seam, (c) refactor `run()` into `run_impl_main` returning `(Value, i32)` dispatched via `dispatch::dispatch_json` to exercise Err paths without `process::exit`. Two tombstone-protected deletions eliminate dead guards. `start_workspace` needs no seam — subprocess tests cover its branches. Final floor bump in `bin/test` (`.flow-coverage-floor.json` does not exist — the issue body is wrong on that detail; the real floors are in `bin/test`'s three `--fail-under-*` flags).

Confidence: 90% | Nodes: 9 | Parallel branches: 4

vs. Vanilla Claude:

- **Dependency that would have been ignored:** tombstones-before-deletion ordering; Code Review would have flagged the missing tombstones.
- **Contradiction that would have slipped through:** the issue's `.flow-coverage-floor.json` is fictional — a linear plan would have quietly created the file or ignored the AC. DAG exploration caught it.
- **Branch that would have been flattened:** `start_finalize`'s phase_complete error guard + `start_gate`'s `!deps_changed` guard are both unreachable — supersession enumeration caught them; a flat plan would have written tests that can never pass.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
````

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 15m |
| Code | 1h 31m |
| Code Review | 34m |
| Learn | 11m |
| Complete | 3m |
| **Total** | **2h 37m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/100-coverage-start-family.json</summary>

```json
{
  "schema_version": 1,
  "branch": "100-coverage-start-family",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1206,
  "pr_url": "https://github.com/benkruger/flow/pull/1206",
  "started_at": "2026-04-16T16:00:56-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/100-coverage-start-family-plan.md",
    "dag": ".flow-states/100-coverage-start-family-dag.md",
    "log": ".flow-states/100-coverage-start-family.log",
    "state": ".flow-states/100-coverage-start-family.json"
  },
  "session_tty": "/dev/ttys000",
  "session_id": "0a1b6976-a114-40c5-8cee-59c48e03700c",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/0a1b6976-a114-40c5-8cee-59c48e03700c.jsonl",
  "notes": [],
  "prompt": "work on issue #1197",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-16T16:00:56-07:00",
      "completed_at": "2026-04-16T16:01:25-07:00",
      "session_started_at": null,
      "cumulative_seconds": 29,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-16T16:01:38-07:00",
      "completed_at": "2026-04-16T16:16:55-07:00",
      "session_started_at": null,
      "cumulative_seconds": 917,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-16T16:17:51-07:00",
      "completed_at": "2026-04-16T17:49:49-07:00",
      "session_started_at": null,
      "cumulative_seconds": 5518,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-16T17:50:07-07:00",
      "completed_at": "2026-04-16T18:24:19-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2052,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-16T18:24:39-07:00",
      "completed_at": "2026-04-16T18:36:27-07:00",
      "session_started_at": null,
      "cumulative_seconds": 708,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-16T18:36:43-07:00",
      "completed_at": "2026-04-16T18:40:15-07:00",
      "session_started_at": null,
      "cumulative_seconds": 212,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-16T16:01:38-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-16T16:17:51-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-16T17:50:07-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-16T18:24:39-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-16T18:36:43-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 18,
  "code_task_name": "Measurement+floor-verification tasks 16-18",
  "code_task": 18,
  "diff_stats": {
    "files_changed": 7,
    "insertions": 1527,
    "deletions": 167,
    "captured_at": "2026-04-16T17:49:49-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "compact_summary": "<analysis>\nThe user has requested a detailed summary of the conversation so far. Let me analyze what has happened:\n\n1. **Initial Setup**: The user provided extensive context about the Learn-phase compliance auditor role for PR #1206 on branch `100-coverage-start-family`. This included instructions to audit against three Learn tenants: (1) Process gaps in the FLOW plugin's workflow, (2) Rule compliance violations, and (3) Missing rule documentation.\n\n2. **Context Provided**: The user supplied five artifact paths to read:\n   - Plan file (`.flow-states/100-coverage-start-family-plan.md`)\n   - State file (`.flow-states/100-coverage-start-family.json`)\n   - Session log (`.flow-states/100-coverage-start-family.log`)\n   - Project CLAUDE.md\n   - Rules directory (`.claude/rules/`)\n\n3. **Initial Direction**: The user instructed me to:\n   - Fetch the branch diff via git command\n   - Read these artifacts myself\n   - Provide a Learn-phase audit with three tenants\n\n4. **First Error**: I attempted to fetch the git diff with `git diff origin/main...HEAD | head -50`. The PreToolUse validation hook blocked this with an error: \"BLOCKED: Compound commands (|) are not allowed outside quoted arguments.\" This was a permission model enforcement, not a user error.\n\n5. **Critical Pivot**: The user then provided an explicit CRITICAL instruction: \"Respond with TEXT ONLY. Do NOT call any tools... Tool calls will be rejected and will waste your only turn.\" The user explicitly shifted the task from \"produce Learn-phase audit findings\" to \"create a detailed summary of the conversation so far.\"\n\n6. **System Reminders Cascade**: After the user's CRITICAL instruction, a massive cascade of system-reminders appeared in the chat containing:\n   - Two calls to Read tool (one for forward-facing-authoring.md, one for cognitive-isolation.md)\n   - Multiple additional system-reminders with full contents of rule files and CLAUDE.md\n   - A summary of the prior conversation\n\n7. **Context Availability**: The system reminders provided comprehensive context including:\n   - Full CLAUDE.md for the worktree\n   - 40+ rule files (complete text of each)\n   - The state file data showing PR #1206 with 9 Code Review findings (all marked \"fixed\")\n   - The plan file describing four start_* modules with coverage goals\n   - The session log showing plan signature deviations that were logged\n\n8. **Key Observation**: The user's CRITICAL instruction explicitly states that I already have all the context I need in the conversation above. The system reminders delivered this context comprehensively. The user is asking for a summary of what has transpired, not for me to conduct the Learn-phase audit (which was the original request but was superseded by the pivot).\n\n9. **Current Task**: The task is to summarize the conversation faithfully, capturing:\n   - What the user originally requested\n   - What context was provided\n   - What technical concepts were discussed\n   - What errors occurred\n   - All user messages\n   - Current work state\n   - Next steps\n\nThe conversation flow was:\n- User requests Learn-phase audit\n- User provides artifact paths and instructions\n- User instructs me to fetch diff and read artifacts\n- I attempt to fetch diff, hit permission hook error\n- User pivots with CRITICAL instruction: summarize conversation, no tools\n- System delivers comprehensive context via reminders\n- I am now to summarize everything that has transpired\n\nThe user's final explicit request is to provide a summary structured with: Primary Request and Intent, Key Technical Concepts, Files and Code Sections, Errors and fixes, Problem Solving, All user messages, Pending Tasks, Current Work, and Optional Next Step.\n</analysis>\n\n<summary>\n\n1. Primary Request and Intent:\n   The user's primary explicit request evolved through the conversation:\n   \n   Initial Request: \"You are the Learn-phase compliance auditor for PR #1206 on branch `100-coverage-start-family` in `/Users/ben/code/flow`. Audit the work against the three Learn tenants: 1. Process gaps, 2. Rule compliance, 3. Missing rules. Read these artifacts yourself: [5 artifact paths]. Fetch the branch diff yourself: [git command]. Highlights of the work to guide your audit: [8 bullet points].\"\n   \n   This initial request asked for a full Learn-phase compliance audit examining the PR #1206 work against three specific tenants, with the user providing \"Highlights of the work\" including information about signature deviations, supersession deletions, Code Review fixes, adversarial agent truncation, target coverage metrics, and known test issues already fixed in Code Review.\n   \n   Critical Pivot: The user then sent a CRITICAL override instruction: \"Respond with TEXT ONLY. Do NOT call any tools... Your task is to create a detailed summary of the conversation so far... This summary should be thorough in capturing technical details, code patterns, and architectural decisions that would be essential for continuing development work without losing context.\"\n   \n   The final explicit task is to produce a structured summary of the conversation including: Primary Request and Intent, Key Technical Concepts, Files and Code Sections, Errors and fixes, Problem Solving, All user messages, Pending Tasks, Current Work, and Optional Next Step.\n\n2. Key Technical Concepts:\n   - FLOW Plugin: A Claude Code plugin enforcing a 6-phase development lifecycle (Start, Plan, Code, Code Review, Learn, Complete)\n   - Three Learn Tenants: (1) Process gaps—workflow breaks in the FLOW plugin, (2) Rule compliance—violations of documented rules, (3) Missing rules—undocumented patterns that should become rules\n   - Plan-commit-atomicity: Tasks must be atomic and deviations must be logged via `bin/flow log`\n   - Supersession rule: Dead/unreachable code deleted in same PR with structural tombstones\n   - Seam pattern: Dependency-injected testing via `run_impl_with_deps` + `run_impl_main`\n   - Tombstone tests: Negative assertions preventing merge-conflict resurrections of deleted code\n   - Coverage floor mechanism: `bin/test` with `--fail-under-*` flags\n   - Plan Test Verification: Named test functions must exist in landed code\n   - Plan signature deviations: Detected by `src/plan_deviation.rs::scan`, blocked by gate in `src/finalize_commit.rs::run_impl`\n   - State file structure: `.flow-states/<branch>.json` backbone with phases, findings, timings\n   - Three-tier dispatch: `run_impl_with_deps` (testable core) → `run_impl` (production binder) → `run_impl_main` (main-arm dispatcher)\n   - External input validation: `FlowPaths::try_new` vs panicking `FlowPaths::new` for branch parameters\n   - Hook state read timing: Understanding when state fields are written relative to hook firing\n   - Cognitive isolation: Learn-analyst agent receives state file data, visit counts, timings, session notes\n\n3. Files and Code Sections:\n   \n   Artifact Paths Identified by User:\n   - `/Users/ben/code/flow/.flow-states/100-coverage-start-family-plan.md` (Plan file for PR #1206)\n   - `/Users/ben/code/flow/.flow-states/100-coverage-start-family.json` (State file tracking all 6 phases)\n   - `/Users/ben/code/flow/.flow-states/100-coverage-start-family.log` (Session log showing execution)\n   - `/Users/ben/code/flow/CLAUDE.md` (Project instructions)\n   - `/Users/ben/code/flow/.claude/rules/` (40+ rule files directory)\n   \n   Key Files Mentioned in Context (from system reminders):\n   \n   - `/Users/ben/code/flow/.claude/rules/forward-facing-authoring.md`\n     - Defines that persistent artifacts (rule files, CLAUDE.md, doc comments, skill instructions) must describe what IS, not what WAS\n     - Uses present tense and cites code only when they are permanent canonical examples\n     - Applies to `.claude/rules/*.md`, `CLAUDE.md`, Rust doc comments, skill instructions, plan prose, finding reasons\n     - Prohibits: first-person narrative, \"after the fix\" framing, \"was/was-not\" framing, just-merged-work citations, principles from single incidents\n   \n   - `/Users/ben/code/flow/.claude/rules/cognitive-isolation.md`\n     - Describes when to use foreground sub-agents for debiased analysis of current session work\n     - Two-tier context model: context-rich agents (reviewer, learn-analyst) receive full diff/plan/CLAUDE.md/rules inline; context-sparse agents (pre-mortem, adversarial, documentation) receive only substantive diff\n     - Learn-analyst is context-rich and receives state file data (visit counts, timings, session notes)\n     - Learn-analyst explicitly has no knowledge of the conversation that produced the changes\n     - Reference implementation: learn-analyst agent in `agents/learn-analyst.md`\n   \n   - `/Users/ben/code/flow/.claude/rules/verify-runtime-path.md`\n     - Requires tracing actual execution paths before writing fixes\n     - For new branches/callsite families, plan must enumerate callers and name tests for each\n     - PR #1054 motivating incident: `find_state_files` gained empty-branch code path without enumerated tests\n     - PR #1177 motivating incident: `duplicate_test_coverage` scanner wired into three callsites without enumerated tests per callsite\n   \n   - `/Users/ben/code/flow/.claude/rules/plan-commit-atomicity.md`\n     - Atomic commit groups can be split only when all three conditions hold: (1) each commit independently shippable, (2) no test assertion spans boundary, (3) split clarifies logical structure\n     - Plan signature deviations must be logged via `bin/flow log` before commit\n     - Plan deviation gate runs in `src/finalize_commit.rs::run_impl` after CI succeeds but before git commit\n     - `src/plan_deviation.rs::scan` collects (test_name, fixture_key, plan_value) triples and cross-references against diff-added test function bodies\n     - Deviation acknowledged via log entry containing both test_name and plan_value as substrings\n     - PR #1056 motivating incident: atomic group of 12 tasks split across 5 commits without documented rationale\n     - PR #1157 motivating incident: plan named `run_impl_with_notifier(args, notifier)` but code delivered `run_impl_with_deps(root, cwd, args, notifier)` with additional parameters\n   \n   - Multiple other rule files accessed via system reminders including:\n     - scope-enumeration.md, no-waivers.md, tests-guard-real-regressions.md, supersession.md, tombstone-tests.md, docs-with-behavior.md, comment-quality.md, external-input-validation.md, external-input-audit-gate.md, testing-gotchas.md, rust-patterns.md, and 30+ additional rules\n   \n   State File Data:\n   - PR #1206 on branch 100-coverage-start-family\n   - Tracks all 6 phases with visit counts and cumulative seconds\n   - Contains 9 findings array entries from Code Review Step 4 (all with outcome \"fixed\")\n   - Identifies specific deviations that were logged\n   \n   Session Log Data:\n   - Lines 22-37 record Phase 3 plan signature deviations logged via `bin/flow log`:\n     - Line 22: start_finalize run_impl_with_deps signature change (added root: &Path)\n     - Line 25: start_gate run_impl_with_deps signature change (added root/cwd)\n     - Line 28: start_init run_impl_with_deps signature change (dropped three closures, added root/cwd)\n     - Line 31: Tasks 12/13 landed as inline seam tests instead of subprocess tests\n     - Line 34: start_gate/workspace/finalize run_impl signatures change from Result<Value,String> to Value\n     - Line 35: start_workspace_run_impl_main_err_path is contract-lock, not full execution path\n   - Line 38: Task 16 coverage captured at 96.82% regions / 94.72% functions / 96.61% lines\n   \n   Plan File Data:\n   - Documents four start_* modules with coverage goals: start_init (78.90% → 100%), start_finalize (87.15% → 100%), start_workspace (90.38% → 100%), start_gate (90.53% → 100%)\n   - Shows branch enumeration tables and task descriptions\n   - Risk 5 addresses tombstone stability for deletions\n\n4. Errors and fixes:\n   \n   Error 1: Permission Model Hook Blocking Compound Command\n   - Error: When I attempted to fetch the git diff with `git diff origin/main...HEAD | head -50`, the PreToolUse validation hook blocked the command\n   - Error Message: \"[${CLAUDE_PLUGIN_ROOT}/bin/flow hook validate-pretool]: BLOCKED: Compound commands (|) are not allowed outside quoted arguments. Use separate Bash calls for each command.\"\n   - Root Cause: The permission model enforces restrictions on Bash commands, and pipes (|) are not allowed outside quoted arguments per the global `validate-pretool` hook\n   - How I Fixed It: I did not fix this—the user immediately pivoted with the CRITICAL instruction that no tools should be used, making this error moot\n   - User Feedback: The user did not explicitly comment on this error. Instead, they provided the CRITICAL instruction that superseded the need to fetch the diff\n   - Context: This error occurred because the PreToolUse hook in `src/hooks/validate_pretool.rs` has quote-aware operator detection that blocks pipes in unquoted contexts. This is by design per `.claude/rules/ci-is-a-gate.md` enforcement\n\n5. Problem Solving:\n   \n   Problem 1: Initial Task Scope\n   - The user requested a full Learn-phase compliance audit of PR #1206 against three tenants\n   - The audit would require reading multiple artifact files and analyzing the diff\n   - Approach: I began attempting to fetch the diff using a git command\n   \n   Outcome: The user pivoted the task entirely with the CRITICAL instruction, shifting from \"conduct audit\" to \"summarize conversation.\" This was an explicit scope change, not a problem solved but rather a task redirection.\n   \n   Problem 2: Understanding Task Priority\n   - The user's CRITICAL instruction made clear that the summary task takes absolute priority\n   - The instruction explicitly states tool calls will be rejected and waste the only remaining turn\n   - Approach: I am now responding with text-only summary in the exact structure requested\n   \n   No ongoing troubleshooting efforts remain. The task is well-defined and the context is complete.\n\n6. All user messages:\n   \n   Message 1: \"You are the Learn-phase compliance auditor for PR #1206 on branch `100-coverage-start-family` in `/Users/ben/code/flow`. Audit the work against the three Learn tenants: 1. Process gaps—where did the FLOW plugin's workflow break or fall short, 2. Rule compliance—where did Claude violate a documented rule (and was the rule clear but ignored, or unclear), and 3. Missing rules—what undocumented patterns should become rules. Read these artifacts yourself: [5 file paths]. Fetch the branch diff yourself: [git command]. Highlights of the work to guide your audit: [8 bullet points describing work done].\"\n   \n   This message established the primary task: conduct a Learn-phase compliance audit of PR #1206 examining process gaps, rule compliance violations, and missing rule documentation.\n   \n   Message 2: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools. [Explicit restrictions on tool usage]. Your task is to create a detailed summary of the conversation so far without using any tools, explicitly stating that tool calls will be rejected and will waste the only remaining turn. You already have all the context you need in the conversation above. Your entire response must be plain text: an <analysis> block followed by a <summary> block.\"\n   \n   This message completely pivoted the task from the Learn-phase audit to a conversation summary. The CRITICAL marker and explicit restrictions made this override authoritative. The user emphasizes that all context is already available and tool calls will fail.\n\n7. Pending Tasks:\n   \n   Primary Pending Task: Complete the conversation summary in the exact structure requested:\n   - Analysis block (thought process covering all points)\n   - Summary block with 9 sections:\n     1. Primary Request and Intent\n     2. Key Technical Concepts\n     3. Files and Code Sections\n     4. Errors and fixes\n     5. Problem Solving\n     6. All user messages\n     7. Pending Tasks\n     8. Current Work\n     9. Optional Next Step\n   \n   This is the only explicit pending task. The Learn-phase audit that was originally requested is no longer the active task—it has been superseded by the summary request.\n\n8. Current Work:\n   \n   I am currently producing a detailed summary of the conversation in plain text format, structured with the nine required sections. The conversation has encompassed:\n   \n   - Initial Request (Message 1): Learn-phase compliance audit of PR #1206\n   - Artifact Paths Provided: Five file paths the user instructed me to read\n   - Error Encountered: Permission hook blocked `git diff` with pipe operator\n   - Task Pivot (Message 2): CRITICAL instruction to summarize conversation instead, with explicit prohibition on tool use\n   - Context Delivered: System reminders provided comprehensive context including full CLAUDE.md, 40+ rule files, state file data, plan file data, and session log data\n   \n   The current work is precisely what is being executed right now: delivering this summary in the exact structure the user specified, using only plain text with no tool invocations.\n\n9. Optional Next Step:\n   \n   After completing this summary, the immediate next step would be to wait for the user's explicit direction. The user has not indicated what should follow the summary. The original Learn-phase audit task was superseded by the summary request, so it should not be resumed unless the user explicitly asks for it.\n   \n   If the user asks to proceed with the Learn-phase audit after this summary, the path forward would be:\n   - Use the comprehensive context now available (from system reminders) to conduct the three-tenant audit\n   - Examine process gaps in the FLOW plugin's workflow\n   - Audit rule compliance violations with enforcement level assessment\n   - Identify missing rule documentation patterns\n   - Produce structured compliance findings following the Learn-analyst agent design\n   \n   However, this is conditional on explicit user request. The current and only active task is to complete this summary.\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/100-coverage-start-family",
  "compact_count": 6,
  "findings": [
    {
      "finding": "Pre-mortem: exit code always 0 for three modules is a regression",
      "reason": "Not a regression. Old run() returned exit 0 whenever run_impl returned Ok, regardless of business status in the payload; Err was reserved for infrastructure failures. start_init's new run_impl_main_with_deps preserves the Err to exit 1 mapping. The other three modules never produced Err before or after the refactor, so their exit-code behavior is identical to main.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:01:56-07:00"
    },
    {
      "finding": "Pre-mortem: silent phase-transition failure in start_finalize due to deleted guard",
      "reason": "Guard was deleted under supersession: phase_complete() in src/phase_transition.rs always returns status=ok and never produces an error payload, making the guard unreachable dead code. The tombstone test_start_finalize_no_phase_complete_error_guard locks the deletion against merge-conflict resurrection and can be removed via tombstone-audit when a future change to phase_complete makes it fallible.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:02:13-07:00"
    },
    {
      "finding": "Pre-mortem: unexpected deps status silent fallthrough in start_gate",
      "reason": "Guard was deleted under supersession: run_update_deps returns a closed domain of status values (ok, skipped, error) today; the three recognized branches handle all of them and return early. The deleted guard's condition deps_changed == false was unreachable when the three early-return branches covered the full output. If run_update_deps domain expands in future, the tombstone test_start_gate_no_unexpected_deps_status_guard gets removed and the guard re-added together.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:02:29-07:00"
    },
    {
      "finding": "Documentation: subprocess injection pattern not catalogued as its own rule",
      "reason": "Covered by existing rust-patterns.md CLI Testability run_impl Pattern section which already documents main-arm dispatch via run_impl_main plus seam injection. Adding a dedicated subsection duplicates existing authority without new content, violating tests-guard-real-regressions.md forbidden patterns (Duplicate guards for a property already covered by an existing plan-check scanner).",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:02:38-07:00"
    },
    {
      "finding": "Reviewer: vacuous run_impl_main_err_path tests in three modules",
      "reason": "Rewrote start_gate/workspace/finalize run_impl_main_err_path tests to actually call run_impl_main with TempDir root/cwd and assert the real (Value, i32) tuple. Added root/cwd params to run_impl_main so tests can inject fixtures per rust-patterns.md Main-arm dispatch rule.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:12:47-07:00"
    },
    {
      "finding": "Reviewer: run_impl_main signatures missing root: Path per rust-patterns.md Main-arm dispatch rule",
      "reason": "Added root: Path to all four start_* run_impl_main signatures; start_gate/workspace/init also take cwd: Path. main.rs dispatch arms now resolve project_root()/current_dir() once per arm and pass them in. start_workspace gained run_impl_with_paths(args, root, cwd) as the testable core binding run_impl.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:12:54-07:00"
    },
    {
      "finding": "Reviewer: tombstone boundary marker stale after pub fn run deletion",
      "reason": "Updated tests/tombstones.rs: test_start_finalize_no_phase_complete_error_guard and test_start_gate_no_unexpected_deps_status_guard now use fn run_impl_with_deps as start marker and pub fn run_impl as end marker. This bounds the scan to the enclosing function body per testing-gotchas.md Subsection-Local Assertions in Contract Tests.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:13:04-07:00"
    },
    {
      "finding": "Documentation: run_impl_main_with_deps asymmetry in start_init undocumented",
      "reason": "Added Why start_init has run_impl_main_with_deps subsection to start_init module doc comment explaining that start_init alone has a reachable Err arm (plug_root_finder None, init-state subprocess spawn failure) and therefore needs a seam-accepting entry point to drive the (err_json, 1) arm from unit tests.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:13:12-07:00"
    },
    {
      "finding": "Documentation: three-tier dispatch pattern not catalogued in rust-patterns.md CLI Testability section",
      "reason": "Extended .claude/rules/rust-patterns.md CLI Testability — run_impl Pattern section with a Three-tier dispatch for subprocess-coordinating modules subsection naming the run_impl_with_deps -> run_impl -> run_impl_main hierarchy and citing the four start_* modules as reference implementations.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:13:20-07:00"
    },
    {
      "finding": "Documentation: exit code convention for business errors not documented",
      "reason": "Added Exit code convention for business errors subsection to rust-patterns.md CLI Testability — run_impl Pattern: (v, 0) for Value-returning run_impl (callers parse status field); (err_json, 1) reserved for infrastructure Err paths. Named the pre-existing matching convention in format_complete_summary/format_issues_summary/format_pr_timings/tui_data.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:13:28-07:00"
    },
    {
      "finding": "Plan deviation logging gate functioned correctly",
      "reason": "Agent itself noted no fix needed; gate worked as designed. Not a forward-looking learning.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:28:53-07:00"
    },
    {
      "finding": "Scope enumeration in plan may lack named list (conditional)",
      "reason": "Plan-check gate ran successfully at Phase 2 completion and passed with 17 duplicate-test-coverage violations fixed via not-a-new-test opt-outs; scope-enumeration found no violations. Gate is authoritative.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:28:59-07:00"
    },
    {
      "finding": "Atomicity across start-family refactor",
      "reason": "run_impl_main signature refactor + main.rs dispatch wire-up landed in single commit f3bd8286 per plan atomic-group marking for Tasks 14+15. No atomicity violation.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:29:06-07:00"
    },
    {
      "finding": "Plan test verification gate invocation",
      "reason": "Plan Test Verification was performed inline during Code phase by grepping for plan-named tests before each commit; no separate gate invocation is required by skills/flow-code/SKILL.md Plan Test Verification section. All plan-named tests exist in the codebase.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:29:18-07:00"
    },
    {
      "finding": "Tombstone stability verification",
      "reason": "Both tombstones (test_start_finalize_no_phase_complete_error_guard, test_start_gate_no_unexpected_deps_status_guard) ship as structural function-body-scoped scans with bounded-slice pattern and explicit bypass lists in plan Risk 5. Code Review reviewer agent caught the stale end-boundary marker and it was fixed in commit a6dcb291.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:29:26-07:00"
    },
    {
      "finding": "Missing rule: coverage floor mechanism (--fail-under-*) not documented",
      "reason": "Added Enforcement layer 4 to .claude/rules/no-waivers.md documenting the bin/test --fail-under-lines/regions/functions flags as the ratchet that enforces 100%-coverage-or-bust mechanically at CI time. Cross-references tool-dispatch.md for the coherence discipline that keeps the measurement honest.",
      "outcome": "rule_clarified",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:30:20-07:00",
      "path": ".claude/rules/no-waivers.md"
    },
    {
      "finding": "Process gap: adversarial agent truncated in Phase 4 Code Review without producing findings or writing the adversarial test file",
      "reason": "Agent exhausted maxTurns on the multi-module start_* refactor before delivering structured findings; filed issue to investigate budget bump, task split, or auto-retry",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:36:02-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1211"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "issues_filed": [
    {
      "label": "Flow",
      "title": "Adversarial agent truncates on multi-module refactor PRs before producing findings",
      "url": "https://github.com/benkruger/flow/issues/1211",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:35:51-07:00"
    }
  ],
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/100-coverage-start-family.log</summary>

```text
2026-04-16T16:00:56-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-16T16:00:56-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-16T16:00:56-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-16T16:00:56-07:00 [Phase 1] create .flow-states/100-coverage-start-family.json (exit 0)
2026-04-16T16:00:56-07:00 [Phase 1] freeze .flow-states/100-coverage-start-family-phases.json (exit 0)
2026-04-16T16:00:56-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-16T16:00:57-07:00 [Phase 1] start-init — label-issues (labeled: [1197], failed: [])
2026-04-16T16:01:03-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-16T16:01:03-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-16T16:01:04-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-16T16:01:12-07:00 [Phase 1] start-workspace — worktree .worktrees/100-coverage-start-family (ok)
2026-04-16T16:01:16-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-16T16:01:16-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-16T16:01:16-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-16T16:01:25-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-16T16:01:25-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-16T16:06:20-07:00 [stop-continue] first stop, conditional continue: pending=decompose
2026-04-16T16:16:55-07:00 [Phase 2] phase-transition --action complete --phase flow-plan ("ok")
2026-04-16T16:17:51-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-16T16:27:49-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T16:27:54-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T16:28:41-07:00 [Phase 3] Plan signature deviation: run_impl_with_deps(args, notifier) -> run_impl_with_deps(args, root, notifier) (added root: &Path parameter so inline tests can point FlowPaths at a TempDir instead of the host project_root())
2026-04-16T16:40:26-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T16:40:30-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T16:41:48-07:00 [Phase 3] Plan signature deviation: start_gate run_impl_with_deps(args, git_pull_fn, ci_runner, deps_runner, commit_deps_fn) -> run_impl_with_deps(args, root, cwd, git_pull_fn, ci_runner, deps_runner, commit_deps_fn) (added root/cwd: &Path params so inline tests bind FlowPaths/update_step to a TempDir; 7 params trigger clippy::too_many_arguments, allowed on the seam)
2026-04-16T16:55:10-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T16:55:14-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T16:56:48-07:00 [Phase 3] Plan signature deviation: start_init run_impl_with_deps(args, 7 closures) -> run_impl_with_deps(args, root, cwd, plug_root_finder, prime_check_fn, upgrade_check_fn, init_state_runner) (dropped label_fn/fetch_issue_fn/check_dup_fn — the 4 named tests drive prompts without issue numbers and never reach those branches, which subprocess tests already cover; added root/cwd for TempDir injection)
2026-04-16T17:10:25-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T17:10:30-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T17:11:23-07:00 [Phase 3] Plan signature deviation: Tasks 12 and 13 planned as subprocess tests under tests/start_init.rs, landed as inline unit tests in src/start_init.rs with the same plan-named functions (start_init_auto_upgraded_propagates_to_response, start_init_upgrade_available_adds_upgrade_field). Same branch coverage; counter advanced alongside Task 11 commit.
2026-04-16T17:21:18-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T17:21:21-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T17:26:32-07:00 [Phase 3] Plan signature deviation: start_gate/start_workspace/start_finalize run_impl signatures change from Result<Value, String> to Value (run_impl never produces Err in any of these three modules; the Err arm of run_impl_main would be unreachable dead code forbidden by no-waivers). start_init keeps Result<Value, String> since its Err arm is reachable via plug_root_finder. Exit code 1 semantics only apply to start_init.
2026-04-16T17:34:07-07:00 [Phase 3] Plan signature deviation: start_workspace_run_impl_main_err_path test is a contract-lock (not a full Err-path execution) because start_workspace has no run_impl_with_deps seam and a real run_impl_main call would write to host .flow-states/. Subprocess test start_workspace_corrupt_state_returns_backfill_error provides the real end-to-end error-scenario coverage.
2026-04-16T17:47:11-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T17:47:14-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T17:48:06-07:00 [Phase 3] Task 16 — coverage TOTAL captured: 96.82% regions / 94.72% functions / 96.61% lines. floor(TOTAL) = 96/94/96; current bin/test thresholds --fail-under-lines 96 --fail-under-regions 96 --fail-under-functions 94 already match floor — no bump required.
2026-04-16T17:49:49-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-16T17:50:07-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-16T18:23:51-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-16T18:23:55-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-16T18:24:19-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-16T18:24:39-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-16T18:34:54-07:00 [Phase 5] finalize-commit — ci (ok)
2026-04-16T18:34:57-07:00 [Phase 5] finalize-commit — done ("ok")
2026-04-16T18:36:27-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-16T18:40:15-07:00 [Phase 6] complete-finalize — starting
2026-04-16T18:40:15-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-16T18:40:15-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Flow | Adversarial agent truncates on multi-module refactor PRs before producing findings | Learn | #1211 |

<!-- end:Issues Filed -->