### PR TITLE
100 Coverage Concurrency State

### DIFF
--- a/src/commands/init_state.rs
+++ b/src/commands/init_state.rs
@@ -43,6 +43,38 @@ pub fn create_state(
     start_steps_total: Option<i64>,
     relative_cwd: &str,
 ) -> Result<(), String> {
+    create_state_with_tty(
+        project_root,
+        branch,
+        skills,
+        prompt,
+        commit_format,
+        start_step,
+        start_steps_total,
+        relative_cwd,
+        detect_tty(),
+    )
+}
+
+/// Test seam for `create_state` that accepts the computed session-tty
+/// value as a parameter. The public wrapper above calls `detect_tty()`
+/// to produce the value; this inner form lets unit tests pass
+/// `Some("/dev/ttys0")` or `None` directly so both arms of the
+/// `match tty { Some(t) => json!(t), None => Value::Null }` branch
+/// are exercised without requiring a real PTY. No production caller
+/// uses this function directly.
+#[allow(clippy::too_many_arguments)]
+fn create_state_with_tty(
+    project_root: &Path,
+    branch: &str,
+    skills: Option<&IndexMap<String, SkillConfig>>,
+    prompt: &str,
+    commit_format: Option<&str>,
+    start_step: Option<i64>,
+    start_steps_total: Option<i64>,
+    relative_cwd: &str,
+    tty: Option<String>,
+) -> Result<(), String> {
     let current_time = now();
     let phases = build_initial_phases(&current_time);
 
@@ -66,8 +98,8 @@ pub fn create_state(
     );
     state.insert(
         "session_tty".into(),
-        match detect_tty() {
-            Some(tty) => json!(tty),
+        match tty {
+            Some(t) => json!(t),
             None => Value::Null,
         },
     );
@@ -306,6 +338,50 @@ mod tests {
         assert_eq!(state["schema_version"], 1);
         assert_eq!(state["branch"], "test-feature");
         assert_eq!(state["current_phase"], "flow-start");
+    }
+
+    /// Covers the `Some(t) => json!(t)` arm on line 94 of
+    /// `create_state_with_tty`: subprocess tests spawn `flow-rs` via
+    /// `.output()` which does not allocate a PTY, so `detect_tty()`
+    /// returns None in every existing test. The inner seam accepts an
+    /// explicit `Option<String>` so this unit test exercises the
+    /// `Some` branch by passing a synthesized tty string.
+    #[test]
+    fn create_state_with_tty_some_writes_tty_to_state() {
+        let dir = tempfile::tempdir().unwrap();
+        create_state_with_tty(
+            dir.path(),
+            "tty-some",
+            None,
+            "prompt",
+            None,
+            None,
+            None,
+            "",
+            Some("/dev/ttys999".to_string()),
+        )
+        .unwrap();
+        let state = read_state(dir.path(), "tty-some");
+        assert_eq!(state["session_tty"], "/dev/ttys999");
+    }
+
+    #[test]
+    fn create_state_with_tty_none_writes_null() {
+        let dir = tempfile::tempdir().unwrap();
+        create_state_with_tty(
+            dir.path(),
+            "tty-none",
+            None,
+            "prompt",
+            None,
+            None,
+            None,
+            "",
+            None,
+        )
+        .unwrap();
+        let state = read_state(dir.path(), "tty-none");
+        assert!(state["session_tty"].is_null());
     }
 
     // --- Null PR fields ---

--- a/src/commands/start_lock.rs
+++ b/src/commands/start_lock.rs
@@ -512,16 +512,44 @@ mod tests {
 
         let stale_self = queue_dir.join("my-feature");
         fs::write(&stale_self, "").unwrap();
+        // Use a 2-hour-old mtime (7200s) to put the entry well past
+        // STALE_TIMEOUT_SECONDS (1800s) regardless of filesystem mtime
+        // precision or the delta between set_file_mtime and the
+        // acquire() call's SystemTime::now(). The 60-second margin the
+        // earlier 1860s value provided was insufficient to guarantee
+        // coverage of the `fs::File::create(&entry)` line after the
+        // stale-removal step on every run.
         set_file_mtime(
             &stale_self,
-            FileTime::from_system_time(SystemTime::now() - Duration::from_secs(1860)),
+            FileTime::from_system_time(SystemTime::now() - Duration::from_secs(7200)),
         )
         .unwrap();
+        let initial_mtime = fs::metadata(&stale_self)
+            .unwrap()
+            .modified()
+            .unwrap()
+            .duration_since(UNIX_EPOCH)
+            .unwrap();
 
         let result = acquire("my-feature", queue_dir);
         assert_eq!(result["status"], "acquired");
         // Entry must still exist (replaced with fresh mtime, not deleted)
         assert!(queue_dir.join("my-feature").exists());
+        // The entry's mtime must have advanced — proof that
+        // `fs::remove_file + fs::File::create` ran. If the stale check
+        // had been skipped, the mtime would still be ~2 hours ago.
+        let final_mtime = fs::metadata(queue_dir.join("my-feature"))
+            .unwrap()
+            .modified()
+            .unwrap()
+            .duration_since(UNIX_EPOCH)
+            .unwrap();
+        assert!(
+            final_mtime > initial_mtime,
+            "entry mtime must advance after stale-replace; initial={:?} final={:?}",
+            initial_mtime,
+            final_mtime
+        );
     }
 
     #[test]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -74,11 +74,12 @@ pub fn detect_branch_from_path(cwd: &Path) -> Option<String> {
                     .ok()?
                     .to_string_lossy()
                     .to_string();
-                return if branch == "." || branch.is_empty() {
-                    None
-                } else {
-                    Some(branch)
-                };
+                // The loop guard `current != *worktrees_dir` prevents
+                // strip_prefix from yielding an empty or "." remainder —
+                // every entry into the body runs while `current` is
+                // strictly a descendant of worktrees_dir, so the
+                // remainder is always a non-empty branch name.
+                return Some(branch);
             }
             current = current.parent()?.to_path_buf();
         }

--- a/src/hooks/stop_continue.rs
+++ b/src/hooks/stop_continue.rs
@@ -873,6 +873,26 @@ mod tests {
         assert!(!should_block);
     }
 
+    /// Covers the `Err(_) => return (false, None)` arm on line 234 of
+    /// `check_qa_pending`: qa_path.exists() succeeds but read_to_string
+    /// fails with EACCES. Uses chmod 000 to make the breadcrumb
+    /// unreadable while still satisfying the existence check.
+    #[test]
+    fn test_check_qa_pending_unreadable_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        fs::create_dir_all(&state_dir).unwrap();
+        let qa_path = state_dir.join("qa-pending.json");
+        fs::write(&qa_path, r#"{"_continue_context": "x"}"#).unwrap();
+        fs::set_permissions(&qa_path, fs::Permissions::from_mode(0o000)).unwrap();
+        let (should_block, context) = check_qa_pending(dir.path());
+        // Restore permissions for tempdir cleanup.
+        let _ = fs::set_permissions(&qa_path, fs::Permissions::from_mode(0o644));
+        assert!(!should_block);
+        assert!(context.is_none());
+    }
+
     // --- set_tab_color ---
     // Note: write_tab_sequences writes to /dev/tty, which may or may not be
     // writable in the test environment. We test that set_tab_color does not
@@ -912,6 +932,26 @@ mod tests {
 
         // Should not panic — falls through to detect_repo fallback
         set_tab_color(dir.path(), "test", &state_path);
+    }
+
+    /// Covers the `Err(_) => write_tab_sequences(...)` arm on line 266
+    /// of `set_tab_color`: state_path.exists() returns true but
+    /// read_to_string fails with EACCES. Uses chmod 000 to make the
+    /// state file unreadable while still satisfying the existence
+    /// check. Verifies that set_tab_color routes through the
+    /// detect_repo fallback without panicking.
+    #[test]
+    fn test_set_tab_color_unreadable_state_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".flow-states");
+        fs::create_dir_all(&state_dir).unwrap();
+        let state_path = state_dir.join("test.json");
+        fs::write(&state_path, r#"{"repo": "owner/repo"}"#).unwrap();
+        fs::set_permissions(&state_path, fs::Permissions::from_mode(0o000)).unwrap();
+        // Should fall through to detect_repo without panicking.
+        set_tab_color(dir.path(), "test", &state_path);
+        let _ = fs::set_permissions(&state_path, fs::Permissions::from_mode(0o644));
     }
 
     // --- format_block_output ---

--- a/src/hooks/stop_continue.rs
+++ b/src/hooks/stop_continue.rs
@@ -873,6 +873,21 @@ mod tests {
         assert!(!should_block);
     }
 
+    /// RAII guard that restores file permissions on Drop. Protects
+    /// chmod-000 tests from leaking a mode-000 file when an assertion
+    /// inside the test body panics before the inline restore runs.
+    /// Per `.claude/rules/panic-safe-cleanup.md`.
+    struct PermissionGuard {
+        path: std::path::PathBuf,
+        restore_mode: u32,
+    }
+    impl Drop for PermissionGuard {
+        fn drop(&mut self) {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&self.path, fs::Permissions::from_mode(self.restore_mode));
+        }
+    }
+
     /// Covers the `Err(_) => return (false, None)` arm on line 234 of
     /// `check_qa_pending`: qa_path.exists() succeeds but read_to_string
     /// fails with EACCES. Uses chmod 000 to make the breadcrumb
@@ -886,9 +901,11 @@ mod tests {
         let qa_path = state_dir.join("qa-pending.json");
         fs::write(&qa_path, r#"{"_continue_context": "x"}"#).unwrap();
         fs::set_permissions(&qa_path, fs::Permissions::from_mode(0o000)).unwrap();
+        let _guard = PermissionGuard {
+            path: qa_path.clone(),
+            restore_mode: 0o644,
+        };
         let (should_block, context) = check_qa_pending(dir.path());
-        // Restore permissions for tempdir cleanup.
-        let _ = fs::set_permissions(&qa_path, fs::Permissions::from_mode(0o644));
         assert!(!should_block);
         assert!(context.is_none());
     }
@@ -949,9 +966,12 @@ mod tests {
         let state_path = state_dir.join("test.json");
         fs::write(&state_path, r#"{"repo": "owner/repo"}"#).unwrap();
         fs::set_permissions(&state_path, fs::Permissions::from_mode(0o000)).unwrap();
+        let _guard = PermissionGuard {
+            path: state_path.clone(),
+            restore_mode: 0o644,
+        };
         // Should fall through to detect_repo without panicking.
         set_tab_color(dir.path(), "test", &state_path);
-        let _ = fs::set_permissions(&state_path, fs::Permissions::from_mode(0o644));
     }
 
     // --- format_block_output ---

--- a/src/hooks/validate_ask_user.rs
+++ b/src/hooks/validate_ask_user.rs
@@ -230,6 +230,25 @@ mod tests {
         assert!(resp.is_none());
     }
 
+    /// Covers the `Err(_) => return (true, String::new(), None)` arm on
+    /// line 67 of `validate`: `state_path.exists()` succeeds but
+    /// `read_to_string` fails. A file mode of `0o000` on macOS passes
+    /// the `exists()` metadata check but the read returns EACCES.
+    #[test]
+    fn test_validate_allows_unreadable_state_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let unreadable = dir.path().join("unreadable.json");
+        fs::write(&unreadable, "{}").unwrap();
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+        let (allowed, msg, resp) = validate(Some(&unreadable));
+        // Restore permissions so tempdir cleanup on drop works.
+        let _ = fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o644));
+        assert!(allowed);
+        assert!(msg.is_empty());
+        assert!(resp.is_none());
+    }
+
     #[test]
     fn test_validate_allows_no_auto_continue() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/hooks/validate_ask_user.rs
+++ b/src/hooks/validate_ask_user.rs
@@ -230,6 +230,23 @@ mod tests {
         assert!(resp.is_none());
     }
 
+    /// RAII guard that restores file permissions on Drop. Protects
+    /// chmod-000 tests from leaking a mode-000 file when an assertion
+    /// inside the test body panics before the inline restore runs.
+    /// Per `.claude/rules/panic-safe-cleanup.md`, any resource whose
+    /// released state is not the default must be wrapped in a Drop
+    /// impl to guarantee cleanup on panic unwind.
+    struct PermissionGuard {
+        path: std::path::PathBuf,
+        restore_mode: u32,
+    }
+    impl Drop for PermissionGuard {
+        fn drop(&mut self) {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&self.path, fs::Permissions::from_mode(self.restore_mode));
+        }
+    }
+
     /// Covers the `Err(_) => return (true, String::new(), None)` arm on
     /// line 67 of `validate`: `state_path.exists()` succeeds but
     /// `read_to_string` fails. A file mode of `0o000` on macOS passes
@@ -241,9 +258,11 @@ mod tests {
         let unreadable = dir.path().join("unreadable.json");
         fs::write(&unreadable, "{}").unwrap();
         fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+        let _guard = PermissionGuard {
+            path: unreadable.clone(),
+            restore_mode: 0o644,
+        };
         let (allowed, msg, resp) = validate(Some(&unreadable));
-        // Restore permissions so tempdir cleanup on drop works.
-        let _ = fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o644));
         assert!(allowed);
         assert!(msg.is_empty());
         assert!(resp.is_none());

--- a/src/hooks/validate_pretool.rs
+++ b/src/hooks/validate_pretool.rs
@@ -1058,6 +1058,22 @@ mod tests {
         assert!(should_block_background("npm run flow", false).is_none());
     }
 
+    /// Covers the `None => return false` arm on line 374 of
+    /// `is_flow_command`: a command whose `split_whitespace().next()`
+    /// returns `None` — i.e., empty string or pure whitespace. A flow
+    /// context (`flow_active = true`) would block non-flow commands via
+    /// the "inside flow" branch; passing `flow_active = false` forces the
+    /// empty-command path through `is_flow_command` directly.
+    #[test]
+    fn test_is_flow_command_empty_returns_false() {
+        assert!(should_block_background("", false).is_none());
+    }
+
+    #[test]
+    fn test_is_flow_command_whitespace_only_returns_false() {
+        assert!(should_block_background("   \t", false).is_none());
+    }
+
     // --- is_bg_truthy: defensive JSON type handling ---
 
     #[test]
@@ -1479,6 +1495,36 @@ mod tests {
         assert!(
             !allowed,
             "backtick inside double quotes must be blocked — bash expands it; got: {msg}"
+        );
+    }
+
+    /// Covers the backslash-escape arm of scan_unquoted's Double state
+    /// (lines 225-229 of validate_pretool.rs): when the scanner is inside
+    /// a double-quoted span and encounters `\`, it advances past the
+    /// escaped byte so the escaped character is treated as literal. A
+    /// double-quoted string containing `\"` should pass through without
+    /// tripping the compound-operator predicate, even though `"` would
+    /// normally close the quote.
+    #[test]
+    fn test_allows_escaped_double_quote_inside_double_quoted_arg() {
+        let cmd = r#"echo "hello \"world\"""#;
+        let (allowed, msg) = validate(cmd, None, true);
+        assert!(
+            allowed,
+            "escaped double quote inside double-quoted arg must be literal; got: {msg}"
+        );
+    }
+
+    /// Covers the backslash-escape arm of scan_unquoted's Double state
+    /// from the redirect-predicate layer: a backslash-escaped `>` inside
+    /// double quotes must not be treated as shell redirection.
+    #[test]
+    fn test_allows_escaped_redirect_inside_double_quoted_arg() {
+        let cmd = r#"echo "result \> output""#;
+        let (allowed, msg) = validate(cmd, None, true);
+        assert!(
+            allowed,
+            "escaped redirect char inside double-quoted arg must be literal; got: {msg}"
         );
     }
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -16,13 +16,32 @@ pub fn mutate_state<F>(state_path: &Path, transform_fn: F) -> Result<Value, Muta
 where
     F: FnOnce(&mut Value),
 {
+    mutate_state_with_lock(state_path, transform_fn, |f| f.lock_exclusive())
+}
+
+/// Test seam for `mutate_state` — accepts an injectable lock closure so
+/// unit tests can simulate `lock_exclusive()` failures without triggering
+/// real OS-level lock contention. The public wrapper above supplies
+/// `fs2::FileExt::lock_exclusive`; the inline `Lock` error test in
+/// `#[cfg(test)] mod tests` passes a closure that returns `Err` so the
+/// `MutateError::Lock` arm is exercised. No production caller uses this
+/// function directly.
+fn mutate_state_with_lock<F, L>(
+    state_path: &Path,
+    transform_fn: F,
+    lock_fn: L,
+) -> Result<Value, MutateError>
+where
+    F: FnOnce(&mut Value),
+    L: FnOnce(&std::fs::File) -> std::io::Result<()>,
+{
     let mut file = OpenOptions::new()
         .read(true)
         .write(true)
         .open(state_path)
         .map_err(|e| MutateError::Io(format!("{}: {}", state_path.display(), e)))?;
 
-    file.lock_exclusive().map_err(|e| {
+    lock_fn(&file).map_err(|e| {
         MutateError::Lock(format!("Failed to lock {}: {}", state_path.display(), e))
     })?;
 
@@ -300,10 +319,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nonexistent.json");
         let err = mutate_state(&path, |_| {}).unwrap_err();
-        match err {
-            MutateError::Io(_) => {}
-            other => panic!("Expected Io variant, got: {:?}", other),
-        }
+        assert!(
+            matches!(err, MutateError::Io(_)),
+            "Expected Io variant, got: {:?}",
+            err
+        );
     }
 
     #[test]
@@ -312,10 +332,36 @@ mod tests {
         let path = dir.path().join("state.json");
         fs::write(&path, "{invalid").unwrap();
         let err = mutate_state(&path, |_| {}).unwrap_err();
-        match err {
-            MutateError::Json(_) => {}
-            other => panic!("Expected Json variant, got: {:?}", other),
-        }
+        assert!(
+            matches!(err, MutateError::Json(_)),
+            "Expected Json variant, got: {:?}",
+            err
+        );
+    }
+
+    /// Covers the `MutateError::Lock` arm (lines 26-27 of the
+    /// pre-refactor `mutate_state` body, now lines 35-37 of
+    /// `mutate_state_with_lock`). The lock failure is simulated by
+    /// passing a closure that returns `Err(io::Error)` in place of
+    /// `fs2::FileExt::lock_exclusive`. No OS-level lock manipulation
+    /// is needed — the seam lets the test inject the failure
+    /// deterministically.
+    #[test]
+    fn mutate_state_with_lock_error_wraps_as_lock_variant() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        fs::write(&path, "{}").unwrap();
+        let err = mutate_state_with_lock(
+            &path,
+            |_| {},
+            |_| Err(std::io::Error::other("simulated lock failure")),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, MutateError::Lock(ref m) if m.contains("simulated lock failure")),
+            "Expected Lock variant with simulated message, got: {:?}",
+            err
+        );
     }
 
     // --- write_and_truncate ---
@@ -354,15 +400,19 @@ mod tests {
         // Open read-only — write_all will fail with a permission error.
         let mut file = OpenOptions::new().read(true).open(&path).unwrap();
         let err = write_and_truncate(&mut file, b"new data").unwrap_err();
-        match err {
-            MutateError::Io(msg) => {
-                assert!(
-                    msg.contains("Failed to write") || msg.contains("Failed to seek"),
-                    "expected write or seek failure, got: {}",
-                    msg
-                );
-            }
-            other => panic!("Expected Io variant, got: {:?}", other),
-        }
+        let msg = match &err {
+            MutateError::Io(m) => m.clone(),
+            _ => String::new(),
+        };
+        assert!(
+            matches!(err, MutateError::Io(_)),
+            "Expected Io variant, got: {:?}",
+            err
+        );
+        assert!(
+            msg.contains("Failed to write") || msg.contains("Failed to seek"),
+            "expected write or seek failure, got: {}",
+            msg
+        );
     }
 }


### PR DESCRIPTION
## What

work on issue #1200.

Closes #1200

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/100-coverage-concurrency-state-plan.md` |
| DAG | `.flow-states/100-coverage-concurrency-state-dag.md` |
| Log | `.flow-states/100-coverage-concurrency-state.log` |
| State | `.flow-states/100-coverage-concurrency-state.json` |

## Plan

<details>
<summary>Implementation plan</summary>

```text
# Plan — 100% coverage for concurrency + state mutation modules

## Context

Issue #1200 drives nine concurrency-touching FLOW Rust modules
to 100% regions, functions, and lines under cargo-llvm-cov.
The affected files are:

- `src/lock.rs`
- `src/commands/start_lock.rs`
- `src/commands/init_state.rs`
- `src/hooks/stop_continue.rs`
- `src/hooks/validate_pretool.rs`
- `src/hooks/validate_ask_user.rs`
- `src/hooks/validate_claude_paths.rs`
- `src/hooks/validate_worktree_paths.rs`
- `src/hooks/mod.rs`

Current per-file coverage sits between 93.33% and 99.77% lines /
regions, with `src/lock.rs` holding the largest reported function
gap at 75.00% (cargo-llvm-cov counts each monomorphization of
`mutate_state<F>` as a distinct function, so production callsites
with uncovered closures show up as uncovered functions in that
file). The goal is to close every per-file gap without adding any
waiver mechanism. The end-of-issue floor bump records the new
aggregate TOTAL in `bin/test`'s `--fail-under-*` flags if any
boundary was crossed.

## Exploration

### Source files targeted

| File | Line % | Region % | Function % | Existing tests |
|------|--------|----------|------------|----------------|
| `src/lock.rs` | 93.33 | 94.26 | 75.00 | 17 inline `#[cfg(test)]` tests covering `mutate_state` happy path + error arms + `write_and_truncate` |
<!-- duplicate-test-coverage: not-a-new-test -->
| `src/commands/start_lock.rs` | 96.60 | 96.93 | 93.33 | ~25 inline tests (queue, stale cleanup, acquire, wait-retry, release, check). `tests/start_lock.rs` has 3 CLI variant tests (`run_acquire_missing_feature_exits_1`, `run_release_missing_feature_exits_1`, `run_no_flag_exits_1`) |
| `src/commands/init_state.rs` | 96.58 | 96.94 | 79.31 | `tests/init_state.rs` has 38 tests covering happy path, phase structure, skills propagation, prompt file, branch-override, issue label guard, duplicate-issue detection, fetch-issue failure, and create-state-write failure |
| `src/hooks/stop_continue.rs` | ~99 | 98.85 | 99.07 | `tests/hooks.rs` via subprocess |
| `src/hooks/validate_pretool.rs` | 98.96 | 99.51 | ~99 | `tests/hooks.rs` + inline |
| `src/hooks/validate_ask_user.rs` | 99.51 | 99.77 | ~99 | `tests/hooks.rs` + inline |
| `src/hooks/validate_claude_paths.rs` | 99.52 | 99.40 | ~99 | `tests/hooks.rs` + inline |
| `src/hooks/validate_worktree_paths.rs` | 99.38 | 99.64 | ~99 | `tests/hooks.rs` + inline |
| `src/hooks/mod.rs` | 98.21 | 96.88 | ~98 | `tests/hooks.rs` via dependents |

### Supporting files

- `bin/test` — defines the aggregate ratchet: `--fail-under-lines 97`,
  `--fail-under-regions 97`, `--fail-under-functions 95`
  (lines 80–82). These values bump only when the aggregate TOTAL
  crosses a whole-percent boundary.
- `.claude/rules/testing-gotchas.md` "Timing-Sensitive Test Isolation"
  — timing tests use `filetime::set_file_mtime`, never `thread::sleep`.
  `src/commands/start_lock.rs` already follows this discipline and is
  the reference pattern.
- `.claude/rules/subprocess-test-hygiene.md` — subprocess tests that
  spawn `CARGO_BIN_EXE_flow-rs` must neutralize `FLOW_CI_RUNNING`,
  `GH_TOKEN`, `HOME` as appropriate.
- `.claude/rules/no-waivers.md` — per-file waiver files
  (`test_coverage.md`, `security_waivers.md`, etc.) are forbidden.
  No such file is introduced by this plan.
- `.claude/rules/tests-guard-real-regressions.md` "Coverage-Required
  Tests" — a test whose sole purpose is exercising a branch is a valid
  test because the 100% coverage gate names its consumer.
- `.claude/rules/rust-patterns.md` "Test Module Section Markers" —
  inline coverage-required tests group under `// --- primary_name ---`
  markers matching the production function's name.

### Existing artifacts (not superseded, not modified)

No production code is superseded by this plan — tests are purely
additive. The plan modifies:

- Source files to add `#[cfg(test)] mod tests` blocks where a branch
  is most cheaply reached by a private-function unit test.
- Integration test files (`tests/init_state.rs`, `tests/start_lock.rs`,
  `tests/hooks.rs`, and a new `tests/lock.rs` if warranted) where a
  branch is reached through the CLI or subprocess surface.
- `bin/test` to bump `--fail-under-*` flags if the aggregate TOTAL
  crosses a whole-percent boundary after the coverage closes.

### Reference patterns to follow

- **Inline unit test for pure helper** —
  `src/lock.rs::mutate_state_error_wraps_missing_file_as_io` shows the
  reference shape for a coverage-required inline unit test that
  exercises one error arm.
- **`filetime::set_file_mtime` for staleness** —
  `src/commands/start_lock.rs` inline tests use `FileTime` to simulate
  stale queue entries without real sleeps.
- **Subprocess integration test** — `tests/hooks.rs` defines
  `setup_pretool_fixture` / `setup_worktree_fixture` helpers and spawns
  the compiled binary through `CARGO_BIN_EXE_flow-rs` with explicit
  env neutralization.
- **Write-and-truncate error path** —
  `src/lock.rs::write_and_truncate_readonly_fd_fails` shows how to
  exercise an `Err` arm in the write path without a real disk-full
  simulation.

## Risks

### Coverage-impact statement

Expected improvement. Closing the remaining gaps in nine modules is
expected to raise the aggregate TOTAL. The current `bin/test` floors
are `--fail-under-lines 97`, `--fail-under-regions 97`, and
`--fail-under-functions 95`. Task 8 runs `bin/flow ci` after the
last coverage-changing commit, reads the new aggregate TOTAL for
each metric, and bumps the matching flag in `bin/test` to the new
`floor(whole_percent)` when a whole-percent boundary is crossed.
Every bump lands in the same commit that earned the improvement.

### DAG freshness

The DAG at `.flow-states/100-coverage-concurrency-state-dag.md` is
the issue body wrapped under a heading — it is not a decompose
output. Files the issue body references
(`src/lock.rs`, `src/commands/*.rs`, `src/hooks/*.rs`,
`tests/start_lock.rs`, `tests/init_state.rs`, `tests/hooks.rs`)
were verified against the current worktree: all exist at the
indicated paths, and their test conventions match the issue's
description.

### `.flow-coverage-floor.json` is not created

The issue's acceptance criterion
"`.flow-coverage-floor.json` entries for all listed files at 100.00"
conflicts with `.claude/rules/no-waivers.md` "The Rule":
per-file waiver files (`test_coverage.md`, `security_waivers.md`,
or any similar per-line exception file) are forbidden — both the
file and the discipline that authorizes one. This plan pursues
the underlying intent (every listed file at 100% regions, functions,
lines) directly through tests, and does not create
`.flow-coverage-floor.json`. The `bin/test` `--fail-under-*`
ratchet in `bin/test` is the project's sanctioned floor mechanism
and is updated in Task 8 when a boundary is crossed.

### `mutate_state<F>` monomorphization accounting

`src/lock.rs` reports 75.00% functions because cargo-llvm-cov
counts every monomorphization of the generic `mutate_state<F>` as
a separate function, and closures at 80 distinct callsites
(`add_issue.rs`, `finalize_commit.rs`, `orchestrate_state.rs`,
`phase_finalize.rs`, `commands/set_blocked.rs`, `phase_enter.rs`,
`plan_extract.rs`, `complete_preflight.rs`,
`complete_post_merge.rs`, `append_note.rs`, `phase_transition.rs`,
`commands/set_timestamp.rs`, `commands/start_step.rs`,
`start_finalize.rs`, `commands/clear_blocked.rs`,
`check_freshness.rs`, `add_notification.rs`, `complete_fast.rs`,
`complete_merge.rs`, `add_finding.rs`, `start_workspace.rs`,
`hooks/stop_continue.rs`, `hooks/post_compact.rs`,
`hooks/stop_failure.rs`, `hooks/validate_ask_user.rs`, plus
`src/lock.rs` itself) produce distinct instantiations. Task 1
measures function coverage for `src/lock.rs` and confirms whether
the reported gap comes from uncovered `mutate_state<F>`
instantiations (in which case the fix is driving the production
callers whose closures are uncovered), or from a different gap
(e.g. `MutateError::Display` or `std::error::Error` blanket) that
a direct inline test covers.

### Named tests must not collide with existing tests

The existing corpus in `tests/init_state.rs` (38 tests) and
`tests/start_lock.rs` (3 CLI variant tests) was enumerated during
exploration and cross-checked against the Code phase's proposed
names. New coverage-required tests in those files carry
branch-specific names that do not normalize (strip `test_` prefix,
lowercase) to any existing test per
`.claude/rules/duplicate-test-coverage.md`. Each new test's name
derives from the production function plus the specific branch it
exercises so collisions are avoided by construction, and every
proposed name is run through `bin/flow plan-check` at commit time
via the `duplicate-test-coverage` scanner before the test lands.

### Timing-sensitive tests discipline

Any test that exercises staleness, retry, or timeout behavior in
`src/lock.rs` or `src/commands/start_lock.rs` uses
`filetime::set_file_mtime` or an injected `sleep_fn` closure per
`.claude/rules/testing-gotchas.md` "Timing-Sensitive Test
Isolation". No test introduces `std::thread::sleep` as a timing
mechanism. The plan confirms `src/commands/start_lock.rs` already
exposes `acquire_with_wait_impl(sleep_fn: F)` as the injected seam
— new tests reuse that seam rather than adding a real-time delay.

### Subprocess test hygiene

Any new `tests/*.rs` test that spawns `CARGO_BIN_EXE_flow-rs` adds
`.env_remove("FLOW_CI_RUNNING")` for the CI-family recursion guard
per `.claude/rules/subprocess-test-hygiene.md`. Tests that reach
the `gh` CLI or Slack surface add the corresponding env
neutralizers (`GH_TOKEN=invalid`, `HOME=<tempdir>`,
`env_remove("SLACK_WEBHOOK_URL")`).

### Hook state-read timing (non-applicable)

This plan does not add new hooks or modify hook state-read timing,
so the `.claude/rules/hook-state-timing.md` analysis is
non-applicable. Tests added for existing hooks exercise existing
read paths only.

### External-input audit (non-applicable)

No plan task adds a `panic!`, `assert!`, `assert_eq!`, or
`assert_ne!` validation on an input parameter. Tests that use
assertions to verify observable output are not subject to the
external-input audit gate because they do not tighten production
validation. <!-- external-input-audit: not-a-tightening -->

### Extract-helper refactor (non-applicable)

No plan task extracts a block of code into a new helper function.
Tests are added against the existing production API surface; no
seam is introduced by this plan.
<!-- extract-helper-refactor: not-an-extraction -->

### Supersession (non-applicable)

No plan task introduces a replacement, backstop, guard, or unified
handler. All work is additive coverage on existing production
code paths.

## Approach

The work is measurement-driven. Task 1 captures a per-file coverage
baseline (uncovered lines and uncovered monomorphizations for each
listed file) by running `bin/flow ci` with coverage and parsing the
cargo-llvm-cov report. Tasks 2–6 close the per-file gaps one file
or file-family at a time, each task driven by the Task 1 baseline.
Task 7 is the hard gate: it re-runs `bin/flow ci` and confirms
every listed file reports 100% regions, 100% functions, and 100%
lines. If any file is below 100%, Task 7 routes the iteration back
to the matching coverage task. Only after every file reads 100%
does the plan proceed to Task 8, which reads the new aggregate
TOTAL and bumps the `bin/test` `--fail-under-*` flags to the new
whole-percent floor in a single commit.

Each coverage task in the group follows the same pattern:

- Read the Task 1 baseline report for the target file.
- For each uncovered line range and each uncovered function, identify
  the branch or monomorphization involved.
- Add a test (inline `#[cfg(test)] mod tests` for private helpers,
  `tests/<file>.rs` for CLI or subprocess branches) whose name
  follows the production function and the branch condition.
- Run the filtered test suite for the target file and confirm the
  coverage gap closes.
- Confirm the new test names do not collide with existing tests
  in the suite.

Coverage-required tests follow the guidance in
`.claude/rules/tests-guard-real-regressions.md` "Coverage-Required
Tests" Placement, using inline unit tests for private-helper
branches and `tests/<module>.rs` integration tests for branches
that require subprocess spawning or real-filesystem fixtures.

## Dependency Graph

| Task | Type | Depends On |
|------|------|------------|
| 1. Measure baseline coverage | design | — |
| 2. Close `src/lock.rs` gaps | test+implement | 1 |
| 3. Close `src/commands/start_lock.rs` gaps | test+implement | 1 |
| 4. Close `src/commands/init_state.rs` gaps | test+implement | 1 |
| 5. Close `src/hooks/stop_continue.rs` gap | test+implement | 1 |
| 6. Close `src/hooks/validate_*.rs` + `src/hooks/mod.rs` gaps | test+implement | 1 |
| 7. Verify per-file 100% (hard gate) | verify | 2, 3, 4, 5, 6 |
| 8. Bump `bin/test` floors on aggregate boundary crossings | implement | 7 |

## Tasks

### Task 1 — Measure baseline coverage

Run `bin/flow ci` and extract the per-file cargo-llvm-cov report
lines for each of the nine target files
(`src/lock.rs`, `src/commands/start_lock.rs`,
`src/commands/init_state.rs`, `src/hooks/stop_continue.rs`,
`src/hooks/validate_pretool.rs`, `src/hooks/validate_ask_user.rs`,
`src/hooks/validate_claude_paths.rs`,
`src/hooks/validate_worktree_paths.rs`, `src/hooks/mod.rs`). For
each file, record the specific uncovered line ranges and
uncovered function names reported by llvm-cov. Record also the
aggregate TOTAL for lines, regions, and functions so Task 8 knows
the pre-change baseline.

Output: a short note in `.flow-states/100-coverage-concurrency-state.log`
via `bin/flow log` recording per-file uncovered-line counts and the
aggregate TOTAL. This is a measurement-only step, not a
completion-gated task — the plan does not declare victory at this
point; Task 7 is the hard gate on per-file 100%.

### Task 2 — Close `src/lock.rs` gaps (TDD pair)

**Test step.** For every uncovered line range and every uncovered
`mutate_state<F>` monomorphization in `src/lock.rs`:

- If the gap is inside a private helper (e.g. `write_and_truncate`
  or a pattern arm in `MutateError::Display`), add an inline
  `#[cfg(test)] mod tests` test in `src/lock.rs` whose name follows
  the production function and the branch it exercises. Group new
  tests under an existing `// --- ` section marker or a new one
  named after the production function per
  `.claude/rules/rust-patterns.md` "Test Module Section Markers".
- If the gap is a `mutate_state<F>` monomorphization reachable only
  through a production callsite (e.g. a specific closure in
  `src/add_finding.rs` or `src/phase_finalize.rs`), add the
  coverage-closing test in the caller module's own test file
  rather than in `src/lock.rs` (the callsite's closure is what
  remains uncovered, not the generic definition).
- If every `mutate_state<F>` callsite already has a test, consider
  adding a small `tests/lock.rs` integration test that exercises
  the public API through a realistic fixture. Skip the new file
  if inline coverage already reaches 100%.

Run `bin/flow test -- lock` and confirm the new tests pass.

**Implementation step.** No production code change. If Task 1
uncovers a genuinely unreachable branch (no production caller can
hit it), refactor the branch out per `.claude/rules/no-waivers.md`
"How to Apply (Code Phase)" default responses (subprocess test,
refactor, or design change — delete the branch if it is truly
unreachable).

Counter: this is a TDD pair — Task 2 test step advances
`code_task` to the test-task index, implementation step advances
to the implementation-task index. Commit once per pair.

### Task 3 — Close `src/commands/start_lock.rs` gaps (TDD pair)

**Test step.** Apply the same pattern as Task 2 to
`src/commands/start_lock.rs`. Any time-sensitive test uses
`filetime::set_file_mtime` or the existing
`acquire_with_wait_impl(sleep_fn: F)` seam per
`.claude/rules/testing-gotchas.md` "Timing-Sensitive Test
Isolation". No test uses `std::thread::sleep`. Place new inline
tests alongside the existing `#[cfg(test)] mod tests` block in
`src/commands/start_lock.rs`. Place CLI-surface tests in
`tests/start_lock.rs` (the file has only three CLI variant tests
today). New test names do not normalize to any existing test in
`tests/start_lock.rs` — the three existing CLI variant tests
were enumerated during exploration and are avoided by
construction. The `duplicate-test-coverage` scanner in
`bin/flow plan-check` runs as a backstop at phase completion.

Run `bin/flow test -- start_lock` and confirm.

**Implementation step.** No production code change unless a
branch is genuinely unreachable, in which case delete it per
Task 2's implementation guidance.

### Task 4 — Close `src/commands/init_state.rs` gaps (TDD pair)

**Test step.** Apply the same pattern to
`src/commands/init_state.rs`. The largest gap is the 20.69%
function gap (23 of 29 functions uncovered) which most likely
comes from branches inside `run()` that the existing
`tests/init_state.rs` subprocess tests do not drive. Likely
uncovered surface: specific create-state error arms,
`--relative-cwd` edge cases not already covered, and non-happy-path
flag combinations. Each new subprocess test in `tests/init_state.rs`
calls `.env_remove("FLOW_CI_RUNNING")` and, when the subcommand
reaches the `gh` CLI, adds `.env("GH_TOKEN", "invalid")` and
`.env("HOME", &root)` per
`.claude/rules/subprocess-test-hygiene.md`. New test names do not
normalize to any existing name in `tests/init_state.rs` (the file
has 38 existing tests, all cataloged during exploration).

Run `bin/flow test -- init_state` and confirm.

**Implementation step.** No production code change unless a
branch is genuinely unreachable, in which case delete it.

### Task 5 — Close `src/hooks/stop_continue.rs` gap (TDD pair)

**Test step.** Add coverage-required tests for the uncovered
~1.15% region gap in `src/hooks/stop_continue.rs`. If the
uncovered surface is a private helper, add an inline test in
the file's `#[cfg(test)] mod tests` block. If it requires a
subprocess spawn through the real hook dispatcher, add the test
to `tests/hooks.rs` with the existing
`setup_pretool_fixture` / `setup_worktree_fixture` helper pattern,
following the `.env_remove("FLOW_CI_RUNNING")` subprocess
discipline. Respect the hook-state-timing discipline for any read
window the new test exercises.

Run `bin/flow test -- hooks::stop_continue` (or
`bin/flow test -- stop_continue` if the module path is not
filterable) and confirm.

**Implementation step.** No production code change unless a
branch is genuinely unreachable, in which case delete it.

### Task 6 — Close `src/hooks/validate_*.rs` and `src/hooks/mod.rs` gaps (TDD pair)

**Test step.** Sweep the remaining five hook files
(`src/hooks/validate_pretool.rs`,
`src/hooks/validate_ask_user.rs`,
`src/hooks/validate_claude_paths.rs`,
`src/hooks/validate_worktree_paths.rs`, `src/hooks/mod.rs`). For
each file, add coverage-required tests for the remaining <2% gap.
Inline for private helpers, `tests/hooks.rs` for subprocess-driven
branches. The sweep respects the
`.claude/rules/rust-patterns.md` "Stateful Predicate-Based
Scanners" contract for `validate_pretool.rs::scan_unquoted` tests
— any predicate-contract test runs only in the scanner's Normal
state per the documented predicate-state scope.

Run `bin/flow test -- hooks` and confirm.

**Implementation step.** No production code change unless a
branch is genuinely unreachable, in which case delete it.

### Task 7 — Verify per-file 100% (hard gate)

Run `bin/flow ci` and parse the cargo-llvm-cov report for each of
the nine target files. Assert **all three** of lines, regions, and
functions read 100.00% for each file. If any file is below 100%
on any metric, return to the task that targeted that file
(Task 2 for `src/lock.rs`, Task 3 for
`src/commands/start_lock.rs`, Task 4 for
`src/commands/init_state.rs`, Task 5 for
`src/hooks/stop_continue.rs`, Task 6 for any of the remaining
hook files) and add the missing coverage before re-running this
task. Only when every file reports 100% on every metric does
Task 7 pass.

This is a hard gate per `.claude/rules/no-waivers.md`
"Measurement-Only Task Antipattern": a task that merely reads the
TOTAL is not a completion criterion. This task proceeds only
when every listed file reads 100% regions, 100% functions, and
100% lines per-file.

Record the aggregate TOTAL (lines, regions, functions) so Task 8
can compute any required floor bump.

### Task 8 — Bump `bin/test` floors on aggregate boundary crossings

Using the aggregate TOTAL captured in Task 7, compare to the
current `bin/test` flags (`--fail-under-lines 97`,
`--fail-under-regions 97`, `--fail-under-functions 95`). For each
metric whose TOTAL's `floor(whole_percent)` is greater than the
current flag value, bump the flag in `bin/test` to the new floor.
For each metric whose TOTAL is in the same whole-percent range as
the current flag, leave the flag unchanged. Never lower a flag.

Commit the bump in the same commit that earned the improvement
per `.claude/rules/no-waivers.md` "Plan-Phase Coverage-Floor
Trigger". If no metric crossed a whole-percent boundary, this
task is a no-op commit guard — document the measurement in the
commit message and move on.
```

</details>

## DAG Analysis

<details>
<summary>Decompose plugin output</summary>

```text
# Pre-Decomposed Analysis: 100% coverage — concurrency + state mutation

# 100% coverage — concurrency + state mutation

## Problem

Concurrency-touching modules below 100%:

- `src/lock.rs` — 94.26% regions, 75.00% functions (11 of 44), 93.33% lines — **no dedicated `tests/lock.rs`**; the 25% function gap is untested error paths in the core lock primitive
- `src/commands/start_lock.rs` — 96.93% regions, 93.33% functions, 96.60% lines
- `src/commands/init_state.rs` — 96.94% regions, 79.31% functions (6 of 29), 96.58% lines

Hook files (all near 100%, sweep to close):
- `src/hooks/stop_continue.rs` — 98.85% regions, 99.07% functions
- `src/hooks/validate_pretool.rs` — 99.51% regions, 98.96% lines
- `src/hooks/validate_ask_user.rs` — 99.77% regions, 99.51% lines
- `src/hooks/validate_claude_paths.rs` — 99.40% regions, 99.52% lines
- `src/hooks/validate_worktree_paths.rs` — 99.64% regions, 99.38% lines
- `src/hooks/mod.rs` — 96.88% regions, 98.21% lines

## Files to Investigate

- `src/lock.rs`, `src/commands/start_lock.rs`, `src/commands/init_state.rs`
- `src/hooks/*.rs` (6 files)
- `tests/start_lock.rs`, `tests/init_state.rs`, `tests/hooks.rs`, `tests/hooks_shared.rs`
- `.claude/rules/testing-gotchas.md` — Timing-Sensitive Test Isolation (use `filetime::set_file_mtime`, NOT `thread::sleep`)

## Acceptance Criteria

- [ ] New test file: `tests/lock.rs` covering stale-lock cleanup, release-without-acquire, wait-timeout, acquire-while-held branches using `filetime::set_file_mtime` per testing-gotchas.md.
- [ ] `commands/init_state.rs`: named tests covering every untested function (derive-branch branches, prompt-file branches, relative-cwd branches).
- [ ] `commands/start_lock.rs`: named tests for remaining uncovered branches.
- [ ] Hook sweep: every hook file at 100% regions, functions, lines.
- [ ] `.flow-coverage-floor.json` entries for all listed files at 100.00.

## Out of Scope

- Non-concurrency modules (owned by other issues).

## End-of-Issue Floor Bump

Run `bin/flow ci`. Read new TOTAL. Bump `bin/test` thresholds to `floor(new TOTAL)`.
```

</details>

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 3m |
| Plan | <1m |
| **Total** | **3m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/100-coverage-concurrency-state.json</summary>

```json
{
  "schema_version": 1,
  "branch": "100-coverage-concurrency-state",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1223,
  "pr_url": "https://github.com/benkruger/flow/pull/1223",
  "started_at": "2026-04-16T22:30:22-07:00",
  "current_phase": "flow-plan",
  "files": {
    "plan": ".flow-states/100-coverage-concurrency-state-plan.md",
    "dag": ".flow-states/100-coverage-concurrency-state-dag.md",
    "log": ".flow-states/100-coverage-concurrency-state.log",
    "state": ".flow-states/100-coverage-concurrency-state.json"
  },
  "session_tty": "/dev/ttys002",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue #1200",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-04-16T22:30:22-07:00",
      "completed_at": "2026-04-16T22:33:44-07:00",
      "session_started_at": null,
      "cumulative_seconds": 202,
      "visit_count": 1
    },
    "flow-plan": {
      "name": "Plan",
      "status": "in_progress",
      "started_at": "2026-04-16T22:33:55-07:00",
      "completed_at": null,
      "session_started_at": "2026-04-16T22:33:55-07:00",
      "cumulative_seconds": 0,
      "visit_count": 1
    },
    "flow-code": {
      "name": "Code",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-complete": {
      "name": "Complete",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-04-16T22:33:55-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-complete": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 8
}
```

</details>

## Session Log

<details>
<summary>.flow-states/100-coverage-concurrency-state.log</summary>

```text
2026-04-16T22:30:21-07:00 [Phase 1] start-init — lock acquire ("acquired")
2026-04-16T22:30:21-07:00 [Phase 1] start-init — prime-check ("ok")
2026-04-16T22:30:22-07:00 [Phase 1] start-init — upgrade-check ("current")
2026-04-16T22:30:22-07:00 [Phase 1] create .flow-states/100-coverage-concurrency-state.json (exit 0)
2026-04-16T22:30:22-07:00 [Phase 1] freeze .flow-states/100-coverage-concurrency-state-phases.json (exit 0)
2026-04-16T22:30:22-07:00 [Phase 1] start-init — init-state ("ok")
2026-04-16T22:30:23-07:00 [Phase 1] start-init — label-issues (labeled: [1200], failed: [])
2026-04-16T22:30:29-07:00 [Phase 1] start-gate — git pull (ok)
2026-04-16T22:33:23-07:00 [Phase 1] start-gate — CI baseline ("ok")
2026-04-16T22:33:24-07:00 [Phase 1] start-gate — update-deps ("ok")
2026-04-16T22:33:31-07:00 [Phase 1] start-workspace — worktree .worktrees/100-coverage-concurrency-state (ok)
2026-04-16T22:33:36-07:00 [Phase 1] start-workspace — commit + push + PR create (ok)
2026-04-16T22:33:36-07:00 [Phase 1] start-workspace — state backfill (ok)
2026-04-16T22:33:36-07:00 [Phase 1] start-workspace — lock released (ok)
2026-04-16T22:33:44-07:00 [Phase 1] phase-finalize --phase flow-start ("ok")
2026-04-16T22:33:44-07:00 [Phase 1] phase-finalize --phase flow-start — notify-slack ("skipped")
2026-04-16T22:37:13-07:00 [Phase 2] exploration — start
```

</details>