### PR TITLE
Route Flow States Writes Through

### DIFF
--- a/.claude/rules/file-tool-preflights.md
+++ b/.claude/rules/file-tool-preflights.md
@@ -1,0 +1,127 @@
+# File-Tool Preflights
+
+Claude Code's Write tool and Edit tool each have a Read-first-in-session
+preflight: Write errors when the target file already exists on disk and
+has not been Read in the conversation, and Edit errors when an edit is
+attempted before a prior Read on the target. FLOW skills that write to
+persistent branch-scoped or project-root paths must route those writes
+through the `bin/flow write-rule` Rust subcommand, which does `fs::write`
+unconditionally so the preflight cannot fire. Skills that instruct Edits
+against named plan or DAG files must precede the Edit with an explicit
+Read-tool instruction so the Edit preflight is satisfied even when the
+model has not naturally read the file in the current turn.
+
+## The Bug Class
+
+When a skill instructs the model to Write a file that may pre-exist, the
+Write tool's preflight fires with "Error writing file" — visible in the
+conversation as a red error line under the Write tool call. Pre-existence
+comes from:
+
+1. A prior attempt in the same session wrote the file before a retry.
+2. The `--continue-step` self-invocation re-enters the skill; prior
+   Write's Read-tracking may not survive the reinvocation context.
+3. Context compaction during a long turn drops Read-tracking.
+4. An aborted earlier session left the file.
+
+## Monitored Target Paths
+
+These paths are branch-scoped or literal persistent targets. Writes to
+them must route through `bin/flow write-rule`:
+
+- `.flow-states/<branch>-dag.md` — the decompose-produced DAG file
+- `.flow-states/<branch>-plan.md` — the Plan-phase implementation plan
+- `.flow-commit-msg` — the commit skill's message file (project root)
+- `.flow-issue-body` — the shared issue body file (project root)
+- `orchestrate-queue.json` — the machine-level orchestration queue
+  (in `.flow-states/`)
+
+Session-scoped `-<id>` temp files used by `flow-create-issue` and
+`flow-decompose-project` are NOT monitored because their unique id
+prevents cross-invocation collision.
+
+Intermediate content files that the model Writes as input to
+`bin/flow write-rule` (for example
+`.flow-states/<branch>-dag-content.md`) are also not monitored — they
+are the Write-tool input, not a persistent target. The `write-rule`
+subcommand reads and deletes them unconditionally.
+
+## The Write-Rule Escape Pattern
+
+The pattern flow-learn has used for `.claude/` writes for some time, now
+extended to all monitored paths:
+
+1. Model Writes content to `.flow-states/<branch>-<purpose>-content.md`
+   using the Write tool. The content file has a unique name per write
+   so pre-existence is rare.
+2. Model invokes `bin/flow write-rule --path <final_target>
+   --content-file <content_file>`. The Rust code reads the content file,
+   calls `std::fs::write(<final_target>, <content>)` unconditionally,
+   and deletes the content file.
+
+Because `std::fs::write` runs inside the `write-rule` subprocess and
+never goes through Claude Code's Write tool, the preflight cannot fire
+on the final target.
+
+Reference implementation: `src/write_rule.rs`.
+
+## The Edit Preamble Pattern
+
+Edit-tool instructions on named `.flow-states/<branch>-*.md` files must
+be preceded by an explicit Read-tool instruction on the same file. The
+preamble ensures the Edit preflight is satisfied even when the model
+has not naturally read the file in the current turn (for example,
+re-entering the plan-check fix loop after `--continue-step`).
+
+Canonical wording, mirrored from `flow-complete/SKILL.md:233`:
+
+> Use the Read tool on the plan file at `.flow-states/<branch>-plan.md`
+> first to satisfy Claude Code's Edit-tool preflight, then use the Edit
+> tool to ...
+
+No new subcommand is needed for the Edit case. Edit's `old_string`
+requirement forces the model to know the existing content, so a Read
+before Edit is already the natural workflow — the preamble just
+guarantees it in paths where the natural order could be skipped.
+
+## Enforcement
+
+Two contract tests in `tests/skill_contracts.rs` enforce both sides of
+the rule:
+
+- `file_tool_preflight_write_paths_route_through_write_rule` — scans
+  every `skills/**/SKILL.md` for "using the Write tool" / "Use the
+  Write tool" instructions adjacent to a monitored path, and asserts a
+  `bin/flow write-rule --path <same-path>` call follows within 30 lines.
+- `file_tool_preflight_edit_paths_preceded_by_read` — scans every
+  SKILL.md for "use the Edit tool" / "using the Edit tool" instructions
+  on named plan or DAG files and asserts a Read-tool instruction on the
+  same file appears within the preceding 12 lines.
+
+When either test fails, the violation names the file and line. The fix
+is to adopt the Write-Rule Escape Pattern or the Edit Preamble Pattern
+respectively — never to add an allow-list that exempts the callsite.
+
+## Why Not Skill Instructions Alone
+
+Per `.claude/rules/hook-vs-instruction.md`: when the consequence of
+non-compliance is user-visible and blocks the flow (which this bug
+does — 10+ minutes of recovery observed twice), the enforcement must
+be mechanical, not advisory. The Write-side fix is mechanical via the
+`write-rule` subprocess. The Edit-side fix is advisory prose in
+SKILL.md, but the contract test locks the prose invariant in so drift
+fails CI.
+
+## Cross-References
+
+- `.claude/rules/hook-vs-instruction.md` — the principle that mandates
+  mechanical enforcement for this class.
+- `.claude/rules/scope-expansion.md` — the scope-boundary decision for
+  combining Write and Edit fixes in one PR.
+- `.claude/rules/tests-guard-real-regressions.md` — names the Write
+  bug as a real observed regression (two incidents 2026-04-16) and the
+  Edit gap as a narrow structural risk rather than speculative scan.
+- `src/write_rule.rs` — the reference Rust subcommand.
+- `skills/flow-learn/SKILL.md:307-345` — the reference SKILL.md pattern
+  that has routed through `write-rule` for CLAUDE.md and
+  `.claude/rules/` writes since before this PR.

--- a/.claude/rules/file-tool-preflights.md
+++ b/.claude/rules/file-tool-preflights.md
@@ -24,10 +24,20 @@ comes from:
 3. Context compaction during a long turn drops Read-tracking.
 4. An aborted earlier session left the file.
 
+Recovery from a preflight block requires manual workaround outside the
+normal skill workflow — the model has to invoke Read on the blocked path
+before the Write can proceed, which wastes turns and can corrupt the
+workflow if the model instead accepts whatever content is already on
+disk.
+
 ## Monitored Target Paths
 
-These paths are branch-scoped or literal persistent targets. Writes to
-them must route through `bin/flow write-rule`:
+Monitored paths are files FLOW skills write to repeatedly across
+invocations (branch-scoped or machine-level singletons) or files that
+may pre-exist from a prior session on fresh re-entry. Session-scoped
+files with a unique `-<id>` suffix are excluded because the id makes
+cross-invocation collision unlikely. Writes to the monitored set must
+route through `bin/flow write-rule`:
 
 - `.flow-states/<branch>-dag.md` — the decompose-produced DAG file
 - `.flow-states/<branch>-plan.md` — the Plan-phase implementation plan
@@ -46,15 +56,21 @@ Intermediate content files that the model Writes as input to
 are the Write-tool input, not a persistent target. The `write-rule`
 subcommand reads and deletes them unconditionally.
 
+When a new persistent path becomes a monitored target (e.g. a new skill
+writes to a shared file or a new machine-level singleton is introduced),
+add it to this list AND to `WRITE_MONITORED_PATHS` in
+`tests/skill_contracts.rs`. The contract test scans every SKILL.md for
+Write-tool instructions adjacent to any entry in that constant.
+
 ## The Write-Rule Escape Pattern
 
-The pattern flow-learn has used for `.claude/` writes for some time, now
-extended to all monitored paths:
+The pattern `flow-learn` uses for `.claude/` writes also applies to all
+monitored paths:
 
-1. Model Writes content to `.flow-states/<branch>-<purpose>-content.md`
+1. The model Writes content to `.flow-states/<branch>-<purpose>-content.md`
    using the Write tool. The content file has a unique name per write
-   so pre-existence is rare.
-2. Model invokes `bin/flow write-rule --path <final_target>
+   (branch + purpose), so pre-existence is rare.
+2. The model invokes `bin/flow write-rule --path <final_target>
    --content-file <content_file>`. The Rust code reads the content file,
    calls `std::fs::write(<final_target>, <content>)` unconditionally,
    and deletes the content file.
@@ -62,6 +78,16 @@ extended to all monitored paths:
 Because `std::fs::write` runs inside the `write-rule` subprocess and
 never goes through Claude Code's Write tool, the preflight cannot fire
 on the final target.
+
+### Intermediate Content File Naming and Lifecycle
+
+Intermediate content files follow the pattern
+`.flow-states/<branch>-<purpose>-content.<ext>` where `<purpose>`
+matches the basename of the final target (e.g. `dag`, `plan`,
+`commit-msg`, `issue-body`, `orchestrate-queue`) and `<ext>` matches the
+target's extension (`.md`, `.json`). The `write-rule` subcommand deletes
+the intermediate file after a successful routing; on error the file is
+left in place so the user can diagnose the routing failure.
 
 Reference implementation: `src/write_rule.rs`.
 
@@ -73,7 +99,7 @@ preamble ensures the Edit preflight is satisfied even when the model
 has not naturally read the file in the current turn (for example,
 re-entering the plan-check fix loop after `--continue-step`).
 
-Canonical wording, mirrored from `flow-complete/SKILL.md:233`:
+Canonical wording:
 
 > Use the Read tool on the plan file at `.flow-states/<branch>-plan.md`
 > first to satisfy Claude Code's Edit-tool preflight, then use the Edit
@@ -90,13 +116,26 @@ Two contract tests in `tests/skill_contracts.rs` enforce both sides of
 the rule:
 
 - `file_tool_preflight_write_paths_route_through_write_rule` — scans
-  every `skills/**/SKILL.md` for "using the Write tool" / "Use the
-  Write tool" instructions adjacent to a monitored path, and asserts a
-  `bin/flow write-rule --path <same-path>` call follows within 30 lines.
+  every `skills/**/SKILL.md` for Write-tool instructions (matching
+  `use`, `using`, `invoke`, `invoking`, `call`, `calling`, `run`,
+  `running` followed by `the Write tool`) adjacent to a monitored
+  path, and asserts a `bin/flow write-rule --path <same-path>` call
+  appears on a SINGLE line within the next 30 lines. Same-line
+  co-occurrence is required so a disconnected `bin/flow write-rule`
+  targeting a different path plus an unrelated mention of the
+  monitored path cannot silently satisfy the check.
 - `file_tool_preflight_edit_paths_preceded_by_read` — scans every
-  SKILL.md for "use the Edit tool" / "using the Edit tool" instructions
-  on named plan or DAG files and asserts a Read-tool instruction on the
-  same file appears within the preceding 12 lines.
+  SKILL.md for Edit-tool instructions on named plan or DAG files and
+  asserts a Read-tool instruction (matching the same verb vocabulary)
+  on the same file appears within the preceding 12 non-blank lines.
+  The backward scan stops at any `## ` or `### ` heading so a Read in
+  a prior step cannot credit an Edit in a later step — a
+  `--continue-step` resume invalidates the prior Read.
+
+Both scans use `write_path_is_bounded` to check BOTH prefix and suffix
+byte boundaries on every path match, rejecting longer paths that embed
+a monitored path as a substring (e.g. `my-orchestrate-queue.json`,
+`.flow-commit-msg.bak`).
 
 When either test fails, the violation names the file and line. The fix
 is to adopt the Write-Rule Escape Pattern or the Edit Preamble Pattern
@@ -105,10 +144,9 @@ respectively — never to add an allow-list that exempts the callsite.
 ## Why Not Skill Instructions Alone
 
 Per `.claude/rules/hook-vs-instruction.md`: when the consequence of
-non-compliance is user-visible and blocks the flow (which this bug
-does — 10+ minutes of recovery observed twice), the enforcement must
-be mechanical, not advisory. The Write-side fix is mechanical via the
-`write-rule` subprocess. The Edit-side fix is advisory prose in
+non-compliance is user-visible and blocks the flow, the enforcement
+must be mechanical, not advisory. The Write-side fix is mechanical via
+the `write-rule` subprocess. The Edit-side fix is advisory prose in
 SKILL.md, but the contract test locks the prose invariant in so drift
 fails CI.
 
@@ -118,10 +156,9 @@ fails CI.
   mechanical enforcement for this class.
 - `.claude/rules/scope-expansion.md` — the scope-boundary decision for
   combining Write and Edit fixes in one PR.
-- `.claude/rules/tests-guard-real-regressions.md` — names the Write
-  bug as a real observed regression (two incidents 2026-04-16) and the
-  Edit gap as a narrow structural risk rather than speculative scan.
+- `.claude/rules/tests-guard-real-regressions.md` — the discipline
+  requiring every test to guard a named regression and name its
+  consumer.
 - `src/write_rule.rs` — the reference Rust subcommand.
-- `skills/flow-learn/SKILL.md:307-345` — the reference SKILL.md pattern
-  that has routed through `write-rule` for CLAUDE.md and
-  `.claude/rules/` writes since before this PR.
+- `skills/flow-learn/SKILL.md` — the reference SKILL.md pattern that
+  routes through `write-rule` for CLAUDE.md and `.claude/rules/` writes.

--- a/skills/flow-code/SKILL.md
+++ b/skills/flow-code/SKILL.md
@@ -383,8 +383,16 @@ subsequent attempt without any code changes, it is flaky. File a
 The issue body must include: the test name, the failure message, how many
 attempts it took to pass, and the task being worked on.
 
-Write the issue body to `.flow-issue-body` in the project root using the
-Write tool, then file:
+Write the issue body to `.flow-states/<branch>-issue-body-content.md` using
+the Write tool, then route it to `.flow-issue-body` in the project root
+via `bin/flow write-rule` (avoids Claude Code's Write-tool preflight on a
+pre-existing body file — see `.claude/rules/file-tool-preflights.md`):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path <project_root>/.flow-issue-body --content-file .flow-states/<branch>-issue-body-content.md
+```
+
+Then file:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow issue --label "Flaky Test" --title "<issue_title>" --body-file .flow-issue-body

--- a/skills/flow-commit/SKILL.md
+++ b/skills/flow-commit/SKILL.md
@@ -214,12 +214,11 @@ Display the full message under the heading **Commit Message**.
 
 Files are already staged from Round 3. No need to `git add -A` again.
 
-**Compose the commit message.** Use the Write tool to write the message
-content to `.flow-states/<branch>-commit-msg-content.md` — a
-branch-scoped temp path, not the final `.flow-commit-msg`. This avoids
-Claude Code's Write-tool preflight tripping on a pre-existing
-`.flow-commit-msg` from a prior commit retry
-(see `.claude/rules/file-tool-preflights.md`).
+Use the Write tool to write the commit message content to
+`.flow-states/<branch>-commit-msg-content.md` — a branch-scoped temp
+path, not the final `.flow-commit-msg`. This avoids Claude Code's
+Write-tool preflight tripping on a pre-existing `.flow-commit-msg`
+from a prior commit retry (see `.claude/rules/file-tool-preflights.md`).
 
 - The file is inside the project, so the Write tool has permission without prompting
 - The Write tool handles newlines and special characters safely — no shell escaping needed
@@ -227,7 +226,8 @@ Claude Code's Write-tool preflight tripping on a pre-existing
 - Never use `python3 -c` to write the message — literal `$(...)` in the body triggers command substitution warnings
 - Never use `git commit -m` with heredoc — the multi-line command fails permission pattern matching
 
-**Apply the write** to the final `.flow-commit-msg` path:
+Route the content to the final `.flow-commit-msg` path via
+`bin/flow write-rule`:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path <project_root>/.flow-commit-msg --content-file .flow-states/<branch>-commit-msg-content.md

--- a/skills/flow-commit/SKILL.md
+++ b/skills/flow-commit/SKILL.md
@@ -214,13 +214,28 @@ Display the full message under the heading **Commit Message**.
 
 Files are already staged from Round 3. No need to `git add -A` again.
 
-1. Use the Write tool to write the commit message to `.flow-commit-msg` in the project root.
-   - Each worktree has its own project root, so concurrent sessions don't collide
-   - The file is inside the project, so the Write tool has permission without prompting
-   - The Write tool handles newlines and special characters safely — no shell escaping needed
-   - Never write to `/tmp/` — paths outside the project trigger permission prompts that settings.json cannot suppress
-   - Never use `python3 -c` to write the message — literal `$(...)` in the body triggers command substitution warnings
-   - Never use `git commit -m` with heredoc — the multi-line command fails permission pattern matching
+**Compose the commit message.** Use the Write tool to write the message
+content to `.flow-states/<branch>-commit-msg-content.md` — a
+branch-scoped temp path, not the final `.flow-commit-msg`. This avoids
+Claude Code's Write-tool preflight tripping on a pre-existing
+`.flow-commit-msg` from a prior commit retry
+(see `.claude/rules/file-tool-preflights.md`).
+
+- The file is inside the project, so the Write tool has permission without prompting
+- The Write tool handles newlines and special characters safely — no shell escaping needed
+- Never write to `/tmp/` — paths outside the project trigger permission prompts that settings.json cannot suppress
+- Never use `python3 -c` to write the message — literal `$(...)` in the body triggers command substitution warnings
+- Never use `git commit -m` with heredoc — the multi-line command fails permission pattern matching
+
+**Apply the write** to the final `.flow-commit-msg` path:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path <project_root>/.flow-commit-msg --content-file .flow-states/<branch>-commit-msg-content.md
+```
+
+Each worktree has its own project root, so concurrent sessions don't
+collide. `finalize-commit` reads and deletes `.flow-commit-msg`
+unchanged by this routing.
 
 ### Round 6 — Finalize
 

--- a/skills/flow-learn/SKILL.md
+++ b/skills/flow-learn/SKILL.md
@@ -457,8 +457,16 @@ is insufficient.
 
 ### Filing process
 
-Write the issue body to `.flow-issue-body` in the project root using
-the Write tool, then file:
+Write the issue body to `.flow-states/<branch>-issue-body-content.md` using
+the Write tool, then route it to `.flow-issue-body` in the project root
+via `bin/flow write-rule` (avoids Claude Code's Write-tool preflight on a
+pre-existing body file — see `.claude/rules/file-tool-preflights.md`):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path <project_root>/.flow-issue-body --content-file .flow-states/<branch>-issue-body-content.md
+```
+
+Then file:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow issue --repo benkruger/flow --label "Flow" --title "<issue_title>" --body-file .flow-issue-body

--- a/skills/flow-orchestrate/SKILL.md
+++ b/skills/flow-orchestrate/SKILL.md
@@ -69,9 +69,19 @@ Stop.
 
 ## Step 2 — Initialize orchestration state
 
-Build the queue from the filtered issues. Sort by issue number ascending. Write the queue to a temporary file and create the orchestration state:
+Build the queue from the filtered issues. Sort by issue number ascending.
+`.flow-states/orchestrate-queue.json` is a machine-level singleton that
+may pre-exist from a prior orchestration; route the write through
+`bin/flow write-rule` so Claude Code's Write-tool preflight cannot fire
+(see `.claude/rules/file-tool-preflights.md`). Each item must have
+`issue_number` (integer) and `title` (string) fields.
 
-Write the queue JSON to `.flow-states/orchestrate-queue.json` using the Write tool. Each item must have `issue_number` (integer) and `title` (string) fields.
+Write the queue JSON to `.flow-states/orchestrate-queue-content.json`
+using the Write tool, then apply the write:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path .flow-states/orchestrate-queue.json --content-file .flow-states/orchestrate-queue-content.json
+```
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow orchestrate-state --create --queue-file .flow-states/orchestrate-queue.json --state-dir .flow-states

--- a/skills/flow-plan/SKILL.md
+++ b/skills/flow-plan/SKILL.md
@@ -170,7 +170,7 @@ issue body with a markdown heading and route it through `bin/flow write-rule`
 so Claude Code's Write-tool preflight cannot fire on a pre-existing DAG file
 (see `.claude/rules/file-tool-preflights.md`).
 
-**Write the content** to `.flow-states/<branch>-dag-content.md` using the Write tool, wrapped with a markdown heading:
+Write the wrapped content to `.flow-states/<branch>-dag-content.md` using the Write tool:
 
 ```text
 # Pre-Decomposed Analysis: <feature description>
@@ -178,13 +178,13 @@ so Claude Code's Write-tool preflight cannot fire on a pre-existing DAG file
 <issue body>
 ```
 
-**Apply the write** to the final DAG path:
+Then route it to the final DAG path via `bin/flow write-rule`:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path <project_root>/.flow-states/<branch>-dag.md --content-file .flow-states/<branch>-dag-content.md
 ```
 
-**Store the path** in the state file:
+Store the path in the state file:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set files.dag=<dag_file_path>
@@ -225,7 +225,7 @@ node-by-node reasoning, and a synthesis.
 
 After the decompose plugin returns, save the complete decompose output. The DAG file at `.flow-states/<branch>-dag.md` may pre-exist from a prior attempt, context compaction, or `--continue-step` re-entry, which would trip Claude Code's Write-tool preflight ("if this is an existing file, you MUST use the Read tool first"). Route the write through `bin/flow write-rule` — it does `fs::write` unconditionally in Rust so the preflight cannot fire. See `.claude/rules/file-tool-preflights.md`.
 
-**Capture the content.** Build the full content to write — the XML DAG plan, all node executions with quality scores, and the synthesis block exactly as the plugin produced it. Do not summarize, condense, reorganize, or rewrite any part of the decompose output. Wrap with a markdown heading:
+Build the full content to write — the XML DAG plan, all node executions with quality scores, and the synthesis block exactly as the plugin produced it. Do not summarize, condense, reorganize, or rewrite any part of the decompose output. Wrap with a markdown heading:
 
 ```text
 # DAG Analysis: <feature description>
@@ -233,15 +233,15 @@ After the decompose plugin returns, save the complete decompose output. The DAG 
 <complete output from decompose plugin>
 ```
 
-**Write the content** to `.flow-states/<branch>-dag-content.md` using the Write tool.
+Write the content to `.flow-states/<branch>-dag-content.md` using the Write tool.
 
-**Apply the write** to the final DAG path via `bin/flow write-rule`:
+Apply the write to the final DAG path via `bin/flow write-rule`:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path <project_root>/.flow-states/<branch>-dag.md --content-file .flow-states/<branch>-dag-content.md
 ```
 
-**Store the path** in the state file:
+Store the path in the state file:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set files.dag=<dag_file_path>

--- a/skills/flow-plan/SKILL.md
+++ b/skills/flow-plan/SKILL.md
@@ -165,9 +165,12 @@ the DAG file and plan file were already created by plan-extract — and the
 `## Implementation Plan` section.
 
 If the `issue_body` from plan-extract is non-null and represents an
-older-format decomposed issue (no Implementation Plan section), write the
-issue body to `<project_root>/.flow-states/<branch>-dag.md` using the
-Write tool, wrapped with a markdown heading:
+older-format decomposed issue (no Implementation Plan section), wrap the
+issue body with a markdown heading and route it through `bin/flow write-rule`
+so Claude Code's Write-tool preflight cannot fire on a pre-existing DAG file
+(see `.claude/rules/file-tool-preflights.md`).
+
+**Write the content** to `.flow-states/<branch>-dag-content.md` using the Write tool, wrapped with a markdown heading:
 
 ```text
 # Pre-Decomposed Analysis: <feature description>
@@ -175,7 +178,13 @@ Write tool, wrapped with a markdown heading:
 <issue body>
 ```
 
-Store the path in the state file:
+**Apply the write** to the final DAG path:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path <project_root>/.flow-states/<branch>-dag.md --content-file .flow-states/<branch>-dag-content.md
+```
+
+**Store the path** in the state file:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set files.dag=<dag_file_path>
@@ -214,23 +223,25 @@ The decompose plugin will produce structured DAG output:
 an impact preview, an XML DAG plan with nodes and dependencies,
 node-by-node reasoning, and a synthesis.
 
-After the decompose plugin returns, save the complete decompose output:
+After the decompose plugin returns, save the complete decompose output. The DAG file at `.flow-states/<branch>-dag.md` may pre-exist from a prior attempt, context compaction, or `--continue-step` re-entry, which would trip Claude Code's Write-tool preflight ("if this is an existing file, you MUST use the Read tool first"). Route the write through `bin/flow write-rule` — it does `fs::write` unconditionally in Rust so the preflight cannot fire. See `.claude/rules/file-tool-preflights.md`.
 
-1. Capture everything the decompose plugin produced — the XML DAG plan,
-   all node executions with quality scores, and the synthesis block.
-   Do not summarize, condense, reorganize, or rewrite any part of the
-   decompose output. The saved file must contain the full response
-   exactly as the plugin produced it.
-   Write it verbatim to `<project_root>/.flow-states/<branch>-dag.md`
-   using the Write tool, wrapped with a markdown heading:
+**Capture the content.** Build the full content to write — the XML DAG plan, all node executions with quality scores, and the synthesis block exactly as the plugin produced it. Do not summarize, condense, reorganize, or rewrite any part of the decompose output. Wrap with a markdown heading:
 
-   ```text
-   # DAG Analysis: <feature description>
+```text
+# DAG Analysis: <feature description>
 
-   <complete output from decompose plugin>
-   ```
+<complete output from decompose plugin>
+```
 
-2. Store the path in the state file:
+**Write the content** to `.flow-states/<branch>-dag-content.md` using the Write tool.
+
+**Apply the write** to the final DAG path via `bin/flow write-rule`:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path <project_root>/.flow-states/<branch>-dag.md --content-file .flow-states/<branch>-dag-content.md
+```
+
+**Store the path** in the state file:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set files.dag=<dag_file_path>
@@ -266,8 +277,14 @@ in the content.
 - Promote all headings by one level: `###` becomes `##`, `####` becomes
   `###`. This converts the issue's nested headings into the plan file's
   top-level structure.
-- Write the promoted content to
-  `<project_root>/.flow-states/<branch>-plan.md` using the Write tool.
+- Write the promoted content to `.flow-states/<branch>-plan-content.md`
+  using the Write tool, then route it to the final plan path via
+  `bin/flow write-rule` so the Write-tool preflight cannot fire on a
+  pre-existing plan file (see `.claude/rules/file-tool-preflights.md`):
+
+  ```bash
+  ${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path <project_root>/.flow-states/<branch>-plan.md --content-file .flow-states/<branch>-plan-content.md
+  ```
 - Light validation: use Glob and Read to verify that files referenced in
   the Tasks section exist. Note any missing files (they may need to be
   created by the implementation) but do not block or re-derive the plan.
@@ -573,9 +590,18 @@ Always include TDD order — test task before every implementation task.
 
 ### Plan file structure
 
-Write the plan file to `<project_root>/.flow-states/<branch>-plan.md`
-where `<branch>` is the feature branch name. This keeps the plan
-alongside other feature artifacts in `.flow-states/`.
+Write the plan to `.flow-states/<branch>-plan-content.md` using the
+Write tool, then route it to the final plan path at
+`<project_root>/.flow-states/<branch>-plan.md` via `bin/flow write-rule`
+so Claude Code's Write-tool preflight cannot fire on a pre-existing
+plan file (see `.claude/rules/file-tool-preflights.md`):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path <project_root>/.flow-states/<branch>-plan.md --content-file .flow-states/<branch>-plan-content.md
+```
+
+`<branch>` is the feature branch name. This keeps the plan alongside
+other feature artifacts in `.flow-states/`.
 
 The plan file should include these sections:
 
@@ -656,7 +682,11 @@ Parse the JSON output:
 - **If `"status": "error"`** — the response contains a `violations`
   array with `file`, `line`, `phrase`, `context`, and `rule` fields.
   Render the violations inline in your response so the user can see
-  each flagged phrase and which rule fired, then use the Edit tool
+  each flagged phrase and which rule fired. Use the Read tool on the
+  plan file at `.flow-states/<branch>-plan.md` first to satisfy Claude
+  Code's Edit-tool preflight ("You must use your Read tool at least
+  once in the conversation before editing" — see
+  `.claude/rules/file-tool-preflights.md`), then use the Edit tool
   on the plan file to fix each violation according to the cited
   `rule`:
   - **`rule: "scope-enumeration"`** — add a named list (inline

--- a/skills/flow-start/SKILL.md
+++ b/skills/flow-start/SKILL.md
@@ -208,8 +208,16 @@ Parse the JSON output and branch on `status`:
 File a "Flaky Test" issue with reproduction data from the `first_failure_output`
 and `attempts` fields, using the `flaky_context` field for the issue body context.
 
-Write the issue body to `.flow-issue-body` in the project root using the
-Write tool, then file:
+Write the issue body to `.flow-states/<branch>-issue-body-content.md` using
+the Write tool, then route it to `.flow-issue-body` in the project root
+via `bin/flow write-rule` (avoids Claude Code's Write-tool preflight on a
+pre-existing body file — see `.claude/rules/file-tool-preflights.md`):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow write-rule --path <project_root>/.flow-issue-body --content-file .flow-states/<branch>-issue-body-content.md
+```
+
+Then file:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow issue --label "Flaky Test" --title "<issue_title>" --body-file .flow-issue-body

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -3486,16 +3486,33 @@ fn phase_1_hard_gate_requires_rerun_with_arguments() {
 
 // --- File-tool preflight invariants ---
 //
-// Claude Code's Write tool and Edit tool each have a Read-first-in-session
-// preflight: Write errors when the target file already exists and has not
-// been Read in the conversation, and Edit errors when any edit is attempted
-// before a prior Read on the target. FLOW skills that write to persistent
-// branch-scoped or project-root paths must route those writes through the
-// `bin/flow write-rule` Rust subcommand — it does `fs::write` unconditionally
-// so the preflight cannot fire. Skills that instruct Edits against named
-// plan files must precede the Edit with an explicit Read-tool instruction so
-// the Edit preflight is satisfied even when the model has not naturally read
-// the file in the current turn.
+// Regression the two tests below guard:
+//   A SKILL.md instruction writes to (or edits) a file whose target may
+//   already exist on disk when the skill runs. Claude Code's Write tool
+//   and Edit tool each have a Read-first-in-session preflight — Write
+//   errors when the target exists and has not been Read, Edit errors
+//   when any edit is attempted before a prior Read. When the preflight
+//   fires mid-skill the tool call surfaces a user-visible error and the
+//   flow cannot continue until the model manually works around it.
+//
+// Code path that produces the regression:
+//   - Write side: a SKILL.md instructs the model to Write to one of the
+//     persistent monitored paths (plan/DAG file, commit-msg, issue-body,
+//     orchestrate queue) without first routing through the
+//     `bin/flow write-rule` subcommand, whose `fs::write` call bypasses
+//     the preflight.
+//   - Edit side: a SKILL.md instructs the model to Edit a named plan or
+//     DAG file without a preceding explicit Read-tool instruction on
+//     the same file in the same `### Step` block.
+//
+// Consumers:
+//   - Every FLOW skill that writes to `.flow-states/` or project-root
+//     persistent files (flow-plan, flow-commit, flow-start, flow-code,
+//     flow-learn, flow-orchestrate) relies on the Write-side invariant
+//     to not block mid-phase.
+//   - `flow-plan`'s plan-check fix loop relies on the Edit-side
+//     invariant so the Edit tool can open the plan on re-entry.
+//   - `.claude/rules/file-tool-preflights.md` authorizes the scans.
 
 /// Target paths whose Write-tool invocations must route through
 /// `bin/flow write-rule`.
@@ -3515,45 +3532,88 @@ const WRITE_MONITORED_PATHS: &[&str] = &[
     "orchestrate-queue.json",
 ];
 
-/// Non-blank lines of forward scan after a "using the Write tool"
-/// instruction to locate the matching `bin/flow write-rule` call. The
-/// window spans a few prose lines, a description of the content, and a
-/// following bash block — 30 lines covers the longest pattern in the
-/// corpus today.
+/// Non-blank lines of forward scan after a Write-tool instruction to
+/// locate the matching `bin/flow write-rule` call. The window spans a
+/// few prose lines, a description of the content, and a following bash
+/// block — 30 lines covers the longest pattern in the corpus today.
 const WRITE_RULE_FORWARD_WINDOW: usize = 30;
 
-/// Check whether a monitored literal path match has a following
-/// character that would extend it into a different (unmonitored) path.
+/// Check whether a monitored literal path match is bounded on BOTH sides
+/// so it is not embedded in a longer unrelated path.
 ///
-/// For literals like `.flow-issue-body`, a trailing `-` extends the path
-/// to `.flow-issue-body-<id>` which is session-scoped and out of scope.
-/// Paths ending in extensions (`.md`, `.json`) or containing placeholders
-/// (`<branch>`) are already unambiguous.
+/// - Prefix boundary: the byte before `start` must not be a character
+///   that would make the path a suffix of a longer path (e.g.
+///   `my-orchestrate-queue.json` must not match `orchestrate-queue.json`).
+/// - Suffix boundary: the byte after the match must not extend the path
+///   (e.g. `.flow-issue-body-<id>` is session-scoped, out of scope;
+///   `.flow-commit-msg.bak` is a different file). `.md` and `.json`
+///   suffixes are themselves terminating so the check short-circuits.
 fn write_path_is_bounded(haystack: &str, path: &str, start: usize) -> bool {
-    // Paths ending in a file extension are self-terminating.
+    let bytes = haystack.as_bytes();
+    // Prefix boundary check — reject if the byte before `start` extends
+    // the path (hyphen, dot, alnum, underscore).
+    if start > 0 {
+        let prev = bytes[start - 1];
+        if prev == b'-' || prev == b'.' || prev == b'_' || prev.is_ascii_alphanumeric() {
+            return false;
+        }
+    }
+    // Suffix boundary check — file-extension suffixes are self-
+    // terminating; otherwise reject byte-extensions into another path.
     if path.ends_with(".md") || path.ends_with(".json") {
         return true;
     }
     let end = start + path.len();
-    match haystack.as_bytes().get(end) {
+    match bytes.get(end) {
         Some(b) => {
-            // Word-boundary-ish: reject if the next byte is `-` or a
-            // path/word character that would extend the match.
             let c = *b;
-            !(c == b'-' || c.is_ascii_alphanumeric() || c == b'_')
+            !(c == b'-' || c == b'.' || c == b'_' || c.is_ascii_alphanumeric())
         }
         None => true,
     }
 }
 
+/// Tool-instruction verb vocabulary matching the curated-closed style of
+/// `.claude/rules/scope-enumeration.md`. Each verb below is a realistic
+/// phrasing a skill author might use ("using the Write tool", "invoke
+/// the Write tool", "call the Write tool", "run the Write tool"). Novel
+/// phrasings slip through intentionally — the rule file is the primary
+/// instrument; future reviewers add verbs here when a new false-negative
+/// is observed.
+const TOOL_VERB_PATTERN: &str = r"(?:us(?:e|ing)|invok(?:e|ing)|call(?:s|ing)?|run(?:s|ning)?)";
+
+/// Build the phrase-detection regex for a given tool name ("Write" or
+/// "Edit"). Matches, case-insensitive and with `\s+` absorbing newlines,
+/// any of the verb forms above followed by "the <Tool> tool".
+fn tool_phrase_regex(tool: &str) -> Regex {
+    let pattern = format!(r"(?si)\b{}\s+the\s+{}\s+tool", TOOL_VERB_PATTERN, tool);
+    Regex::new(&pattern).unwrap()
+}
+
+/// Walk forward-window lines and return true when any single line
+/// contains BOTH `bin/flow write-rule` AND the monitored path. Requiring
+/// co-occurrence on the same line closes the disconnected-substring
+/// bypass (a write-rule call targeting a DIFFERENT path plus an
+/// unrelated mention of the monitored path both present in the window
+/// without being wired together).
+fn forward_has_write_rule_line(
+    lines: &[&str],
+    start_idx: usize,
+    end_idx: usize,
+    path: &str,
+) -> bool {
+    let end = end_idx.min(lines.len());
+    for line in &lines[start_idx..end] {
+        if line.contains("bin/flow write-rule") && line.contains(path) {
+            return true;
+        }
+    }
+    false
+}
+
 #[test]
 fn file_tool_preflight_write_paths_route_through_write_rule() {
-    // Match Write-tool instructions in both phrasings: "using the
-    // Write tool" (passive) and "Use the Write tool" (imperative).
-    // The `(?s)` flag makes `.` match newlines; `\s+` absorbs one-or-
-    // more whitespace (including `\n`) so the phrase matches whether
-    // authored on one line or wrapped.
-    let phrase_re = Regex::new(r"(?si)\bus(?:e|ing)\s+the\s+Write\s+tool").unwrap();
+    let phrase_re = tool_phrase_regex("Write");
 
     let skills_dir = common::skills_dir();
     let files = common::collect_md_files(&skills_dir);
@@ -3566,14 +3626,13 @@ fn file_tool_preflight_write_paths_route_through_write_rule() {
         let lines: Vec<&str> = content.lines().collect();
 
         for m in phrase_re.find_iter(content) {
-            // Line number of the match start (1-based for human output).
             let line_num = content[..m.start()].matches('\n').count() + 1;
             let idx = line_num - 1;
 
             // Identify the monitored target by looking at a small window
             // around the instruction (3 lines back, current, plus next
             // two) because the target path is typically mentioned on the
-            // line right before "using the Write tool".
+            // line right before the Write-tool instruction.
             let start_back = idx.saturating_sub(3);
             let end_ctx = (idx + 3).min(lines.len());
             let surrounding = lines[start_back..end_ctx].join("\n");
@@ -3584,16 +3643,13 @@ fn file_tool_preflight_write_paths_route_through_write_rule() {
             });
             let Some(path) = matched_path else { continue };
 
-            // Check forward N lines for a `bin/flow write-rule` call
-            // that targets the same path. Both conditions required —
-            // a bare `bin/flow write-rule` pointing at some other path
-            // does not satisfy the preflight escape for THIS target.
-            let end_fwd = (idx + WRITE_RULE_FORWARD_WINDOW).min(lines.len());
-            let forward = lines[idx..end_fwd].join("\n");
-            let has_write_rule = forward.contains("bin/flow write-rule") && forward.contains(*path);
-            if !has_write_rule {
+            // Same-line co-occurrence of `bin/flow write-rule` + the
+            // path inside the forward window. See `forward_has_write_rule_line`
+            // for the rationale.
+            let end_fwd = idx + WRITE_RULE_FORWARD_WINDOW;
+            if !forward_has_write_rule_line(&lines, idx, end_fwd, path) {
                 violations.push(format!(
-                    "{}:{} — Write-tool instruction targets monitored path `{}` but no `bin/flow write-rule --path <...{}>` call follows within {} lines",
+                    "{}:{} — Write-tool instruction targets monitored path `{}` but no `bin/flow write-rule --path <...{}>` call on a single line follows within {} lines",
                     rel,
                     line_num,
                     path,
@@ -3623,18 +3679,44 @@ const EDIT_MONITORED_PATHS: &[&str] = &[
 ];
 
 /// Non-blank lines backward from an Edit-tool instruction to look for
-/// a paired Read-tool instruction on the same path. Six lines covers a
-/// short prose preamble without reaching the previous `### Step`.
+/// a paired Read-tool instruction on the same path. Twelve lines covers
+/// a short prose preamble plus an intervening bash fence. The scan
+/// stops at any `### Step N`, `### ` subsection, or `## Section`
+/// heading encountered during the walk so a Read in a prior step does
+/// not credit an Edit in a later step (a `--continue-step` re-entry
+/// would invalidate the prior Read).
 const EDIT_READ_BACKWARD_WINDOW: usize = 12;
+
+/// Walk backward from `idx` up to `window` non-blank lines, stopping at
+/// any Markdown heading line (`## ` or `### `). Returns the slice of
+/// lines between the first encountered boundary and `idx` (inclusive)
+/// as a joined string. Callers then scan the returned slice for a
+/// Read-tool instruction co-occurring with the monitored path on the
+/// SAME line.
+fn backward_read_window(lines: &[&str], idx: usize, window: usize) -> String {
+    let mut start = idx;
+    let mut taken = 0;
+    while start > 0 && taken < window {
+        start -= 1;
+        let trimmed = lines[start].trim_start();
+        if trimmed.starts_with("## ") || trimmed.starts_with("### ") {
+            // Include the heading itself for context, then stop.
+            break;
+        }
+        taken += 1;
+    }
+    lines[start..=idx.min(lines.len().saturating_sub(1))].join("\n")
+}
 
 #[test]
 fn file_tool_preflight_edit_paths_preceded_by_read() {
-    // Match Edit-tool instructions in both phrasings: "using the Edit
-    // tool" (passive) and "use the Edit tool" (imperative).
-    let phrase_re = Regex::new(r"(?si)\bus(?:e|ing)\s+the\s+Edit\s+tool").unwrap();
-    // Read-tool reference — either "Read tool" (noun) or "Read the"
-    // (imperative verb form on the same path).
-    let read_re = Regex::new(r"(?si)\bRead\s+(?:tool|the)").unwrap();
+    let phrase_re = tool_phrase_regex("Edit");
+    // Require an explicit Read-tool instruction ("use/using/invoke/
+    // invoking/call/run the Read tool"). Prose like "Read the plan"
+    // or "Read the current state" no longer counts — the preflight
+    // requires an actual Read tool call, and the scanner must match
+    // that discipline.
+    let read_re = tool_phrase_regex("Read");
 
     let skills_dir = common::skills_dir();
     let files = common::collect_md_files(&skills_dir);
@@ -3650,24 +3732,30 @@ fn file_tool_preflight_edit_paths_preceded_by_read() {
             let line_num = content[..m.start()].matches('\n').count() + 1;
             let idx = line_num - 1;
 
-            // Window around the instruction to find a monitored path.
+            // Window around the Edit instruction to find a monitored path.
             let start_back = idx.saturating_sub(3);
             let end_ctx = (idx + 3).min(lines.len());
             let surrounding = lines[start_back..end_ctx].join("\n");
-            let matched_path = EDIT_MONITORED_PATHS
-                .iter()
-                .find(|p| surrounding.contains(**p));
+            let matched_path = EDIT_MONITORED_PATHS.iter().find(|p| {
+                surrounding
+                    .match_indices(**p)
+                    .any(|(pos, _)| write_path_is_bounded(&surrounding, p, pos))
+            });
             let Some(path) = matched_path else { continue };
 
-            // Look backward for a Read-tool instruction on the same
-            // path. The Read instruction must mention both "Read" and
-            // the path within the backward window.
-            let read_start = idx.saturating_sub(EDIT_READ_BACKWARD_WINDOW);
-            let backward = lines[read_start..=idx.min(lines.len() - 1)].join("\n");
+            // Step-scoped backward window (stops at `### Step N` /
+            // `## Section` headings) so a Read in a prior step cannot
+            // credit an Edit in a later step.
+            let backward = backward_read_window(&lines, idx, EDIT_READ_BACKWARD_WINDOW);
+
+            // Require both the Read-tool phrase and the path somewhere
+            // in the window. Perfect same-line co-occurrence is too
+            // strict for Edit (skill authors often phrase the Read on
+            // one line and identify the path on an adjacent line).
             let has_read = read_re.is_match(&backward) && backward.contains(*path);
             if !has_read {
                 violations.push(format!(
-                    "{}:{} — Edit-tool instruction on monitored path `{}` but no `Read` of the same path in the preceding {} lines",
+                    "{}:{} — Edit-tool instruction on monitored path `{}` but no `Read` tool instruction on the same path in the preceding {} lines (scan stops at `## ` / `### ` headings)",
                     rel,
                     line_num,
                     path,

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -3483,3 +3483,203 @@ fn phase_1_hard_gate_requires_rerun_with_arguments() {
         );
     }
 }
+
+// --- File-tool preflight invariants ---
+//
+// Claude Code's Write tool and Edit tool each have a Read-first-in-session
+// preflight: Write errors when the target file already exists and has not
+// been Read in the conversation, and Edit errors when any edit is attempted
+// before a prior Read on the target. FLOW skills that write to persistent
+// branch-scoped or project-root paths must route those writes through the
+// `bin/flow write-rule` Rust subcommand — it does `fs::write` unconditionally
+// so the preflight cannot fire. Skills that instruct Edits against named
+// plan files must precede the Edit with an explicit Read-tool instruction so
+// the Edit preflight is satisfied even when the model has not naturally read
+// the file in the current turn.
+
+/// Target paths whose Write-tool invocations must route through
+/// `bin/flow write-rule`.
+///
+/// Branch-scoped and literal paths only. Session-scoped `-<id>` temp files
+/// used by `flow-create-issue` and `flow-decompose-project` are excluded
+/// because the unique id makes cross-invocation collision unlikely.
+/// Intermediate input files used BY `bin/flow write-rule` (e.g. paths
+/// ending in `-content.md` that the Rust code reads and deletes) are
+/// also not monitored — they are the Write-tool input, not a persistent
+/// target.
+const WRITE_MONITORED_PATHS: &[&str] = &[
+    ".flow-states/<branch>-dag.md",
+    ".flow-states/<branch>-plan.md",
+    ".flow-commit-msg",
+    ".flow-issue-body",
+    "orchestrate-queue.json",
+];
+
+/// Non-blank lines of forward scan after a "using the Write tool"
+/// instruction to locate the matching `bin/flow write-rule` call. The
+/// window spans a few prose lines, a description of the content, and a
+/// following bash block — 30 lines covers the longest pattern in the
+/// corpus today.
+const WRITE_RULE_FORWARD_WINDOW: usize = 30;
+
+/// Check whether a monitored literal path match has a following
+/// character that would extend it into a different (unmonitored) path.
+///
+/// For literals like `.flow-issue-body`, a trailing `-` extends the path
+/// to `.flow-issue-body-<id>` which is session-scoped and out of scope.
+/// Paths ending in extensions (`.md`, `.json`) or containing placeholders
+/// (`<branch>`) are already unambiguous.
+fn write_path_is_bounded(haystack: &str, path: &str, start: usize) -> bool {
+    // Paths ending in a file extension are self-terminating.
+    if path.ends_with(".md") || path.ends_with(".json") {
+        return true;
+    }
+    let end = start + path.len();
+    match haystack.as_bytes().get(end) {
+        Some(b) => {
+            // Word-boundary-ish: reject if the next byte is `-` or a
+            // path/word character that would extend the match.
+            let c = *b;
+            !(c == b'-' || c.is_ascii_alphanumeric() || c == b'_')
+        }
+        None => true,
+    }
+}
+
+#[test]
+fn file_tool_preflight_write_paths_route_through_write_rule() {
+    // Match Write-tool instructions in both phrasings: "using the
+    // Write tool" (passive) and "Use the Write tool" (imperative).
+    // The `(?s)` flag makes `.` match newlines; `\s+` absorbs one-or-
+    // more whitespace (including `\n`) so the phrase matches whether
+    // authored on one line or wrapped.
+    let phrase_re = Regex::new(r"(?si)\bus(?:e|ing)\s+the\s+Write\s+tool").unwrap();
+
+    let skills_dir = common::skills_dir();
+    let files = common::collect_md_files(&skills_dir);
+    let mut violations: Vec<String> = Vec::new();
+
+    for (rel, content) in &files {
+        if !rel.ends_with("SKILL.md") {
+            continue;
+        }
+        let lines: Vec<&str> = content.lines().collect();
+
+        for m in phrase_re.find_iter(content) {
+            // Line number of the match start (1-based for human output).
+            let line_num = content[..m.start()].matches('\n').count() + 1;
+            let idx = line_num - 1;
+
+            // Identify the monitored target by looking at a small window
+            // around the instruction (3 lines back, current, plus next
+            // two) because the target path is typically mentioned on the
+            // line right before "using the Write tool".
+            let start_back = idx.saturating_sub(3);
+            let end_ctx = (idx + 3).min(lines.len());
+            let surrounding = lines[start_back..end_ctx].join("\n");
+            let matched_path = WRITE_MONITORED_PATHS.iter().find(|p| {
+                surrounding
+                    .match_indices(**p)
+                    .any(|(pos, _)| write_path_is_bounded(&surrounding, p, pos))
+            });
+            let Some(path) = matched_path else { continue };
+
+            // Check forward N lines for a `bin/flow write-rule` call
+            // that targets the same path. Both conditions required —
+            // a bare `bin/flow write-rule` pointing at some other path
+            // does not satisfy the preflight escape for THIS target.
+            let end_fwd = (idx + WRITE_RULE_FORWARD_WINDOW).min(lines.len());
+            let forward = lines[idx..end_fwd].join("\n");
+            let has_write_rule = forward.contains("bin/flow write-rule") && forward.contains(*path);
+            if !has_write_rule {
+                violations.push(format!(
+                    "{}:{} — Write-tool instruction targets monitored path `{}` but no `bin/flow write-rule --path <...{}>` call follows within {} lines",
+                    rel,
+                    line_num,
+                    path,
+                    path,
+                    WRITE_RULE_FORWARD_WINDOW,
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "SKILL.md Write-tool instructions target paths that may pre-exist and trip Claude Code's Write preflight, but do not route through `bin/flow write-rule`. See `.claude/rules/file-tool-preflights.md`:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// Named plan-file paths whose Edit-tool invocations must be preceded
+/// by an explicit Read-tool instruction. The Edit tool's preflight
+/// ("You must use your Read tool at least once in the conversation
+/// before editing") fires when the model has not naturally Read the
+/// file in the current turn — for example, re-entering the plan-check
+/// fix loop after a `--continue-step` resume.
+const EDIT_MONITORED_PATHS: &[&str] = &[
+    ".flow-states/<branch>-plan.md",
+    ".flow-states/<branch>-dag.md",
+];
+
+/// Non-blank lines backward from an Edit-tool instruction to look for
+/// a paired Read-tool instruction on the same path. Six lines covers a
+/// short prose preamble without reaching the previous `### Step`.
+const EDIT_READ_BACKWARD_WINDOW: usize = 12;
+
+#[test]
+fn file_tool_preflight_edit_paths_preceded_by_read() {
+    // Match Edit-tool instructions in both phrasings: "using the Edit
+    // tool" (passive) and "use the Edit tool" (imperative).
+    let phrase_re = Regex::new(r"(?si)\bus(?:e|ing)\s+the\s+Edit\s+tool").unwrap();
+    // Read-tool reference — either "Read tool" (noun) or "Read the"
+    // (imperative verb form on the same path).
+    let read_re = Regex::new(r"(?si)\bRead\s+(?:tool|the)").unwrap();
+
+    let skills_dir = common::skills_dir();
+    let files = common::collect_md_files(&skills_dir);
+    let mut violations: Vec<String> = Vec::new();
+
+    for (rel, content) in &files {
+        if !rel.ends_with("SKILL.md") {
+            continue;
+        }
+        let lines: Vec<&str> = content.lines().collect();
+
+        for m in phrase_re.find_iter(content) {
+            let line_num = content[..m.start()].matches('\n').count() + 1;
+            let idx = line_num - 1;
+
+            // Window around the instruction to find a monitored path.
+            let start_back = idx.saturating_sub(3);
+            let end_ctx = (idx + 3).min(lines.len());
+            let surrounding = lines[start_back..end_ctx].join("\n");
+            let matched_path = EDIT_MONITORED_PATHS
+                .iter()
+                .find(|p| surrounding.contains(**p));
+            let Some(path) = matched_path else { continue };
+
+            // Look backward for a Read-tool instruction on the same
+            // path. The Read instruction must mention both "Read" and
+            // the path within the backward window.
+            let read_start = idx.saturating_sub(EDIT_READ_BACKWARD_WINDOW);
+            let backward = lines[read_start..=idx.min(lines.len() - 1)].join("\n");
+            let has_read = read_re.is_match(&backward) && backward.contains(*path);
+            if !has_read {
+                violations.push(format!(
+                    "{}:{} — Edit-tool instruction on monitored path `{}` but no `Read` of the same path in the preceding {} lines",
+                    rel,
+                    line_num,
+                    path,
+                    EDIT_READ_BACKWARD_WINDOW,
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "SKILL.md Edit-tool instructions on named plan/DAG files must be preceded by an explicit Read-tool instruction to satisfy Claude Code's Edit preflight. See `.claude/rules/file-tool-preflights.md`:\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
## What

fix issue: Route .flow-states/ Writes through write-rule; add Read-before-Edit preamble to plan-check loop #1209.

Closes #1209

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/route-flow-states-writes-through-plan.md` |
| DAG | `.flow-states/route-flow-states-writes-through-dag.md` |
| Log | `.flow-states/route-flow-states-writes-through.log` |
| State | `.flow-states/route-flow-states-writes-through.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/1bb583c5-0d8d-4125-ac2f-1dbe4fb54b28.jsonl` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
## Context

FLOW skills invoke Claude Code's Write and Edit tools on files under `.flow-states/<branch>-*` and adjacent project-root temp paths. Claude Code's Write tool has a preflight requiring Read-before-Write when the target exists; Edit has a similar Read-before-Edit preflight. When a skill instructs the model to Write a file that may pre-exist (resume, compaction, retry), the preflight trips with "Error writing file" — observed twice on 2026-04-16 in `flow-plan` Step 2 post-decompose. Goal: route `.flow-states/` Writes through the existing `bin/flow write-rule` Rust subcommand (which does `std::fs::write` unconditionally), and add a Read-before-Edit preamble to the one structurally-exposed Edit callsite. Guard both invariants with a single contract test.

## Exploration

**Write callsites in `skills/**/SKILL.md` (8+ in this bug class):**

- `flow-plan/SKILL.md:224–225` — post-decompose DAG Write (standard path)
- `flow-plan/SKILL.md:169–170` — older-format decomposed DAG Write
- `flow-plan/SKILL.md:269–270` — extracted path plan Write
- `flow-plan/SKILL.md:576` — standard path plan Write (prose reference)
- `flow-commit/SKILL.md:217` — `.flow-commit-msg` Write
- `flow-start/SKILL.md:211`, `flow-code/SKILL.md:386`, `flow-learn/SKILL.md:460` — `.flow-issue-body` Writes
- `flow-orchestrate/SKILL.md:74` — `orchestrate-queue.json` Write

**Edit callsites:**

- `flow-plan/SKILL.md:659` — plan-check fix loop (latent trap)
- `flow-complete/SKILL.md:233–234, 492–493` — merge conflict (already has explicit Read-before-Edit)

**Reference implementations:**

- `src/write_rule.rs` — existing `bin/flow write-rule --path <target> --content-file <temp>` command. Reads temp, `fs::write`s target unconditionally, deletes temp. No change required.
- `flow-learn/SKILL.md:307, 337` — existing skill-prose pattern for routing through `write-rule`: model Writes content to `.flow-states/<branch>-rule-content.md`, then calls `bin/flow write-rule --path <target> --content-file <temp>`.
- `flow-complete/SKILL.md:233` — explicit Read-before-Edit pattern to mirror.

**Contract-test host:** `tests/skill_contracts.rs` — existing glob-based skill-content scanner.

**Rule alignment files:**

- `.claude/rules/hook-vs-instruction.md` — mandates mechanical enforcement for user-visible cross-skill consequences.
- `.claude/rules/scope-expansion.md` — three conditions for combining fixes in one PR.
- `.claude/rules/tests-guard-real-regressions.md` — contract tests must guard named regressions.

## Risks

- **Contract-test pattern scope.** The test must detect Write-tool invocations on `.flow-states/<branch>-*` paths (and project-root temp paths `.flow-commit-msg`, `.flow-issue-body*`, `orchestrate-queue.json`) and assert each is routed through `bin/flow write-rule`. False positives could fire on legitimate bash blocks that mention the path in comments; the detection must fence on actual Write-tool prose (regex over "using the Write tool" adjacent to the path, not a raw path match). The Plan phase must enumerate the detection regex and the monitored-path allowlist.
- **Path heuristic boundary.** Scope the test to known targets (`.flow-states/<branch>-*` + the four project-root temp files) rather than wildcard the whole project root, to avoid catching CLAUDE.md or other intentional Writes.
- **Temp file pre-existence.** The `write-rule` approach still has the model Write content to a temp file (e.g., `.flow-states/<branch>-dag-content.md`) before invoking `bin/flow write-rule`. If that temp file pre-exists from a crashed prior run, the same preflight trips — but one tier deeper and easily recoverable (model Reads temp, overwrites). Risk is strictly smaller than today.
- **Contract-test text windows.** For the Edit preamble check, a "Read before Edit" assertion needs a text window (e.g., "within the same `### Step N` block"). Too narrow window false-positives; too wide under-enforces. Must verify the window with targeted test fixtures.
- **Heading-promotion drift.** The Implementation Plan uses `###` subsections which become `##` after `flow-plan` heading promotion. Tasks use `####` which become `###`. Verified by reading `src/plan_extract.rs::promote_headings`.

## Approach

**Two mechanisms, one PR, one contract test, one optional rule file.**

1. **Write-side route.** For each `.flow-states/<branch>-*` Write-tool callsite in SKILL.md, replace the "Write ... using the Write tool" prose block with the flow-learn-style pattern: Write content to `.flow-states/<branch>-<purpose>-content.md` via the Write tool, then call `bin/flow write-rule --path <project_root>/.flow-states/<branch>-<purpose>.md --content-file .flow-states/<branch>-<purpose>-content.md`. Follow with `set-timestamp --set files.dag=...` (or equivalent state field) where applicable. Use the worktree-absolute-path pattern from `.claude/rules/filing-issues.md` for temp paths during active flows.
2. **Edit-side preamble.** Before `skills/flow-plan/SKILL.md:659` plan-check fix-loop instruction, add explicit prose: "Use the Read tool on the plan file to ensure the Edit-tool preflight is satisfied, then use the Edit tool to fix each violation." Mirror `flow-complete/SKILL.md:233` phrasing style.
3. **Contract test** (`tests/skill_contracts.rs::test_file_tool_preflight_paths`): walk every SKILL.md; extract Write-tool prose callsites via regex `(?i)using\s+the\s+Write\s+tool`; for each, assert either (a) the adjacent target path is not in the monitored set (plan/DAG/issue-body/commit-msg/queue), or (b) a `bin/flow write-rule` invocation follows within the same step. Separately, assert that each explicit `use the Edit tool` instruction on a named `.flow-states/<branch>-*` or project-root plan file has a preceding Read-tool instruction within the same `### Step N` block. <!-- external-input-audit: not-a-tightening -->
4. **Optional rule file** (`.claude/rules/file-tool-preflights.md`): one-page rule codifying the class ("any Claude Code file-modifying tool with a Read-first-in-session preflight must be invoked on a file where the preflight is satisfied or bypassed"), the `write-rule` escape pattern, and the contract test as mechanical enforcement.

**TDD order.** For each SKILL.md change, write the contract test covering the callsite first (ensuring it fails on the pre-change content), then make the SKILL.md edit to pass.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add contract test for Write-side routing | test | — |
| 2. Add contract test for Edit-side Read-before-Edit preamble | test | — |
| 3. (Optional) Draft `.claude/rules/file-tool-preflights.md` | docs | — |
| 4. Route flow-plan DAG Writes (170, 224) through `write-rule` | implement | 1 |
| 5. Route flow-plan plan Write (269–270) through `write-rule` | implement | 1 |
| 6. Update flow-plan plan Write prose reference (576) | implement | 1 |
| 7. Route flow-commit `.flow-commit-msg` Write through `write-rule` | implement | 1 |
| 8. Route flow-start/flow-code/flow-learn `.flow-issue-body` Writes through `write-rule` | implement | 1 |
| 9. Route flow-orchestrate queue Write through `write-rule` | implement | 1 |
| 10. Add Read-before-Edit preamble to flow-plan:659 | implement | 2 |
| 11. Run `bin/flow ci`; fix any cascading contract-test failures | validate | 4,5,6,7,8,9,10 |
| 12. Verify end-to-end with QA flow or real `/flow:flow-plan` invocation | validate | 11 |

## Tasks

### Task 1: Contract test — Write-tool callsites route through `bin/flow write-rule`
- File: `tests/skill_contracts.rs`
- Content: new test function scanning every SKILL.md; for each "using the Write tool" invocation adjacent to a monitored path (`.flow-states/<branch>-*`, `.flow-commit-msg`, `.flow-issue-body*`, `orchestrate-queue.json`), assert a `bin/flow write-rule` call follows within the same `### Step N` block (or same `## Section` for top-level steps).
- TDD note: fixture SKILL.md with a bare Write-to-state-path block must cause the test to fail; a SKILL.md routing through `write-rule` must pass.

### Task 2: Contract test — Edit-tool callsites are preceded by Read
- File: `tests/skill_contracts.rs`
- Content: new assertion in the same (or sibling) test function; for every "use the Edit tool" instruction adjacent to a named `.flow-states/<branch>-*` path or to a named plan file, assert a Read-tool instruction on the same path appears earlier in the same `### Step N` block.
- TDD note: fixture SKILL.md with Edit lacking Read must fail; one with Read-then-Edit must pass.

### Task 3 (optional): Draft `.claude/rules/file-tool-preflights.md`
- File: `.claude/rules/file-tool-preflights.md`
- Content: codify the class (Write + Edit preflights), the `write-rule` escape pattern, the Read-before-Edit pattern, and a pointer to the contract test.
- TDD note: no test; prose rule file referenced by contract-test failure messages.

### Task 4: Route flow-plan DAG Writes through `write-rule`
- File: `skills/flow-plan/SKILL.md`
- Change: replace the post-decompose DAG Write (224–231) and the older-format DAG Write (169–184) with flow-learn-style two-step pattern (Write temp, call `bin/flow write-rule`).
- TDD note: Task 1 test must now pass for flow-plan DAG callsites.

### Task 5: Route flow-plan plan Write (extracted path) through `write-rule`
- File: `skills/flow-plan/SKILL.md`
- Change: same transformation for the extracted-path plan Write at 269–270.
- TDD note: Task 1 passes for extracted-path plan Write.

### Task 6: Update flow-plan standard-path plan Write reference (line 576)
- File: `skills/flow-plan/SKILL.md`
- Change: update the line-576 prose to describe Write-via-`write-rule` rather than direct Write.
- TDD note: Task 1 scanner treats the prose reference consistently (or the directive is removed from the scan's monitored set with rationale).

### Task 7: Route flow-commit `.flow-commit-msg` Write through `write-rule`
- File: `skills/flow-commit/SKILL.md`
- Change: transform the Write at line 217 using the two-step pattern. Ensure existing flow (finalize-commit reads the message file) still works — `write-rule` writes the final `.flow-commit-msg`, finalize-commit reads and deletes as before.
- TDD note: Task 1 passes for flow-commit.

### Task 8: Route `.flow-issue-body` Writes through `write-rule`
- Files: `skills/flow-start/SKILL.md:211`, `skills/flow-code/SKILL.md:386`, `skills/flow-learn/SKILL.md:460`
- Change: transform each Write to use the two-step pattern. `bin/flow issue` reads `.flow-issue-body` by the same path, so `write-rule --path <project_root>/.flow-issue-body` produces the same on-disk artifact.
- TDD note: Task 1 passes for all three callsites.

### Task 9: Route flow-orchestrate queue Write through `write-rule`
- File: `skills/flow-orchestrate/SKILL.md`
- Change: transform line-74 Write with the two-step pattern.
- TDD note: Task 1 passes for flow-orchestrate.

### Task 10: Add Read-before-Edit preamble to flow-plan plan-check loop
- File: `skills/flow-plan/SKILL.md:658–689`
- Change: before "use the Edit tool on the plan file to fix each violation," insert: "Use the Read tool on the plan file first to satisfy the Edit-tool preflight, then use the Edit tool..." Mirror `flow-complete/SKILL.md:233` phrasing.
- TDD note: Task 2 passes.

### Task 11: Validate `bin/flow ci` passes
- Change: run the full CI gate.
- TDD note: any cascading contract-test failure is a real finding to address in the same PR.

### Task 12: Validate end-to-end with real flow or QA fixture
- Change: invoke `/flow-qa` or run `/flow:flow-plan` in a worktree where the DAG file exists; verify Step 2 completes with no "Error writing file" event.
- TDD note: evidence captured in PR description.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: Route .flow-states/ Writes through write-rule; add Read-before-Edit preamble to plan-check loop

## Problem

The Claude Code Write tool's preflight check — "if this is an existing file, you MUST use the Read tool first" — trips in FLOW skills when a `.flow-states/<branch>-*` file already exists at Write time. Two incidents observed on 2026-04-16:

- Flow `100-coverage-start-family`: `Write(~/code/flow/.flow-states/100-coverage-start-family-dag.md)` → **Error writing file**. Recovered via Grep/Read of the existing file, then proceeded. Recovery took ~10 minutes of model "deliberating" turns.
- Flow `100-coverage-mainrs-cli-dispatch`: `Write(~/code/flow/.flow-states/100-coverage-mainrs-cli-dispatch-dag.md)` → **Error writing file**. Same recovery pattern, ~12 minutes.

Both recovered by luck — the prior failed/partial Write had left correct bytes on disk, so the model's fallback (Read the file, proceed to Step 3 with its content) produced the right result. Under different timing (interrupted mid-Write, different content than the decompose re-run produced), recovery would have kept stale or truncated content.

**Root cause.** `skills/flow-plan/SKILL.md:224–231` (Step 2 Standard DAG decomposition, post-decompose) instructs the model: "Write it verbatim to `<project_root>/.flow-states/<branch>-dag.md` using the Write tool." The DAG file can pre-exist because of:

1. A prior decompose run in the same session wrote the file successfully before the model re-ran decompose or re-entered Step 2.
2. The `--continue-step` self-invocation re-enters the skill; prior Write's Read-tracking may not survive the reinvocation context.
3. Context compaction during the long decompose run drops Read-tracking.
4. An aborted earlier session left the file.

**Broader bug class.** Write-tool preflight affects every SKILL.md bash block that Writes a file that may pre-exist. Grep of `skills/**/SKILL.md` reveals 8+ callsites in this class:

| Skill:line | Target | Pre-exists because |
|---|---|---|
| flow-plan:224 | `<branch>-dag.md` (standard path) | resume/compaction/retry |
| flow-plan:170 | `<branch>-dag.md` (older-format decomposed) | same |
| flow-plan:270 | `<branch>-plan.md` (extracted path) | plan-check fix loop / dag_file resume |
| flow-plan:576 | `<branch>-plan.md` (standard path) | dag_file resume entry |
| flow-commit:217 | `.flow-commit-msg` | commit retry iterations |
| flow-start:211, flow-code:386, flow-learn:460 | `.flow-issue-body` | multiple issues per flow |
| flow-orchestrate:74 | `orchestrate-queue.json` | machine-level singleton |

**Sibling gap — Edit tool.** Claude Code's Edit tool has the same preflight shape ("You must use your Read tool at least once in the conversation before editing"). Grep of `skills/**/SKILL.md` for explicit Edit-tool instructions reveals:

- `flow-plan:659` (plan-check fix loop) — **latent trap**: the plan file was just Written in Step 3; if the model skips a natural Read and goes straight to Edit after plan-check returns violations, preflight trips. No incidents observed but the structural risk exists.
- `flow-complete:234, 493` (merge conflict resolution) — **already safe**: skill prescribes Read-before-Edit explicitly.
- `flow-code` / `flow-code-review` implicit Edits — **workflow-naturally safe**: model must Read to construct `old_string`.

**Solution.** Two mechanisms, one PR, one contract test:

1. **Write side (the observed bug)**: route every `.flow-states/<branch>-*` Write in SKILL.md through the existing `bin/flow write-rule --path <target> --content-file <temp>` subcommand (`src/write_rule.rs`). `write-rule` does `std::fs::write` unconditionally in Rust, bypassing Claude Code's Write-tool preflight. Already used by flow-learn for CLAUDE.md/rules writes — this is the FLOW-sanctioned Claude-Code-Write-preflight escape.
2. **Edit side (the latent gap)**: add a Read-before-Edit preamble to `skills/flow-plan/SKILL.md:659` plan-check fix loop. No new subcommand (Edit's `old_string` semantics already push Read naturally; full Rust subcommand would be speculative per `.claude/rules/tests-guard-real-regressions.md`).
3. **Unified guard**: one contract test in `tests/skill_contracts.rs` asserting both invariants. Test phrased around the class, not enumerated tools, so NotebookEdit/MultiEdit inherit the rule if FLOW ever adopts them.
4. **Optional rule file**: `.claude/rules/file-tool-preflights.md` codifying the class and pointing at the contract test.

## Acceptance Criteria

1. Every `.flow-states/<branch>-*` Write-tool invocation in `skills/**/SKILL.md` is either replaced with a `bin/flow write-rule` call or preceded by an explicit Read-tool instruction within the same step.
2. `skills/flow-plan/SKILL.md:659` plan-check fix loop includes a Read-tool instruction on the plan file before the Edit-tool instruction.
3. A new contract test in `tests/skill_contracts.rs` fails if any SKILL.md bash block Writes to a `.flow-states/<branch>-*` path without routing through `bin/flow write-rule`.
4. The same contract test fails if any SKILL.md instruction to Edit a named `.flow-states/<branch>-*` file is not preceded by a Read instruction on the same file within a configurable prose window.
5. `bin/flow ci` passes on the change.
6. No runtime behavior change — the diff is prose + test only (plus optional rule file).
7. Re-running flow `/flow:flow-plan` on an issue whose DAG file already exists completes Step 2 with no "Error writing file" event in the conversation.

## Implementation Plan

### Context

FLOW skills invoke Claude Code's Write and Edit tools on files under `.flow-states/<branch>-*` and adjacent project-root temp paths. Claude Code's Write tool has a preflight requiring Read-before-Write when the target exists; Edit has a similar Read-before-Edit preflight. When a skill instructs the model to Write a file that may pre-exist (resume, compaction, retry), the preflight trips with "Error writing file" — observed twice on 2026-04-16 in `flow-plan` Step 2 post-decompose. Goal: route `.flow-states/` Writes through the existing `bin/flow write-rule` Rust subcommand (which does `std::fs::write` unconditionally), and add a Read-before-Edit preamble to the one structurally-exposed Edit callsite. Guard both invariants with a single contract test.

### Exploration

**Write callsites in `skills/**/SKILL.md` (8+ in this bug class):**

- `flow-plan/SKILL.md:224–225` — post-decompose DAG Write (standard path)
- `flow-plan/SKILL.md:169–170` — older-format decomposed DAG Write
- `flow-plan/SKILL.md:269–270` — extracted path plan Write
- `flow-plan/SKILL.md:576` — standard path plan Write (prose reference)
- `flow-commit/SKILL.md:217` — `.flow-commit-msg` Write
- `flow-start/SKILL.md:211`, `flow-code/SKILL.md:386`, `flow-learn/SKILL.md:460` — `.flow-issue-body` Writes
- `flow-orchestrate/SKILL.md:74` — `orchestrate-queue.json` Write

**Edit callsites:**

- `flow-plan/SKILL.md:659` — plan-check fix loop (latent trap)
- `flow-complete/SKILL.md:233–234, 492–493` — merge conflict (already has explicit Read-before-Edit)

**Reference implementations:**

- `src/write_rule.rs` — existing `bin/flow write-rule --path <target> --content-file <temp>` command. Reads temp, `fs::write`s target unconditionally, deletes temp. No change required.
- `flow-learn/SKILL.md:307, 337` — existing skill-prose pattern for routing through `write-rule`: model Writes content to `.flow-states/<branch>-rule-content.md`, then calls `bin/flow write-rule --path <target> --content-file <temp>`.
- `flow-complete/SKILL.md:233` — explicit Read-before-Edit pattern to mirror.

**Contract-test host:** `tests/skill_contracts.rs` — existing glob-based skill-content scanner.

**Rule alignment files:**

- `.claude/rules/hook-vs-instruction.md` — mandates mechanical enforcement for user-visible cross-skill consequences.
- `.claude/rules/scope-expansion.md` — three conditions for combining fixes in one PR.
- `.claude/rules/tests-guard-real-regressions.md` — contract tests must guard named regressions.

### Risks

- **Contract-test pattern scope.** The test must detect Write-tool invocations on `.flow-states/<branch>-*` paths (and project-root temp paths `.flow-commit-msg`, `.flow-issue-body*`, `orchestrate-queue.json`) and assert each is routed through `bin/flow write-rule`. False positives could fire on legitimate bash blocks that mention the path in comments; the detection must fence on actual Write-tool prose (regex over "using the Write tool" adjacent to the path, not a raw path match). The Plan phase must enumerate the detection regex and the monitored-path allowlist.
- **Path heuristic boundary.** Scope the test to known targets (`.flow-states/<branch>-*` + the four project-root temp files) rather than wildcard the whole project root, to avoid catching CLAUDE.md or other intentional Writes.
- **Temp file pre-existence.** The `write-rule` approach still has the model Write content to a temp file (e.g., `.flow-states/<branch>-dag-content.md`) before invoking `bin/flow write-rule`. If that temp file pre-exists from a crashed prior run, the same preflight trips — but one tier deeper and easily recoverable (model Reads temp, overwrites). Risk is strictly smaller than today.
- **Contract-test text windows.** For the Edit preamble check, a "Read before Edit" assertion needs a text window (e.g., "within the same `### Step N` block"). Too narrow window false-positives; too wide under-enforces. Must verify the window with targeted test fixtures.
- **Heading-promotion drift.** The Implementation Plan uses `###` subsections which become `##` after `flow-plan` heading promotion. Tasks use `####` which become `###`. Verified by reading `src/plan_extract.rs::promote_headings`.

### Approach

**Two mechanisms, one PR, one contract test, one optional rule file.**

1. **Write-side route.** For each `.flow-states/<branch>-*` Write-tool callsite in SKILL.md, replace the "Write ... using the Write tool" prose block with the flow-learn-style pattern: Write content to `.flow-states/<branch>-<purpose>-content.md` via the Write tool, then call `bin/flow write-rule --path <project_root>/.flow-states/<branch>-<purpose>.md --content-file .flow-states/<branch>-<purpose>-content.md`. Follow with `set-timestamp --set files.dag=...` (or equivalent state field) where applicable. Use the worktree-absolute-path pattern from `.claude/rules/filing-issues.md` for temp paths during active flows.
2. **Edit-side preamble.** Before `skills/flow-plan/SKILL.md:659` plan-check fix-loop instruction, add explicit prose: "Use the Read tool on the plan file to ensure the Edit-tool preflight is satisfied, then use the Edit tool to fix each violation." Mirror `flow-complete/SKILL.md:233` phrasing style.
3. **Contract test** (`tests/skill_contracts.rs::test_file_tool_preflight_paths`): walk every SKILL.md; extract Write-tool prose callsites via regex `(?i)using\s+the\s+Write\s+tool`; for each, assert either (a) the adjacent target path is not in the monitored set (plan/DAG/issue-body/commit-msg/queue), or (b) a `bin/flow write-rule` invocation follows within the same step. Separately, assert that each explicit `use the Edit tool` instruction on a named `.flow-states/<branch>-*` or project-root plan file has a preceding Read-tool instruction within the same `### Step N` block.
4. **Optional rule file** (`.claude/rules/file-tool-preflights.md`): one-page rule codifying the class ("any Claude Code file-modifying tool with a Read-first-in-session preflight must be invoked on a file where the preflight is satisfied or bypassed"), the `write-rule` escape pattern, and the contract test as mechanical enforcement.

**TDD order.** For each SKILL.md change, write the contract test covering the callsite first (ensuring it fails on the pre-change content), then make the SKILL.md edit to pass.

### Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Add contract test for Write-side routing | test | — |
| 2. Add contract test for Edit-side Read-before-Edit preamble | test | — |
| 3. (Optional) Draft `.claude/rules/file-tool-preflights.md` | docs | — |
| 4. Route flow-plan DAG Writes (170, 224) through `write-rule` | implement | 1 |
| 5. Route flow-plan plan Write (269–270) through `write-rule` | implement | 1 |
| 6. Update flow-plan plan Write prose reference (576) | implement | 1 |
| 7. Route flow-commit `.flow-commit-msg` Write through `write-rule` | implement | 1 |
| 8. Route flow-start/flow-code/flow-learn `.flow-issue-body` Writes through `write-rule` | implement | 1 |
| 9. Route flow-orchestrate queue Write through `write-rule` | implement | 1 |
| 10. Add Read-before-Edit preamble to flow-plan:659 | implement | 2 |
| 11. Run `bin/flow ci`; fix any cascading contract-test failures | validate | 4,5,6,7,8,9,10 |
| 12. Verify end-to-end with QA flow or real `/flow:flow-plan` invocation | validate | 11 |

### Tasks

#### Task 1: Contract test — Write-tool callsites route through `bin/flow write-rule`
- File: `tests/skill_contracts.rs`
- Content: new test function scanning every SKILL.md; for each "using the Write tool" invocation adjacent to a monitored path (`.flow-states/<branch>-*`, `.flow-commit-msg`, `.flow-issue-body*`, `orchestrate-queue.json`), assert a `bin/flow write-rule` call follows within the same `### Step N` block (or same `## Section` for top-level steps).
- TDD note: fixture SKILL.md with a bare Write-to-state-path block must cause the test to fail; a SKILL.md routing through `write-rule` must pass.

#### Task 2: Contract test — Edit-tool callsites are preceded by Read
- File: `tests/skill_contracts.rs`
- Content: new assertion in the same (or sibling) test function; for every "use the Edit tool" instruction adjacent to a named `.flow-states/<branch>-*` path or to a named plan file, assert a Read-tool instruction on the same path appears earlier in the same `### Step N` block.
- TDD note: fixture SKILL.md with Edit lacking Read must fail; one with Read-then-Edit must pass.

#### Task 3 (optional): Draft `.claude/rules/file-tool-preflights.md`
- File: `.claude/rules/file-tool-preflights.md`
- Content: codify the class (Write + Edit preflights), the `write-rule` escape pattern, the Read-before-Edit pattern, and a pointer to the contract test.
- TDD note: no test; prose rule file referenced by contract-test failure messages.

#### Task 4: Route flow-plan DAG Writes through `write-rule`
- File: `skills/flow-plan/SKILL.md`
- Change: replace the post-decompose DAG Write (224–231) and the older-format DAG Write (169–184) with flow-learn-style two-step pattern (Write temp, call `bin/flow write-rule`).
- TDD note: Task 1 test must now pass for flow-plan DAG callsites.

#### Task 5: Route flow-plan plan Write (extracted path) through `write-rule`
- File: `skills/flow-plan/SKILL.md`
- Change: same transformation for the extracted-path plan Write at 269–270.
- TDD note: Task 1 passes for extracted-path plan Write.

#### Task 6: Update flow-plan standard-path plan Write reference (line 576)
- File: `skills/flow-plan/SKILL.md`
- Change: update the line-576 prose to describe Write-via-`write-rule` rather than direct Write.
- TDD note: Task 1 scanner treats the prose reference consistently (or the directive is removed from the scan's monitored set with rationale).

#### Task 7: Route flow-commit `.flow-commit-msg` Write through `write-rule`
- File: `skills/flow-commit/SKILL.md`
- Change: transform the Write at line 217 using the two-step pattern. Ensure existing flow (finalize-commit reads the message file) still works — `write-rule` writes the final `.flow-commit-msg`, finalize-commit reads and deletes as before.
- TDD note: Task 1 passes for flow-commit.

#### Task 8: Route `.flow-issue-body` Writes through `write-rule`
- Files: `skills/flow-start/SKILL.md:211`, `skills/flow-code/SKILL.md:386`, `skills/flow-learn/SKILL.md:460`
- Change: transform each Write to use the two-step pattern. `bin/flow issue` reads `.flow-issue-body` by the same path, so `write-rule --path <project_root>/.flow-issue-body` produces the same on-disk artifact.
- TDD note: Task 1 passes for all three callsites.

#### Task 9: Route flow-orchestrate queue Write through `write-rule`
- File: `skills/flow-orchestrate/SKILL.md`
- Change: transform line-74 Write with the two-step pattern.
- TDD note: Task 1 passes for flow-orchestrate.

#### Task 10: Add Read-before-Edit preamble to flow-plan plan-check loop
- File: `skills/flow-plan/SKILL.md:658–689`
- Change: before "use the Edit tool on the plan file to fix each violation," insert: "Use the Read tool on the plan file first to satisfy the Edit-tool preflight, then use the Edit tool..." Mirror `flow-complete/SKILL.md:233` phrasing.
- TDD note: Task 2 passes.

#### Task 11: Validate `bin/flow ci` passes
- Change: run the full CI gate.
- TDD note: any cascading contract-test failure is a real finding to address in the same PR.

#### Task 12: Validate end-to-end with real flow or QA fixture
- Change: invoke `/flow-qa` or run `/flow:flow-plan` in a worktree where the DAG file exists; verify Step 2 completes with no "Error writing file" event.
- TDD note: evidence captured in PR description.

## Files to Investigate

- `skills/flow-plan/SKILL.md` — two Write callsites (lines 169–170, 224–225), two more plan-file Writes (lines 269–270, 576), one Edit callsite (line 659). The most changes in any one file.
- `skills/flow-commit/SKILL.md:217` — `.flow-commit-msg` Write target.
- `skills/flow-start/SKILL.md:211`, `skills/flow-code/SKILL.md:386`, `skills/flow-learn/SKILL.md:460` — `.flow-issue-body` Writes.
- `skills/flow-orchestrate/SKILL.md:74` — `orchestrate-queue.json` Write.
- `src/write_rule.rs` — reference implementation of the escape hatch. No change expected; the subcommand is reused as-is.
- `skills/flow-learn/SKILL.md:307, 337` — already routes through `write-rule` for rule content; reference pattern for the skill prose shape.
- `tests/skill_contracts.rs` — home for the new contract test.
- `.claude/rules/hook-vs-instruction.md`, `.claude/rules/scope-expansion.md`, `.claude/rules/tests-guard-real-regressions.md` — rules the fix aligns with; cited in plan prose.
- `skills/flow-complete/SKILL.md:233` — reference pattern for explicit Read-before-Edit instruction.

## Out of Scope

- NotebookEdit / MultiEdit — not used in any FLOW skill today; the contract test phrasing will inherit them for free if FLOW ever adopts them, but no preemptive changes.
- Implicit Edit-tool usage in `flow-code` and `flow-code-review` source edits — workflow-naturally Read-first by virtue of the Edit tool's `old_string` requirement. No changes.
- A new `bin/flow apply-edit` subcommand — speculative per `.claude/rules/tests-guard-real-regressions.md`; Edit's `old_string` semantics are a structural Read-backstop.
- Fixing the existing DAG/plan files already on disk for flows `100-coverage-start-family` and `100-coverage-mainrs-cli-dispatch` — both flows recovered correctly; file contents are valid decompose output. No data fix needed.
- Retroactive correction of historical incidents' log entries — the observed failures were end-user-visible but not data-corrupting. No post-hoc log work.
- Expanding the rule to non-FLOW skills in the target project — scope is the FLOW plugin repo only.

## Context

**Incidents.** Two Write failures observed 2026-04-16 during Phase 2 (Plan) across flows `100-coverage-start-family` and `100-coverage-mainrs-cli-dispatch`. Both flows recovered — start-family transitioned to Phase 3 (Code) with 18 tasks; mainrs-cli-dispatch reached plan_step=4 with both DAG (307 lines) and plan (889 lines) files correctly populated. Recovery time: 10–12 minutes of model deliberation each. Under less forgiving timing (mid-Write interruption, different decompose output on retry) recovery would have kept wrong content.

**Design alignment.**
- `.claude/rules/hook-vs-instruction.md`: user-visible + cross-skill + universal consequence ⇒ mechanical enforcement, not advisory prose. The `write-rule` route is the mechanical path; a Read-before-Write instruction alone is the advisory path the rule explicitly warns against.
- `.claude/rules/scope-expansion.md`: all three conditions hold for combining Write + Edit + contract test into one PR — fixes are inert (prose/test only), a single contract test covers the class forward, splitting would re-do the codebase sweep.
- `.claude/rules/tests-guard-real-regressions.md`: the Write guard is a real-regression guard (two observed incidents); the Edit prose-plus-test is a narrow-risk guard on the one structurally-exposed callsite, not a speculative scan.

**Existing reference pattern.** `bin/flow write-rule --path <target> --content-file <temp>` already exists (`src/write_rule.rs`) and is used by `flow-learn` for `.claude/` writes. The skill pattern is: model Writes content to a temp file at `.flow-states/<branch>-rule-content.md`, calls `bin/flow write-rule --path <target> --content-file <temp>`, and the Rust code reads the temp, writes the target unconditionally, deletes the temp. Adapting this pattern to `.flow-states/<branch>-*` targets is strictly reuse — no new Rust surface area.

**Boundary.** The rule is "any Claude Code file-modifying tool with a Read-first-in-session preflight must be invoked on a file where the preflight is satisfied or bypassed." Today that means Write and Edit. If Claude Code adds a new tool in this class, the rule applies.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 1m |
| Plan | <1m |
| Code | 58m |
| Code Review | 25m |
| Learn | 5m |
| Complete | <1m |
| **Total** | **1h 31m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/route-flow-states-writes-through.json</summary>

```json
{
  "schema_version": 1,
  "branch": "route-flow-states-writes-through",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1210,
  "pr_url": "https://github.com/benkruger/flow/pull/1210",
  "started_at": "2026-04-16T16:53:28-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/route-flow-states-writes-through-plan.md",
    "dag": ".flow-states/route-flow-states-writes-through-dag.md",
    "log": ".flow-states/route-flow-states-writes-through.log",
    "state": ".flow-states/route-flow-states-writes-through.json"
  },
  "session_tty": "/dev/ttys007",
  "session_id": "1bb583c5-0d8d-4125-ac2f-1dbe4fb54b28",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/1bb583c5-0d8d-4125-ac2f-1dbe4fb54b28.jsonl",
  "notes": [],
  "prompt": "fix issue: Route .flow-states/ Writes through write-rule; add Read-before-Edit preamble to plan-check loop #1209",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-16T16:53:28-07:00",
      "completed_at": "2026-04-16T16:54:33-07:00",
      "session_started_at": null,
      "cumulative_seconds": 65,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-04-16T16:54:48-07:00",
      "completed_at": "2026-04-16T16:55:33-07:00",
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 2
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-04-16T16:57:14-07:00",
      "completed_at": "2026-04-16T17:55:58-07:00",
      "session_started_at": null,
      "cumulative_seconds": 3524,
      "visit_count": 1
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-04-16T17:56:12-07:00",
      "completed_at": "2026-04-16T18:22:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1553,
      "visit_count": 1
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-04-16T18:22:21-07:00",
      "completed_at": "2026-04-16T18:27:47-07:00",
      "session_started_at": null,
      "cumulative_seconds": 326,
      "visit_count": 1
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-04-16T18:28:01-07:00",
      "completed_at": "2026-04-16T18:28:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 19,
      "visit_count": 1
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-16T16:54:48-07:00"
    },
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-16T16:55:33-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-04-16T16:57:14-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-04-16T17:56:12-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-04-16T18:22:21-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-04-16T18:28:01-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 3,
  "code_tasks_total": 12,
  "code_task_name": "Route .flow-states/ Writes through write-rule; add Read-before-Edit preamble to plan-check loop",
  "diff_stats": {
    "files_changed": 8,
    "insertions": 444,
    "deletions": 38,
    "captured_at": "2026-04-16T17:55:58-07:00"
  },
  "code_task": 12,
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "compact_summary": "<analysis>\nThe user has provided a detailed learning analysis prompt requesting a compliance audit and process analysis of PR #1210 in the FLOW plugin repository. The prompt contains:\n\n1. An extensive system context (approximately 180KB) including:\n   - Project-level CLAUDE.md rules\n   - 50+ detailed rule files covering architectural patterns, security, testing, git operations, etc.\n   - State file data showing a completed flow (all phases \"complete\" except Learn which is \"in_progress\")\n   - A plan file describing the feature to route .flow-states/ Writes through write-rule\n   - A log file showing the session's execution path\n   - Two commits: 9ad8954d (initial implementation) and 6564495b (Code Review fixes)\n\n2. The explicit request: \"You are a compliance auditor and process analyst reviewing a completed feature. You have no knowledge of the conversation that produced these changes, what the developer intended, or what trade-offs were considered.\"\n\n3. The analysis framework requires identifying three categories of findings:\n   - Tenant 1: FLOW process workflow gaps\n   - Tenant 2: Rule compliance violations\n   - Tenant 3: Missing rules that should exist\n\nHowever, the user has now issued a CRITICAL constraint: \"Respond with TEXT ONLY. Do NOT call any tools.\" This directly contradicts the setup, which positioned me as a tool-using auditor who would investigate the codebase.\n\nThe user's most recent message is NOT about the initial learning analysis task. It is a meta-request asking me to summarize the conversation so far, WITHOUT using any tools, in a specific structured format.\n\nKey observation: There has been NO conversation \"so far\" — this is the first user message in this session. The user has provided a large prompt containing project context, rules, and a diff, then immediately asked for a summary of the conversation without ever engaging in back-and-forth dialogue.\n\nThe task interpretation:\n- The user is asking me to summarize the conversation up to this point\n- Since this is the very first exchange, there is minimal conversation to summarize\n- However, the system context provided is extensive and represents the \"state\" of the analysis task\n- I should acknowledge that this is the opening message, but I can structure a summary based on the materials provided and the stated purpose\n\nThe user's explicit instruction is clear: TEXT ONLY, NO TOOLS. I will comply with this instruction.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user has provided a learning analysis task that frames me as a compliance auditor and process analyst for PR #1210 in the FLOW plugin repository. The request is to analyze a completed feature that routed .flow-states/ Writes through the write-rule subcommand and added a Read-before-Edit preamble to the plan-check loop. The analysis should identify:\n   - Tenant 1: Process gaps in FLOW's workflow (tools, skills, hooks, phase gates)\n   - Tenant 2: Rule compliance violations with enforcement assessment (Unclear vs Ignored)\n   - Tenant 3: Missing rules that should exist based on patterns in the diff\n\n   However, the most recent user message (this request) explicitly constrains the response to TEXT ONLY, asking for a summary of the conversation so far in a structured format WITHOUT using any tools.\n\n2. Key Technical Concepts:\n   - FLOW plugin: 6-phase development lifecycle (Start, Plan, Code, Code Review, Learn, Complete)\n   - Write-Rule Escape Pattern: Writing content to temp file, then invoking bin/flow write-rule to unconditionally fs::write the target\n   - Edit Preamble Pattern: Preceding Edit-tool instructions with explicit Read-tool instruction\n   - Claude Code preflight: Write tool errors when target file pre-exists and hasn't been Read in conversation; Edit tool requires prior Read\n   - State files: .flow-states/<branch>.json containing phase status, timing, task counters\n   - Contract tests: SKILL.md assertions checked at CI time\n   - Pre-mortem agent: Code Review subagent for identifying risks (truncated mid-session per state file)\n\n3. Files and Code Sections:\n   The analysis materials include:\n\n   - /Users/ben/code/flow/.worktrees/route-flow-states-writes-through/.claude/rules/file-tool-preflights.md\n     - New rule file (127 lines) codifying the Write-Rule Escape and Edit Preamble patterns\n     - Documents bug class: Claude Code's preflight blocks pre-existing files\n     - Lists monitored paths: .flow-states/<branch>-dag.md, .flow-states/<branch>-plan.md, .flow-commit-msg, .flow-issue-body, orchestrate-queue.json\n     - Enforcement via two contract tests in tests/skill_contracts.rs\n\n   - skills/flow-plan/SKILL.md (863 lines, substantially modified)\n     - Step 2 post-decompose: Routes Write through bin/flow write-rule\n     - Step 3 plan write: Routes through write-rule using content files\n     - Step 4 plan-check loop: Added Read-before-Edit preamble\n\n   - tests/skill_contracts.rs (200 lines added)\n     - Two new contract tests: file_tool_preflight_write_paths_route_through_write_rule and file_tool_preflight_edit_paths_preceded_by_read\n     - Forward window check: bin/flow write-rule must appear on same line as monitored path mention\n     - Backward window check: Read-tool instruction must precede Edit within 12 non-blank lines, stopped by ### Step boundary\n\n   - skills/flow-commit/SKILL.md, skills/flow-start/SKILL.md, skills/flow-code/SKILL.md, skills/flow-learn/SKILL.md, skills/flow-orchestrate/SKILL.md\n     - Each routed their respective Write callsites through write-rule\n\n   - Code Review findings (state file findings[] array shows 13 findings):\n     - Dismissed (2): Case-sensitive path match, false-flagged generic prose\n     - Fixed (11): Contract test strengthening (same-line co-occurrence, path bounding, step-scoped windows, verb regex broadening), forward-facing language in rule file, removal of bold sub-step markers\n\n4. Errors and fixes:\n   The session state file indicates Code Review completed with all findings triaged to either \"fixed\" or \"dismissed\" outcomes. The notes indicate:\n   - Pre-mortem agent was truncated (silent ceiling hit per cognitive-isolation.md)\n   - Plan signature deviation was logged: plan named test_file_tool_preflight_paths (single function) but code delivered two sibling tests for independent failure isolation\n   - Tasks 1+4-9+10 bundled into atomic commit because intermediate states would fail CI\n   - Code phase experienced live instance of the bug being fixed (Edit preflight tripping during SKILL.md editing itself)\n\n5. Problem Solving:\n   The session solved the problem of Write-tool preflights blocking .flow-states/ file updates across 6 SKILL.md files. Key decisions:\n   - Use existing bin/flow write-rule subcommand (unconditional fs::write bypasses preflight)\n   - Add Read preamble for Edit cases where preflight still applies\n   - Guard both patterns with contract tests that check real SKILL.md structure\n   - Implemented plan signature deviation logging when implementation diverged from plan (two tests instead of one, for independent failure isolation)\n\n6. All user messages:\n   - This is the first and only user message in this session. It provided extensive project context (CLAUDE.md, 50+ rule files, state file data, plan file, log file, diff summary) and then immediately requested a text-only summary without using tools.\n\n7. Pending Tasks:\n   None explicitly pending. The state file indicates all phases completed through Code Review. Learn phase is \"in_progress\" (status field), but no explicit pending tasks were assigned in this conversation.\n\n8. Current Work:\n   This is the opening message of the session. The user has provided all context needed for a compliance audit of PR #1210 but has not requested me to begin that audit. Instead, they have requested a summary of the conversation in a specific structured format. The actual compliance analysis (investigating Tenant 1/2/3 findings) has not begun.\n\n9. Optional Next Step:\n   If the user desires, I can proceed with the compliance audit once they confirm this summary is adequate. The audit would investigate:\n   - FLOW process gaps: e.g., did the pre-mortem agent's early truncation indicate insufficient context budget?\n   - Rule compliance: e.g., check forward-facing-authoring.md compliance in file-tool-preflights.md (which was flagged as a Code Review fix)\n   - Missing rules: e.g., rules about agent prompt-size discipline or when re-decompose should be offered\n   \n   However, the user's explicit instruction \"Respond with TEXT ONLY. Do NOT call any tools.\" suggests they want only this summary for now, not the detailed audit work.\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/route-flow-states-writes-through",
  "compact_count": 6,
  "findings": [
    {
      "finding": "Case-sensitive monitored path match",
      "reason": "FLOW paths are literal lowercase by convention (.flow-states/, .flow-commit-msg, .flow-issue-body). No corpus instance uses mixed case. Asymmetric normalization is a theoretical gap without a realistic bypass vector.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:08:25-07:00"
    },
    {
      "finding": "Generic 'When using the Write tool' prose false-flagged",
      "reason": "After tightening the forward-window check to require same-line co-occurrence of bin/flow write-rule and the path, generic prose mentions no longer trip the scanner because the co-occurrence predicate fails.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:08:35-07:00"
    },
    {
      "finding": "CLAUDE.md Key Files missing file-tool-preflights.md",
      "reason": "Key Files section lists architectural files; individual .claude/rules/*.md entries are referenced in the Conventions bullet list, matching the pattern for scope-enumeration.md and hook-vs-instruction.md. Will add to Conventions instead.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:08:43-07:00"
    },
    {
      "finding": "Strengthen Write contract test: same-line co-occurrence of bin/flow write-rule and path",
      "reason": "Reviewer and Adversarial both flagged disconnected-substring bypass where unrelated write-rule call + path mention satisfy check. Replaced with forward_has_write_rule_line scan requiring same-line co-occurrence.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:18:22-07:00"
    },
    {
      "finding": "Tighten Edit read_re to require explicit Read-tool phrasing",
      "reason": "Reviewer flagged that (?:tool|the) alternation let 'Read the X' prose satisfy gate. Replaced with tool_phrase_regex(\"Read\") which uses the same verb vocabulary as Write/Edit side.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:18:33-07:00"
    },
    {
      "finding": "Path bounding: reject prefix extensions and trailing dots",
      "reason": "Adversarial proved my-orchestrate-queue.json and .flow-commit-msg.bak bypassed/false-flagged the check. Extended write_path_is_bounded to check prefix byte and reject trailing dot.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:18:50-07:00"
    },
    {
      "finding": "Broaden phrase regex to catch invoke/call/run verbs",
      "reason": "Adversarial proved 'invoke the Write tool' phrasing evaded regex. Introduced TOOL_VERB_PATTERN + tool_phrase_regex helper covering use/using/invoke/invoking/call/calling/run/running.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:19:01-07:00"
    },
    {
      "finding": "Step-scoped Edit backward window",
      "reason": "Adversarial proved Read in Step 1 + Edit in Step 2 passed gate despite --continue-step invalidating prior Read. Added backward_read_window helper that stops at ## or ### headings.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:19:10-07:00"
    },
    {
      "finding": "file-tool-preflights.md backward-facing language removed",
      "reason": "Reviewer flagged 'for some time, now extended' (line 51), 'mirrored from flow-complete/SKILL.md:233' (line 76), and incident-count citation (line 109). Rewrote all three per forward-facing-authoring rule.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:19:22-07:00"
    },
    {
      "finding": "Add monitored-path selection criterion and intermediate-file lifecycle to rule",
      "reason": "Documentation flagged missing criterion and lifecycle. Added selection criterion paragraph before monitored-paths list and new Intermediate Content File Naming and Lifecycle subsection.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:19:33-07:00"
    },
    {
      "finding": "Remove bold sub-step markers in flow-plan Step 2 and flow-commit Round 5",
      "reason": "Documentation agent correctly flagged violation of skill-authoring.md Flat Sequential Step Numbering rule. Converted **Capture / Write / Apply / Store** and **Compose / Apply** to plain prose paragraphs.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:19:43-07:00"
    },
    {
      "finding": "Added regression/consumer doc comments to contract tests",
      "reason": "Documentation flagged tests lacked tests-guard-real-regressions.md statement. Added top-of-section doc block naming the regression, the producing code path, and consumers.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:19:51-07:00"
    },
    {
      "finding": "Fix EDIT_READ_BACKWARD_WINDOW doc comment value",
      "reason": "Reviewer flagged comment said 'Six lines' but constant is 12. Updated comment to 'Twelve lines covers...'.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:19:59-07:00"
    },
    {
      "finding": "skill-authoring.md and CLAUDE.md Conventions cross-references deferred",
      "reason": "Documentation flagged missing cross-refs. Deferred to follow-up: low-priority docs additions with minor impact; contract tests mechanically enforce the discipline regardless of where it's cross-referenced. File-tool-preflights.md itself is discoverable via its descriptive name.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-04-16T18:20:08-07:00"
    },
    {
      "finding": "Pre-mortem sub-agent truncated on substantive-diff PR",
      "reason": "Agent returned 'Autocompact is thrashing' and zero findings. The parent skill correctly detected truncation per .claude/rules/cognitive-isolation.md, but the context exhaustion suggests the agent's prompt was too large. Per memory 'never file issues without approval', surfacing in Step 7 report rather than auto-filing — user decides whether to escalate.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:26:02-07:00"
    },
    {
      "finding": "Forward-facing authoring not mechanically enforced on rule files",
      "reason": "Agent flagged that a contract test could catch backward-facing rule prose. Per tests-guard-real-regressions.md corpus-scan viability check, adding such a scanner against .claude/rules/ prose would require a false-positive sweep first — speculative without that evidence. Rule remains instructional.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:26:11-07:00"
    },
    {
      "finding": "Plan signature deviation logging correctness",
      "reason": "Agent uncertain whether mechanical gate was satisfied. Verified: deviation was logged via bin/flow log before the commit per plan-commit-atomicity.md Plan Signature Deviations Must Be Logged section. Gate satisfied. No action needed.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:26:20-07:00"
    },
    {
      "finding": "Contract test window boundaries not documented in a dedicated rule",
      "reason": "Agent proposed a new rule codifying window-sizing discipline. The contract tests added in this PR already carry doc comments explaining their window sizes and rationale (WRITE_RULE_FORWARD_WINDOW=30, EDIT_READ_BACKWARD_WINDOW=12 with step-boundary stop). Adding a rule file is speculative without a recurring pattern of window-sizing mistakes across multiple contract tests. Defer to a future PR that surfaces the pattern.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:26:29-07:00"
    },
    {
      "finding": "Write-rule escape hatch discipline",
      "reason": "Agent asked for exit-criteria rule. The file-tool-preflights.md rule file already documents the monitored path set, the selection criterion, and the extension discipline. Agent's speculative question about 'when can a skill revert to direct Write' is handled by the rule's existing scope boundary (only monitored paths require routing; non-monitored paths Write directly).",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:26:37-07:00"
    },
    {
      "finding": "Edit preamble contract test only scans markdown",
      "reason": "Agent flagged that the test reads prose, not bash execution. By design: skills ARE markdown instructions that drive the model. The test validates the authoring invariant (Read instruction precedes Edit instruction in SKILL.md prose). Runtime compliance is the model's responsibility; the Edit tool's built-in preflight is the mechanical runtime enforcer. The test's scope is correct.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-04-16T18:26:46-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Session Log

<details>
<summary>.flow-states/route-flow-states-writes-through.log</summary>

```text
2026-04-16T16:53:27-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-16T16:53:27-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-16T16:53:28-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-16T16:53:29-07:00 [Phase 1] create .flow-states/route-flow-states-writes-through.json (exit 0)
2026-04-16T16:53:29-07:00 [Phase 1] freeze .flow-states/route-flow-states-writes-through-phases.json (exit 0)
2026-04-16T16:53:29-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-16T16:53:31-07:00 [Phase 1] start-init — label-issues (labeled: [1209], failed: [])
2026-04-16T16:53:45-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-16T16:53:45-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-16T16:53:48-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-16T16:54:08-07:00 [Phase 1] start-workspace — worktree .worktrees/route-flow-states-writes-through (ok)
2026-04-16T16:54:13-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-16T16:54:13-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-16T16:54:13-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-16T16:54:33-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-16T16:54:33-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-16T16:54:51-07:00 [Phase 2] plan-extract — plan-check violations (scope 0 / audit 1 / dup 0) in .flow-states/route-flow-states-writes-through-plan.md (exit 0)
2026-04-16T16:57:14-07:00 [Phase] phase-enter --phase flow-code ("ok")
2026-04-16T17:01:43-07:00 [Phase 3] Task 1 — designing Write-tool preflight contract test
2026-04-16T17:02:52-07:00 [stop-continue] first stop, no pending — discussion mode
2026-04-16T17:05:23-07:00 [Phase 3] Task 1 — Plan signature deviation: plan named 'test_file_tool_preflight_paths' single function, code uses two sibling functions 'file_tool_preflight_write_paths_route_through_write_rule' and 'file_tool_preflight_edit_paths_preceded_by_read' for independent failure isolation
2026-04-16T17:05:48-07:00 [Phase 3] Task 1 — locating file end to append test
2026-04-16T17:15:17-07:00 [Phase 3] Plan signature deviation: combining Tasks 1+4+5+6+7+8+9 into one commit (atomic by necessity — each intermediate state fails CI per plan-commit-atomicity.md); also combining Tasks 2+10 into another commit for Edit-side
2026-04-16T17:55:03-07:00 [Phase 3] finalize-commit — ci (ok)
2026-04-16T17:55:07-07:00 [Phase 3] finalize-commit — done ("ok")
2026-04-16T17:55:58-07:00 [Phase 3] phase-finalize --phase flow-code ("ok")
2026-04-16T17:56:12-07:00 [Phase] phase-enter --phase flow-code-review ("ok")
2026-04-16T18:21:34-07:00 [Phase 4] finalize-commit — ci (ok)
2026-04-16T18:21:39-07:00 [Phase 4] finalize-commit — done ("ok")
2026-04-16T18:22:05-07:00 [Phase 4] phase-finalize --phase flow-code-review ("ok")
2026-04-16T18:22:21-07:00 [Phase] phase-enter --phase flow-learn ("ok")
2026-04-16T18:27:47-07:00 [Phase 5] phase-finalize --phase flow-learn ("ok")
2026-04-16T18:28:20-07:00 [Phase 6] complete-finalize — starting
2026-04-16T18:28:20-07:00 [Phase 6] phase-transition --action complete --phase flow-complete ("ok")
2026-04-16T18:28:20-07:00 [Phase 6] complete-post-merge — phase-transition (ok)
```

</details>