### PR TITLE
Trim CLAUDE.md and rule corpus to forward-facing prose, lock opt-out inventory.

### DIFF
--- a/.claude/rules/adversarial-probe-lifecycle.md
+++ b/.claude/rules/adversarial-probe-lifecycle.md
@@ -74,16 +74,3 @@ audit the adversarial probe file. For each test in the probe:
 The default is delete. The probe's purpose is to surface findings
 during Code Review, not to live as a long-lived regression guard.
 Regression guards belong in `tests/<path>/<name>.rs`.
-
-## Cross-References
-
-- `skills/flow-code-review/SKILL.md` — Step 2 launches the
-  adversarial agent; Step 4 fixes findings; this rule covers the
-  reconciliation that closes the loop.
-- `.claude/rules/test-placement.md` — named regression guards
-  live in `tests/<path>/<name>.rs`, not in the throwaway probe.
-- `agents/adversarial.md` — agent prompt that produces the probe.
-- `assets/bin-stubs/test.sh` — recommended per-language probe
-  paths.
-- `src/prime_check.rs::EXCLUDE_ENTRIES` — `.git/info/exclude`
-  patterns that keep the throwaway probe out of `git status`.

--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -36,13 +36,6 @@ intervene to say "please continue the thing I already told you to
 continue." Every such intervention costs trust and round-trip
 latency.
 
-The specific failure mode this rule targets: a long Code phase
-(many tasks, many commits) where the session begins to feel
-context pressure and injects a pause to "check in" with the user.
-The user then has to say "you stopped for no reason, keep going."
-This happened during PR #1046 twice in the same Code phase; see
-the state file's `findings[]` for the recorded learnings.
-
 ## How to Apply
 
 - At every step boundary in a `continue: auto` phase, the next
@@ -107,8 +100,3 @@ the user invokes it during an in-progress autonomous phase, the
 hook blocks that confirmation. Workaround: invoke with `--auto`
 to skip the confirmation, or accept the block by switching the
 current phase to `manual` before aborting.
-
-This is the hook-level escalation described by
-`.claude/rules/hook-vs-instruction.md` — the rule exists because
-the user-visible pauses observed during PR #1046 proved that
-instruction-level enforcement alone was insufficient.

--- a/.claude/rules/branch-path-safety.md
+++ b/.claude/rules/branch-path-safety.md
@@ -19,7 +19,6 @@ nested subdirectory the discovery scanners cannot see.
 
 ## The Rule
 
-<!-- scope-enumeration: imperative -->
 Branch names that flow into a `.flow-states/` or `.worktrees/`
 path must reach the filesystem through one of three guards:
 
@@ -84,17 +83,11 @@ accepts a branch.
 ## Cross-References
 
 - `.claude/rules/external-input-validation.md` — the broader
-  prose discipline for fallible constructors. This rule is a
-  specialization of that one for the specific case of branch
-  names flowing into directory paths.
+  prose discipline for fallible constructors.
 - `.claude/rules/external-input-audit-gate.md` — the Plan-phase
-  gate that requires a callsite audit table. Branch-validation
-  tightenings trigger that gate; the table must enumerate both
-  hook and CLI callsite families.
+  gate that requires a callsite audit table.
 - `src/flow_paths.rs` — `FlowPaths::is_valid_branch`,
   `FlowPaths::new`, and `FlowPaths::try_new` are the canonical
-  guards. Their doc comments name the four rejection classes
-  with the cleanup-blast-radius rationale inline.
+  guards.
 - `tests/flow_paths.rs` — coverage for every rejection class
-  through every entry point (predicate, fallible constructor,
-  panicking constructor).
+  through every entry point.

--- a/.claude/rules/ci-is-a-gate.md
+++ b/.claude/rules/ci-is-a-gate.md
@@ -42,7 +42,7 @@ fence — so adjacent bash blocks in the same section must each carry
 their own preamble, not inherit from a distant section across
 unrelated blocks.
 
-The CI-running subcommand family (as of issue #1182):
+The CI-running subcommand family:
 
 - `bin/flow ci` — the direct CI runner
 - `bin/flow start-gate` — runs CI on the base branch under the start

--- a/.claude/rules/cli-output-contracts.md
+++ b/.claude/rules/cli-output-contracts.md
@@ -48,9 +48,7 @@ contract specification listing four items:
    code signals to the caller. The default success/failure
    convention (`0` ok, `1` error) is acceptable but must be
    stated; non-default codes (e.g., `2` for input-resolution
-   failures) must be named with their trigger and how the caller
-   distinguishes them from accidental scripting errors that
-   happen to share the same exit code.
+   failures) must be named with their trigger.
 3. **Error messages.** What appears on stderr for each error
    class. Errors fall into two buckets: `infrastructure errors`
    (subprocess failed, file system unavailable — caller cannot
@@ -96,20 +94,15 @@ The plan task must name the normalization rule explicitly:
 **Plan phase.** Add the four-item contract plus the
 caller-side normalization rule to the implementation task. Cite
 the consumers that will read the output (skill bash block paths,
-Rust caller modules) so the contract's audience is explicit. The
-contract is a section of the task description, not a deferred
-Risks note — Plan-phase reviewers read the Tasks section and
-check the contract for completeness.
+Rust caller modules) so the contract's audience is explicit.
 
 **Code phase.** Implement the subcommand or flag to match the
 contract verbatim. Adding a fallback or changing an exit code
 mid-Code phase is a plan deviation per
-`.claude/rules/plan-commit-atomicity.md` "Plan Signature
-Deviations Must Be Logged" and must be logged via `bin/flow log`
-before the commit lands. The Code Review reviewer agent
-cross-references the contract against the implementation; any
-mismatch (added fallback, changed exit code, new error class) is
-a Real finding.
+`.claude/rules/plan-commit-atomicity.md` and must be logged via
+`bin/flow log` before the commit lands. The Code Review reviewer
+agent cross-references the contract against the implementation;
+any mismatch is a Real finding.
 
 **Code Review phase.** Verify the contract is present in the
 plan and that the implementation matches it. Findings:
@@ -124,26 +117,3 @@ plan and that the implementation matches it. Findings:
 - Caller-side normalization missing or incomplete → Real
   finding, fix in Step 4 by adding the explicit normalization
   prose to the SKILL.md.
-
-## Cross-References
-
-- `.claude/rules/docs-with-behavior.md` — the new-subcommand
-  documentation rule. New subcommands also require CLAUDE.md
-  Key Files entries and `docs/reference/flow-state-schema.md`
-  updates when state mutations are involved; this rule covers
-  the API contract layer of the same change.
-- `.claude/rules/plan-commit-atomicity.md` "Plan Signature
-  Deviations Must Be Logged" — the discipline for handling
-  contract changes discovered during Code phase.
-- `.claude/rules/external-input-validation.md` — when
-  subcommand output flows back into another subcommand's
-  input, the consumer must validate the value through
-  fallible constructors (`FlowPaths::try_new`, etc.).
-- `.claude/rules/security-gates.md` "Normalize Before
-  Comparing" — when subcommand output is compared against
-  string constants in a gate, the comparison must normalize
-  both sides.
-- `.claude/rules/tool-dispatch.md` — bin-stub conventions for
-  the `bin/format` / `bin/lint` / `bin/build` / `bin/test`
-  family. Flag additions to those stubs that produce consumed
-  output also fall under this rule.

--- a/.claude/rules/code-review-scope.md
+++ b/.claude/rules/code-review-scope.md
@@ -23,19 +23,13 @@ Mechanical enforcement ensures the path is absent:
 - `bin/flow add-finding` applies a positive allowlist: the outcome
   must be in `{fixed, dismissed}` when `--phase flow-code-review`.
   Both inputs are normalized (whitespace trimmed, NULs stripped,
-  ASCII-lowercased) before comparison, so whitespace or case drift
-  in CLI arguments cannot bypass the gate. Any outcome outside the
-  allowed set — including `filed` and any future outcome added to
-  `VALID_OUTCOMES` — is rejected.
+  ASCII-lowercased) before comparison.
 - `bin/flow issue` blocks issue creation when the state file shows
-  `current_phase == "flow-code-review"` (normalized via the same
-  trim + NUL-strip + lowercase). The gate fails CLOSED when a
-  non-empty state file exists but its `current_phase` cannot be
-  determined (invalid JSON, BOM prefix, wrong type, missing key).
-  The `--override-code-review-ban` flag bypasses the gate and is
-  the deliberate-friction escape hatch for exceptional cases
-  (e.g., a FLOW process gap raised inside a Code Review that
-  genuinely cannot wait for Phase 5 Learn).
+  `current_phase == "flow-code-review"`. The gate fails CLOSED
+  when a non-empty state file exists but its `current_phase`
+  cannot be determined. The `--override-code-review-ban` flag
+  bypasses the gate and is the deliberate-friction escape hatch
+  for exceptional cases.
 
 ## Supersession Exception
 
@@ -43,8 +37,7 @@ Before classifying a finding as Real or False positive, run the
 supersession test from `.claude/rules/supersession.md`. If the
 finding describes code the PR has made permanently redundant, the
 in-scope action is deletion regardless of file location — not
-filing. The supersession check is complementary to this rule; it
-routes superseded code to Step 4 for deletion.
+filing.
 
 ## Value-vs-Bureaucracy Finding Triage
 
@@ -65,8 +58,7 @@ other in adjacent sections, or a missing redundant doc comment
 that restates what the source already says. The fix lands quickly
 and looks productive, but it does not change behavior, does not
 unblock a future reader, and does not prevent any class of
-regression. Every such fix is pure churn — a maintenance cost
-paid in exchange for the appearance of diligence.
+regression.
 
 ### The triage test
 
@@ -99,9 +91,7 @@ because their fixes change behavior or prevent bugs.
 
 The trap concentrates in tenant 6 (documentation): doc-drift
 findings that restate information already encoded elsewhere.
-Apply the test most rigorously there, where the cost of a
-redundant fix is lowest and the rate of agent over-flagging is
-highest.
+Apply the test most rigorously there.
 
 The "Key Files" addition in `CLAUDE.md` is the canonical edge
 case: per `.claude/rules/docs-with-behavior.md` "What Counts," a
@@ -134,18 +124,15 @@ skill update lands on **the base branch** (the integration branch
 the flow coordinates against — `main` for standard repos,
 `staging`/`develop`/etc. for non-main-trunk repos) during an active
 Code or Code Review phase on an already-started branch. Both rule
-files (`.claude/rules/*.md`) and skill files (`skills/**/SKILL.md`
-and `.claude/skills/**/SKILL.md`) flow into the current session via
-the auto-inserted `system-reminder` that surfaces edited files —
-the Code phase sees the updated text even though the feature branch
+files and skill files flow into the current session via the
+auto-inserted `system-reminder` that surfaces edited files — the
+Code phase sees the updated text even though the feature branch
 forked before it was written.
 
 Skills are the same drift surface as rules: both are dynamic
 instructions the Code phase follows. A skill that adds a new step,
 changes a gate, or tightens a commit convention can retroactively
-flag the current branch's in-progress work, exactly the way a rule
-update does. The decision tree below is written against rules, but
-every criterion applies identically to skill updates.
+flag the current branch's in-progress work.
 
 When this happens, the Code phase has a decision to make:
 
@@ -192,23 +179,3 @@ noticed the change and consciously chose a path" from "Claude
 ignored the change". The Learn phase analyst reads the log when
 auditing compliance and treats an undocumented decision as a
 process gap.
-
-### Motivating incident
-
-PR #1157 (Coverage: HTTP client trait seam) was mid-Code-phase when
-`.claude/rules/external-input-validation.md` was updated on main to
-extend the `FlowPaths::try_new` discipline to CLI subcommand
-`--branch` overrides (per issue #1137). The Code phase notes
-indicated awareness of the rule update but elected not to fix the
-pre-existing `FlowPaths::new(root, branch)` call in
-`phase_finalize::run_impl_with_deps`. Code Review's reviewer agent
-caught the violation under the new rule's lens, and the fix landed
-as a Code Review finding in the same PR. The deferral was a valid
-scope-management decision per this rule's "defer" criterion
-(wide-blast-radius is arguable; the call was adjacent to already-
-changed code, so "proactively sweep" would also have been
-defensible). What was missing was the log entry — the decision was
-implicit, leaving Learn to infer the reasoning from commit messages
-and absent state notes. This section codifies the logging
-discipline. The incident involved a rule update; the same logging
-discipline applies to skill updates by symmetry.

--- a/.claude/rules/code-task-counter.md
+++ b/.claude/rules/code-task-counter.md
@@ -27,13 +27,6 @@ The counter has two readers:
    under-count makes the audit incorrectly flag the PR as
    incomplete and produces a false process-gap finding.
 
-PR #1156 surfaced this exactly. The plan listed 13 tasks and the
-PR delivered all 13, but `code_task` only reached 7 because each
-test+implementation pair (Tasks 3+4, 5+6, 7+8, 9+10) was treated
-as a single increment. The Learn audit had to manually
-reconstruct the actual task count from commit messages instead of
-trusting the counter.
-
 ## How to Apply
 
 When a plan task description names a paired test+implementation
@@ -53,8 +46,7 @@ group (TDD pair):
 When a plan marks a set of tasks as an atomic commit group
 (per `.claude/rules/plan-commit-atomicity.md`), the same
 discipline applies: increment the counter once per task in the
-group before the single commit lands. The atomic-group rule
-governs commit boundaries; this rule governs the counter.
+group before the single commit lands.
 
 For atomic groups, batch all counter advances in a single CLI
 call using multiple `--set` arguments:
@@ -78,7 +70,7 @@ Example: Task 2 lands its implementation, but the new code
 introduces an `Option::None` branch in `check_X` that only Task
 9's edge-case tests exercise. Coverage gate is 100/100/100. To
 land Task 2's commit green, Task 9's tests must already exist in
-the diff. The Code phase writes Tasks 9's test code in the same
+the diff. The Code phase writes Task 9's test code in the same
 commit as Tasks 1-4.
 
 The counter rule still requires +1 per task. Apply this shape:
@@ -123,14 +115,3 @@ validated against the state as mutated by preceding `--set` args
 in the same call. A jump (e.g., `--set code_task=5` when current
 is 0) is rejected; sequential steps (e.g., `--set code_task=1
 --set code_task=2`) succeed.
-
-## Cross-References
-
-- CLAUDE.md "State Mutations" section names the
-  increment-by-exactly-1 invariant.
-- `.claude/rules/plan-commit-atomicity.md` covers commit-grouping
-  rules; this rule covers counter-grouping rules. The two are
-  orthogonal: a paired test+implementation group can land in one
-  commit (atomic) while the counter advances twice (per task).
-- `skills/flow-code/SKILL.md` "Commit" section is where the
-  per-task increment instruction lives.

--- a/.claude/rules/comment-quality.md
+++ b/.claude/rules/comment-quality.md
@@ -79,11 +79,6 @@ The correct rewrite discipline:
    only makes sense to a reader who has read the old comment, it is
    still backward-facing — go back to step 1.
 
-Rewrites that miss this discipline produce a second round of
-violations: the scanner or a reviewer flags the rewrite, another
-Code Review cycle fixes it, and the fix commit doubles the work.
-Read the code first, write from the code.
-
 ## Enforcement
 
 `tests/tombstones.rs::test_no_backward_facing_comments_in_rust_source`
@@ -91,11 +86,10 @@ mechanically enforces this rule at CI time. The scanner walks every
 `*.rs` file under `src/` and `tests/`, filters out lines matching the
 tombstone exception (`Tombstone:.*?PR #`), and asserts no line contains
 any phrase from a curated prohibited-pattern list (covering parity
-references to a deleted Python codebase, historical PR provenance,
-origin stories, "Before the fix" narratives, and dead section markers).
-The scanner self-excludes its own file via canonicalized-path
-comparison because it must contain the prohibited patterns as search
-input.
+references, historical PR provenance, origin stories, "Before the fix"
+narratives, and dead section markers). The scanner self-excludes its
+own file via canonicalized-path comparison because it must contain
+the prohibited patterns as search input.
 
 The pattern list is curated rather than regex-based: it captures every
 phrasing the rule explicitly prohibits, plus the phrasings observed in

--- a/.claude/rules/concurrency-model.md
+++ b/.claude/rules/concurrency-model.md
@@ -21,24 +21,20 @@ Ask: "What happens when two flows hit this at the same time?"
   resources (like `start.lock` for base-branch operations).
   Most operations should not need locks because they operate
   on branch-scoped resources.
-- **Base branch (the integration branch the flow coordinates
+- **Base branch** (the integration branch the flow coordinates
   against — `main` for standard repos, `staging`/`develop`/etc.
-  for non-main-trunk repos)** — is the only shared local
-  resource. Any operation on the base branch (pull, commit,
-  push) must be serialized via the start lock or avoided
-  entirely.
+  for non-main-trunk repos) is the only shared local resource.
+  Any operation on the base branch (pull, commit, push) must be
+  serialized via the start lock or avoided entirely.
 - **Start-gate runs CI on the base branch under the start lock
   as a coordination surface**, not a sandboxable safety check.
   The first flow-start repairs dependency breakage once via
   `ci-fixer`; subsequent flows inherit the fix via the CI
   sentinel. Moving the CI check to a disposable worktree would
   force every concurrent flow to rediscover and independently
-  repair the same breakage — O(N) work instead of O(1). Tools
-  that write artifacts under the base branch's `target/` must
-  stay coherent across the many source generations that
-  long-lived target dir sees. See CLAUDE.md "Start-Gate CI on
-  the Base Branch as Serialization Point" for the full
-  architecture.
+  repair the same breakage — O(N) work instead of O(1). See
+  CLAUDE.md "Start-Gate CI on the Base Branch as Serialization
+  Point" for the full architecture.
 
 ## Completed Flow State File Leftovers
 
@@ -115,21 +111,17 @@ by basename suffix so absolute paths like
   quote pair around the launcher.
 - **`git -c key=value commit ...`** and **`git -C path commit ...`** —
   the matcher walks past these flag pairs to find the effective
-  subcommand, so config overrides and explicit-cwd flags do not
-  hide the `commit`.
+  subcommand.
 - **`bash -c '<inner>'` and `sh -c '<inner>'`** — one level of
   shell wrapping is unwrapped, and the inner script is
   re-evaluated through the same matcher.
 - **`git -C <other_repo> commit ...`** — branch resolution reads
   from BOTH the hook's process cwd AND the `-C` argument's path,
   and Layer 10 blocks if EITHER resolves to its own integration
-  branch. So redirecting git's effective cwd onto a different
-  repo on `main` does not bypass the gate when the hook is
-  running from a feature-branch worktree.
+  branch.
 - **`bin/flow <flag> finalize-commit`** — the `bin/flow` arm
   matches `finalize-commit` as any subsequent token, not just
-  the immediate next one, so a future global flag (e.g.
-  `--verbose`, `--log-level <value>`) cannot slip the
+  the immediate next one, so a future global flag cannot slip the
   subcommand past the matcher.
 
 ### Active-Flow Trigger
@@ -142,16 +134,12 @@ running. The trigger is the existence of
 `.flow-states/<branch>/state.json` at the resolved project root,
 detected via the canonical `is_flow_active(branch, root)` helper
 shared with every other flow-aware hook (`validate-ask-user`,
-`validate-claude-paths`, `stop_continue`, etc.) — no parallel
-detection logic exists.
+`validate-claude-paths`, `stop_continue`, etc.).
 
 The active-flow context covers the same bypasses as the
-integration-branch context (quoted command names, `git -c k=v`,
-`git -C path`, `bash -c`/`sh -c`, `bin/flow <flag>
-finalize-commit`) and applies to both candidate cwds (process
-cwd and any `-C` target). When both predicates fire on the same
-candidate (the rare case of an active flow on the integration
-branch itself), the integration-branch message wins.
+integration-branch context and applies to both candidate cwds
+(process cwd and any `-C` target). When both predicates fire on
+the same candidate, the integration-branch message wins.
 
 User-direction interaction mirrors the integration-branch
 posture: an explicit user direction in the current session does
@@ -159,11 +147,7 @@ NOT lift the active-flow gate. The way to commit during an
 active flow is `/flow:flow-commit`, which routes through
 `bin/flow finalize-commit` from inside the skill — that path
 runs CI before `git commit` and is the only sanctioned commit
-surface during a flow. The active-flow gate exists because the
-rule "always commit through `/flow:flow-commit`" was previously
-mechanical only on the integration branch; PR #1322 surfaced
-that feature-branch commits could land without CI, and the
-gate's expansion closes the open backdoor.
+surface during a flow.
 
 The pre-flow editing scenario remains unblocked: if no state
 file exists at `.flow-states/<branch>/state.json` (the user
@@ -174,23 +158,18 @@ once a flow is genuinely active.
 **Skill-commit carve-out.** The active-flow gate would otherwise
 block the legitimate skill path itself, because
 `/flow:flow-commit` invokes `bin/flow finalize-commit` via the
-Bash tool and `is_commit_invocation` matches both `git commit`
-and `bin/flow ... finalize-commit`. The carve-out passes the
-invocation through iff BOTH conditions hold for the candidate
-cwd:
+Bash tool. The carve-out passes the invocation through iff BOTH
+conditions hold for the candidate cwd:
 
 1. The command shape is `bin/flow ... finalize-commit` (NOT
    `git commit`). Raw `git commit` is never legitimate during a
-   flow even with the marker present — the skill never invokes
-   bare git commit, so the marker plus a `git commit` command is
-   always a bypass attempt.
+   flow even with the marker present.
 2. The state file at `.flow-states/<branch>/state.json` has
    `_continue_pending == "commit"`. The flow-code, flow-code-
    review, and flow-learn skills all set this field via
    `bin/flow set-timestamp` immediately before invoking
    `/flow:flow-commit`, and `phase_enter()` clears it on phase
-   advance — so the marker is `"commit"` only during the skill-
-   driven commit window.
+   advance.
 
 The integration-branch context is NOT carved out — commits on
 the integration branch are blocked regardless of the marker.
@@ -204,12 +183,9 @@ the skill's diff review and commit-message review. The hook
 preserves the CI invariant — `finalize-commit` runs
 `ci::run_impl()` before `git commit` regardless — but the
 surrounding choreography is upheld by the rule discipline, not
-by the hook. A stronger one-shot-token gate (token written by
-`/flow:flow-commit`'s preflight, validated and consumed by
-`finalize-commit`, checked by Layer 10) is the next iteration
-if the marker-only design proves insufficient in practice.
+by the hook.
 
-### Known Limitations in v1
+### Known Limitations
 
 The current matcher does not defend against the following shapes.
 Each is captured by an explicit test (or, where the test would be
@@ -219,32 +195,26 @@ rather than an accident:
 
 - **Env-var indirection.** `GIT_DIR=/path git commit` and
   `GIT_WORK_TREE=...` redirect git's view of the repo via env
-  vars rather than CLI flags. Env vars are not visible to the
-  matcher in the simple form.
+  vars rather than CLI flags.
 - **User-defined git aliases.** `git ci -m x` (with
   `alias.ci = commit` configured) shows `ci` to the matcher, not
-  `commit`. Git resolves aliases internally after the hook fires.
+  `commit`.
 - **Command-construction launchers.** `xargs git commit`,
   `node finalize-commit`, and similar shapes hide the commit
-  invocation behind another binary. The matcher only fires on
-  recognized first tokens (`git`, `bin/flow`, `bash`, `sh`).
+  invocation behind another binary.
 - **Nested shell wrappers.** `bash -c 'bash -c "..."'` is
-  unwrapped at most one level — a deeper nesting falls through.
+  unwrapped at most one level.
 - **Bash with flags before `-c`.** `bash --norc -c '...'` does
-  not match the literal `bash -c ` prefix the unwrapper looks
-  for, so the inner script is not re-evaluated.
+  not match the literal `bash -c ` prefix.
 - **Repos with no configured `origin/HEAD`.** `default_branch_in`
   falls back to `"main"` when `git symbolic-ref --short
-  refs/remotes/origin/HEAD` fails. A user committing on a
-  branch literally named `main` in a remote-less repository
-  will be blocked — a documented false-positive that the
-  remote-aware path covers correctly.
+  refs/remotes/origin/HEAD` fails.
 
-These limitations are not security holes — they are documented
-v1 boundaries. The default-no-edit-on-the-base-branch discipline
+These limitations are documented v1 boundaries, not security
+holes. The default-no-edit-on-the-base-branch discipline
 above remains the primary instrument; Layer 10 is the
-merge-conflict trip-wire for the four shapes Claude is most
-likely to produce by accident.
+merge-conflict trip-wire for the shapes Claude is most likely to
+produce by accident.
 
 ## Common Mistakes
 
@@ -256,4 +226,3 @@ likely to produce by accident.
 - Assuming a GitHub label or issue state hasn't changed since
   last check
 - Acquiring a lock under one name and releasing under another
-  (e.g., feature name vs canonical branch name)

--- a/.claude/rules/config-source-mapping.md
+++ b/.claude/rules/config-source-mapping.md
@@ -5,11 +5,7 @@ When a plan task modifies a config file (`.claude/settings.json`,
 that a derived value (a hash, a checksum, a generated artifact) is
 affected by such a modification, the plan must cite the specific
 Rust code, hook script, or downstream consumer that reads the
-value being changed. Wrong assumptions about config-source
-mapping produce plans that propose work the consumer never
-performs (e.g., a hash bump for a value the hash function does
-not read) and confuse Code-phase review when the proposed effect
-fails to materialize.
+value being changed.
 
 ## Why
 
@@ -19,16 +15,14 @@ about the system's data flow. If the hash function actually reads
 Rust constants in `src/prime_check.rs::UNIVERSAL_ALLOW`/
 `FLOW_DENY` and not the JSON file at all, the plan's task list
 is built on a false premise: the hash bump never happens, and
-every downstream task that depends on it (e.g., updating a pinned
-hash literal in tests, signaling a re-prime requirement) is
-either redundant or wrong.
+every downstream task that depends on it is either redundant or
+wrong.
 
 The fix is upstream of Code phase: the plan must verify which
 code reads the modified value before making downstream claims.
 The verification step is cheap (one grep, one Read of the
 identified consumer) and catches the assumption while it is
-still in plan prose, where it costs minutes to fix instead of
-hours of Code-phase rework.
+still in plan prose.
 
 ## The Rule
 
@@ -49,16 +43,14 @@ Tasks or Risks section must enumerate:
    the modified value is in the input set.
 4. **The verification path.** A grep, Read, or bin/flow
    subcommand invocation that confirms the consumer reads the
-   value as claimed. Place the verification artifact in the
-   plan's Risks or Exploration section so Code phase can
-   re-run it.
+   value as claimed.
 
 ## Canonical Config-Source Mappings
 
 These are the load-bearing config-to-reader mappings in the
-FLOW codebase as of this rule's authoring. New mappings
-discovered during plan exploration should be added here so
-future plan authors can cite an authoritative reference.
+FLOW codebase. New mappings discovered during plan exploration
+should be added here so future plan authors can cite an
+authoritative reference.
 
 ### `compute_config_hash`
 
@@ -81,8 +73,6 @@ prompts honor the allow/deny lists, and the global
 active flows. No Rust subcommand parses this file.
 
 Modifications take effect immediately for the active session.
-There is no compile-time consumer that needs re-running on
-change.
 
 ### `.flow.json`
 
@@ -90,8 +80,7 @@ Read at flow-start by `start-init`/`init_state` and copied into
 the per-flow state file. After `flow-start`, the running flow
 reads its preferences (`skills`, `commit_format`, etc.) from
 `.flow-states/<branch>/state.json`, never from `.flow.json`
-directly. Code, Code Review, Learn, and Complete phases
-operate from the state file copy.
+directly.
 
 Hash inputs: `config_hash` and `setup_hash` are stored in
 `.flow.json` and compared by `prime_check.rs` when version
@@ -103,15 +92,14 @@ above), not from `.flow.json` itself.
 Read at runtime by `bin/flow check-phase`, `phase-enter`,
 `phase-finalize`, and `phase-transition`. Defines the phase
 state machine: phase names, commands, valid back-transitions.
-A change to phase ordering or back-transitions takes effect on
-the next subcommand invocation.
+A change takes effect on the next subcommand invocation.
 
 ### `hooks/hooks.json`
 
 Read by Claude Code at session start. Defines hook
 registration: which Rust subcommand handles each tool-use
 event. A change requires a new Claude Code session to take
-effect (Claude Code caches the hook map).
+effect.
 
 ### `assets/bin-stubs/<tool>.sh`
 
@@ -142,27 +130,11 @@ config file:
 
 **Code phase.** When discovery during implementation reveals
 the plan's mapping was wrong, log the deviation per
-`.claude/rules/plan-commit-atomicity.md` "Plan Signature
-Deviations Must Be Logged" and update the plan or the canonical
-mapping table above.
+`.claude/rules/plan-commit-atomicity.md` and update the plan or
+the canonical mapping table above.
 
 **Code Review phase.** The reviewer agent checks every
 config-modification task in the diff against the plan's cited
 consumers. A modification with no cited consumer or with a
 consumer that does not actually read the modified value is a
-Real finding fixed in Step 4 by either adjusting the plan's
-claim or removing the misguided downstream task.
-
-## Cross-References
-
-- `.claude/rules/plan-commit-atomicity.md` "Plan Signature
-  Deviations Must Be Logged" — the mechanism for recording
-  Code-phase discoveries that contradict plan-time
-  assumptions.
-- `.claude/rules/external-input-validation.md` — sibling rule
-  for runtime input validation. This rule is about plan-time
-  data-flow assumptions; that rule is about runtime input
-  trust.
-- `src/prime_check.rs` — the canonical home of the
-  `UNIVERSAL_ALLOW`/`FLOW_DENY`/`EXCLUDE_ENTRIES` constants
-  and their hash function.
+Real finding fixed in Step 4.

--- a/.claude/rules/docs-with-behavior.md
+++ b/.claude/rules/docs-with-behavior.md
@@ -51,8 +51,7 @@ data is available. When a skill changes what artifacts it passes to
 a sub-agent (e.g. switching from full diff to substantive diff),
 update the agent's Input section in the same commit. Stale Input
 sections mislead the agent about available context and produce
-incorrect reasoning. CI cannot enforce this (agent Input sections
-are prose).
+incorrect reasoning.
 
 **Plan-phase enumeration requirement.** When a plan task modifies
 a skill that invokes one or more sub-agents, the plan's Exploration
@@ -87,9 +86,7 @@ tell users the only valid value is the original hardcoded one.
 **The trigger.** A plan task that adds a parameter, state field,
 or configuration axis where prior code hardcoded the value. Symptom
 language in the plan: "now reads X from Y," "previously hardcoded,"
-"plumb through," "honor the configured value." When such language
-appears in a plan task, the same plan must enumerate every prose
-surface that mentions the old hardcoded value.
+"plumb through," "honor the configured value."
 
 **The enumeration.** Grep the entire prose corpus for the old
 hardcoded value before Code phase begins:
@@ -115,9 +112,7 @@ Every matching file is in-scope. Group findings by classification:
 The distinguishing test: would the prose still be correct if it
 were applied to a target project where the configurable parameter
 holds a different value? If yes → universal → generalize. If no →
-self-referential → leave alone. Mixed-mode files (CLAUDE.md often
-contains both) are common; identify each section's classification
-individually.
+self-referential → leave alone.
 
 **Plan-phase task template.** A plan that introduces a
 configurable parameter must include a "Generalize universal prose"
@@ -130,9 +125,7 @@ task with these subtasks:
 4. Mark the universal-prose task as atomic with the
    implementation task per
    `.claude/rules/plan-commit-atomicity.md` so the prose lands
-   in the same PR as the code (the inverse of "self-referential
-   prose drift": code change without prose update produces
-   exactly that drift).
+   in the same PR as the code.
 
 **Code-phase verification.** Before committing the
 implementation, re-run the grep to confirm no universal-prose
@@ -185,10 +178,6 @@ fixing drift caused by a renamed or removed identifier. For the
 sibling rule covering **coverage claims** — plan prose that
 asserts a guard applies universally to a code family without
 naming its members — see `.claude/rules/scope-enumeration.md`.
-The two rules are complementary: the rename-side grep finds every
-file that still mentions the old identifier, while the
-coverage-side scanner catches universal-quantifier claims that
-lack a named sibling list.
 
 When renaming a command, replacing a subcommand, or fixing
 documentation drift, grep all files for the old identifier before

--- a/.claude/rules/duplicate-test-coverage.md
+++ b/.claude/rules/duplicate-test-coverage.md
@@ -17,14 +17,6 @@ twice is pure cost. The
 section calls this out as a duplicate guard, and the cheapest catch
 is at Plan time before the second test is written.
 
-Issue #1175 / PR #1173 surfaced this. The plan named
-`stop_continue_qa_pending_fallback_blocks` as a new subprocess
-test; a pre-existing `test_stop_continue_qa_pending_fallback_blocks`
-(identical except for the `test_` prefix) already exercised the same
-production path. Code Review caught the duplicate and deleted the
-older test, costing a full review cycle on work the Plan-phase gate
-could have prevented.
-
 ## The Rule
 
 The scanner normalizes every candidate test name via
@@ -71,21 +63,17 @@ Two line-level HTML comments suppress a trigger:
 
 - `<!-- duplicate-test-coverage: not-a-new-test -->` — the plan
   prose is discussing or referencing an existing test by name, not
-  proposing a new one. Use when a plan's Exploration section cites
-  an existing test as prior art.
+  proposing a new one.
 - `<!-- duplicate-test-coverage: intentional-duplicate -->` — the
   author is knowingly adding a parallel test whose name collides
   with an existing test. See the "Named Tests After Refactor"
   section of `.claude/rules/docs-with-behavior.md` for the class of
-  case this handles: a refactor that makes a test appear redundant
-  still requires the named test to exist, driven through a test
-  seam so the caller-level contract is independently asserted.
+  case this handles.
 
 Walk-back grammar matches sibling rules: the comment applies to
 its own line, the next non-blank line, or two lines below with a
 single blank line between. No chaining across more than one blank
-line. This mirrors `.claude/rules/scope-enumeration.md` and
-`.claude/rules/external-input-audit-gate.md`.
+line.
 
 ## Enforcement Topology
 
@@ -104,35 +92,22 @@ Three callsites share `duplicate_test_coverage::scan`:
 
 All three callsites return the same JSON error shape
 (`status="error"`, `violations[]`, `message`) with per-violation
-`rule="duplicate-test-coverage"` tags, so the repair loop is
-identical regardless of which path triggered the failure.
+`rule="duplicate-test-coverage"` tags.
 
 ### No corpus contract test
 
 Unlike the sibling `scope_enumeration` and `external_input_audit`
 rules, this rule intentionally ships without a corpus contract
 test over `CLAUDE.md`, `.claude/rules/*.md`, `skills/**/SKILL.md`,
-and `.claude/skills/**/SKILL.md`. The reason is empirical: the
-first attempt at such a scanner produced 18+ false positives on
-legitimate educational citations — `test_agent_frontmatter_only_supported_keys`
-in CLAUDE.md naming an enforcement mechanism,
-`production_ci_decider_tree_changed_returns_not_skipped` in
-`.claude/rules/extract-helper-refactor.md` as a reference pattern,
-and similar references across 8 rule files.
+and `.claude/skills/**/SKILL.md`. Legitimate educational citations
+of test names in rule files would false-positive at scale.
 
-Per `.claude/rules/tests-guard-real-regressions.md` "Forbidden
-patterns: Duplicate guards for a property already covered by an
-existing plan-check scanner," the corpus scan adds no protection
-on top of the Plan-phase gate already shipped. A plan that
-copy-pastes a test name from committed prose is caught by the
-same `plan_check` invocation that runs over plan content, so the
-documented-name-in-prose path never escapes the gate. Per
-`.claude/rules/scope-enumeration.md` "False-positive sweep before
-expanding the vocabulary" (count ≥ 5 → revert), the corpus scan
-was reverted to a documented empty marker at
-`tests/duplicate_test_coverage.rs`; its module doc comment
-records the rationale so future sessions do not re-derive this
-conclusion.
+Per `.claude/rules/tests-guard-real-regressions.md`, the corpus
+scan adds no protection on top of the Plan-phase gate already
+shipped — a plan that copy-pastes a test name from committed prose
+is caught by the same `plan_check` invocation that runs over plan
+content. `tests/duplicate_test_coverage.rs` ships as a documented
+empty marker; its module doc comment records the rationale.
 
 ## How to Apply
 
@@ -144,8 +119,7 @@ When `bin/flow plan-check` returns a violation tagged
    test and its location.
 2. Decide the correct path:
    - **Rename** — if the new test exercises a distinct property,
-     rename it so the normalized form differs from the existing
-     test's normalized form.
+     rename it so the normalized form differs.
    - **Strengthen** — if the new test exercises the same property,
      delete the new-test proposal from the plan and strengthen the
      existing test if its assertion is weaker than the plan
@@ -187,10 +161,7 @@ time but at the cost of a full plan-rewrite cycle.
 
 The pattern recurs most often with pre-decomposed issues
 (`/flow:flow-create-issue`) because the issue body is drafted
-ahead of plan-time codebase exploration. The
-`flow-create-issue` skill cannot afford to enumerate every test
-file in the repo at issue-filing time, so the discovery
-responsibility shifts to the Plan phase. Plan authors fed a
+ahead of plan-time codebase exploration. Plan authors fed a
 pre-decomposed issue with a `## Implementation Plan` section
 must NOT trust the test names in the issue verbatim — they must
 re-validate against the current state of the test corpus before
@@ -202,24 +173,4 @@ The length-filter threshold (≥ 10 characters) and the two-item
 opt-out grammar are closed and curated. Novel false-positive
 phrasings are handled by extending the vocabulary in follow-up
 commits, mirroring the discipline documented in
-`.claude/rules/scope-enumeration.md` "Vocabulary Extensibility."
-The rule file is the primary instrument; the scanner is the
-merge-conflict trip-wire.
-
-## Cross-References
-
-- `.claude/rules/tests-guard-real-regressions.md` — the prose
-  discipline this gate enforces mechanically. Also the authority
-  that explains why no corpus contract test ships.
-- `.claude/rules/scope-enumeration.md` — structurally sibling
-  gate; shares the opt-out grammar and three-callsite topology.
-- `.claude/rules/external-input-audit-gate.md` — the other
-  structurally sibling gate.
-- `.claude/rules/docs-with-behavior.md` "Named Tests After
-  Refactor" — the motivating class for the
-  `intentional-duplicate` opt-out.
-- `src/duplicate_test_coverage.rs` — the scanner implementation.
-- `src/plan_check.rs` — the standard-path gate.
-- `src/plan_extract.rs` — the extracted and resume gates.
-- `tests/duplicate_test_coverage.rs` — documented empty marker
-  explaining why no corpus contract test ships.
+`.claude/rules/scope-enumeration.md`.

--- a/.claude/rules/external-input-audit-gate.md
+++ b/.claude/rules/external-input-audit-gate.md
@@ -16,28 +16,15 @@ HOW the gate enforces it at Plan-phase completion.
 
 ## Why
 
-Issue #1054 surfaced this exactly. The plan tightened
-`FlowPaths::new` on the assumption that `branch_name()` sanitization
-applied to the function's callers. The assumption was wrong:
-`branch_name()` only runs at flow-start, while `current_branch()`
-returns raw git refs that commonly contain slashes
-(`feature/foo`, `dependabot/*`). Five hooks and `format-status`
-crashed with a Rust panic for users on standard git branches.
-The adversarial agent caught the regression in Code Review — too
-late; the cheaper catch is at Plan time.
+Reviewers cannot manually catch every callsite assumption. Adversarial
+testing surfaces gaps but only after the Code phase has already
+written the panic. The audit is cheap to write — a four-column table
+per panic-introducing plan is on the order of minutes; the cost of a
+missed audit is one full Code Review cycle plus a hot-fix.
 
-The rule exists because:
-
-1. **Reviewers cannot manually catch every callsite assumption.**
-   PR #1054's plan went through Code Review and only the
-   adversarial agent (writing failing tests) noticed the gap.
-2. **The audit is cheap to write.** A four-column table per
-   panic-introducing plan is on the order of minutes; the cost of
-   a missed audit is one full Code Review cycle plus a hot-fix.
-3. **Force-functioning the conversation works.** Requiring the
-   table at Plan completion forces the author to enumerate
-   callers — which is the same activity that catches the
-   `current_branch()` assumption directly.
+Force-functioning the conversation works. Requiring the table at Plan
+completion forces the author to enumerate callers — which is the
+same activity that catches assumption errors directly.
 
 ## The Trigger Vocabulary
 
@@ -96,12 +83,9 @@ A canonical audit table looks like:
 | `current_branch()` (`src/git.rs`) | git subprocess output | Trusted-but-external | `try_new`, treat `None` as no-active-flow |
 | `state["branch"]` (`src/start_init.rs`) | state file written by `branch_name()` | Guaranteed valid | `new` directly |
 
-The gate validates **table presence**, not row content. The rule's
-authority validates rows; the gate is a forcing function for the
-audit conversation. A TBD-content table (`| TBD | TBD | TBD | TBD |`)
-will pass the gate, but it signals author irresponsibility to the
-reviewer — that signal is the rule's responsibility, not the
-gate's.
+The gate validates **table presence**, not row content. A TBD-content
+table (`| TBD | TBD | TBD | TBD |`) will pass the gate, but it
+signals author irresponsibility to the reviewer.
 
 ## Opt-Out Grammar
 
@@ -114,12 +98,7 @@ tightening proposal) can carry the opt-out comment
 - two lines above with a single blank line in between.
 
 Larger gaps do not chain — the rule is "the next non-blank line
-with at most one blank line separating them," matching the
-sibling opt-out grammar in `scope-enumeration.md`.
-
-The opt-out walks back exactly one blank line by design — a stray
-opt-out at the top of a section cannot silence arbitrary triggers
-further down.
+with at most one blank line separating them."
 
 ## Enforcement Topology
 
@@ -127,18 +106,13 @@ Three callsites share `external_input_audit::scan`:
 
 - **Standard plan path** — `bin/flow plan-check` (called from
   `skills/flow-plan/SKILL.md` Step 4 →
-  `src/plan_check.rs::run_impl`). This is the gate the model hits
-  for plans it writes from scratch.
-- **Pre-decomposed extracted path** —
-  `src/plan_extract.rs` extracted path (~line 668) runs the
-  scanner against the promoted plan content for issues filed via
-  `/flow:flow-create-issue` with an `## Implementation Plan`
-  section.
-- **Resume path** — `src/plan_extract.rs` resume path (~line 432)
-  re-runs the scanner against the existing plan file when the
-  user re-enters Phase 2 after a prior violation. A plan edited
-  to fix the violations passes the gate here and the phase
-  completes.
+  `src/plan_check.rs::run_impl`).
+- **Pre-decomposed extracted path** — `src/plan_extract.rs` extracted
+  path runs the scanner against the promoted plan content for
+  issues filed via `/flow:flow-create-issue`.
+- **Resume path** — `src/plan_extract.rs` resume path re-runs the
+  scanner against the existing plan file when the user re-enters
+  Phase 2 after a prior violation.
 
 All three callsites return the same JSON error shape
 (`status="error"`, `violations[]`, `message`) so the repair loop
@@ -159,11 +133,7 @@ When `bin/flow plan-check` returns a violation tagged
 
 1. Read the cited line in the plan file. Identify the function
    the proposal tightens.
-2. Grep for the function's callers across `src/` (the rule file
-   `.claude/rules/external-input-validation.md` lists the
-   canonical hook callsite inventory as one example —
-   `stop_continue.rs`, `stop_failure.rs`, `post_compact.rs`,
-   `validate_ask_user.rs`, `validate_claude_paths.rs`).
+2. Grep for the function's callers across `src/`.
 3. Build the four-column audit table near the trigger in the
    plan. For each caller row:
    - **Caller** — file path and line range
@@ -179,16 +149,3 @@ When `bin/flow plan-check` returns a violation tagged
 If the trigger is a discussion mention rather than a proposal, add
 the `<!-- external-input-audit: not-a-tightening -->` opt-out
 comment using the walk-back rule above.
-
-## Cross-References
-
-- `.claude/rules/external-input-validation.md` — the prose
-  discipline (constructor patterns, `try_new` convention, hook
-  callsite rules).
-- `.claude/rules/scope-enumeration.md` — the structurally sibling
-  gate this design is modeled on, sharing the windowing
-  heuristic, opt-out grammar, and three-callsite topology.
-- `src/external_input_audit.rs` — the scanner implementation.
-- `src/plan_check.rs` — the standard-path gate.
-- `src/plan_extract.rs` — the extracted and resume gates.
-- `tests/external_input_audit.rs` — the corpus contract test.

--- a/.claude/rules/external-input-path-construction.md
+++ b/.claude/rules/external-input-path-construction.md
@@ -29,7 +29,7 @@ filesystem:
    redirect a read to `../../etc/passwd`,
    `~/.config/gh/hosts.yml`, or any file the running user can
    read. The fail-open pattern (`.ok()?`) makes the redirect
-   silent — no error surfaces to the user.
+   silent.
 2. **Unbounded resource consumption.** A transcript file or
    session log can grow to hundreds of megabytes during a long
    autonomous flow. When a per-step capture re-reads the file
@@ -102,8 +102,7 @@ When in doubt, treat as state-derived and validate.
 
 ## Reference Implementation
 
-`src/window_snapshot.rs` is the canonical example after the
-Code Review hardening:
+`src/window_snapshot.rs` is the canonical example:
 
 - `is_safe_session_id(s: &str) -> bool` — accepts only ASCII
   alphanumeric plus `-` and `_`; rejects empty, `.`, `..`, and
@@ -137,9 +136,7 @@ must enumerate:
 4. **Cap.** For every file read, the byte cap that bounds I/O.
 
 A plan that proposes a new external-input read without naming
-all four is incomplete — Code Review's pre-mortem and
-adversarial agents will surface the gap, but the cheaper catch
-is at Plan time.
+all four is incomplete.
 
 ## How to Apply
 
@@ -169,8 +166,7 @@ in the same PR per `.claude/rules/code-review-scope.md`.
 ## Cross-References
 
 - `.claude/rules/external-input-validation.md` — the parent
-  rule covering panicking constructors. This rule extends the
-  same discipline to silent path-construction sinks.
+  rule covering panicking constructors.
 - `.claude/rules/external-input-audit-gate.md` — the
   Plan-phase mechanical gate. Its trigger vocabulary today
   catches `panic!` / `assert!` tightenings; the patterns here
@@ -181,12 +177,7 @@ in the same PR per `.claude/rules/code-review-scope.md`.
   `fs::File::open(<state-value>)` patterns.
 - `.claude/rules/security-gates.md` "Normalize Before
   Comparing" — the sibling rule for string comparisons in
-  gates. Path-construction validation is the same shape
-  applied to a different sink.
+  gates.
 - `.claude/rules/subprocess-argument-escaping.md` — the
   sibling rule for state-derived strings flowing into shell /
-  AppleScript / SQL interpolation. Path construction is the
-  filesystem variant of the same threat.
-- `src/window_snapshot.rs` — reference implementation with
-  validators (`is_safe_session_id`, `is_safe_transcript_path`),
-  prefix containment, and the `TRANSCRIPT_BYTE_CAP` pattern.
+  AppleScript / SQL interpolation.

--- a/.claude/rules/external-input-validation.md
+++ b/.claude/rules/external-input-validation.md
@@ -16,27 +16,9 @@ place (git, user config, subprocess output, parsed JSON, env vars)
 and does not validate upstream, the check is a denial-of-service
 vector for legitimate inputs the external system permits.
 
-Issue #1054 surfaced this exactly: `FlowPaths::new` was changed to
-<!-- external-input-audit: not-a-tightening -->
-panic on slash-containing branches, under the assumption that
-`branch_name()` sanitization applied to its inputs. The assumption
-was wrong — `branch_name()` only runs at flow-start, while
-`current_branch()` returns raw git refs that commonly contain
-slashes (`feature/foo`, `dependabot/*`). Five hook entry points and
-`format-status` crashed with a Rust panic for every user on a
-standard git branch. Adversarial testing caught it; planning should
-have.
-
-Issue #1137 surfaced a second instance of the same class — this time
-in a CLI subcommand rather than a hook. `bin/flow complete-fast
---branch feature/foo` panicked in `src/complete_fast.rs:read_state`
-because `read_state` called `FlowPaths::new(root, branch)` directly
-with the unvalidated `--branch` CLI override. The rule's callsite
-inventory listed only `src/hooks/*.rs`, so the Plan phase did not
-audit the CLI-entry callsite. The fix used `FlowPaths::try_new` with
-a structured error return. The motivating lesson is that **any CLI
-subcommand accepting a `--branch` override is a branch-validation
-callsite just like a hook**, and must use the fallible constructor.
+A `--branch` CLI override is also an external input — `clap` accepts
+any string the shell passes, including slash-containing and empty
+values. The override is no more trusted than a git subprocess result.
 
 ## Mechanical Enforcement
 
@@ -56,7 +38,6 @@ function parameter, the plan must include a caller audit for that
 function. The audit enumerates the callsites. For every row in the
 audit:
 
-<!-- scope-enumeration: imperative -->
 1. Record the exact source of the validated argument (e.g. state-
    file key, `current_branch()` subprocess, CLI flag, struct
    field).
@@ -89,13 +70,11 @@ tags, commit SHAs), the public API must expose at least one fallible
 constructor alongside the panicking one. Callers that receive the
 value from `current_branch()`, `resolve_branch()`, `resolve_branch_in()`,
 or any subprocess running `git` must use the fallible variant. **A
-`--branch` CLI override is also an external input** — `clap` accepts
-any string the shell passes, including slash-containing and empty
-values, so the override is no more trusted than a git subprocess
-result. Callers that accept `--branch` must use the fallible variant.
-The panicking variant is reserved for callers that have already
-validated the value at a prior boundary (state-file keyspace,
-`branch_name()` output, upstream `try_new` success).
+`--branch` CLI override is also an external input** — callers that
+accept `--branch` must use the fallible variant. The panicking
+variant is reserved for callers that have already validated the
+value at a prior boundary (state-file keyspace, `branch_name()`
+output, upstream `try_new` success).
 
 The reference implementation is `FlowPaths::new` / `FlowPaths::try_new`:
 
@@ -137,12 +116,9 @@ hook panic.
 The CLI subcommand entry inventory that receives a branch via
 `--branch` (and therefore must guard with `FlowPaths::try_new` or
 pre-validate via `FlowPaths::is_valid_branch`) includes
-`src/complete_fast.rs:read_state` (commit `12b098f6`, the issue
-#1137 fix). Any new CLI subcommand that accepts `--branch` and
-constructs a `FlowPaths` must follow the same discipline. When
-refactoring an existing CLI subcommand, audit its `read_state` /
-`FlowPaths::new` callsites against this discipline before declaring
-the refactor complete.
+`src/complete_fast.rs:read_state`. Any new CLI subcommand that
+accepts `--branch` and constructs a `FlowPaths` must follow the
+same discipline.
 
 ### Code Review enforcement
 
@@ -164,7 +140,4 @@ and asserts the hook exits 0 / returns early without panicking.
 
 CLI subcommands that accept `--branch` must include a regression
 test that exercises the slash-branch path and asserts a structured
-error (not a panic). The issue-#1137 fix added
-`read_state_slash_branch_returns_structured_error_no_panic` and
-`run_impl_inner_slash_branch_returns_structured_error_no_panic` as
-the reference pattern.
+error (not a panic).

--- a/.claude/rules/extract-helper-refactor.md
+++ b/.claude/rules/extract-helper-refactor.md
@@ -7,24 +7,18 @@ concrete testing strategy for each branch.
 
 This rule is the mechanical complement to the
 **Extract-Helper Branch Enumeration** subsection in
-`skills/flow-plan/SKILL.md` Step 3. The SKILL.md subsection is the
-Plan-phase trigger; this file is the full reference the subsection
-cross-references.
+`skills/flow-plan/SKILL.md` Step 3.
 
 ## Vocabulary
 
 - **seam** — a parameterized injection point in a function's
   signature that lets tests substitute a mock for a concrete
-  dependency. When this rule says "lift X into a seam," it means
-  turning `X` into a parameter the caller passes in rather than a
-  hard-coded call inside the function body.
+  dependency.
 - **decider** — a closure or trait object that encapsulates a
   yes/no or branch-selection decision, passed into a function as a
   seam so tests can control the decision.
 - **sentinel** — a small cached marker file that records the tree
-  state from the most recent successful `bin/flow ci` run. See
-  `src/ci.rs::tree_snapshot` and `src/ci.rs::sentinel_path` for
-  the canonical readers/writers.
+  state from the most recent successful `bin/flow ci` run.
 - **CiDecider** — the concrete type alias in `src/complete_fast.rs`
   for the Complete-phase CI dirty-check seam:
   `dyn Fn(&Path, &Path, &str, bool) -> (bool, Option<String>)`.
@@ -36,32 +30,18 @@ not the same as a plan that enumerates the branches of the extracted
 helper. The first measures the caller's test surface; the second
 measures the helper's. When the two diverge, the Code phase
 discovers uncovered branches inside the helper only after the
-extraction has landed — and the branch-level test design ends up
-negotiated ad hoc instead of by design.
-
-PR #1155 surfaced this. Task 2 extracted the Complete-phase CI
-dirty-check block from `run_impl` into a new `production_ci_decider`
-helper and added ten tests for the `run_impl_inner` seam that
-delegates to the decider. The plan counted those ten tests and
-stopped. But `production_ci_decider` itself had four internal
-branches (`tree_changed == true`, sentinel hit, CI failure on miss,
-CI success on miss) that the plan never named. Three of the four
-branches were not reached by the seam tests, and the Code phase had
-to decide each branch's test strategy after the extraction was
-already written.
+extraction has landed.
 
 The rule force-functions the enumeration conversation at Plan time:
-the plan author enumerates the helper's branches before the Code
-phase begins, names a concrete test for each one, and refactors
-further if any branch cannot fit under one of the three
-classifications.
+enumerate the helper's branches before the Code phase begins, name
+a concrete test for each one, and refactor further if any branch
+cannot fit under one of the three classifications.
 
 ## The Rule
 
 The rule fires when a Plan task description or Approach prose
 proposes extracting a block of code into a new helper function,
-method, seam, or closure — or any equivalent refactor-for-testability
-phrasing. Canonical trigger phrasings:
+method, seam, or closure. Canonical trigger phrasings:
 
 - "extract *X* into a new *Y*"
 - "lift the *X* block into *Y*"
@@ -94,31 +74,23 @@ Column definitions:
 
 - **Testable via seam** — the caller injects a closure, trait
   object, or `Command` via a parameter, and the branch is exercised
-  by passing a mock implementation. Reference pattern:
+  by passing a mock implementation. Reference:
   `run_impl_inner(args, root, runner, ci_decider)` in
-  `src/complete_fast.rs`, where `ci_decider` is a `&CiDecider`
-  closure the tests can replace with a mock.
+  `src/complete_fast.rs`.
 - **Testable directly** — a unit test with a self-contained fixture
   exercises the branch without any mocking or indirection. Typical
   fixtures: a `tempfile::TempDir`, a prepared state-file JSON, or an
-  in-memory value. Reference pattern:
-  `production_ci_decider_tree_changed_returns_not_skipped` in
-  `src/complete_fast.rs` — a unit test that passes `tree_changed =
-  true` and asserts the early-return path.
+  in-memory value.
 - **Testable via subprocess** — the test spawns the compiled binary
   through `tests/main_dispatch.rs` and exercises the branch through
-  the real CLI surface. cargo-llvm-cov instruments subprocess calls
-  when they spawn the same binary, so the branch's lines appear in
-  the coverage report. Reference pattern: `check_phase_first_phase_exits_0`
-  in `tests/main_dispatch.rs`.
+  the real CLI surface.
 
 If a branch cannot be classified under one of the three, the
-extraction design is wrong. The remedy is to refactor further: push
-the untested surface behind a seam so the branch becomes Testable
-via seam, fold the branch into its caller so it becomes Testable
-directly at the caller, or delete the branch entirely if it is
-unreachable from any production path. Every branch must land under
-one of the three classifications before the plan is complete.
+extraction design is wrong. Refactor further: push the untested
+surface behind a seam, fold the branch into its caller, or delete
+the branch entirely if it is unreachable from any production path.
+Every branch must land under one of the three classifications
+before the plan is complete.
 
 ## Constructor Invariant Audit
 
@@ -138,12 +110,10 @@ The audit answers two questions per panicking constructor:
    is sourced from a CLI flag (`--branch`), state-file value, git
    subprocess output, env var, or any other external source, the
    extraction is also a callsite of the panicking constructor under
-   the discipline named in `.claude/rules/external-input-validation.md`
-   ("Trusted-but-external" or "Untrusted" classification). The new
-   public surface MUST use the fallible variant
+   the discipline named in `.claude/rules/external-input-validation.md`.
+   The new public surface MUST use the fallible variant
    (`FlowPaths::try_new`, `Option`-returning, `Result`-returning)
-   and translate the invalid case into a structured error rather
-   than propagating the panic.
+   and translate the invalid case into a structured error.
 
 The audit produces a row in the plan's
 `.claude/rules/external-input-audit-gate.md` callsite table even
@@ -151,73 +121,32 @@ when the extraction is not adding a new panic — perpetuating an
 existing one across an extraction boundary still counts as a
 new public callsite.
 
-The motivating incident is PR #1224 (issue #1201, the gh-tools
-coverage refactor): the Code phase extracted ten state-mutator
-`run_impl_main` functions out of their pre-existing `run` wrappers
-and preserved the `FlowPaths::new(root, &branch)` call inside the
-new public surface. The branches arrived from
-`resolve_branch(args.branch.as_deref(), ...)` — which forwards
-`--branch` raw from the CLI. Four of the new public surfaces
-(`add_finding`, `add_issue`, `add_notification`, `append_note`)
-panicked on `--branch feature/foo` and on `--branch ''`. Code Review
-adversarial caught all four, and Step 4 fixed each by switching to
-`FlowPaths::try_new`. A Plan-phase Constructor Invariant Audit
-would have surfaced the gap before the extraction landed.
-
-The audit complements the Branch Enumeration Table — branch
-enumeration covers internal control flow; constructor invariant
-audit covers the input contract the extracted block carries.
-
 ## Enforcement
 
-Iteration 1 of this rule is **prose-only** — there is no scanner
-in `src/plan_check.rs` that mechanically blocks a Plan phase from
-completing without a Branch Enumeration Table. This is a deliberate
-choice per `.claude/rules/skill-authoring.md` "Simplest Approach
-First," mirroring `.claude/rules/supersession.md`'s model.
+This rule is prose-only — there is no scanner that mechanically
+blocks a Plan phase from completing without a Branch Enumeration
+Table. The enforcement layers are:
 
-The enforcement layers in iteration 1 are:
-
-1. **The rule file itself** (this file) — the primary instrument.
-   Plan authors read it via the cross-reference from
-   `skills/flow-plan/SKILL.md` Step 3.
+1. **The rule file itself** — the primary instrument.
 2. **The SKILL.md subsection** — reminds the Plan phase of the
    discipline at authoring time.
 3. **The Code Review reviewer agent** — cross-references the plan's
    Branch Enumeration Table against the landed tests and raises a
-   Real finding per `.claude/rules/code-review-scope.md` when a
-   plan-named test is missing.
+   Real finding when a plan-named test is missing.
 4. **The adversarial agent in Code Review** — writes failing tests
-   against uncovered branches, surfacing the same gap as test
-   failures.
-
-If a future iteration adds a mechanical scanner, the natural home
-is `src/extract_helper_refactor.rs` following the topology of
-`src/scope_enumeration.rs` and `src/external_input_audit.rs`. That
-scanner is **not present today**; any session that goes looking
-for one should stop at this section rather than spending turns
-searching.
+   against uncovered branches.
 
 ## Opt-Out Grammar
 
 When the plan prose mentions extraction in discussion rather than as
-a proposal — for example, when the Risks section references a prior
-extraction or when the Approach discusses rejected alternatives that
-involved extraction — add the opt-out comment
+a proposal, add the opt-out comment
 `<!-- extract-helper-refactor: not-an-extraction -->` on:
 
 - the trigger line itself (same-line, anywhere on the line),
 - the line directly above the trigger, or
 - two lines above with a single blank line in between.
 
-Larger gaps do not chain — the rule is "the next non-blank line with
-at most one blank line separating them," matching the sibling
-opt-out grammar in `.claude/rules/scope-enumeration.md` and
-`.claude/rules/external-input-audit-gate.md`.
-
-The grammar is documented now as part of the rule's stable API so
-that when a scanner is eventually implemented it inherits the
-placement rules verbatim. Today the comment is inert.
+Larger gaps do not chain.
 
 ## How to Apply
 
@@ -231,99 +160,19 @@ and every Approach paragraph for the trigger phrasings listed in
    early return, or conditional expression is a candidate branch.
 3. For every branch, classify it under one of the three labels.
 4. For every classification, name the concrete test function that
-   will exercise the branch. The test function name commits the plan
-   author to writing that test in Code phase.
+   will exercise the branch.
 5. If any branch fails the classification step, revise the extraction
-   design until every branch fits. Do not ship the plan with an
-   unclassified branch.
+   design until every branch fits.
 6. Apply the Constructor Invariant Audit to every panicking
-   constructor call inside the extracted block. If any input arrives
-   from an external source, the new public surface must use the
-   fallible variant and translate invalid inputs into structured
-   errors. Cross-reference the audit row in the plan's
-   external-input-audit table.
+   constructor call inside the extracted block.
 
 **Code phase.** Execute the plan tasks in order. For each branch the
 plan enumerated, write the named test before or alongside the
-implementation per the `.claude/rules/skill-authoring.md` Plan Task
-Ordering rule. A Plan Test Verification check at commit time
-confirms every plan-named test function exists in the codebase. For
-every panicking constructor in the extracted block, replace the call
-with the fallible variant per the Constructor Invariant Audit.
+implementation. For every panicking constructor in the extracted
+block, replace the call with the fallible variant per the
+Constructor Invariant Audit.
 
 **Code Review phase.** The reviewer agent cross-references the plan's
 Branch Enumeration Table against the landed tests. Any plan-named
 test function missing from the codebase is a Real finding fixed in
-Step 4 per `.claude/rules/code-review-scope.md`. The adversarial
-agent writes failing tests against external-input boundaries
-(slash branches, empty strings, NUL bytes) of every new public
-surface — these tests catch missed Constructor Invariant Audits.
-
-## Motivating Incident
-
-PR #1155 (`Coverage Pattern Completefast`, merge commit `8cb5e80c`)
-is the incident that produced this rule. The PR's plan for Task 2
-extracted the Complete-phase CI dirty-check block from
-`src/complete_fast.rs::run_impl` into a new `production_ci_decider`
-helper, and Task 3 added ten behavior-preservation tests exercising
-the `run_impl_inner` seam through a mock `ci_decider`. The ten seam
-tests proved that `run_impl_inner`'s dispatch branches were correct,
-but they did not exercise the four branches inside the real
-`production_ci_decider` wrapper.
-
-The four branches were:
-
-1. `tree_changed == true` → early return `(false, None)`
-2. `tree_changed == false` ∧ sentinel file exists ∧ snapshot
-   matches → `(true, None)` skip
-3. `tree_changed == false` ∧ sentinel miss → dispatches to
-   `ci::run_impl`, CI fails → `(false, Some(msg))`
-4. Same as (3) but CI succeeds → `(false, None)`
-
-Only Branch 1 has a direct unit test today
-(`production_ci_decider_tree_changed_returns_not_skipped` at
-`src/complete_fast.rs:1409`). Branches 2, 3, and 4 require either a
-deeper trait seam around `ci::run_impl` (so the test can inject a
-mock CI runner) or subprocess tests that spawn the binary and drive
-it through a fixture with a pre-seeded sentinel file.
-
-Had PR #1155's plan enumerated the four branches up front, the
-design conversation would have surfaced the need for the deeper
-`ci::run_impl` seam before the extraction landed. This rule exists
-to force that conversation at Plan time on every future
-extract-helper refactor.
-
-Commit references:
-
-- `8cb5e80c` — PR #1155 merge commit
-- `59844b30` — Extract `run_impl_inner` seam and add ten
-  behavior-preservation tests (Task 2+3 of PR #1155)
-- `fcc9a69c` — Record the missing branches of
-  `production_ci_decider` (Task 4 of PR #1155, later superseded by
-  the full rule framework on main)
-
-## Cross-References
-
-- `skills/flow-plan/SKILL.md` Step 3 — the SKILL.md subsection that
-  invokes this rule during Plan phase.
-- `.claude/rules/supersession.md` — the structural sibling rule.
-  Supersession enumerates code a refactor makes redundant;
-  extract-helper enumeration enumerates branches a refactor
-  introduces. The two rules run at the same Plan-phase step and
-  share the prose-only enforcement model.
-- `.claude/rules/external-input-validation.md` — the prose
-  discipline for fallible constructors. The Constructor Invariant
-  Audit subsection forwards every panicking constructor encountered
-  during extraction to this rule's callsite classification.
-- `.claude/rules/external-input-audit-gate.md` — the Plan-phase
-  gate that enforces a callsite audit table when a plan proposes
-  panic/assert tightenings. Extracting an existing panic across a
-  refactor boundary is the same shape — the audit table must name
-  the new public surface.
-- `.claude/rules/skill-authoring.md` — Plan Task Ordering (TDD order)
-  and Simplest Approach First (iteration 1 is instructional only, no
-  mechanical scanner).
-- `src/complete_fast.rs` lines 453–495 — the reference
-  `production_ci_decider` helper cited throughout this rule.
-- `tests/main_dispatch.rs` — the reference subprocess test surface
-  used by the `Testable via subprocess` classification.
+Step 4.

--- a/.claude/rules/file-tool-preflights.md
+++ b/.claude/rules/file-tool-preflights.md
@@ -27,8 +27,7 @@ comes from:
 Recovery from a preflight block requires manual workaround outside the
 normal skill workflow — the model has to invoke Read on the blocked path
 before the Write can proceed, which wastes turns and can corrupt the
-workflow if the model instead accepts whatever content is already on
-disk.
+workflow.
 
 ## Monitored Target Paths
 
@@ -59,11 +58,10 @@ Intermediate content files that the model Writes as input to
 are the Write-tool input, not a persistent target. The `write-rule`
 subcommand reads and deletes them unconditionally.
 
-When a new persistent path becomes a monitored target (e.g. a new skill
-writes to a shared file or a new machine-level singleton is introduced),
-add it to this list AND to `WRITE_MONITORED_PATHS` in
-`tests/skill_contracts.rs`. The contract test scans every SKILL.md for
-Write-tool instructions adjacent to any entry in that constant.
+When a new persistent path becomes a monitored target, add it to this
+list AND to `WRITE_MONITORED_PATHS` in `tests/skill_contracts.rs`. The
+contract test scans every SKILL.md for Write-tool instructions adjacent
+to any entry in that constant.
 
 ## Canonical Location for `.flow-states/`
 
@@ -73,23 +71,21 @@ writes to `<project_root>/.worktrees/<branch>/.flow-states/...` (the
 worktree-internal copy at the worktree root) or
 `<project_root>/.worktrees/<branch>/<service>/.flow-states/...` (the
 mono-repo service-subdirectory variant) would create a misplaced state
-copy that the readers (cleanup, discovery scanners, hooks) cannot see
-because they only scan the canonical location.
+copy that the readers (cleanup, discovery scanners, hooks) cannot see.
 
 The `validate-worktree-paths` PreToolUse hook
 (`src/hooks/validate_worktree_paths.rs`) enforces the canonical
 location at the tool-call layer. The
 `detect_misplaced_flow_states(file_path, project_root)` helper detects
-the misplacement via pure string operations (no `Path` construction
-or filesystem reads, so untrusted model output cannot cause a path-
-traversal sink) and returns the canonical destination. When the helper
-matches, `validate()` returns `(false, message)` with a `BLOCKED`
-message naming the canonical path the caller should use instead.
+the misplacement via pure string operations and returns the canonical
+destination. When the helper matches, `validate()` returns
+`(false, message)` with a `BLOCKED` message naming the canonical path
+the caller should use instead.
 
 The check fires on every Edit, Write, Read, Glob, and Grep tool call
-the hook is registered for in `hooks/hooks.json`. Both `file_path`
-(Edit/Write/Read) and `path` (Glob/Grep) input shapes resolve through
-`get_file_path` before the helper runs.
+the hook is registered for. Both `file_path` (Edit/Write/Read) and
+`path` (Glob/Grep) input shapes resolve through `get_file_path`
+before the helper runs.
 
 ## Managed-Artifact Canonicalization Gate (CLI Layer)
 
@@ -116,20 +112,14 @@ variant matches, it computes the canonical destination via
 `canonical_path(art, &project_root(), current_branch().as_deref())`,
 resolves the provided path to absolute (relative paths join against
 `project_root`), lexically normalizes both sides (resolving `..`
-segments — `Path::components` already drops mid-path `.` segments),
-and rejects when the two normalized PathBufs differ.
+segments), and rejects when the two normalized PathBufs differ.
 
 **Ordering invariants.** The gate runs BEFORE `read_content_file` so
-a rejection does not destroy the caller's input file
-(`read_content_file` deletes the source as part of its normal
-contract, so a post-read rejection would leave the caller with no
-content to retry). When the gate accepts, the actual `fs::write` call
-uses the resolved absolute path — never the original `args.path` —
-so a relative `--path` validated against `project_root` cannot be
-silently re-resolved by `fs::write` against the process cwd at write
-time. From a mono-repo subdirectory cwd the two resolutions diverge,
-and using the gate-validated absolute path is what keeps the on-disk
-write at the canonical destination the gate approved.
+a rejection does not destroy the caller's input file. When the gate
+accepts, the actual `fs::write` call uses the resolved absolute path —
+never the original `args.path` — so a relative `--path` validated
+against `project_root` cannot be silently re-resolved by `fs::write`
+against the process cwd at write time.
 
 **The error shape.** A rejection returns JSON to stdout and exits 1:
 
@@ -154,19 +144,12 @@ pattern depends on.
 artifacts (`PlanMd`, `DagMd`, `CommitMsgTxt`) require a valid
 non-empty branch. In detached-HEAD or invalid-branch (slash-
 containing) contexts, `canonical_path` returns `None` and the gate
-stays silent — write-rule writes the path verbatim. Pass-through in
-this context preserves writes the model has no branch information to
-redirect; a rejection here would have no recovery path because the
-caller cannot supply a branch the gate would accept.
+stays silent.
 
 The gate complements the tool-call-layer hook above: write-rule
 canonicalizes its `--path` argument before `fs::write`, and the
 `validate-worktree-paths` hook canonicalizes the tool-call layer
-before either Write or write-rule runs. Together they cover both
-surfaces — the model invoking the Write tool directly with a
-worktree-internal path, and the model invoking write-rule with one —
-so the canonical-only invariant holds regardless of which entry
-point a future skill picks.
+before either Write or write-rule runs.
 
 ## The Write-Rule Escape Pattern
 
@@ -202,8 +185,7 @@ Reference implementation: `src/write_rule.rs`.
 Edit-tool instructions on named `.flow-states/<branch>/*.md` files must
 be preceded by an explicit Read-tool instruction on the same file. The
 preamble ensures the Edit preflight is satisfied even when the model
-has not naturally read the file in the current turn (for example,
-re-entering the plan-check fix loop after `--continue-step`).
+has not naturally read the file in the current turn.
 
 Canonical wording:
 
@@ -222,37 +204,29 @@ Two contract tests in `tests/skill_contracts.rs` enforce both sides of
 the rule:
 
 - `file_tool_preflight_write_paths_route_through_write_rule` — scans
-  every `skills/**/SKILL.md` for Write-tool instructions (matching
-  `use`, `using`, `invoke`, `invoking`, `call`, `calling`, `run`,
-  `running` followed by `the Write tool`) adjacent to a monitored
-  path, and asserts a `bin/flow write-rule --path <same-path>` call
-  appears on a SINGLE line within the next 30 lines. Same-line
-  co-occurrence is required so a disconnected `bin/flow write-rule`
-  targeting a different path plus an unrelated mention of the
-  monitored path cannot silently satisfy the check.
+  every `skills/**/SKILL.md` for Write-tool instructions adjacent to
+  a monitored path, and asserts a `bin/flow write-rule --path <same-path>`
+  call appears on a SINGLE line within the next 30 lines.
 - `file_tool_preflight_edit_paths_preceded_by_read` — scans every
   SKILL.md for Edit-tool instructions on named plan or DAG files and
-  asserts a Read-tool instruction (matching the same verb vocabulary)
-  on the same file appears within the preceding 12 non-blank lines.
-  The backward scan stops at any `## ` or `### ` heading so a Read in
-  a prior step cannot credit an Edit in a later step — a
-  `--continue-step` resume invalidates the prior Read.
+  asserts a Read-tool instruction on the same file appears within the
+  preceding 12 non-blank lines. The backward scan stops at any `## ` or
+  `### ` heading so a Read in a prior step cannot credit an Edit in a
+  later step — a `--continue-step` resume invalidates the prior Read.
 
 Both scans use `write_path_is_bounded` to check BOTH prefix and suffix
 byte boundaries on every path match, rejecting longer paths that embed
-a monitored path as a substring (e.g. `my-orchestrate-queue.json`,
-`.flow-states/<branch>/commit-msg.txt.bak`).
+a monitored path as a substring.
 
 The CLI-layer canonicalization gate is enforced by the
 `tests/write_rule.rs` subprocess matrix: each managed artifact has a
 canonical-success cell and a worktree-misroute-reject cell, plus the
-non-managed pass-through and detached-HEAD pass-through cells. A
-regression in `classify_path`, `canonical_path`, or `normalize_lexical`
-fails CI immediately.
+non-managed pass-through and detached-HEAD pass-through cells.
 
-When either test fails, the violation names the file and line. The fix
-is to adopt the Write-Rule Escape Pattern or the Edit Preamble Pattern
-respectively — never to add an allow-list that exempts the callsite.
+When either contract test fails, the violation names the file and line.
+The fix is to adopt the Write-Rule Escape Pattern or the Edit Preamble
+Pattern respectively — never to add an allow-list that exempts the
+callsite.
 
 ## Why Not Skill Instructions Alone
 
@@ -262,21 +236,3 @@ must be mechanical, not advisory. The Write-side fix is mechanical via
 the `write-rule` subprocess. The Edit-side fix is advisory prose in
 SKILL.md, but the contract test locks the prose invariant in so drift
 fails CI.
-
-## Cross-References
-
-- `.claude/rules/hook-vs-instruction.md` — the principle that mandates
-  mechanical enforcement for this class.
-- `.claude/rules/scope-expansion.md` — the scope-boundary decision for
-  combining Write and Edit fixes in one PR.
-- `.claude/rules/tests-guard-real-regressions.md` — the discipline
-  requiring every test to guard a named regression and name its
-  consumer.
-- `src/write_rule.rs` — the reference Rust subcommand, including the
-  `ManagedArtifact` enum, `classify_path`, `canonical_path`, and the
-  `run_impl_main` gate.
-- `src/hooks/validate_worktree_paths.rs` — the reference hook with the
-  `detect_misplaced_flow_states` helper that enforces the canonical
-  `.flow-states/` location at the tool-call layer.
-- `skills/flow-learn/SKILL.md` — the reference SKILL.md pattern that
-  routes through `write-rule` for CLAUDE.md and `.claude/rules/` writes.

--- a/.claude/rules/forward-facing-authoring.md
+++ b/.claude/rules/forward-facing-authoring.md
@@ -91,14 +91,3 @@ forward-facing before commit. A rule addition or doc comment
 that names the current PR, branch, or file the session just
 modified is a Real finding that must be rewritten before Step 4
 concludes.
-
-## Cross-References
-
-- `.claude/rules/comment-quality.md` — the same Forward-Facing
-  Test applied to inline code comments specifically
-- `.claude/rules/tests-guard-real-regressions.md` — tests must
-  guard a named regression; this rule's equivalent for prose
-  artifacts is to name a general principle, not a specific PR
-- `.claude/rules/no-waivers.md` — prohibits waiver
-  documentation; this rule prohibits backward-facing rule
-  documentation more broadly

--- a/.claude/rules/gate-consumer-enumeration.md
+++ b/.claude/rules/gate-consumer-enumeration.md
@@ -22,10 +22,6 @@ actually reads the `reason` field and branches on it. When the Plan
 phase names tasks for the gate implementation but not for the
 consuming skill's error-handling, the Code phase ships a producer
 that emits the new reason and a consumer that silently drops it.
-Code Review's pre-mortem agent then surfaces the gap as a
-correctness bug and Step 4 fixes it. The cycle is avoidable: the
-caller enumeration is cheap to write at Plan time, and writing it
-forces the author to consider all consumers up front.
 
 ## The Rule
 
@@ -87,16 +83,14 @@ For every new error reason:
    <name>` invocation in `skills/`, `.claude/skills/`,
    `hooks/`, `agents/`, and `src/`. The audit table has one row
    per callsite.
-2. **Classify each consumer's parse.** Read
-   the surrounding 5-10 lines to see which JSON fields the
-   consumer reads. A consumer that captures `$(bin/flow ...)`
-   into a variable and uses only `formatted_time` from it is
-   reading `formatted_time`; it is NOT reading `status` or
-   `reason`.
+2. **Classify each consumer's parse.** Read the surrounding 5-10
+   lines to see which JSON fields the consumer reads. A consumer
+   that captures `$(bin/flow ...)` into a variable and uses only
+   `formatted_time` from it is reading `formatted_time`; it is NOT
+   reading `status` or `reason`.
 3. **For each consumer that does not currently branch on
    `status`/`reason`, add a Code-phase task** to extend the
-   parse. The task description must name the branch's behavior
-   (retry, escalate, propagate, etc.).
+   parse. The task description must name the branch's behavior.
 4. **Mark exempt consumers explicitly** — never leave a row
    blank. An exempt consumer named in the table proves the
    author considered it; an absent consumer is a Plan-phase
@@ -114,8 +108,7 @@ group entry.
 **Code phase.** Execute the producer change and every consumer
 change in the same PR. A producer that emits a new reason and a
 consumer that does not handle it is an internally-inconsistent
-PR — Code Review's pre-mortem agent will catch it, but the
-cheaper catch is at Plan time.
+PR.
 
 **Code Review phase.** The reviewer agent cross-checks every
 new error reason in the diff against the consumer enumeration
@@ -124,21 +117,3 @@ the diff did not extend is a Real finding fixed in Step 4.
 Conversely, a new reason that has no enumeration table at all
 is a Plan-phase gap — fix in Step 4 by writing the table
 retroactively, then verifying every consumer is correct.
-
-## Cross-References
-
-- `.claude/rules/cli-output-contracts.md` — the broader rule for
-  CLI output contracts (output format, exit codes, error
-  messages, fallback behavior). This rule extends it: when a
-  contract changes, every consumer must be enumerated.
-- `.claude/rules/scope-enumeration.md` — sibling rule for
-  universal-coverage claims. Both rules force enumeration before
-  the Code phase begins; this rule is the error-handling
-  dimension.
-- `.claude/rules/code-review-scope.md` — Real findings fixed in
-  the PR. A missing consumer-side update surfaced by Code Review
-  is fixed in Step 4 regardless of which file it lives in.
-- `.claude/rules/plan-commit-atomicity.md` — when the consumer
-  update lives in a different file from the producer, the plan
-  must mark the producer task and the consumer task as an
-  atomic group so they land in the same commit.

--- a/.claude/rules/hook-state-timing.md
+++ b/.claude/rules/hook-state-timing.md
@@ -10,23 +10,17 @@ must know when those mutations land relative to when the hook fires.
 
 ## Why
 
-The initial `validate-ask-user` block path (PR #1053) gated on
-`skills.<current_phase>.continue == "auto"` without accounting for
-WHEN `current_phase` is written. `phase_complete()` advances
-`current_phase` to the NEXT phase before the completing skill's
-HARD-GATE fires `AskUserQuestion`. With a manual→auto transition
-(Code=manual with Code Review=auto in the Recommended preset), the
-skill fires the approval prompt, the hook reads `current_phase` =
-the next (auto) phase, and blocks the approval — flow deadlocked.
+A hook that gates on `current_phase` without accounting for WHEN
+`current_phase` is written will fire in unintended states.
+`phase_complete()` advances `current_phase` to the NEXT phase
+before the completing skill's HARD-GATE fires `AskUserQuestion`.
+With a manual→auto transition, the skill fires the approval prompt,
+the hook reads `current_phase` = the next (auto) phase, and blocks
+the approval — flow deadlocked.
 
-The fix was to add a phase-status predicate
-(`phases.<current_phase>.status == "in_progress"`) so the block
-only fires when the phase is actively executing. The bug was
-catchable at Plan time if the Risks section had enumerated state
-reads against state writes; it wasn't, so Code Review's pre-mortem
-agent caught it post-implementation. Escalating the rule from
-instruction-level to hook-level is a class of change where this
-pattern is most likely to recur.
+The fix is to add a phase-status predicate (e.g.
+`phases.<current_phase>.status == "in_progress"`) so the block only
+fires when the phase is actively executing.
 
 ## The Rule
 

--- a/.claude/rules/no-waivers.md
+++ b/.claude/rules/no-waivers.md
@@ -74,8 +74,6 @@ must:
 
 A task that writes "record the achievable baseline" or "accept the
 current measurement as the achievable target" violates this rule.
-Those phrasings are forbidden in plan prose, per the "Forbidden Plan
-Prose" list above.
 
 **Plan-phase verification.** When a plan's acceptance criteria state
 "all N files reach 100%" but the plan's tasks only verify the
@@ -105,7 +103,7 @@ enforced at four layers:
    coverage strategy.
 2. **Plan-check scanner**. `bin/flow plan-check` should scan plan
    prose for waiver-suggestion phrases and reject plans that
-   contain them. (Tracking issue: see `benkruger/flow` Flow label.)
+   contain them.
 3. **Code Review reviewer agent**. The reviewer agent flags any
    diff that adds a `test_coverage.md` entry as a Real finding to
    be deleted in Step 4.
@@ -113,14 +111,10 @@ enforced at four layers:
    run passes `--fail-under-lines 100 --fail-under-regions 100
    --fail-under-functions 100` to `cargo llvm-cov nextest`. Any
    uncovered region, function, or line fails CI and blocks the
-   commit. The thresholds are pinned at 100 and never lowered — a
-   regression is a CI-blocking failure, not grounds to relax the
-   gate. The flags live on the `cargo llvm-cov nextest` invocation
-   inside `bin/test`, so every CI run by every engineer on every
-   branch inherits the same gate. `.claude/rules/tool-dispatch.md`
-   "`bin/test` Sweeps Profraws Before Every Run" documents the
-   complementary coverage-coherence discipline that keeps the
-   measurement honest across main's long-lived `target/` dir.
+   commit. The thresholds are pinned at 100 and never lowered. The
+   flags live on the `cargo llvm-cov nextest` invocation inside
+   `bin/test`, so every CI run by every engineer on every branch
+   inherits the same gate.
 
 ## How to Apply (Plan Phase)
 
@@ -135,8 +129,7 @@ When designing a plan that touches code:
 4. After writing the plan, grep for waiver-suggestion phrases. If
    any appear, rewrite them.
 5. If the plan has a "verify 100%" task, confirm the task body
-   hard-gates on per-file 100% (not measurement-only). Measurement
-   tasks are not coverage completion tasks.
+   hard-gates on per-file 100% (not measurement-only).
 
 ## How to Apply (Code Phase)
 
@@ -162,18 +155,3 @@ When triaging findings:
    for deletion in Step 4 regardless of file location. Per
    `.claude/rules/supersession.md`, the entry is dead code in the
    PR's wake.
-
-## Cross-References
-
-- `.claude/rules/docs-with-behavior.md` — must be updated to remove
-  any "Waiver Discipline" prose that authorized `test_coverage.md`
-  entries. The two rules are now in conflict; this rule wins.
-- `.claude/rules/tool-dispatch.md` "Full-Suite `bin/test` Runs Clean
-  First" — the coverage-coherence discipline that makes the
-  `--fail-under-*` numbers trustworthy on main's long-lived target
-  dir.
-- `tests/main_dispatch.rs` — reference subprocess test surface for
-  CLI dispatch coverage.
-- `src/dispatch.rs` and the `run_impl_main` extraction — reference
-  refactor pattern for hoisting `process::exit` out of the testable
-  surface.

--- a/.claude/rules/panic-safe-cleanup.md
+++ b/.claude/rules/panic-safe-cleanup.md
@@ -9,20 +9,14 @@ calls at function exit.
 
 ## Why
 
-Issue #1135 / PR #1154 surfaced this in the TUI: `run_tui_terminal`
-enabled crossterm's raw mode and entered the alternate screen, ran
-the event loop, then called `disable_raw_mode()` and
-`LeaveAlternateScreen` AFTER the loop returned. Rust panics unwind
-the stack — they do NOT execute code after the panicking call. A
-panic inside the event loop would skip the inline cleanup, leaving
-the user's terminal in raw mode with no echo, no line discipline,
-and the alternate screen still active. Recovery requires `reset`
-or closing the terminal tab.
-
 Inline cleanup at scope-exit is a footgun for any resource whose
-"unset" state must be restored. The Drop impl runs on every exit
-path including panic unwind — that is the only mechanism the
-language guarantees.
+"unset" state must be restored. Rust panics unwind the stack — they
+do NOT execute code after the panicking call. A panic inside the
+work block skips inline cleanup, leaving the resource in its
+acquired state.
+
+The Drop impl runs on every exit path including panic unwind — that
+is the only mechanism the language guarantees.
 
 ## The Rule
 
@@ -59,7 +53,7 @@ fn do_thing() -> Result<()> {
   bracketed paste. Reference: `TerminalGuard<F>` in `src/tui_terminal.rs`.
 - **File locks** — `flock`, `fcntl` advisory locks. The lockfile
   must be released even on panic or the next process blocks
-  forever (or until 30-minute stale timeout, in FLOW's case).
+  forever.
 - **Spawned child processes you intend to wait on** — orphaning
   is sometimes acceptable but only after explicit decision.
 - **Mutated global state** — env vars set for the duration of an
@@ -70,9 +64,9 @@ fn do_thing() -> Result<()> {
   `shutdown()`.
 
 NOT every resource needs a Drop guard. Allocations that release
-naturally on drop (Vec, String, Box) handle themselves through
-their own Drop impls. The discipline applies specifically to
-resources whose "released" state is not the default.
+naturally on drop (Vec, String, Box) handle themselves. The
+discipline applies specifically to resources whose "released" state
+is not the default.
 
 ## Reference Implementation
 
@@ -104,34 +98,27 @@ impl<F: FnMut()> Drop for TerminalGuard<F> {
 
 The guard:
 
-1. Owns the cleanup closure (here, a closure capturing the shared
-   handle to the same terminal the draw closure renders into,
-   plus the crossterm `disable_raw_mode` and `LeaveAlternateScreen`
-   calls)
+1. Owns the cleanup closure.
 2. Implements `Drop` with errors swallowed inside the closure
    (`let _ = ...`) because Drop cannot return them and a
-   panic-during-cleanup is worse than a swallowed error
-3. Uses `Option::take` so the closure runs at most once even if
-   the guard is somehow dropped twice
-4. Is placed in scope BEFORE the work that might panic, so
-   stack-unwinding drops it
+   panic-during-cleanup is worse than a swallowed error.
+3. Uses `Option::take` so the closure runs at most once.
+4. Is placed in scope BEFORE the work that might panic.
 5. Is a named struct (not `defer!`-style scope_guard crate) so
-   the responsibility is documented in the type system
+   the responsibility is documented in the type system.
 
 The closure-injection design — exposing `release_fn` as a generic
 parameter rather than hardcoding the cleanup body — also makes
 the Drop unit-testable without a real terminal. See
 `.claude/rules/rust-patterns.md` "Seam-injection variant for
-externally-coupled code" for the broader pattern this guard
-exemplifies.
+externally-coupled code".
 
 ## Plan-Phase Trigger
 
 When a plan task acquires a resource of any of the categories
-listed above ("What Counts" section), the plan must enumerate:
+listed above, the plan must enumerate:
 
-1. The **resource** being acquired (terminal mode, file lock,
-   etc.)
+1. The **resource** being acquired (terminal mode, file lock, etc.)
 2. The **release call** that must run on every exit path
 3. The **guard struct name** that wraps the release in Drop
 4. Where the guard is placed in scope (must be BEFORE the
@@ -151,6 +138,7 @@ survive panic.
 3. Test the guard explicitly. The simplest test acquires the
    resource, panics, catches the panic, and verifies the resource
    is released:
+
    ```rust
    #[test]
    fn guard_releases_on_panic() {
@@ -159,9 +147,10 @@ survive panic.
            panic!("simulated work failure");
        });
        assert!(result.is_err());
-       assert!(resource_is_released()); // <-- the load-bearing assertion
+       assert!(resource_is_released());
    }
    ```
+
 4. Document the guard's Drop behavior in its type doc comment —
    what gets cleaned up, what errors are swallowed, why.
 
@@ -173,13 +162,3 @@ acquisition in production code, verify:
 1. The release path is in a Drop impl, not inline at scope-exit
 2. The guard is in scope BEFORE any operation that might panic
 3. There is a test that proves cleanup runs on panic unwind
-
-## Cross-References
-
-- `src/tui_terminal.rs::TerminalGuard<F>` — the reference implementation
-- `.claude/rules/rust-patterns.md` — Seam-injection variant for
-  externally-coupled code (the closure-injection pattern that
-  makes the Drop unit-testable)
-- `.claude/rules/concurrency-model.md` — file lock rules; the
-  start lock specifically benefits from Drop-based release
-- Rust reference on RAII and Drop semantics

--- a/.claude/rules/per-file-coverage-iteration.md
+++ b/.claude/rules/per-file-coverage-iteration.md
@@ -35,9 +35,7 @@ scope:
   - Completes in ~3 minutes
 
 For iterating on one file, the per-file gate is the **same gate,
-same file, same thresholds** — just 30× faster. Running full CI
-between iterations wastes ~2m55s per attempt; across a dozen
-iterations that's 35 minutes that should have been 1.
+same file, same thresholds** — just 30× faster.
 
 ## The Rule
 
@@ -67,10 +65,6 @@ Full CI (or `bin/flow ci --test`) is the right tool when:
   has verified the target file, but the commit still needs the
   cross-file sanity pass.
 
-The trigger "change crosses file boundaries" is on the author to
-decide. When uncertain, `bin/test tests/<affected-file>.rs` for
-each affected file is still faster than one full-CI run.
-
 ## Phantom Misses (Stale Instrumented Binaries)
 
 `bin/test` runs with `cargo llvm-cov --no-clean` so test binaries
@@ -94,18 +88,14 @@ once; the stale instantiations remain unexecuted forever.
 1. Run `bin/test --funcs <basename>.rs` — lists every function
    instantiation with its execution count. Multiple entries for
    the same demangled name with different mangled crate hashes
-   (e.g., `_RNvNtCs8fXSiUa7bCM_*`, `_RNvNtCsaO9B8DlJywj_*`,
-   `_RNvNtCslT5c56zUrC1_*` all alongside the live
-   `_RNvNtCscjLNWQIh9gP_*`) confirm stale binaries.
+   confirm stale binaries.
 2. Run `bin/flow ci --clean`. This is the user-facing reset:
    removes `target/llvm-cov-target/debug/deps/`, the
    `incremental/` dir, and every `*.profraw`. The next test run
    rebuilds fresh instrumentation with one crate hash per binary
    and the phantom misses disappear.
 3. Re-run `bin/test tests/<name>.rs`. The reported coverage now
-   reflects the actual code state. If the file is still <100%,
-   the remaining gap is real and addressable via tests or
-   refactor.
+   reflects the actual code state.
 
 The cleanup is a ~12-second one-shot followed by a ~45-second
 fresh compile on the first subsequent test run. Cheap relative
@@ -126,14 +116,3 @@ to the cost of chasing phantom misses for hours.
 
 Any one of those is sufficient — clean and re-measure before
 spending more time on test design.
-
-## Cross-References
-
-- `CLAUDE.md` "Development Environment" — names the three `bin/test`
-  invocation shapes (full suite, single-phase, per-file).
-- `.claude/rules/ci-is-a-gate.md` — explains why `bin/flow ci` is the
-  pre-commit gate; this rule is about iteration, not the gate.
-- `.claude/rules/no-waivers.md` — defines the 100/100/100 threshold
-  both the per-file and full-suite gates enforce.
-- `bin/test` — the script that implements both modes; per-file
-  dispatch is the `tests/<path>/<name>.rs` argument form.

--- a/.claude/rules/permission-blocked-workarounds.md
+++ b/.claude/rules/permission-blocked-workarounds.md
@@ -11,21 +11,16 @@ artifact in the worktree.
 
 ## The Pattern
 
-Claude needs to run a Bash command N times (e.g., run the same
-test 10 times to catch a flake). The Bash allow list forbids
-compound commands, shell loops, and arbitrary script invocations
-like `bash /path/to/helper.sh`. Tempted to batch the work,
-Claude writes `.helper-runner.sh` and tries to invoke it. The
-invocation is blocked. The cleanup `rm /path/to/helper-runner.sh`
-is also blocked because `rm` is not on the allow list. The file
-now sits in the worktree.
+The temptation: Claude needs to run a Bash command N times. The
+allow list forbids compound commands, shell loops, and arbitrary
+script invocations. To batch the work, Claude writes a helper
+script and tries to invoke it. The invocation is blocked. The
+cleanup `rm` is also blocked. The file now sits in the worktree.
 
-To keep the orphan out of the commit, Claude may then modify
-a shared config file (typically `.gitignore`) without user
-permission — which is a second scope-expansion violation
-(see `shared-config-files.md`). The scope of a simple "run this
-10 times" task balloons into a multi-file commit involving a
-script, a `.gitignore` entry, and a scramble to revert both.
+To keep the orphan out of the commit, Claude may then modify a
+shared config file (typically `.gitignore`) without user permission
+— a second scope-expansion violation (see
+`.claude/rules/permissions.md` "Shared Config Files").
 
 ## The Correct Path
 
@@ -54,37 +49,13 @@ The permission model is not an obstacle to work around — it is
 a deliberate narrowing of the action surface that the user has
 reviewed and approved. Creating artifacts to bypass the model
 defeats the review. Worse, orphan artifacts force scope
-expansion (`.gitignore` entries, manual cleanup requests)
-that further dilutes the user's review.
-
-The motivating incident is PR #1166 (Code phase of
-`thundering_herd_zero_delay` fix). Claude created
-`.flow-loop-runner.sh` to batch ten test invocations during
-Task 7. The execution was blocked, the cleanup was blocked, and
-Claude added the filename to `.gitignore` without user
-permission as a workaround. The user corrected both mistakes
-(see correction notes in the state file) and asked for the
-cleanup command, which they ran manually. The entire detour
-consumed several hours of wall-clock time that the direct
-path (ten sequential Bash tool calls) would have avoided.
+expansion (`.gitignore` entries, manual cleanup requests) that
+further dilutes the user's review.
 
 ## Cross-References
 
 - `.claude/rules/permissions.md` "Shared Config Files — Express
-  User Permission Required" section documents the second half
-  of the anti-pattern (modifying `.gitignore` etc. to hide the
-  orphan).
+  User Permission Required" documents the second half of the
+  anti-pattern (modifying `.gitignore` etc. to hide the orphan).
 - `.claude/rules/ci-is-a-gate.md` documents the related rule
-  that `bin/flow` subcommands must never run in the background —
-  a similarly-shaped case where the permission model's design
-  is load-bearing and workarounds defeat it.
-
-## Enforcement
-
-A proposed `PreToolUse` hook would match `Write` calls creating
-`*.sh` files (or files with executable-script extensions)
-during an active FLOW phase and warn with a pointer to this
-rule. See the filed GitHub issue for the enforcement proposal.
-Until the hook lands, the rule file is the primary instrument:
-every FLOW session must read it when considering a script-based
-workaround for a permission-model limitation.
+  that `bin/flow` subcommands must never run in the background.

--- a/.claude/rules/permissions.md
+++ b/.claude/rules/permissions.md
@@ -58,27 +58,23 @@ Forgetting either side breaks `bin/flow ci`: the contract test in
 `tests/permissions.rs` walks every SKILL.md bash block, extracts the
 command, and asserts it matches at least one allow-list entry. A
 new skill bash command without a matching entry fails CI in Code
-phase. Without Plan-time enumeration, the gap surfaces as a
-mid-Code permission failure that triggers an unplanned plan
-deviation log + a `CURRENT_CONFIG_HASH` bump (the allow-list
-addition changes the config-hash inputs).
+phase.
 
 ### What counts as a new bash command
 
 A bash block in a SKILL.md introduces a "new" command when its
 first token (the program name, modulo `${CLAUDE_PLUGIN_ROOT}/`
 prefix) is not already covered by an existing `UNIVERSAL_ALLOW`
-entry under the project's permission-pattern matching. Examples:
+entry. Examples:
 
 - A skill that adds `bin/test --adversarial-path` introduces a new
   command — `Bash(bin/test --adversarial-path)` is the matching
-  entry (or `Bash(bin/test *)` if the project wants to broaden).
+  entry.
 - A skill that adds `${CLAUDE_PLUGIN_ROOT}/bin/flow custom-subcmd`
   is covered by the existing `Bash(*bin/flow *)` entry — no
   permission change needed.
-- A skill that adds `gh release upload <tag> <file>` is covered by
-  existing `Bash(gh release create *)` only if patterns subsume —
-  most likely a new `Bash(gh release upload *)` entry is needed.
+- A skill that adds `gh release upload <tag> <file>` likely needs
+  a new `Bash(gh release upload *)` entry.
 
 ### How to apply
 
@@ -86,8 +82,7 @@ entry under the project's permission-pattern matching. Examples:
 add a bash block, the task description must include a "Permission
 coverage" subsection naming:
 
-1. The command's first token (e.g., `bin/test --adversarial-path`,
-   `${CLAUDE_PLUGIN_ROOT}/bin/flow <new-subcmd>`).
+1. The command's first token.
 2. The matching existing `UNIVERSAL_ALLOW` entry, OR the new
    `Bash(<pattern>)` entry the plan will add to both
    `src/prime_check.rs::UNIVERSAL_ALLOW` and
@@ -98,10 +93,7 @@ coverage" subsection naming:
 
 **Code phase.** When implementing the SKILL.md change, the same
 commit must include the matching allow-list addition + the
-`CURRENT_CONFIG_HASH` bump. Discovering the gap mid-Code is a
-plan-deviation event per
-`.claude/rules/plan-commit-atomicity.md` and must be logged via
-`bin/flow log` before the commit lands.
+`CURRENT_CONFIG_HASH` bump.
 
 **Code Review phase.** The reviewer agent cross-checks every new
 SKILL.md bash command in the diff against the diff's allow-list
@@ -134,15 +126,12 @@ explicit ask" — the user implicitly asks for it by running
 themselves placed in conflicting lists. The merge does not
 remove deny entries that have no allow-list counterpart, and
 `UNIVERSAL_ALLOW` / `FLOW_DENY` are validated against each other
-by the `no_allow_deny_overlap_in_plugin_permissions` test so
-FLOW never engineers a conflict that would silently strip a
-user's deny.
+by the `no_allow_deny_overlap_in_plugin_permissions` test.
 
 The match is exact-string only. A user with `Bash(git push)` in
 their deny list and `Bash(git *)` (broader pattern) in their
 allow list keeps the deny — subsumption-based removal is out of
-scope. See `src/prime_setup.rs::merge_settings_with` for the
-implementation and the doc comment that records the contract.
+scope. See `src/prime_setup.rs::merge_settings_with`.
 
 ## Never Edit Permissions Mid-Flow
 
@@ -154,26 +143,15 @@ blocks mid-session.
 
 Permission lockdown changes belong in `src/prime_check.rs`
 (UNIVERSAL_ALLOW, FLOW_DENY) for target projects. The FLOW repo's
-own `.claude/settings.json` is updated on main after the PR merges,
-or during the next `/flow:flow-prime` run.
+own `.claude/settings.json` is updated on the base branch after
+the PR merges, or during the next `/flow:flow-prime` run.
 
 ### Mechanical enforcement at the subprocess layer
 
-The `validate-claude-paths` PreToolUse hook intentionally does NOT
-protect `.claude/settings.json` (`is_protected_path` matches only
-`CLAUDE.md`, `.claude/rules/*`, `.claude/skills/*`), so a model
-that wants to mutate the settings file directly via Edit or Write
-is blocked by the broader `validate-worktree-paths` hook only for
-the limited set of shared-config filenames it tracks. But
-`bin/flow promote-permissions --worktree-path <worktree>` is a
-subprocess that reads `.claude/settings.local.json` and writes
-`.claude/settings.json` at the worktree root — entirely outside
-the hook surface. Without an additional gate, that subprocess can
-land permission changes mid-flow.
-
-`src/promote_permissions.rs::active_flow_gate` closes the hole.
-Before the merge runs, it walks up the resolved `--worktree-path`
-looking for `.flow-states/`, derives the branch via
+`src/promote_permissions.rs::active_flow_gate` blocks
+`bin/flow promote-permissions` mid-flow. Before the merge runs, it
+walks up the resolved `--worktree-path` looking for
+`.flow-states/`, derives the branch via
 `crate::hooks::detect_branch_from_path`, and checks
 `crate::hooks::is_flow_active(&branch, &main_root)`. When a flow
 is active and the caller did NOT pass `--confirm-on-flow-branch`,
@@ -190,18 +168,7 @@ sanctioned mid-flow caller) completes the merge.
 
 The `--confirm-on-flow-branch` flag is the bypass. `flow-learn`
 Step 4 passes it; any other caller documenting a legitimate
-mid-flow promotion must do the same. A model that constructs the
-flag itself to bypass the gate inherits the prose-only trust
-contract — symmetric with the `_continue_pending=commit` carve-out
-documented in `.claude/rules/concurrency-model.md` "Mechanical
-Enforcement". The gate exists to prevent accidental mid-flow
-mutations, not adversarial bypass.
-
-See `src/promote_permissions.rs::active_flow_gate` for the
-implementation and `tests/promote_permissions.rs` for the
-active-flow matrix (without-confirm-skips, with-confirm-proceeds,
-no-active-flow-proceeds, inactive-branch-proceeds,
-branch-undetectable-proceeds, relative-path-resolution).
+mid-flow promotion must do the same.
 
 ## Shared Config Files — Express User Permission Required
 
@@ -223,41 +190,13 @@ The canonical list:
   every PR in the repo
 - `.config/` (everything under it — `nextest.toml`, build profile
   configs, language-toolchain configs, etc.) — shared
-  build/test infrastructure that every engineer's CI run inherits.
-  A change to `.config/nextest.toml` (test timeouts, test groups,
-  parallelism limits) reshapes every concurrent flow's CI behavior.
+  build/test infrastructure that every engineer's CI run inherits
 - `.claude/settings.json` — covered by "Never Edit Permissions
   Mid-Flow" above
 
 When a PR's scope is narrow (e.g., "fix one flaky test"), editing
 any of these files expands the diff into territory the user never
-agreed to review. Even a one-line change to `.gitignore` or
-`.config/nextest.toml` is a scope expansion — the user has not
-seen or approved that entry.
-
-## The Anti-Pattern
-
-The motivating incident (PR #1166): Claude created a helper
-script `.flow-loop-runner.sh` whose execution was blocked by the
-permission model. To keep the orphan file out of the commit,
-Claude added the filename to `.gitignore` without user permission.
-The user had to revert the `.gitignore` change manually after
-catching it. Two violations compounded: the script never should
-have been created (see
-`.claude/rules/permission-blocked-workarounds.md`), and
-`.gitignore` never should have been modified to work around the
-script.
-
-A second motivating incident: a CI test under nextest's
-`slow-timeout` was failing under heavy machine load (video call).
-Claude attempted to add a serial test-group override in
-`.config/nextest.toml` to "fix" the flake. That was scope
-expansion into shared infrastructure (every engineer's CI
-inherits the override) AND it was solving an environmental noise
-problem with a config change rather than waiting for load to
-return to normal. The user reverted both. See also
-`.claude/rules/testing-gotchas.md` "Distinguish Environmental
-Load From Flaky Tests" for the test-side discipline.
+agreed to review.
 
 ## The Correct Path
 
@@ -266,9 +205,9 @@ file, stop and ask the user:
 
 > "The cleanest solution here requires adding one line to
 > `.gitignore` (or modifying `.github/workflows/ci.yml`,
-> `.config/nextest.toml`, etc.).
-> This is shared config that every engineer reads. May I modify
-> it, or should I change the approach to avoid the edit?"
+> `.config/nextest.toml`, etc.). This is shared config that
+> every engineer reads. May I modify it, or should I change the
+> approach to avoid the edit?"
 
 Prefer approaches that keep the diff scoped to task-relevant
 code. Ask before expanding scope into shared territory. If the
@@ -293,40 +232,14 @@ directory component.
 (e.g., `.config/nextest.toml`). The prose rule above forbids
 unapproved edits to those files; the hook does not yet enforce
 them. Until the hook is extended, the model must follow the prose
-rule manually for `.config/` writes — every Edit/Write to a
-`.config/*` file under an active flow requires explicit user
-approval before the call. Future work is to extend the
-`is_shared_config` predicate to match any path passing through a
-`.config/` directory component, mirroring the existing
-`.github/` treatment.
+rule manually for `.config/` writes.
 
 The `validate_shared_config` function gates on tool name: only
 `Edit` and `Write` tool calls are blocked (exit 2). `Read`,
-`Glob`, and `Grep` calls pass through so codebase exploration is
-unaffected. The block fires only when the CWD is inside a
-`.worktrees/` directory (the flow-active proxy) and the target
-path is inside the worktree.
+`Glob`, and `Grep` calls pass through. The block fires only when
+the CWD is inside a `.worktrees/` directory and the target path
+is inside the worktree.
 
 The block message directs the model to confirm with the user via
 `AskUserQuestion` before proceeding, and points to this section
-for context. No hook registration changes are needed — the
-existing `validate-worktree-paths` entries for Edit and Write in
-`hooks/hooks.json` already cover the tool surface.
-
-## Cross-References
-
-- `.claude/rules/permission-blocked-workarounds.md` — documents the
-  first half of the compound anti-pattern (creating the orphan
-  artifact) that commonly motivates shared-config modification.
-- `.claude/rules/code-review-scope.md` "Rules Landed on Main
-  Mid-Flow" — covers the adjacent case of shared rules updated
-  on main during an active branch.
-- `.claude/rules/testing-gotchas.md` "Distinguish Environmental
-  Load From Flaky Tests" — the test-side discipline that
-  prevents shared-config edits from being used to paper over
-  environmental load events.
-- `.claude/rules/cli-output-contracts.md` — when a new skill
-  bash command is also a new consumed-output subcommand or stub
-  flag, the Plan-phase enumeration here couples with the
-  output-contract discipline there. The plan must specify both
-  the permission entry AND the output contract before Code phase.
+for context.

--- a/.claude/rules/plan-commit-atomicity.md
+++ b/.claude/rules/plan-commit-atomicity.md
@@ -18,19 +18,7 @@ individual outputs would leave the tree in an intermediate state that
 CI or reviewers cannot interpret correctly.
 
 When the Code phase later decides to split an atomic group across
-multiple commits, the decision must be explicit and defensible — the
-plan's atomicity requirement was a design constraint, and relaxing it
-silently discards that constraint. PR #1056 documented the split
-decision in each commit message as a resilience choice (each commit
-independently CI-green), but the rationale was never captured in the
-plan or state file.
-
-The risk of an unexplained split: a future session inheriting the
-pattern may split a GENUINELY atomic group (where CI failure in the
-intermediate state would block merging, or where a test asserts the
-presence of content that's removed and re-added) and the split will
-fail in ways the original atomic-commit guarantee would have
-prevented.
+multiple commits, the decision must be explicit and defensible.
 
 ## The Rule
 
@@ -43,9 +31,7 @@ only when ALL three conditions hold:
 2. **No test assertion spans the boundary.** No test asserts the
    presence of content that another commit in the group removes and
    later re-adds. If such a test exists, the removal and re-addition
-   must land in the same commit. Check `tests/skill_contracts.rs`
-   and any content-presence scanners for assertions that the removal
-   would invalidate.
+   must land in the same commit.
 3. **The split clarifies the logical structure.** The split must
    reflect a meaningful boundary (e.g., "core scanner" vs
    "integration" vs "documentation") and not just a context-budget
@@ -57,11 +43,11 @@ land the group in one commit.
 ## How to Apply
 
 **Plan phase.** When marking a set of tasks as an atomic commit
-group, state the WHY explicitly in the plan's Tasks section: "atomic
-because test X asserts content that task N removes and task M
-re-adds" or "atomic because the intermediate state leaves CI
-failing." Without the WHY, the Code phase has no basis for deciding
-whether to honor the atomicity requirement or split.
+group, state the WHY explicitly: "atomic because test X asserts
+content that task N removes and task M re-adds" or "atomic because
+the intermediate state leaves CI failing." Without the WHY, the
+Code phase has no basis for deciding whether to honor the atomicity
+requirement or split.
 
 **Code phase.** Before splitting a marked atomic group, verify all
 three conditions above. If verified, document the split decision in
@@ -72,9 +58,7 @@ commit atomically.
 **Learn phase.** The learn-analyst audit checks whether any marked
 atomic group was split across commits. A split without documented
 rationale in either a state note or each commit message is a process
-gap — either the Code phase skipped the verification check, or the
-plan's atomicity was not actually load-bearing and the marker was
-misused. Either way, the finding reaches this file.
+gap.
 
 ## Optimization-Driven Batching (Non-Atomic Tasks Combined)
 
@@ -102,11 +86,6 @@ moment of batching:
 bin/flow log <branch> "[Phase 3] Batch decision: combining Tasks N-M (<description>) into one commit for <reason>. Each task is independently shippable; no test assertion spans the boundary; the split would <cost>."
 ```
 
-The log entry serves the same three readers as the split-decision
-log (immediate Code phase, Code Review reviewer agent, Learn
-analyst) and captures the criterion so future sessions can
-recognize the same shape.
-
 ### When NOT to batch
 
 Combining non-atomic tasks into one commit is NOT permitted when:
@@ -115,22 +94,18 @@ Combining non-atomic tasks into one commit is NOT permitted when:
   task — at a minimum, the content-presence rule from the atomic-
   group criterion applies.
 - The commit message would need to describe two unrelated concerns
-  (e.g., "add coverage tests" and "refactor state-file parsing")
   — that is a sign the tasks belong in separate commits for
   review clarity.
 - The plan explicitly lists the tasks as separate with distinct
-  commit-message subjects — the plan author already made the
-  call; Code should honor it unless the Code-phase discovery
-  genuinely supersedes the plan's intent (in which case log the
-  deviation and combine).
+  commit-message subjects — the plan author already made the call;
+  Code should honor it unless the Code-phase discovery genuinely
+  supersedes the plan's intent (in which case log the deviation).
 
 ### Learn-phase audit
 
 The learn-analyst checks for undocumented batching the same way it
 checks for undocumented atomic-group splits. An unlogged batch
-becomes a process-gap finding. The fix is either to add the log
-entry retroactively in a state note or to ensure future Code
-phases log the batch decision at the point it is made.
+becomes a process-gap finding.
 
 ## Plan Signature Deviations Must Be Logged
 
@@ -138,11 +113,10 @@ The atomic-group rule above covers commit boundaries. The same
 discipline extends to **any Code-phase deviation from a plan-level
 interface prototype** — a function signature, a type name, a file
 name, or a task count. When the Code phase discovers that a plan's
-prototype is internally inconsistent (e.g., a test requirement that
-cannot be satisfied by the prototype's parameter list) and resolves
-the inconsistency by extending the prototype, the deviation must be
-recorded in the state log via `bin/flow log` before the commit that
-delivers the extended interface lands.
+prototype is internally inconsistent and resolves the inconsistency
+by extending the prototype, the deviation must be recorded in the
+state log via `bin/flow log` before the commit that delivers the
+extended interface lands.
 
 ### Why
 
@@ -150,12 +124,10 @@ When the Plan phase produces a prototype like
 `run_impl_with_notifier(args, notifier)` but the Code phase delivers
 `run_impl_with_deps(root, cwd, args, notifier)` — with additional
 parameters that unlock testing surfaces the plan implied but could
-not express — the deviation is often a valid and well-considered
-design improvement. But if the deviation is not logged anywhere a
-future session can find it, the Learn phase audit replays the plan,
-sees the rename, and flags it as "plan said X but X is not there"
-without context. The Learn analyst then has to infer the justification
-from commit messages, which is expensive and sometimes impossible.
+not express — the deviation is often a valid design improvement.
+But if the deviation is not logged, the Learn phase audit replays
+the plan, sees the rename, and flags it as "plan said X but X is
+not there" without context.
 
 The lowest-cost path is for the Code phase to record the deviation
 at the moment of discovery:
@@ -164,12 +136,12 @@ at the moment of discovery:
 bin/flow log <branch> "[Phase 3] Plan signature deviation: run_impl_with_notifier -> run_impl_with_deps (added root/cwd injection to satisfy finalize_with_notifier_cwd_scope_rejects test requirement)"
 ```
 
-The log entry serves three readers: (1) the immediate Code phase as a
-reminder when composing the commit message, (2) Code Review's
+The log entry serves three readers: (1) the immediate Code phase as
+a reminder when composing the commit message, (2) Code Review's
 reviewer agent when cross-referencing plan vs. implementation, and
 (3) the Learn phase audit when distinguishing "plan said X, code has
-Y, Learn should investigate" from "plan said X, code has Y, Learn
-should move on — this was a documented pivot."
+Y, Learn should investigate" from "plan said X, code has Y, this was
+a documented pivot."
 
 ### What Counts as a Deviation
 
@@ -191,9 +163,7 @@ It is NOT required for:
   while reading the task description.
 - **Whitespace or formatting adjustments** to code the plan sketched
   as pseudocode.
-- **Test-function renames** that stay within the plan's stated scope
-  (e.g., the plan said `test_foo_success` and Code wrote
-  `test_foo_happy_path_success` for clarity).
+- **Test-function renames** that stay within the plan's stated scope.
 
 ### How to Apply (Deviation Logging)
 
@@ -212,30 +182,10 @@ requires extending the plan's prototype:
    the log file and confirm the deviation was documented. An
    undocumented deviation becomes a Learn-phase process-gap finding.
 
-### Motivating Incident
-
-PR #1157 (Coverage: HTTP client trait seam for `notify_slack` and
-`phase_finalize`) planned `run_impl_with_notifier(args, notifier)`
-as Task 6's function prototype. Task 5's test list included
-`finalize_with_notifier_cwd_scope_rejects`, which requires the
-caller to control `cwd` — but the prototype had no `cwd` parameter.
-The Code phase discovered the contradiction during implementation
-and extended the prototype to
-`run_impl_with_deps(root, cwd, args, notifier)`. The extension was
-architecturally sound and every test passed on the first compile. But no state log entry recorded the deviation — the only
-trace was the commit message, which Learn had to read to confirm
-the pivot was intentional. The Learn-analyst audit surfaced this as
-a rule-compliance gap because the discipline for logging plan
-deviations was not documented in any rule file. This section
-codifies the discipline.
-
 ### Mechanical Enforcement
 
-Instructional enforcement alone leaves the rule a suggestion — a
-Code-phase agent can drift from plan-named fixtures and commit
-without logging. The plan-deviation gate inside
-`src/finalize_commit.rs::run_impl` converts the instructional
-discipline into a mechanical check.
+The plan-deviation gate inside `src/finalize_commit.rs::run_impl`
+converts the instructional discipline into a mechanical check.
 
 **What it detects.** `src/plan_deviation.rs::scan` walks the plan
 file's `## Tasks` section, collects `(test_name, fixture_key,
@@ -250,27 +200,14 @@ not contain the literal `"expected"`.
 **Where it runs.** The gate fires inside
 `finalize_commit::run_impl`, after `ci::run_impl()` succeeds and
 before `finalize_commit_inner` calls `git commit`. Every commit
-path — `/flow:flow-commit`, direct `bin/flow finalize-commit`
-invocations, any future wrapper — routes through `run_impl` and
-therefore through the gate. There is no bypass path that lands a
-commit without the gate running first. The gate runs during Code
-phase rather than Plan phase because it cross-references the plan
-against the actual staged implementation — a comparison that
-requires implementation code to exist. The scope-enumeration and
-external-input-audit gates validate plan prose against itself and
-therefore run at Plan phase completion; the plan-deviation gate
-validates plan prose against code and therefore runs at commit
-time.
+path routes through `run_impl` and therefore through the gate.
 
-**How to acknowledge.** When a deviation is intentional (the Code
-phase discovered a better fixture value, or the plan's prototype
-was internally inconsistent), the user logs the deviation via
-`bin/flow log <branch> "[Phase 3] Plan signature deviation: <text
-naming the test and the plan value>"`. The gate re-reads the log
-file on every invocation and clears any deviation whose
-`(test_name, plan_value)` pair both appear as substrings on a
-single log line. After logging, the user re-runs the commit and
-the gate passes.
+**How to acknowledge.** When a deviation is intentional, the user
+logs the deviation via `bin/flow log <branch> "[Phase 3] Plan
+signature deviation: <text naming the test and the plan value>"`.
+The gate re-reads the log file on every invocation and clears any
+deviation whose `(test_name, plan_value)` pair both appear as
+substrings on a single log line.
 
 **What is intentionally out of scope.** Tests that the Code phase
 adds that the plan never names are invisible to this gate — the
@@ -279,35 +216,4 @@ that separate invariant. Multi-line string literals are
 single-line only in v1. Prefix-renamed tests (plan says
 `fn test_foo`, code writes `fn test_foo_happy_path`) are not
 matched because exact `fn <name>(` matching is the v1 contract.
-Plan prose outside `## Tasks` (Context, Risks, Approach) is not
-scanned.
-
-**Structural context.** The scanner follows the peer pattern
-established by `src/scope_enumeration.rs` and
-`src/external_input_audit.rs` — a pure `scan` function returning
-a structured violation vector and a thin `run_impl` orchestrator
-that reads files from disk. Unit and integration coverage lives
-in `tests/plan_deviation.rs` and
-`tests/plan_deviation_integration.rs`, which drive the public
-scanner surface directly and spawn the compiled `flow-rs` binary
-against fixture repos to drive the five branches the gate adds
-to `finalize_commit::run_impl`. Test placement follows
-`.claude/rules/test-placement.md` — no inline `#[cfg(test)]`
-blocks in `src/*.rs`.
-
-## Motivating Incident (Atomic Group Split)
-
-PR #1056 (Plan-phase external-input audit gate) planned Task 21 as
-"Commit atomic group: Tasks 3, 5, 6, 9, 11, 13, 14, 15, 16, 17, 18,
-19 land in one commit." The Code phase split the work across five
-commits (25542b67, 9f69924b, 89cfee33, d96f3fb5, 4ed5dcfc, 2dc21114)
-for context-management resilience. Each commit independently passed
-CI and each was individually shippable, so the split was safe —
-Condition 1 held. No test assertion spanned the boundary —
-Condition 2 held. Each commit grouped a logical unit (scanner + unit
-tests; corpus contract test + cleanup; plan_check integration;
-plan_extract integration; rule file + SKILL.md + CLAUDE.md + docs) —
-Condition 3 held. All three conditions were met, so the split was
-acceptable. But the decision was implicit — no state note documented
-the verification. The Learn audit surfaced this as a process gap and
-this rule codifies the explicit check.
+Plan prose outside `## Tasks` is not scanned.

--- a/.claude/rules/reachable-is-testable.md
+++ b/.claude/rules/reachable-is-testable.md
@@ -77,11 +77,7 @@ The required investigation:
    it's fine."
 
 If a line is genuinely uncovered in the aggregate, return to the
-three triage questions. The discipline forbids reporting any
-form of partial coverage as final; "covered elsewhere" is the
-specific phrasing that tries to slip past this discipline by
-displacing the responsibility to a test the speaker has not named
-or verified.
+three triage questions.
 
 ## Fixture recipes for the common hard cases
 
@@ -138,20 +134,3 @@ before approving any workaround. A claim of "covered elsewhere"
 must cite the specific test function and binary, and the reviewer
 should confirm the full-CI aggregate reads 100/100/100 before
 accepting.
-
-## Cross-references
-
-- `.claude/rules/testability-means-simplicity.md` — the response
-  when the triage surfaces an over-engineered branch.
-- `.claude/rules/no-waivers.md` — the 100/100/100 gate this rule
-  protects.
-- `.claude/rules/per-file-coverage-iteration.md` — the per-file
-  gate is for iteration speed, not for completion reporting; the
-  full-CI gate is the authority.
-- `.claude/rules/rust-patterns.md` "Seam-injection variant for
-  externally-coupled code" — the seam patterns whose production
-  bindings the fixture recipes above test.
-- `.claude/rules/test-placement.md` — every test lives in
-  `tests/<path>/<name>.rs` and drives through the public
-  interface. The triage above is how that discipline stays
-  honest when the public path is fixture-hungry.

--- a/.claude/rules/rust-patterns.md
+++ b/.claude/rules/rust-patterns.md
@@ -40,27 +40,16 @@ implementation for this pattern.
 
 - **Predicate state scope.** Document explicitly which scanner states
   invoke the predicate. `scan_unquoted` calls its predicate only in
-  Normal state — quoted bytes are inert by construction. A caller who
-  expected the predicate to run inside double quotes would be surprised,
-  so the scanner's doc comment must say so outright.
-
+  Normal state — quoted bytes are inert by construction.
 - **Scanner-internal universal matches.** When a match is universal
   across multiple states (e.g. `$(` and backticks are structural in
   both Normal and Double state because bash expands them in both), the
   scanner itself must perform the match rather than relying on
-  predicates to agree. `scan_unquoted` hardcodes `$(` and backtick
-  detection inside the Double state arm because every predicate would
-  otherwise have to duplicate that logic — duplication invites drift.
-  Only Single-quoted state fully suppresses expansion in bash; the
-  scanner encodes this invariant once.
-
+  predicates to agree. Duplication invites drift.
 - **Shared scanner, multiple predicates.** When the same state machine
-  backs multiple CLI layers (Layer 1 compound operators and Layer 2
-  redirection in `validate_pretool::validate`), both layers must go
-  through the same scanner function so a quote-semantics bug fix in
-  the scanner automatically applies to every layer. Layering two
-  independent scanners produces drift.
-
+  backs multiple CLI layers, both layers must go through the same
+  scanner function so a quote-semantics bug fix in the scanner
+  automatically applies to every layer.
 - **Unclosed-state fallback.** When the scanner finishes inside a
   non-Normal state (unclosed quote, unterminated escape), return a
   distinct `Err(ScanError::Unclosed)` variant rather than silently
@@ -70,9 +59,6 @@ implementation for this pattern.
 
 **How to apply:**
 
-<!-- scope-enumeration: imperative -->
-When designing a new stateful scanner that accepts predicates:
-
 1. Enumerate every scanner state the predicate will run in. Pick one
    (typically "outside all non-literal contexts") and document it.
 2. List every operator class the scanner must catch. Split them into
@@ -81,14 +67,7 @@ When designing a new stateful scanner that accepts predicates:
 3. Treat the state machine as shared infrastructure, not caller-owned.
    Do NOT let consumers bring their own state machine — that defeats
    the shared-scanner guarantee.
-4. Add an explicit error variant for each malformed-input class
-   (unclosed quote, unterminated escape, unbalanced bracket). Consumers
-   must match on the error type, not treat it as "no match."
-
-When reviewing an existing predicate-based scanner, check that the
-predicates are consistent about which states they run in. If one
-predicate assumes it runs in Normal only and another assumes it runs
-everywhere, the scanner has a silent contract gap.
+4. Add an explicit error variant for each malformed-input class.
 
 ## State Mutation Object Guards
 
@@ -102,8 +81,7 @@ guards — check the type of each intermediate level before assigning.
 When a nested field like `state["phases"]` must be an object for
 downstream IndexMut access, reset it to `json!({})` if its type is
 wrong. This auto-heal approach prevents panics from corrupted or
-legacy state files while allowing the operation to proceed with
-empty data rather than failing entirely.
+legacy state files.
 
 ## Hook Input Boolean Field Tolerance
 
@@ -127,13 +105,9 @@ have the main arm call one of the centralized helpers in
 `src/dispatch.rs`:
 
 - `dispatch::dispatch_json(Value, i32)` — for subcommands whose
-  stdout contract is JSON (e.g., `check_phase::run_impl_main`,
-  `phase_transition::run_impl_main`, `tui_data::run_impl_main`,
-  `format_complete_summary::run_impl_main`,
-  `format_issues_summary::run_impl_main`,
-  `format_pr_timings::run_impl_main`).
+  stdout contract is JSON.
 - `dispatch::dispatch_text(&str, i32)` — for subcommands whose
-  stdout contract is plain text (e.g., `format_status::run_impl_main`).
+  stdout contract is plain text.
 
 Return type choices:
 
@@ -141,18 +115,13 @@ Return type choices:
 - `(String, i32)` — plain-text stdout, no stderr path.
 - `Result<(Value, i32), (String, i32)>` — when the arm has a stderr
   error path. `Ok` routes to stdout via `dispatch_json`; `Err` goes
-  to stderr with the paired exit code. Reference:
-  `tui_data::run_impl_main` (no-flag error) and
-  `format_status::run_impl_main` (branch-resolution failure at exit
-  2). The main arm pattern-matches the Result.
+  to stderr with the paired exit code.
 
 `run_impl_main` functions take `root: &Path` (and `cwd: &Path` where
 the arm enforces cwd drift) as parameters rather than calling
 `project_root()` / `current_dir()` internally, so integration tests
 in `tests/<name>.rs` can pass a `TempDir` fixture without colliding
-with the host worktree. Main.rs resolves those values once per arm
-and passes them in, matching the shape of the pre-existing
-`run_impl` seam in `ci.rs::run()`.
+with the host worktree.
 
 **Seam-injection variant for externally-coupled code.** When a
 module's production wrapper depends on resources `cargo nextest`
@@ -164,9 +133,9 @@ keep the production wrapper a thin closure-supplier.
 "externally-coupled" resources that justify a pub test seam is
 exactly: real TTY (`libc::isatty`), raw-mode terminal (crossterm
 `enable_raw_mode`/`LeaveAlternateScreen`), live crossterm event
-loop, network socket opened inside the module. Nothing else. In
-particular, the following do NOT qualify as externally coupled and
-cannot be used to justify a pub test seam:
+loop, network socket opened inside the module. Nothing else. The
+following do NOT qualify and cannot be used to justify a pub test
+seam:
 
 - Subprocess calls to `gh`, `git`, `bin/flow`, or any other binary —
   these are fixture-controllable (prepend a fake binary to PATH,
@@ -191,23 +160,14 @@ accepts `is_tty_fn: FnOnce() -> bool` and `run_terminal_fn:
 FnOnce(&mut TuiApp) -> io::Result<()>` so unit tests substitute
 mock closures and assert each branch's return tuple. The production
 wrapper `run_tui_arm` returns `!` and calls `run_tui_arm_impl` with
-real implementations (`libc::isatty`, the crossterm event loop),
-then matches the Result to `process::exit` — keeping the exit
-dispatch inside the module leaves main.rs's match arm a single
-fully-covered expression. Crossterm code that physically cannot run
-without a TTY (raw mode, alternate screen) lives in a private
-helper (`run_terminal`) whose internal coverage is the module's
-concern, not main.rs's.
+real implementations, then matches the Result to `process::exit`.
 
 The same closure-injection pattern applies to RAII guards whose
 release path needs unit-test verification: parameterize the cleanup
 closure (`TerminalGuard<F: FnMut()>` with `release_fn: Option<F>`)
 so unit tests construct a guard with a flag-setting closure, panic
 inside `std::panic::catch_unwind`, and assert the flag was set on
-Drop unwind. The production caller passes the real cleanup closure
-(disable_raw_mode, LeaveAlternateScreen) and gets the same
-guarantee. Per `.claude/rules/panic-safe-cleanup.md`, the closure
-must swallow its own errors because `Drop` cannot return them.
+Drop unwind.
 
 **Three-tier dispatch for subprocess-coordinating modules.**
 
@@ -216,9 +176,7 @@ pub-for-testing. Before adopting it, confirm the dependencies truly
 cannot be exercised via the real production path with fixtures. If
 the dependencies are `gh`/`git`/`bin/flow` subprocess calls, fixture
 them via a fake binary on PATH instead of introducing a `_with_deps`
-pub seam. If the dependencies are filesystem reads or environment
-variables, fixture them via tempdir and `Command::env`. A
-`_with_deps` variant whose only non-test caller is the
+pub seam. A `_with_deps` variant whose only non-test caller is the
 same-module `run_impl` production binder fails the bright-line
 test in `.claude/rules/test-placement.md` and is forbidden.
 
@@ -238,24 +196,12 @@ approaches have been tried and documented as insufficient.
 3. `pub fn run_impl_main(args, root, cwd) -> (Value, i32)` — main-arm
    dispatcher that wraps into the `(Value, i32)` contract.
 
-Reference implementations: the four start-family modules
-(`src/start_init.rs`, `src/start_gate.rs`, `src/start_workspace.rs`,
-`src/start_finalize.rs`) follow this three-tier pattern. Only
-`start_init` keeps `run_impl -> Result<Value, String>` and adds a
-seam-level `run_impl_main_with_deps` — its module doc comment
-documents the asymmetry and the reason (`plug_root_finder=None` and
-init-state subprocess `Err` are reachable infrastructure failures
-that need to map to exit code 1).
-
 **Exit code convention for business errors.** When `run_impl` returns
 `Value` unconditionally, the paired `run_impl_main` wraps as
 `(v, 0)` — exit code is always `0`. Callers distinguish success from
 failure by parsing the JSON `status` field, not by shell exit code.
-This matches the pre-existing convention of `format_complete_summary`,
-`format_issues_summary`, `format_pr_timings`, and `tui_data`. Exit
-code `1` is reserved for infrastructure failures that escape the JSON
-contract (surfaced via `Err` from a fallible `run_impl`, then wrapped
-as `(err_json, 1)` by `run_impl_main`).
+Exit code `1` is reserved for infrastructure failures that escape the
+JSON contract.
 
 ## Test Subprocess Stdio
 
@@ -297,8 +243,7 @@ When other modules need the same tolerance, import from `crate::utils`
 ## Saturating Arithmetic on Counter Reads
 
 Counter reads via `tolerant_i64` can return values at or near `i64::MAX`
-when state files carry corrupt or legacy values (hand edits, external
-writers, or integer overflow from a prior session). Raw `+ 1` or
+when state files carry corrupt or legacy values. Raw `+ 1` or
 `+ elapsed` arithmetic on those values panics in debug builds and wraps
 silently to `i64::MIN` in release builds, corrupting the counter.
 
@@ -348,8 +293,7 @@ user-controlled directories.
 Use `fs::symlink_metadata(&path).is_ok()` for the existence check
 instead. `symlink_metadata` does not follow symlinks, so it returns
 `Ok` for files, directories, valid symlinks, AND dangling symlinks —
-every entry the filesystem considers present. The installer then
-skips the path without writing, preserving whatever is already there.
+every entry the filesystem considers present.
 
 ```rust
 // Correct
@@ -374,10 +318,7 @@ directory, and missing-path cases.
 The rule is scoped to **writes and file-creation calls only**. Deletion
 paths (`fs::remove_file`, `fs::remove_dir`) do not have the same
 symlink-escape risk — `fs::remove_file` on a symlink removes the link
-itself, never its target. Citing this rule for a deletion-path concern
-is a false positive. For the separate concern of iterating a directory
-and deleting entries, see "Safe Directory Iteration and Deletion"
-below.
+itself, never its target.
 
 ## Safe Directory Iteration and Deletion
 
@@ -403,12 +344,7 @@ explicitly:
 3. **Partial success return shape.** With continue-past-error, the
    return value must distinguish three states: no matches (`"skipped"`),
    at least one file deleted successfully (`"deleted"`), and matches
-   existed but every attempt failed (`"failed: <first_error>"`). Do
-   NOT use `"deleted"` when only some matches were removed and
-   others failed — that hides the failures. The first-error-reporting
-   shape (only report failure when NO file was deleted) balances
-   signal strength against noise: a single transient error does not
-   block the entire cleanup, but a hard failure is still surfaced.
+   existed but every attempt failed (`"failed: <first_error>"`).
 
 Canonical shape:
 
@@ -455,33 +391,13 @@ fn try_delete_matching(dir: &Path, prefix: &str) -> String {
 }
 ```
 
-**Plan phase checklist for `fs::read_dir` + delete loops.** When a
-plan task describes a helper that iterates a directory and deletes
-matching entries, enumerate these three risks explicitly in the
-Risks section before Code Review catches them:
+**Plan phase checklist for `fs::read_dir` + delete loops.** Enumerate
+these three risks explicitly in the Risks section before Code Review
+catches them:
 
-- Non-file entries that happen to match the filter prefix (directories,
-  sockets, named pipes) — must be skipped, not deleted, not aborting
-  the loop
-- Partial failure aggregation — loop must continue past individual
-  errors so one bad entry cannot orphan the others
-- Return shape for partial success — distinct statuses for
-  no-match, any-deleted, all-failed
-
-**Test coverage for directory iteration helpers.** Every new helper
-of this shape must ship with tests covering:
-
-- Single matching file → `"deleted"`, file gone
-- No matching files → `"skipped"`
-- Multiple matching files → `"deleted"`, all gone
-- Directory entry matching the prefix alongside real files → directory
-  untouched, files still deleted, step returns `"deleted"`
-- Missing target directory (`read_dir` returns `Err`) → `"skipped"`,
-  no panic
-- Branch-scoped or prefix-scoped isolation (concurrent callers with
-  different prefixes do not interfere)
-- Trailing-separator precision when the prefix ends in a
-  character-class boundary (e.g., `"foo."` must not match `"foo_bar"`)
+- Non-file entries that happen to match the filter prefix
+- Partial failure aggregation
+- Return shape for partial success
 
 ## Guard Universality Across CLI Entry Points
 
@@ -497,10 +413,7 @@ family. FLOW has two relevant families:
 - **State mutators:** `bin/flow phase-enter`, `bin/flow phase-finalize`,
   `bin/flow phase-transition`, `bin/flow set-timestamp`,
   `bin/flow add-finding`, `bin/flow add-issue`,
-  `bin/flow add-notification`, `bin/flow append-note`
-  (`src/phase_enter.rs`, `src/phase_finalize.rs`, the
-  `PhaseTransition` branch in `src/main.rs`, `src/commands/*.rs`,
-  `src/add_finding.rs`, etc.).
+  `bin/flow add-notification`, `bin/flow append-note`.
 
 **Read-only exemption.** Subcommands that only READ the state file
 and plan/worktree files (no mutations, no tool dispatch) are
@@ -508,12 +421,9 @@ exempt from `cwd_scope::enforce` — a wrong cwd on a read-only
 command cannot drift the flow because the command produces no
 side effects. The current exempt set is:
 
-- `bin/flow format-status` (`src/format_status.rs`) — renders the
-  status panel from state
-- `bin/flow tombstone-audit` (`src/tombstone_audit.rs`) — scans
-  `tests/*.rs` for tombstone PR references and queries GitHub
-- `bin/flow plan-check` (`src/plan_check.rs`) — runs the
-  scope-enumeration scanner against the current plan file
+- `bin/flow format-status` (`src/format_status.rs`)
+- `bin/flow tombstone-audit` (`src/tombstone_audit.rs`)
+- `bin/flow plan-check` (`src/plan_check.rs`)
 
 When adding a new read-only subcommand, add it to this list AND
 to the corresponding list in CLAUDE.md's Subdirectory Context
@@ -522,11 +432,7 @@ section so the two canonical enumerations stay in sync.
 Before merging a PR that adds a guard, grep `src/main.rs` for every
 `Commands::` variant in the target family and verify the guard lands
 in every `run_impl` or `run()` entry. A guard that exists in only one
-runner creates divergent behavior: the user hits the same failure
-mode in the unguarded sibling. The class of bug is invisible to
-individual unit tests — only a contract test that enumerates every
-variant can catch it mechanically. Consider adding such a contract
-test whenever a new guard is introduced.
+runner creates divergent behavior.
 
 When tests spawn `CARGO_BIN_EXE_flow-rs` subprocesses while the test
 suite itself is running inside a `bin/flow ci` invocation,
@@ -538,9 +444,7 @@ fresh invocation.
 The two family lists above are also the canonical enumeration used
 by `.claude/rules/scope-enumeration.md` — the prose-side rule that
 requires every universal-quantifier claim about a code family to
-carry a named sibling list. When you add a new member to either
-family, update both this section and any plan prose that references
-the family by its universal noun so the named list stays in sync.
+carry a named sibling list.
 
 ## Cwd-Inside-Destructive-Path Guard
 
@@ -586,27 +490,19 @@ Three properties matter:
 - **Equality OR prefix.** A cwd nested inside the worktree
   (`<worktree>/<sub>/...`) must trigger the gate too. The
   `cwd_canon.starts_with(&worktree_canon)` check covers descendants;
-  the `==` check covers the exact-root case (some platforms strip
-  trailing separators that would otherwise break `starts_with`).
+  the `==` check covers the exact-root case.
 - **Skip on canonicalize error, do not panic.** When either path
-  can't be canonicalized (worktree path doesn't yet exist, cwd
-  vanished mid-call), the guard falls through and lets downstream
-  steps surface a more specific error. The guard's job is to catch
-  the common case cleanly, not to be the universal error path.
+  can't be canonicalized, the guard falls through and lets downstream
+  steps surface a more specific error.
 
 The error envelope uses the same `(status, reason, message)` shape
-as `cwd_scope::enforce` (`reason="cwd_drift"` there,
-`reason="cwd_inside_worktree"` here). The exit code stays at 0 per
-the "Exit code convention for business errors" note above —
-the JSON `status` field is the actual signal callers parse.
+as `cwd_scope::enforce`. The exit code stays at 0 per the
+"Exit code convention for business errors" note above — the JSON
+`status` field is the actual signal callers parse.
 
 When adding a new subcommand whose execution path removes the
-caller's cwd (e.g. a future `flow worktree purge` or any helper
-that calls `git worktree remove` against a runtime-supplied path),
-plant the same guard at the top of its `run_impl` before any side
-effect runs. The pair to `cwd_scope::enforce` covers both directions
-of cwd hazard: drift away from the expected directory, and
-self-deletion of the current directory.
+caller's cwd, plant the same guard at the top of its `run_impl`
+before any side effect runs.
 
 ## Local Doc Comments
 
@@ -635,9 +531,7 @@ integration test file, not in the source file.
 - Wrong: `// --- tolerant_i64(v: &Value) ---`
 
 Before adding a new marker, grep the test file for existing
-`// --- ` lines and match their style. A marker that deviates from
-the file's convention is a maintainability regression — the pattern
-is discoverable only by reading the file, so consistency matters.
+`// --- ` lines and match their style.
 
 ## Session Log Message Format
 

--- a/.claude/rules/scope-enumeration.md
+++ b/.claude/rules/scope-enumeration.md
@@ -9,21 +9,11 @@ downstream reviewers consistently catch uncovered siblings.
 ## Why
 
 A universal-quantifier claim without a named list is an invisible
-checklist. Two observed incidents (#1033):
-
-- A plan for `cwd_scope::enforce` said the guard applied to the
-  state-mutating subcommand family. Code landed the guard in the
-  five CI-tier tool runners (`ci`, `build`, `lint`, `format`,
-  `test`) and missed the five state mutators (`add-finding`,
-  `phase-finalize`, `phase-enter`, `phase-transition`,
-  `set-timestamp`). Code Review caught the gap; the fix touched
-  another five files.
-- A `FLOW_CI_RUNNING` recursion guard landed in `ci.rs::run()` but
-  missed `build.rs`, `lint.rs`, `format_check.rs`, and
-  `test_runner.rs`.
-
-Both plans used a universal phrase without enumerating. Both ended
-with avoidable Code Review back-and-forth.
+checklist. A plan saying "the guard applies to the state-mutating
+subcommand family" doesn't tell the Code phase WHICH subcommands
+to touch — and the Code phase will land the guard in some siblings
+and miss others. Code Review then has to find the misses, costing
+a full review cycle on work the Plan phase could have prevented.
 
 ## The Rule
 
@@ -59,13 +49,11 @@ to two optional intervening adjectives:
 
 **Intentional gaps.** Bare `command` and bare `module` are NOT in
 the vocabulary. Adding them would catch novel phrasings but also
-flag pre-existing imperative prose in this tree (e.g. "every Bash
-command", "every command in every step", "every mutate_state
-module"). The scanner's curated-closed philosophy prefers to miss
-a novel phrasing over introducing mass false positives — the rule
-file itself is the primary instrument and the contract test is the
-drift tripwire. The unit tests
-`trigger_rejects_bare_command_intentionally` and
+flag pre-existing imperative prose in this tree. The scanner's
+curated-closed philosophy prefers to miss a novel phrasing over
+introducing mass false positives — the rule file itself is the
+primary instrument and the contract test is the drift tripwire.
+Unit tests `trigger_rejects_bare_command_intentionally` and
 `trigger_rejects_bare_module_intentionally` lock these gaps in so
 a future widening is a deliberate decision, not an accident.
 
@@ -96,8 +84,8 @@ use the opt-out comment instead of a forced list.
 - **`.claude/rules/*.md`** — same contract test.
 - **`skills/**/SKILL.md` and `.claude/skills/**/SKILL.md`** — same
   contract test.
-- **Agent prompts and issue bodies** — not mechanically enforced in
-  iteration 1; the rule is the primary instrument.
+- **Agent prompts and issue bodies** — not mechanically enforced;
+  the rule is the primary instrument.
 
 ## Opt-Out Comments
 
@@ -111,8 +99,7 @@ Two line-level opt-out comments are recognized by the scanner:
 The opt-out applies to its own line and to the next non-blank line,
 with **at most one blank line separating them**. An opt-out at the
 top of a section cannot silence arbitrary triggers further down —
-the walk-back is bounded to one blank line by `is_optout_line` so
-a stray comment cannot globally disable the gate.
+the walk-back is bounded to one blank line.
 
 Example of the imperative form (rendered inside a fenced block so
 the example does not itself trigger the scanner):
@@ -131,19 +118,12 @@ Two mechanical enforcers back the rule:
   Step 4, the pre-decomposed extracted path in `src/plan_extract.rs`,
   and the resume path in the same file). All three callsites share
   `src/scope_enumeration.rs::scan` so the trigger vocabulary and the
-  enumeration-present heuristic cannot drift. A non-empty violation
-  list blocks phase completion; editing the plan file in place is
-  the only way through.
+  enumeration-present heuristic cannot drift between callsites. A
+  non-empty violation list blocks phase completion; editing the plan
+  file in place is the only way through.
 - `tests/scope_enumeration.rs` runs during every `bin/flow ci`
-  invocation and scans the committed prose corpus (`CLAUDE.md`,
-  `.claude/rules/*.md`, `skills/**/SKILL.md`,
-  `.claude/skills/**/SKILL.md`). A single new unenumerated universal
-  claim fails the build automatically — this is a drift tripwire,
-  not a manual check.
-
-Both enforcers share `src/scope_enumeration.rs::scan` so the trigger
-vocabulary and the enumeration-present heuristic cannot drift
-between the plan-time gate and the prose-drift tripwire.
+  invocation and scans the committed prose corpus. A single new
+  unenumerated universal claim fails the build automatically.
 
 ## Enumeration Heuristic
 
@@ -163,10 +143,7 @@ enumeration near a trigger:
 
 Loose backtick counts alone (two unrelated code references in the
 same paragraph) do NOT satisfy the heuristic — a real structured
-list is required. This is the stricter revision that replaced the
-initial "≥ 2 backticks anywhere in the window" heuristic after Code
-Review found that unrelated identifiers near a trigger defeated the
-check.
+list is required.
 
 ## Vocabulary Extensibility
 
@@ -187,11 +164,9 @@ Before accepting a proposed vocabulary expansion, run a mandatory
 false-positive sweep. The protocol is:
 
 1. Add the candidate noun to `SCOPE_TRIGGER_PATTERN` on a scratch
-   branch (or via a local `git stash` edit) and run
-   `bin/flow ci --test -- scope_enumeration`. The contract test in
-   `tests/scope_enumeration.rs` will report every pre-existing
-   prose line in `CLAUDE.md`, `.claude/rules/*.md`, `skills/**/SKILL.md`,
-   and `.claude/skills/**/SKILL.md` that now triggers.
+   branch and run `bin/flow ci --test -- scope_enumeration`. The
+   contract test in `tests/scope_enumeration.rs` will report every
+   pre-existing prose line that now triggers.
 2. Count the new violations. If the count is **zero or low** (≤ 4),
    audit each flagged line — if they are genuine missing enumerations,
    fix them in the same commit as the vocabulary expansion. If they
@@ -204,13 +179,11 @@ false-positive sweep. The protocol is:
    Update the Intentional Gaps note above to document the decision
    and cite the unit test.
 4. Never ship a vocabulary expansion that requires a sweeping
-   opt-out cleanup across unrelated files. That expansion is not
-   an improvement — it is a forced rewrite with a pass-the-buck
-   disguise. The curated-closed philosophy prefers to miss a novel
-   phrasing over introducing mass false positives.
+   opt-out cleanup across unrelated files. The curated-closed
+   philosophy prefers to miss a novel phrasing over introducing
+   mass false positives.
 
 The false-positive sweep converts an adversarial finding about a
-missing noun (e.g. Adversarial A1/A3 for `command` and `module`)
-from a one-line fix into a deliberate decision with evidence. It
-also makes gap documentation cheap: the unit test and the
-Intentional Gaps note are the entire artifact.
+missing noun from a one-line fix into a deliberate decision with
+evidence. It also makes gap documentation cheap: the unit test and
+the Intentional Gaps note are the entire artifact.

--- a/.claude/rules/security-gates.md
+++ b/.claude/rules/security-gates.md
@@ -28,9 +28,7 @@ normalized before comparison:
 3. **Lowercase with ASCII semantics** (`to_ascii_lowercase()`)
    when the comparison is conceptually case-insensitive. Phase
    names, outcome names, and command names in FLOW are all
-   intended to be case-insensitive for robustness — a caller
-   passing the wrong case is a caller bug, not an attack, but
-   the gate defending against it is cheap.
+   intended to be case-insensitive for robustness.
 
 Normalization runs on BOTH sides of the comparison: if you are
 checking `input == "flow-code-review"`, either normalize
@@ -39,7 +37,7 @@ already normalized. Asymmetric normalization is the bug that
 adversarial tests find.
 
 Extract normalization into a named helper when multiple gates
-share the same logic, so the contract is visible and reusable:
+share the same logic:
 
 ```rust
 fn normalize_gate_input(s: &str) -> String {
@@ -74,9 +72,7 @@ if outcome_norm == "filed" {
 ```
 
 The allowlist makes the rule's invariant explicit in code: "Code
-Review accepts exactly these outcomes." The denylist encodes
-"Code Review rejects exactly this outcome," which is weaker and
-brittle to future additions.
+Review accepts exactly these outcomes."
 
 ## Fail Closed When State Is Unreliable
 
@@ -97,10 +93,6 @@ Fail-closed semantics matter most when the state file signals
 that a flow is active but the gate cannot tell which phase. A
 kill signal, interrupted write, or hand edit that leaves the
 file unparseable must not silently disable the gate.
-
-The rejection message should name the failure mode (invalid JSON,
-missing field, wrong type) and point the user at the override or
-recovery path if one exists.
 
 ## Gate-Action Atomicity for Validated Paths
 
@@ -181,9 +173,7 @@ enumerate:
    gate-validated destination).
 
 A plan that introduces a transforming gate without naming all
-four is incomplete. Pre-mortem and adversarial agents will
-catch the gap during Code Review at the cost of a full review
-cycle; the cheaper catch is at Plan time.
+four is incomplete.
 
 ### Code-phase Discipline
 
@@ -245,12 +235,10 @@ Minimum variant checklist for every string-input gate:
 For each variant, add a test case. The unit tests for the pure
 gate helper cover most of these; the integration test (binary
 spawn with prepared state) covers the ones that depend on
-subprocess state (state-file reads, exit codes).
+subprocess state.
 
 The discipline: write the variant list FIRST, then write the
-tests from the list, then write the implementation. The goal is
-to be boring — the gate passes every test on first implementation
-because the test list already anticipated every bypass.
+tests from the list, then write the implementation.
 
 ## How to Apply
 

--- a/.claude/rules/skill-authoring.md
+++ b/.claude/rules/skill-authoring.md
@@ -5,8 +5,7 @@
 When designing a skill change, start with the simplest solution that
 works. If the user proposes a simple approach, do not add machinery
 (resume checks, self-invocation, state counters) unless you can
-explain in one sentence why the simple approach fails. If you cannot
-articulate the failure, the simple approach is correct.
+explain in one sentence why the simple approach fails.
 
 When you agree to simplify and then re-introduce the same complexity
 in the next response, you are flip-flopping. Stop, re-read what you
@@ -62,17 +61,15 @@ always run `git add -A` before `git diff --cached`.
 The commit message lives at
 `<project_root>/.flow-states/<branch>/commit-msg.txt`, branch-
 scoped under `.flow-states/` alongside other branch-scoped
-state. The path is centralized in
-`FlowPaths::commit_msg()` so future layout changes (see issue
-#1045) flip in one place. `.flow-states/` is gitignored, so
-`git add -A` never picks the file up — there is no need for a
-`git restore --staged` step.
+state. The path is centralized in `FlowPaths::commit_msg()`.
+`.flow-states/` is gitignored, so `git add -A` never picks the
+file up — there is no need for a `git restore --staged` step.
 
 Parent phases that invoke `/flow:flow-commit` must never write
-the commit-msg file themselves. The commit skill owns the
-file: it routes the message through `bin/flow write-rule` in
-Round 5, and `finalize-commit` reads and deletes it after the
-git commit succeeds. The skill owns the file end to end.
+the commit-msg file themselves. The commit skill owns the file
+end to end: it routes the message through `bin/flow write-rule`
+in Round 5, and `finalize-commit` reads and deletes it after the
+git commit succeeds.
 
 ## Sub-Agent Safety
 
@@ -113,11 +110,7 @@ applies equally to skill removals and Rust source removals — the
 `.claude/rules/tombstone-tests.md` "When to Add" criterion is
 universal and covers every intentional removal of a named feature,
 not just skill-scoped ones. Without a tombstone, the removal has no
-CI-visible protection — Code Review catches the gap, but the Plan
-phase should have prevented it. See `.claude/rules/tombstone-tests.md`
-for the test pattern and consolidation guidance (standalone tombstones
-live in `tests/tombstones.rs`; topical tombstones integral to a test
-domain stay in their respective test files).
+CI-visible protection.
 
 ## Decompose Completeness
 
@@ -165,12 +158,10 @@ it or the target path will not exist.
 Files under `.flow-states/` at the project root are NOT inside the
 worktree — they live in the main repo's directory tree and persist
 across worktree removal. Cleanup steps that operate on those files
-(state_file, plan_file, dag_file, log_file, frozen_phases,
-ci_sentinel, timings_file, closed_issues_file, issues_file,
-adversarial_test) may be placed after the worktree removal step
-without risk. The distinguishing test is "does this step's target
-path pass through `.worktrees/<branch>/`?" If yes, it must precede
-`git worktree remove`. If no, placement is free.
+may be placed after the worktree removal step without risk. The
+distinguishing test is "does this step's target path pass through
+`.worktrees/<branch>/`?" If yes, it must precede `git worktree
+remove`. If no, placement is free.
 
 Similarly, any SKILL.md command that reads `.flow-states/` files
 (state file, log, CI sentinel) must be placed in a numbered step
@@ -187,15 +178,12 @@ Hard Rules section forbids `cd` before invoking `bin/flow`.
 The exception is `bin/flow complete-finalize`. The command removes
 the worktree as part of cleanup. When the caller's shell sits inside
 the worktree at invocation time, a successful removal leaves the
-shell in a deleted directory and every subsequent command emits
-`getcwd: cannot access parent directories`. The skill that invokes
+shell in a deleted directory. The skill that invokes
 `complete-finalize` must therefore `cd <project_root>` before the
 invocation. The subcommand also self-gates: it returns
 `{"status":"error","reason":"cwd_inside_worktree"}` when its
 canonicalized cwd equals or sits beneath the canonicalized
-`--worktree`. The gate produces a clean error rather than shell
-corruption, but the `cd` should still happen first because the gate
-otherwise short-circuits the entire finalize flow.
+`--worktree`.
 
 This carve-out applies only to subcommands whose execution path
 removes the caller's cwd. New subcommands that only mutate state
@@ -230,8 +218,7 @@ has already been explored.
 
 The HARD-GATE must prohibit all action without explicit user approval:
 proceeding to the next step, proposing direct edits, committing changes,
-or taking any action outside the active skill flow. The enforcement
-language is what distinguishes a gate from a suggestion.
+or taking any action outside the active skill flow.
 
 ## Hard Rules Consistency
 
@@ -272,21 +259,6 @@ and branch on the result. If the field was never set, the gate sees an
 empty value and either passes trivially or errors in a way the skill
 does not anticipate.
 
-Two real incidents shaped this rule:
-
-- The Phase 2 Plan skill's scope-enumeration gate in
-  `bin/flow plan-check` reads `files.plan` from the state file to
-  locate the plan. An earlier revision of Step 4 invoked `plan-check`
-  BEFORE `set-timestamp --set files.plan`, so on the standard plan
-  path the gate never had a plan file to scan. Code Review Reviewer
-  Finding 1 caught the reachability bug. A Plan-phase risk check
-  that enumerated "state fields read by this gate" would have
-  caught it before Code phase.
-- Any new gate that consumes a state field exposes the same class of
-  bug: the gate runs but reads an empty field and passes silently.
-  The failure is invisible until a downstream phase fails to find
-  the artifact the gate was supposed to protect.
-
 **Plan-phase verification.** When a plan task adds a gate command to a
 SKILL.md step, the plan's Risks section must enumerate (a) every state
 field the gate reads, and (b) every prior step that must write that
@@ -309,15 +281,12 @@ orderings hold in the committed SKILL.md:
 
 A textual-only ordering test catches regression A (someone moves the
 gate above the state mutation). The adjacency check catches regression
-B (someone inserts a new step in the middle). Both are mechanical
-regressions that instructional prose cannot prevent.
+B (someone inserts a new step in the middle).
 
 **How to apply.** When adding a gate command to a SKILL.md, search the
 file for every `set-timestamp --set` call that writes a field the gate
 reads, verify textual and adjacent ordering, and write the contract
-test in the same commit as the gate. Do not rely on Code Review to
-catch ordering bugs — the contract test is the merge-conflict
-trip-wire, the Plan-phase risk audit is the authoring-time trip-wire.
+test in the same commit as the gate.
 
 ## Destination Renumbering
 
@@ -325,7 +294,7 @@ When renumbering destinations or steps within a SKILL.md, grep for the
 old numbers throughout the entire file before marking the change complete.
 Preamble summary lines (e.g. "Use `<worktree_path>` for destinations 2
 and 4") are easy to miss because they sit far from the destination table
-they reference. A grep for the old number catches these stale references.
+they reference.
 
 Also audit spelled-out step counts in prose sections (e.g. "six review
 steps" buried inside a paragraph). These do not follow the `Step N`
@@ -335,9 +304,7 @@ count as a word ("six", "three", etc.) in addition to as a digit.
 Also audit skip/jump targets — instructions like "Skip directly to
 Step 8 (cleanup)" that reference steps by number. When inserting a new
 step, these targets must be reconsidered for intent, not just
-mechanically incremented. A skip that pointed to cleanup before the
-insertion should now point to the new step if the new step should also
-run in that path.
+mechanically incremented.
 
 When a step is moved (not added), range boundaries need special
 attention. "Steps 2–11" does not become "Steps 2–12" just because every
@@ -365,12 +332,11 @@ assumptions before they become bugs in the implementation.
 ## Verify Command References in Issues
 
 When an issue body or plan references a `/flow:<skill-name>` command as
-a user directive (e.g. "the user should run `/flow:flow-continue`"),
-verify `skills/<skill-name>/` exists in the repo during the Plan phase.
-Prior-session issue authors — including Claude — can reference skills
-that have since been removed. A single glob for the skill directory
-catches stale references before they become error messages that direct
-users to non-existent commands.
+a user directive, verify `skills/<skill-name>/` exists in the repo
+during the Plan phase. Prior-session issue authors — including Claude —
+can reference skills that have since been removed. A single glob for
+the skill directory catches stale references before they become error
+messages that direct users to non-existent commands.
 
 ## Verify Test Function References in Issues
 
@@ -390,19 +356,7 @@ The cheapest signal: for every backtick-quoted test or function
 identifier in the issue body or `## Implementation Plan` section,
 run a single Grep over `tests/` (or the relevant `src/` directory)
 to confirm the identifier appears as a definition (e.g.
-`fn <name>(`), not just as a prose reference. If the identifier
-does not exist, the plan task referencing it must take one of three
-paths: (a) name an existing nearby identifier that serves the same
-purpose, (b) propose creating the named entity as part of the
-task, or (c) drop the task and document the deviation per
-`.claude/rules/plan-commit-atomicity.md` "Plan Signature Deviations
-Must Be Logged".
-
-This pairs with the "Verify Script Behavior Claims in Issues"
-discipline above: that rule covers behavioral assertions ("script X
-populates field Y"); this rule covers structural assertions ("test
-function X exists at file Y"). Both run during Plan phase, both
-catch issue-author errors before they become Code-phase bugs.
+`fn <name>(`), not just as a prose reference.
 
 ## Config Chain Integrity
 
@@ -425,8 +379,6 @@ ignores at Skill tool turn boundaries. The correct pattern: after each
 sub-step completes, invoke the skill itself as the FINAL action with
 a `--continue-step` flag. The skill's Resume Check reads a step counter
 from the state file and dispatches to the next sub-step on re-entry.
-This mirrors how phase-to-phase transitions work — the Skill invocation
-is the last action, never a mid-response call.
 
 ## Target Project Mindset
 
@@ -444,8 +396,7 @@ that run in target projects should simulate a target project layout
 Every new feature — not just skill bash blocks — must have a clear
 answer to: "How does a plugin user in a target project access this?"
 before implementation begins. If the answer is unclear, the feature
-will ship unreachable. Issue #362 is the cautionary example: 27+
-commits built a TUI that no plugin user could launch.
+will ship unreachable.
 
 There are exactly three valid access paths for plugin users:
 
@@ -464,9 +415,7 @@ design that makes it reachable.
 Every `bin/flow` call in a plugin skill bash block must use
 `${CLAUDE_PLUGIN_ROOT}/bin/flow`. Bare `bin/flow` only
 resolves in the FLOW repo itself — target projects do not have
-it. This works during plugin development (the FLOW repo has
-`bin/flow` locally) but fails with exit 127 in every target
-project. CI enforces this via
+it. CI enforces this via
 `test_plugin_skills_use_plugin_root_for_bin_flow`.
 
 ## Worktree bin/flow for Repo-Modifying Commands
@@ -550,11 +499,6 @@ permission tests, placeholder substitution in `tests/permissions.rs`).
 Inconsistent naming means only one variant gets tested and the others
 silently substitute wrong values or skip validation entirely.
 
-How to apply: after writing a parameterized table, scan every cell for
-angle-bracket placeholders and verify every row uses identical names
-for the same semantic value. If Code Review fixes a placeholder in one
-row, verify all rows in the same pass.
-
 ## Placeholder Resolution Must Match Runtime Paths
 
 When a skill instruction or agent prompt uses a placeholder to name a
@@ -569,11 +513,7 @@ A placeholder that represents a conceptual file (`<temp_test_file>` =
 producing code actually writes a concrete file with an additional
 suffix (`.flow-states/<branch>/adversarial_test.rs`) creates a silent
 cleanup gap: `rm <temp_test_file>` targets a path that never exists,
-succeeds with no effect, and the real file orphans. Issue #1037
-documents this class of bug — the adversarial agent writes
-`<temp_test_file>.<ext>` but two cleanup layers `rm <temp_test_file>`
-(no extension), so both layers silently no-op and the file survives
-until a later phase can glob it by prefix.
+succeeds with no effect, and the real file orphans.
 
 ### How to apply
 
@@ -586,21 +526,15 @@ until a later phase can glob it by prefix.
    extension too (so the cleanup matches exactly what was written),
    (b) use a glob pattern that matches the runtime variants, or
    (c) defer cleanup to a phase that can enumerate matches by
-   prefix (e.g., `fs::read_dir` + prefix filter in Rust code).
+   prefix.
 3. **Abstractions are for documentation, not for cleanup commands.**
-   It is fine to describe a file conceptually in prose
-   (`<temp_test_file>` the Phase 4 adversarial test file), but the
+   It is fine to describe a file conceptually in prose, but the
    actual `rm`, `Write`, or `Read` call must use a path that resolves
-   to the real bytes on disk. If the prose placeholder cannot be made
-   concrete (because the runtime chooses part of the name), split
-   the placeholder into a documented prefix plus a runtime suffix,
-   and have the cleanup command operate on the prefix via glob —
-   never directly via `rm <prefix>`.
+   to the real bytes on disk.
 4. **Plan phase verification.** When a plan adds or modifies a skill
    that writes a temp file and cleans it up later, grep both the
    writer's and cleaner's references to the placeholder and confirm
-   the resolved path matches byte-for-byte. Record this check in
-   the Risks section so Code Review can verify it.
+   the resolved path matches byte-for-byte.
 
 ## Purpose Preamble for Behavioral Sections
 

--- a/.claude/rules/subprocess-argument-escaping.md
+++ b/.claude/rules/subprocess-argument-escaping.md
@@ -10,25 +10,15 @@ interpreter's literal-syntax rules before interpolation. Raw
 
 ## Why
 
-Issue #1135 / PR #1154 surfaced this in the TUI: `session_tty` was
-read verbatim from a flow's state JSON and interpolated raw into
-an AppleScript double-quoted string literal:
+State files live on disk and are writable by any process with
+filesystem access — including a future extension or a hand edit
+that produced a malformed value. Subprocess output is constrained
+by the producer but not by FLOW. CLI args accept any string a shell
+can pass.
 
-```rust
-fn build_iterm_activation_script(session_tty: &str) -> String {
-    format!(
-        r#"... if tty of s is "{tty}" then ..."#,
-        tty = session_tty
-    )
-}
-```
-
-A crafted `session_tty` containing `"` would close the AppleScript
-literal early and let everything after run as code under the user's
-privileges. The state file is on disk and writable by any process
-with filesystem access — including a future FLOW extension or a
-hand edit that produced a malformed value. The adversarial agent
-caught this in Code Review with a test that proved injection.
+A crafted value containing the target language's structural
+characters (e.g., `"` in AppleScript) closes the literal early and
+lets everything after run as code under the user's privileges.
 
 ## The Rule
 
@@ -39,10 +29,10 @@ escape helper before `format!`. The escape helper:
 1. **Names the target language** in its function name —
    `escape_applescript_string`, `escape_shell_arg`,
    `escape_sql_literal`, etc. Generic "sanitize" or "clean" helpers
-   are a smell — every target language has different escape rules.
-2. **Has a doc comment that names the structural characters**
-   for that language. AppleScript's are `\` and `"`. Shell's are
-   the full operator set plus quotes. SQL's depend on the dialect.
+   are a smell.
+2. **Has a doc comment that names the structural characters** for
+   that language. AppleScript's are `\` and `"`. Shell's are the
+   full operator set plus quotes. SQL's depend on the dialect.
 3. **Is exhaustively unit-tested** against:
    - the empty input,
    - input containing only safe chars,
@@ -51,43 +41,38 @@ escape helper before `format!`. The escape helper:
    - input that LOOKS safe but contains the escape char itself
      (e.g. backslash before quote in AppleScript).
 4. **Is the ONLY path** by which external values reach the
-   interpolation site. No shortcuts, no "this caller is safe" —
-   the rule is uniform across callers because callers change.
+   interpolation site. No shortcuts, no "this caller is safe."
 
 ## Reference Implementation
 
-The canonical example in this codebase is
-`escape_applescript_string` in `src/tui.rs`, used by
-`build_iterm_activation_script`. It escapes `\` and `"` (the only
-structural characters inside AppleScript double-quoted literals)
-with a leading backslash. The function is paired with adversarial
-tests `iterm_script_escapes_double_quote_in_tty` and
-`iterm_script_escapes_backslash_in_tty` that prove the injection
-substring `" then do shell script` cannot appear unescaped in the
-output for a malicious input.
+The canonical example is `escape_applescript_string` in
+`src/tui.rs`, used by `build_iterm_activation_script`. It escapes
+`\` and `"` (the only structural characters inside AppleScript
+double-quoted literals) with a leading backslash. Adversarial tests
+prove the injection substring `" then do shell script` cannot
+appear unescaped in the output for a malicious input.
 
 ## Where This Applies
 
 - **`osascript -e <script>`** — escape AppleScript string literals
-  before interpolation (this rule's motivating case)
+  before interpolation.
 - **`Command::new("sh").arg("-c").arg(<script>)`** — avoid shell
   interpolation entirely; pass arguments via `.arg()` instead. If
   shell interpolation is unavoidable, escape per shell-quoting
-  rules
+  rules.
 - **`format!("SELECT * WHERE x = '{}'", val)`** — never. Use a
-  parameterized query
+  parameterized query.
 - **`format!("{{\"key\": \"{}\"}}", val)`** — never. Use
-  `serde_json::to_string`
+  `serde_json::to_string`.
 - **Any external value reaching a regex pattern** — use
-  `regex::escape`
+  `regex::escape`.
 - **Any external value reaching a shell command via `bash -c`** —
-  use a quoting helper or restructure to avoid `bash -c`
+  use a quoting helper or restructure to avoid `bash -c`.
 
 ## Plan-Phase Trigger
 
 When a plan task proposes building an interpolated string from
-external input — state file value, git subprocess output, CLI flag,
-parsed JSON, env var — the plan's Risks section must enumerate:
+external input, the plan's Risks section must enumerate:
 
 1. The **target interpreter** the string will be parsed by
 2. The **structural characters** that interpreter treats as syntax
@@ -95,21 +80,13 @@ parsed JSON, env var — the plan's Risks section must enumerate:
    interpolation
 4. The **adversarial test** that will prove injection is impossible
 
-A plan that interpolates external input without naming all four is
-incomplete — the adversarial agent will surface the gap in Code
-Review at the cost of one full review cycle.
-
 ## How to Apply (Code Phase)
-
-When implementing code that interpolates external input into a
-language-bearing string:
 
 1. Write the escape helper FIRST. Test it before writing the
    interpolation site — TDD applies here even more strongly than
    usual because the security property is non-obvious.
 2. Make the interpolation site call the escape helper with NO
-   conditional bypass. "Trusted callers" don't exist over time —
-   today's trusted caller is tomorrow's regression vector.
+   conditional bypass. "Trusted callers" don't exist over time.
 3. Write at least one adversarial test that:
    - Constructs a value that would inject if interpolated raw
    - Calls the production interpolation function
@@ -126,13 +103,3 @@ of external input, verify:
 3. The interpolation site uses the helper with no bypass path
 4. The helper's `format!` (or equivalent) interpolates the
    ESCAPED value, not the raw input
-
-## Cross-References
-
-- `.claude/rules/external-input-validation.md` — the broader rule
-  that branches FROM (validation/panic-handling) and TO
-  (escape-before-interpolation) — both apply when an external value
-  reaches a non-trivial sink
-- `.claude/rules/external-input-audit-gate.md` — the Plan-phase
-  gate that catches `panic!`/`assert!` on external input; this
-  rule covers the sibling discipline for interpolation sinks

--- a/.claude/rules/subprocess-test-hygiene.md
+++ b/.claude/rules/subprocess-test-hygiene.md
@@ -20,8 +20,7 @@ the binary. Anything the child does beyond that path is pollution:
   state (creates labels, closes issues, opens PRs).
 - **Coverage artifact leaks** — a child that inherits
   `LLVM_PROFILE_FILE` pointing to a path it cannot resolve writes
-  profraw files to its cwd. When the child's cwd is the worktree
-  root, those files persist into `git status`.
+  profraw files to its cwd.
 - **Ambient config** — a child that inherits `HOME` can read
   `~/.gitconfig`, `~/.cargo/config.toml`, `~/.config/gh/*`, and
   dozens of other dotfiles that vary by engineer, introducing
@@ -44,8 +43,7 @@ environment — must explicitly neutralize these surfaces:
    - Slack: `SLACK_WEBHOOK_URL`, `SLACK_BOT_TOKEN`,
      `SLACK_CHANNEL` — set to empty or `env_remove`
    - AWS / GCP / Azure — whichever cloud's SDK the subject
-     uses: `AWS_ACCESS_KEY_ID`, `GOOGLE_APPLICATION_CREDENTIALS`,
-     `AZURE_STORAGE_ACCOUNT` — `env_remove`
+     uses: `env_remove` the relevant credential vars
 2. **Ambient config homes**:
    - `HOME` — set to the test's canonical tempdir root so the
      child reads no user dotfiles
@@ -118,8 +116,7 @@ When a plan task adds a test that spawns a subprocess:
    listed neutralizer
 
 A subprocess test that omits a required neutralizer is a
-Plan-phase gap — the adversarial and pre-mortem agents will
-catch it in Code Review, but the cheaper catch is at Plan time.
+Plan-phase gap.
 
 ## How to Apply (Code Review)
 
@@ -134,20 +131,3 @@ subprocess test lacking env neutralization:
    credential set (e.g., `GH_TOKEN=<real-token> bin/flow ci --test
    -- <test>`) — the test must still pass without making
    network calls
-
-## Enforcement
-
-Iteration 1 is rule-prose only. A future contract test in
-`tests/subprocess_hygiene.rs` could scan every `Command::new`
-in `tests/**/*.rs` for missing env-neutralization patterns; see
-the filed plugin issue for the enforcement proposal.
-
-## Cross-References
-
-- `.claude/rules/testing-gotchas.md` — Rust parallel test env
-  var races; the "never `set_var` in tests" discipline is the
-  sibling rule for inside-process env safety, this rule covers
-  the child-process side.
-- `.claude/rules/concurrency-model.md` — shared GitHub state
-  coordination; the rule explains why neutralizing `GH_TOKEN`
-  matters (real API calls mutate shared state across engineers).

--- a/.claude/rules/test-placement.md
+++ b/.claude/rules/test-placement.md
@@ -18,8 +18,7 @@ via a private helper, one of two things is true:
    — and the test — need alike. Add the seam.
 
 Both outcomes improve the code. Neither requires moving the privacy
-boundary. Calling code reaches private helpers through a public
-entry point every time; tests do the same.
+boundary.
 
 Three secondary wins fall out of the placement rule:
 
@@ -29,14 +28,10 @@ Three secondary wins fall out of the placement rule:
   in `tests/` at the same relative path.
 - **Fast per-file green loop** — `bin/test tests/<path>/<name>.rs`
   drives the mirrored src file to 100/100/100 in isolation. Edit
-  the src file, run the one test file, see red or green. No need
-  to reason about which inline `mod tests` block covers which
-  branch.
+  the src file, run the one test file, see red or green.
 - **Clean diffs** — production edits and test edits land in
   separate files. A source-file diff shows only behavior change; a
-  test-file diff shows only coverage change. Review is easier to
-  scope and the Code phase's commit boundaries align with the
-  atomic-commit rule.
+  test-file diff shows only coverage change.
 
 ## The Rule
 
@@ -79,6 +74,7 @@ the mirror rule:
 - `tests/structural.rs` — config invariants
 - `tests/permissions.rs` — permission allow/deny simulation
 - `tests/docs_sync.rs` — docs completeness
+- `tests/opt_out_inventory.rs` — frozen list of bypass comments in the rule corpus
 
 Adding a new meta-test without a src counterpart requires amending
 this list. Every other test under `tests/` must mirror a src file.
@@ -106,17 +102,14 @@ Flagged contexts include:
 - Any other surface that produces the exact substring on a line.
 
 A single flagged line fails the build. The scanner is strict by
-design — this is a drift tripwire, not a negotiation surface. It
-is not lowered, opt-outed, or relaxed to handle edge cases.
+design — this is a drift tripwire, not a negotiation surface.
 
 When a src file genuinely needs the characters `#[cfg(test)]` in a
 string literal (e.g., a test-corpus scanner's fixture construction),
 there is exactly one canonical escape: split the literal via
 `concat!("#[cfg", "(test)]")`. The `concat!` output produces the
 same runtime string without placing the literal substring on any
-source line. This matches the existing `concat!("#[", "ignore",
-"]")` pattern used in `tests/duplicate_test_coverage.rs` fixtures
-to avoid tripping the `no_skipped_or_excluded` contract test.
+source line.
 
 No other escapes exist. If a src file is flagged:
 
@@ -161,9 +154,7 @@ test:
      the src file until every branch reaches the public surface.
 3. Never make a private item `pub` solely to enable the test.
    That inverts the rule's intent — exposure for testing expands
-   the public surface without a production consumer, and every
-   future maintainer must treat the exposed item as part of the
-   crate's contract.
+   the public surface without a production consumer.
 
    **Bright-line test for `pub` additions.** Before adding `pub`
    to any item, the author MUST name the non-test production
@@ -229,8 +220,7 @@ test:
    ```
 
    Use `#[path = "../common/mod.rs"] mod common;` at the top of
-   the subdirectory test file to access shared helpers (adjust the
-   `../` depth for deeper subdirs).
+   the subdirectory test file to access shared helpers.
 5. Run `bin/test tests/<path>/<name>.rs` and iterate until the
    mirrored src file reads 100/100/100.
 
@@ -251,26 +241,4 @@ the two mechanical follow-ups.
 **Migrating section markers.** The `// --- <primary_name> ---`
 grouping convention from `.claude/rules/rust-patterns.md` still
 applies inside the integration test file — the home of the markers
-moves from `src/<path>/<name>.rs` to `tests/<path>/<name>.rs`, the
-convention itself is unchanged.
-
-## Cross-References
-
-- `.claude/rules/testability-means-simplicity.md` — the principle
-  this rule mechanically enforces. When a branch can't be tested
-  via the public surface, simplify or seam-inject; never widen
-  privacy.
-- `.claude/rules/tests-guard-real-regressions.md` — every test in
-  the migrated tests file must still guard a named regression, one
-  per branch.
-- `.claude/rules/rust-patterns.md` — seam-injection patterns
-  (`run_impl_main`, `run_impl_with_deps`, closure-parameter
-  variants) that make interface-only testing tractable for
-  externally-coupled code.
-- `.claude/rules/no-waivers.md` — 100/100/100 coverage gate.
-  Interface-only testing must still reach the gate; when a branch
-  resists public-surface testing, the answer is one of the three
-  responses in that rule (subprocess test, refactor, design
-  change), never a waiver.
-- `tests/test_placement.rs` — the contract test that enforces the
-  rule at CI time.
+moves from `src/<path>/<name>.rs` to `tests/<path>/<name>.rs`.

--- a/.claude/rules/testability-means-simplicity.md
+++ b/.claude/rules/testability-means-simplicity.md
@@ -67,30 +67,6 @@ When a coverage gap resists two or three straightforward tests:
 5. **Re-write the tests against the simpler function.** They
    should now be boring: call the function, assert the output.
 
-## Example
-
-`run_with_drain_and_timeout` in `src/analyze_issues.rs` was
-40 lines that spawned a `Child`, drained stdout/stderr in
-background threads, polled `try_wait()` in a loop, and killed
-on timeout. To make it testable required a `ChildController`
-trait, a `MockChild` struct, a seam-injected
-`wait_for_exit_with_timeout` helper, and explicit unit tests
-for each trait method — all of it existing only because the
-real `Child` type couldn't be mocked.
-
-The single sentence: "call `gh`, return stdout or an error."
-
-The simple primitive: `std::process::Command::output()`. It
-drains automatically, it returns a `Result`, and every branch
-is a single `match` arm any test can drive. No timeout (gh has
-its own network timeout; a hung process is a Ctrl-C scenario,
-not a coverage concern).
-
-Result: the 40-line function collapses to ~15, the trait +
-mock + seam helper delete entirely, and the two stubborn
-uncovered-region gaps disappear because the regions no longer
-exist.
-
 ## Cross-references
 
 - `.claude/rules/reachable-is-testable.md` — the triage that
@@ -101,11 +77,10 @@ exist.
   tests that exist only to hit an over-engineered branch are
   not naming a real regression.
 - `.claude/rules/rust-patterns.md` — seam-injection variant
-  patterns (`run_impl_with_deps`, `ChildController`) are
-  legitimate when the production caller genuinely needs a
-  dependency it cannot mock in-process (TTYs, real sockets, &c.).
-  They become over-engineering when the simpler primitive would
-  have sufficed.
+  patterns are legitimate when the production caller genuinely
+  needs a dependency it cannot mock in-process (TTYs, real sockets,
+  &c.). They become over-engineering when the simpler primitive
+  would have sufficed.
 - `.claude/rules/no-waivers.md` — the 100% coverage gate forces
   this discipline. When you can't reach 100% on a branch, the
   rule says fix the code, not the threshold.

--- a/.claude/rules/testing-gotchas.md
+++ b/.claude/rules/testing-gotchas.md
@@ -70,8 +70,7 @@ environmental.
 `.config/*`, test-group overrides, parallelism limits) to paper
 over single-machine load events.** That expands the PR's diff into
 shared territory the user has not approved and conflates an
-environmental incident with a real config change. Every engineer
-running CI inherits the change.
+environmental incident with a real config change.
 
 **Investigation steps before classifying as flaky:**
 
@@ -86,11 +85,6 @@ running CI inherits the change.
    different days or load profiles — does the test merit a "flaky
    test" classification.
 
-The Phase 3 `flow-code` SKILL.md "Flaky test detection" instruction
-that authorizes filing Flaky Test issues based on a single
-failure-then-pass pattern is overridden by this rule: investigate
-load before filing.
-
 ## Cross-Branch Verification Before Claiming Infrastructure Bugs
 
 Before concluding that a build tool, test runner, or CI script
@@ -100,20 +94,13 @@ on a worktree is evidence of something — but until both observations
 exist, the failure cannot be located in the worktree's changes
 versus the shared infrastructure those changes inherit.
 
-**Why.** The default attribution when a test command misbehaves
-is "my branch broke it," not "the tool is broken." The worktree
-contains uncommitted changes; the integration branch contains
-code that has already passed CI. If the same command passes on
-the integration branch and fails or behaves unexpectedly in the
-worktree, the worktree is the cause. If the command reproduces
-the same behavior on both, only then is "infrastructure bug"
-a credible diagnosis.
-
-This is the verification side of the broader discipline in
-"Distinguish Environmental Load From Flaky Tests" above —
-environmental noise is one explanation for a transient anomaly,
-but a worktree-specific change is a more common explanation, and
-the cross-branch check distinguishes the two.
+The default attribution when a test command misbehaves is "my
+branch broke it," not "the tool is broken." The worktree contains
+uncommitted changes; the integration branch contains code that has
+already passed CI. If the same command passes on the integration
+branch and fails or behaves unexpectedly in the worktree, the
+worktree is the cause. If the command reproduces the same behavior
+on both, only then is "infrastructure bug" a credible diagnosis.
 
 **The Rule.** Before declaring `bin/test`, `bin/flow ci`,
 `cargo`, `nextest`, or any other build/test tool buggy, slow, or
@@ -121,8 +108,8 @@ broken:
 
 1. Capture the failing or anomalous command and its observed
    timing/exit code in the worktree.
-2. Run the exact same command on the integration branch
-   (`main` for FLOW). Capture timing and exit code there.
+2. Run the exact same command on the integration branch. Capture
+   timing and exit code there.
 3. Compare. Only when the integration-branch run reproduces the
    anomaly does "tool bug" become a valid hypothesis. Otherwise
    the worktree's changes are the cause — investigate them.
@@ -135,10 +122,7 @@ A diagnosis without step 2 is speculation. The user's evidence —
 "`bin/test` is slow," "the runner has a bug," "CI is broken,"
 "the suite timeout is wrong," or any equivalent statement that
 locates the fault in shared infrastructure rather than in the
-current branch's changes. The trigger fires on timing
-observations as much as on failures — a CI run that took twice
-its usual time is not evidence of an infrastructure regression
-until the integration-branch baseline confirms it.
+current branch's changes.
 
 ## Ambiguous Check Name Filters
 
@@ -162,18 +146,15 @@ because the recreated directory contains only fresh files.
 ## Test Doc Comment Must Support the Test Name
 
 A test's doc comment should describe what the test verifies in terms
-consistent with the test function's name. Never rewrite a doc comment
-during code review in a way that disavows the test name's assertion —
-e.g., a test named `deps_stdout_does_not_corrupt_return_value` whose
-comment says "the structural guarantee lives in production, not this
-test". If the test's exercise path only indirectly verifies the
-property the name claims (e.g., the property is enforced structurally
-in production code, and the test trip-wires a regression of that
-structure), the comment should explain HOW the exercise path
-trip-wires a regression of the named property — not that the property
-is someone else's responsibility. A reader whose first exposure to
-the test is its name should find the comment affirmatively supporting
-the name, not contradicting it.
+consistent with the test function's name. Never write a doc comment
+that disavows the test name's assertion — e.g., a test named
+`deps_stdout_does_not_corrupt_return_value` whose comment says "the
+structural guarantee lives in production, not this test". If the
+test's exercise path only indirectly verifies the property the name
+claims (e.g., the property is enforced structurally in production
+code, and the test trip-wires a regression of that structure), the
+comment should explain HOW the exercise path trip-wires a regression
+of the named property.
 
 ## Message Content Assertions — Per Variant, Not Just Presence
 
@@ -183,8 +164,7 @@ variants of that input (e.g. `bin/flow ci` and `bin/ci`), every test
 that exercises a different variant must assert on the message content,
 not just `msg.is_some()`. A single hardcoded message string that names
 only one variant will silently mislead callers who triggered the
-function via the other variant — the test passes because the message
-exists, but the content is wrong.
+function via the other variant.
 
 Pattern:
 
@@ -199,9 +179,7 @@ fn test_bin_ci_variant_produces_correct_message() {
 
 How to apply: when writing tests for a function with multi-variant
 message output, enumerate the variants in the test list and add one
-content assertion per variant. If the function returns the same
-message for every variant, use a generalized message that names all
-variants so the assertion is meaningful across the test set.
+content assertion per variant.
 
 ## Suffix-Match Path Coverage
 
@@ -210,10 +188,7 @@ file or binary (e.g. `first.ends_with("/bin/ci")`), tests must
 include BOTH the bare form (`bin/ci`) and the absolute-path form
 (`/Users/name/project/bin/ci` or `/opt/tools/bin/ci`). Parallel
 tests for each path variant document the intended coverage and
-catch bugs where the suffix match is silently broken (e.g. a
-refactor that accidentally changes `ends_with` to `starts_with`).
-
-Pattern for every `ends_with(path)` callsite in production code:
+catch bugs where the suffix match is silently broken.
 
 ```rust
 #[test]
@@ -229,8 +204,7 @@ fn test_absolute_path_matches() {
 
 How to apply: during Plan phase, enumerate every `ends_with` pattern
 the implementation will use, then add one test per pattern for each
-form (bare + absolute). The test count is small — two tests per
-pattern — and it locks the intended match surface.
+form (bare + absolute).
 
 ## Subsection-Local Assertions in Contract Tests
 
@@ -245,34 +219,12 @@ sibling section still carries the expected substring.
 
 ### Why
 
-When a new section is added to a multi-section file (for example,
-a subsection inside `skills/flow-code/SKILL.md` whose job is to
-route a specific task shape to `/flow:flow-commit`), a contract
-test proves the subsection exists and carries the correct routing.
-A naive implementation looks like:
-
-```rust
-// WRONG — after_heading covers everything from the heading to EOF
-let after_heading = c
-    .split("Measurement-Only Tasks")
-    .nth(1)
-    .expect("heading checked above");
-assert!(after_heading.contains("/flow:flow-commit"));
-```
-
 `split("H").nth(1)` returns the *entire* remainder of the file from
 the first occurrence of `"H"` forward. Any later section in the
-same file that happens to mention `/flow:flow-commit` satisfies the
-assertion — including the standard Commit section that every
-iteration of the skill has always had. A malicious (or merely
-careless) refactor that empties the new subsection of its
-`/flow:flow-commit` reference while leaving the rest of the file
-intact passes CI because the later unrelated mention still lives in
-`after_heading`.
+same file that happens to mention the asserted token satisfies the
+assertion — including unrelated sibling sections.
 
-The same class of gap appears whenever the assertion scope exceeds
-the logical unit under test. If the test's English claim is "the
-Measurement-Only Tasks subsection routes through `/flow:flow-commit`,"
+If the test's English claim is "the X subsection routes through Y,"
 the slice must cover only that subsection, not everything after its
 opening heading.
 
@@ -296,18 +248,13 @@ assert!(subsection.contains("/flow:flow-commit"));
 ```
 
 `split_once` is preferred over `split().nth(1)` because it makes
-the intent explicit (one split, two pieces) and avoids the iterator
-`nth()` ambiguity on strings that contain multiple occurrences of
-the split delimiter.
+the intent explicit (one split, two pieces).
 
 For Markdown files, "next section boundary" is usually the next
 heading of the same or higher level. The end delimiter should
 match the heading marker of the section being tested:
 
-- For a `### ` subsection, split on `"\n### "` (stops at the next
-  `### ` or a higher-level `## `/`# ` by virtue of the newline
-  anchor and the assumption that the subsection's parent ends with
-  `## `, not `### `).
+- For a `### ` subsection, split on `"\n### "`.
 - For a `## ` section, split on `"\n## "`.
 
 For Rust source files, use the `fn ` or `mod ` tokens that bound
@@ -316,11 +263,9 @@ the sub-document.
 
 ### Fallback to EOF
 
-When the section being tested is the last section in the file, the
-next-section split returns no matches. Use `.unwrap_or(tail)` so
-the assertion scope falls back to the end of the file rather than
-panicking. This keeps the test robust against a future edit that
-reorders sections and leaves the one under test at EOF.
+When the section being tested is the last section in the file, use
+`.unwrap_or(tail)` so the assertion scope falls back to the end of
+the file rather than panicking.
 
 ### How to apply
 
@@ -328,8 +273,7 @@ When writing a new contract test that asserts content inside a
 named section:
 
 1. Identify the heading or boundary marker that starts the section.
-2. Identify the marker that ends the section (the next peer heading,
-   the next mod block, the next top-level key).
+2. Identify the marker that ends the section.
 3. Walk to the start using `split_once(start_marker)`.
 4. Walk to the end using a second `split_once(end_marker)` on the
    tail, falling back to the tail itself via `unwrap_or(tail)`.
@@ -341,15 +285,6 @@ When reviewing an existing contract test that uses
 grep the file being tested for the asserted substrings. If any of
 them appear in multiple sections, the test is fragile — replace it
 with the bounded-slice pattern above.
-
-The motivating incident is benkruger/flow#1167 — the initial
-contract test for the Measurement-Only Tasks subsection matched
-`/flow:flow-commit` anywhere after the heading, including the
-standard Commit section ~L443 of `skills/flow-code/SKILL.md`. A
-gutted subsection passed the test. The fix bounded the slice with
-`split_once("### Measurement-Only Tasks")` followed by
-`split_once("\n### ")`. This rule codifies the pattern so future
-contract tests ship bounded from the start.
 
 ## macOS Subprocess Path Canonicalization
 
@@ -458,5 +393,4 @@ time per CI run, compounding across the test corpus.
 identify which time source the production code reads (mtime, system
 clock, sleep duration) and inject a seam at that point. If the
 production code does not accept a seam, refactor it to accept one
-before writing the test. A test that uses `thread::sleep` is a
-signal that the production code lacks a time-injection seam.
+before writing the test.

--- a/.claude/rules/tests-guard-real-regressions.md
+++ b/.claude/rules/tests-guard-real-regressions.md
@@ -22,10 +22,9 @@ broken. Speculative tests have three costs:
 The project already has strong mechanical enforcement for the
 drift surfaces that matter: tombstones in `tests/tombstones.rs`,
 corpus scanners like `tests/scope_enumeration.rs` and
-`tests/external_input_audit.rs` (each with a named trigger
-vocabulary backed by a concrete incident), and plan-check gates.
-Adding broader "safety net" scans on top of that accumulates test
-code without covering new regressions.
+`tests/external_input_audit.rs`, and plan-check gates. Adding
+broader "safety net" scans on top of that accumulates test code
+without covering new regressions.
 
 ## The Rule
 
@@ -51,16 +50,15 @@ name.
   the deleted content is gone. See
   `.claude/rules/tombstone-tests.md`.
 - **Structural contract tests** — assert a specific invariant in a
-  specific file (e.g., "flow-plan SKILL.md contains the
-  Extract-Helper Branch Enumeration subsection"). The regression
-  is an accidental edit; the consumer is the skill's cross-
-  reference or the subsection's role in the workflow.
+  specific file. The regression is an accidental edit; the consumer
+  is the skill's cross-reference or the subsection's role in the
+  workflow.
 - **Targeted corpus scans** — the scanner must have a named
-  trigger vocabulary tied to a documented incident and a named
+  trigger vocabulary tied to a documented constraint and a named
   consumer (the rule file that authorizes the scan). See
   `tests/scope_enumeration.rs` and
   `tests/external_input_audit.rs`. Broader scans without a named
-  incident or vocabulary are speculative.
+  vocabulary are speculative.
 
 ### Multi-file contract tests
 
@@ -75,12 +73,10 @@ explain what specifically breaks if any one of the files drifts.
 **Default shape: per-file siblings.** Rather than a single
 `multi_file_contract` test asserting "all four agents reference
 the new diff range," write four separate tests — one per file —
-each naming the agent and the regression
-(`reviewer_agent_input_describes_substantive_diff`,
-`pre_mortem_agent_input_describes_substantive_diff`, etc.).
-Per-file tests give failure output that names the drifted file
-immediately, instead of forcing the maintainer to read assertion
-internals to find which file regressed.
+each naming the agent and the regression. Per-file tests give
+failure output that names the drifted file immediately, instead of
+forcing the maintainer to read assertion internals to find which
+file regressed.
 
 **Single-test shape: only when coordination is the invariant.**
 When the assertion is genuinely a single coordinated invariant
@@ -142,18 +138,6 @@ corpus-class contract test:
    future session looking for the contract test finds the rationale
    without re-deriving it.
 
-**Motivating incident.** PR #1177's `duplicate_test_coverage`
-scanner flagged 18+ legitimate educational test-name citations in
-the prose corpus (e.g. `test_agent_frontmatter_only_supported_keys`
-in CLAUDE.md documenting an enforcement mechanism,
-`production_ci_decider_tree_changed_returns_not_skipped` in
-`extract-helper-refactor.md` as a reference pattern). The Plan-phase
-gate catches the real regression path (a plan proposing a duplicate
-test name is flagged at plan-check time regardless of where the
-name appeared in committed prose), so the corpus scanner added no
-protection on top of the existing gate. `tests/duplicate_test_coverage.rs`
-now ships as a documented empty marker per step 4 above.
-
 ### Forbidden patterns
 
 - **"Just in case"** scans over broad file sets without a named
@@ -206,14 +190,11 @@ the coverage surface:
 - **Library-level tests** — call `pub` items from the `flow_rs`
   crate directly (`run_impl_main` seams, public helpers, injected
   closure variants). Used when the branch under test is reachable
-  through the public surface of the subject module. Reference
-  pattern: `tests/complete_fast.rs` exercises
-  `run_impl_with_deps` through the public seam.
+  through the public surface of the subject module.
 - **Subprocess tests** — spawn the compiled binary via
   `CARGO_BIN_EXE_flow-rs` to exercise CLI dispatch, real
   filesystem interactions, or behavior that requires a fresh
-  process. Reference pattern: subprocess tests in
-  `tests/main_dispatch.rs` and `tests/concurrency.rs`.
+  process.
 
 If a coverage-required branch resists both modes, the fix is one
 of the three default responses in `.claude/rules/no-waivers.md`:
@@ -271,8 +252,7 @@ correctness depends on byte-stability.
 Discovering the golden value by running the production code and
 copying its output into the test is the fastest path but
 provides ZERO regression protection if the code is wrong at
-authoring time. The test would assert the buggy output equals
-itself.
+authoring time.
 
 The discipline:
 
@@ -280,8 +260,7 @@ The discipline:
    expected output through a separate path — a reference
    implementation, a spec-derived calculation, manual computation
    on a small input, or cross-check against an existing
-   downstream artifact (e.g., a stored `.flow.json` hash from a
-   previous release). Document the verification path in the
+   downstream artifact. Document the verification path in the
    test's doc comment.
 2. **If no independent path exists, pin the value but require a
    second-source confirmation.** Add an inline comment naming the
@@ -302,12 +281,9 @@ under a section marker. Tag the golden constant with
 `CURRENT_<purpose>` (e.g., `CURRENT_CONFIG_HASH`) so a grep for
 the prefix surfaces every frozen value in the codebase.
 
-A reference implementation: `compute_config_hash_uses_python_default_formatter`
-in `tests/prime_check.rs` pins a 12-character SHA-256 prefix
-produced from `UNIVERSAL_ALLOW`/`FLOW_DENY`/`EXCLUDE_ENTRIES`
-through the `PythonDefaultFormatter`. The pinned value protects
-every stored `.flow.json` hash in the wild from silent
-invalidation.
+Reference: `compute_config_hash_uses_python_default_formatter` in
+`tests/prime_check.rs` pins a 12-character SHA-256 prefix produced
+from `UNIVERSAL_ALLOW`/`FLOW_DENY`/`EXCLUDE_ENTRIES`.
 
 ## How to Apply
 
@@ -332,43 +308,3 @@ deleting it.
 
 **Learn phase.** User corrections that flag speculative tests
 surface as missing-rule findings. This rule is the reference.
-
-## Motivating Incident
-
-Issue #1160 / PR #1168 surfaced this. During the Code phase, I
-added a `no_waiver_language_in_authoring_corpus` contract test
-that scanned `.claude/rules/*.md`, `CLAUDE.md`, `skills/**/SKILL.md`,
-and `.claude/skills/**/SKILL.md` for forbidden waiver substrings,
-with an exemption list for `no-waivers.md` and the new
-`extract-helper-refactor.md`. The test was ~100 lines of Rust. The
-user flagged it: main already has three specific tombstones
-covering the three surfaces where waivers had been historically
-introduced (`test_coverage.md`, `docs-with-behavior.md` Waiver
-Discipline section, CLAUDE.md `test_coverage.md` references), plus
-the `.claude/rules/no-waivers.md` rule prose, plus plan-check
-scanners. The corpus scan's only realistic regression paths were
-already covered; the scan would only fire on the exempt files
-themselves (silently). I reverted the test.
-
-## Cross-References
-
-- `.claude/rules/tombstone-tests.md` — the canonical form for
-  guarding named deletions.
-- `.claude/rules/scope-enumeration.md` and
-  `.claude/rules/external-input-audit-gate.md` — canonical forms
-  for targeted corpus scans with named trigger vocabularies.
-- `.claude/rules/scope-enumeration.md` "False-positive sweep before
-  expanding the vocabulary" — the original protocol that the
-  Corpus-scan viability check section generalizes.
-- `.claude/rules/skill-authoring.md` "Plan Task Ordering" — TDD
-  discipline that this rule complements.
-- `.claude/rules/duplicate-test-coverage.md` "Enforcement Topology"
-  — a rule that intentionally ships without a corpus contract
-  test per the viability check above, with the deferral rationale
-  inline.
-- `.claude/rules/no-waivers.md` — the 100% coverage discipline
-  that names coverage-required tests as having a valid named
-  consumer.
-- `.claude/rules/rust-patterns.md` "Test Module Section Markers"
-  — naming and grouping conventions for coverage-required tests
-  placed inline in source files or grouped in `tests/*.rs`.

--- a/.claude/rules/tombstone-tests.md
+++ b/.claude/rules/tombstone-tests.md
@@ -33,10 +33,7 @@ invisible to the audit.
 no matter how old the underlying PR is. Use `PR #<number>` exactly,
 even if the conceptual "source" of the removal was an issue — cite
 the merge PR that performed the removal, not the issue that filed
-the request. If the removal landed outside a PR (e.g. a direct
-push, which should never happen in this repo but can in others),
-the tombstone is inauditable and should be accompanied by a doc
-comment explaining why.
+the request.
 
 ```rust
 #[test]
@@ -73,11 +70,7 @@ tombstone for each:
   `Cargo.toml`/`Gemfile.lock`/`package.json`, environment-
   variable defaults, feature-flag entries. Tombstone shape:
   source-content check that asserts the removed entry's exact
-  string does NOT appear in the config file. The
-  `Bash(rm -rf *.qa-repos*)` allow-list entry from
-  `.claude/settings.json` is the canonical example: a
-  permission was removed, so a tombstone reads the JSON and
-  asserts the entry is absent.
+  string does NOT appear in the config file.
 - **External plugin dependency.** A reference to another
   Claude Code plugin (`code-review:code-review`,
   `decompose:decompose`), a third-party MCP server, or any
@@ -92,12 +85,7 @@ tombstone for each:
   current count, so a future re-numbering catches drift.
 
 Every category benefits from a stability argument per
-"Literal tombstones — stability checklist" below — config-axis
-literals (e.g. allow-list entries) typically pass the checklist
-trivially because JSON does not permit interpolated string
-construction inside permissions arrays, but the argument
-should still be documented in the doc comment so future
-maintainers see the reasoning.
+"Literal tombstones — stability checklist" below.
 
 ## Naming Convention
 
@@ -139,14 +127,6 @@ fails to catch ALL of:
 - `.arg("start-").arg("lock")` — chained method calls that pass
   the two halves as separate arguments
 
-PR #1166 proved all eight of these bypasses with failing adversarial
-tests. The initial tombstone for that PR shipped with a byte-
-substring check and had to be rewritten under Code Review pressure.
-The rewrite scans the function body of each protected test for
-`Command::new(FLOW_RS)` — a construct no bypass can hide. This
-section documents the strength criteria so future tombstones ship
-strong from the start.
-
 ### Two kinds of tombstone
 
 A tombstone protects against resurrection of one of:
@@ -154,10 +134,10 @@ A tombstone protects against resurrection of one of:
 1. **A stable source literal.** The forbidden thing is a fixed
    string that appears in source — a CLI argument quoted with
    double quotes (`"start-lock"`), a function name that cannot be
-   synthesized at runtime (e.g. `post_message`), a file path, a
-   config key. A byte-substring check is acceptable AS LONG AS
-   the literal cannot be constructed by any of the patterns above
-   and still produce the same runtime effect.
+   synthesized at runtime, a file path, a config key. A
+   byte-substring check is acceptable AS LONG AS the literal
+   cannot be constructed by any of the patterns above and still
+   produce the same runtime effect.
 2. **A structural construct.** The forbidden thing is a class of
    runtime behavior (spawning a subprocess, opening a network
    socket, calling a deprecated API) that can be expressed through
@@ -224,8 +204,6 @@ fn test_concurrency_no_subprocess_start_lock() {
 The `split_once("#[test]")` bounds the assertion scope to the
 function body. An `unwrap_or(tail)` fallback handles the case
 where the protected function is the last `#[test]` in the file.
-For protected functions in the middle of the file, the bound is
-the next `#[test]` attribute.
 
 ### Literal tombstones — stability checklist
 
@@ -268,8 +246,7 @@ When a plan proposes a tombstone, the Tasks section must specify:
    above.
 
 A tombstone proposal without this documentation is a Plan-phase
-gap. Code Review's adversarial agent will write failing tests
-against the weak assertion; the cheaper catch is at Plan time.
+gap.
 
 ## Consolidation
 
@@ -283,8 +260,7 @@ tombstones integral to a test domain stay in their domain's
 If a tombstone needs to call a crate-internal function, convert it
 to a source-content assertion — read the source file at runtime
 with `std::fs::read_to_string` and assert the removed pattern does
-not appear. Source-content assertions run from `tests/` and need
-no privileged access to the crate's internals.
+not appear.
 
 ## Lifecycle
 

--- a/.claude/rules/tool-dispatch.md
+++ b/.claude/rules/tool-dispatch.md
@@ -66,17 +66,15 @@ When adding a new stub template or a new auto-installed script:
 `target/llvm-cov-target/` at the start of every invocation —
 full-suite, filtered, and forced. This is the coherence mechanism
 that keeps coverage measurements bounded to a single source
-generation on long-lived target directories (notably main's).
-
-### Why
+generation on long-lived target directories.
 
 cargo-llvm-cov's `--no-clean` flag preserves accumulated
-instrumented binaries across runs for incremental speed. On main's
-long-lived `target/`, stale `flow_rs-*` binaries accumulate as PRs
-merge and source evolves. Without a profraw sweep, old profraws
-from prior runs match the stale binaries' function hashes and
-contribute execution counts against old source layouts, producing
-Frankenstein coverage numbers.
+instrumented binaries across runs for incremental speed. On the
+base branch's long-lived `target/`, stale `flow_rs-*` binaries
+accumulate as PRs merge and source evolves. Without a profraw
+sweep, old profraws from prior runs match the stale binaries'
+function hashes and contribute execution counts against old source
+layouts, producing Frankenstein coverage numbers.
 
 By sweeping all `*.profraw` at the top of every `bin/test`
 invocation, llvm-cov's report is scoped to profdata produced by
@@ -97,9 +95,9 @@ without matching fresh profdata.
   when a full fresh-clone experience is wanted.
 
 When adding a new tool that writes coverage-like artifacts under
-`target/llvm-cov-target/` on a long-lived target dir (main's), the
-same discipline applies: either the tool must sweep its stale
-artifacts before measuring, or it must not be invoked on main.
+`target/llvm-cov-target/` on a long-lived target dir, the same
+discipline applies: either the tool must sweep its stale artifacts
+before measuring, or it must not be invoked on the base branch.
 
 ## Stub Lifecycle Integration Tests
 
@@ -127,9 +125,7 @@ mode only manifests across the priming ↔ runner boundary.
 `EXCLUDE_ENTRIES` in `src/prime_check.rs` is the canonical source for
 patterns that prime adds to `.git/info/exclude` at install time. When a
 plan extends `EXCLUDE_ENTRIES` to cover a new family of project-managed
-files (e.g. throwaway probe tests, scratch caches, generated artifacts
-that share a basename convention but live inside the project's source
-tree), the plan must enumerate the pattern set exhaustively across every
+files, the plan must enumerate the pattern set exhaustively across every
 language whose convention the file family targets — before Code phase
 begins.
 
@@ -143,17 +139,6 @@ be excluded." The cost of a missed language is paid silently on every
 project that uses that language; the cost of an over-broad pattern (a
 leading wildcard that matches user-named legitimate tests) is paid
 silently in lost work.
-
-The first iteration of a `bin/test --adversarial-path` PR (PR #1333)
-shipped two patterns (`test_adversarial_flow.*`,
-`*_adversarial_flow_test.rb`) and missed Go, Rails Minitest, RSpec, and
-Swift conventions. The Code Review reviewer + adversarial agents both
-caught the gap; Step 4 replaced the patterns with five exact-basename
-entries (`test_adversarial_flow.*`, `adversarial_flow_test.go`,
-`adversarial_flow_test.rb`, `adversarial_flow_spec.rb`,
-`AdversarialFlowTests.swift`) and bumped `CURRENT_CONFIG_HASH` a second
-time within the same PR. Plan-time enumeration would have surfaced the
-full pattern set in one design pass and avoided the second hash bump.
 
 ### The Rule
 
@@ -185,20 +170,16 @@ to every entry:
 
 - **No leading wildcards.** A pattern like `*_adversarial_flow_test.rb`
   silently excludes any user-named legitimate test ending in
-  `_adversarial_flow_test.rb` (e.g.
-  `authentication_adversarial_flow_test.rb`). Use exact basenames or
-  trailing-only wildcards (`<exact_prefix>.*`) so user files cannot
-  collide.
+  `_adversarial_flow_test.rb`. Use exact basenames or trailing-only
+  wildcards (`<exact_prefix>.*`) so user files cannot collide.
 - **Trailing-wildcard scope.** `test_adversarial_flow.*` matches any
   file whose basename is `test_adversarial_flow.<extension>`. The `.*`
   end-of-basename wildcard is acceptable because it requires the exact
   prefix; user files named `test_adversarial_flow_local_dev.py` are
-  NOT matched (the `_local_dev` segment violates the prefix anchor).
+  NOT matched.
 
-When in doubt, prefer five exact-basename patterns over one
-leading-wildcard pattern. The cost of an extra entry is one line in
-`.git/info/exclude`; the cost of a leading wildcard is invisible
-exclusion of legitimate files.
+When in doubt, prefer multiple exact-basename patterns over one
+leading-wildcard pattern.
 
 ### Hash-Bump Discipline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,39 +1,32 @@
 # CLAUDE.md
 
-FLOW is a Claude Code plugin (`flow:` namespace) that enforces an opinionated 6-phase development lifecycle: Start, Plan, Code, Code Review, Learn, Complete. Each phase is a skill that Claude reads and follows. Phase gates prevent skipping ahead — you must complete each phase before entering the next. Language-agnostic — every project owns its toolchain via repo-local `bin/format`, `bin/lint`, `bin/build`, `bin/test` scripts that FLOW orchestrates without dispatching by language.
+FLOW is a Claude Code plugin (`flow:` namespace) that enforces an opinionated 6-phase development lifecycle: Start, Plan, Code, Code Review, Learn, Complete. Each phase is a skill that Claude reads and follows. Phase gates prevent skipping ahead. Language-agnostic — every project owns its toolchain via repo-local `bin/format`, `bin/lint`, `bin/build`, `bin/test` scripts that FLOW orchestrates.
 
 This repo is the plugin source code. When installed in a target project, skills and hooks run in the target project's working directory, not here. State files, worktrees, and logs all live in the target project. If you are developing FLOW itself, you are modifying the plugin — not using it.
 
 ## Design Philosophy
 
-Four core tenets guide every design decision:
+Four core tenets:
 
-1. **Unobtrusive** — zero dependencies. Prime commits `.claude/settings.json` and the four `bin/*` stubs as project config. `.flow.json` is always git-excluded. Everything else lives in `.git/` or is gitignored.
-2. **As autonomous or manual as you want** — configurable autonomy via `.flow.json` skills settings.
-3. **Safe for local env** — no containers needed, no permission prompts ever. Native tools only, no external dependencies.
-4. **N×N×N concurrent** — N engineers running N flows on N boxes at the same time is the primary use case, not an edge case. Every feature, fix, and design decision must work when multiple flows are active simultaneously — on the same machine (multiple worktrees) and across machines (shared GitHub state). Local state (`.flow-states/`, worktrees) is per-machine. Shared state (PRs, issues, labels) is coordinated through GitHub. Nothing assumes a single active flow.
+1. **Unobtrusive** — zero dependencies. Prime commits `.claude/settings.json` and the four `bin/*` stubs as project config. `.flow.json` is git-excluded.
+2. **As autonomous or manual as you want** — configurable via `.flow.json` skills settings.
+3. **Safe for local env** — no containers, no permission prompts ever, native tools only.
+4. **N×N×N concurrent** — N engineers running N flows on N boxes simultaneously is the primary use case. Local state (`.flow-states/`, worktrees) is per-machine; shared state (PRs, issues, labels) is coordinated through GitHub. Nothing assumes a single active flow.
 
-In the target project:
-
-- `.claude/settings.json` and the `bin/*` stubs are committed during prime. `.flow.json` is always git-excluded
-- `.flow-states/` is gitignored and deleted at Complete
-- After Complete, the only permanent artifacts are the merged PR and any CLAUDE.md learnings
-- Skills are pure Markdown instructions, not executable code
-- Tool dispatch is repo-local: `bin/flow ci` runs `./bin/format`, `./bin/lint`, `./bin/build`, `./bin/test` from cwd. Each repo owns its commands; FLOW provides the orchestration layer (sentinel, retry/flaky classification, recursion guard, fail-fast ordering, JSON contract). Adding a language means writing the four `bin/*` scripts in your project, not editing FLOW
-- Multiple flows run simultaneously via branch-scoped worktrees and state files — nothing assumes a single active flow
+After Complete, the only permanent artifacts are the merged PR and any CLAUDE.md learnings. Skills are pure Markdown instructions, not executable code. Tool dispatch is repo-local: `bin/flow ci` runs `./bin/format`, `./bin/lint`, `./bin/build`, `./bin/test` from cwd.
 
 ## The 6 Phases
 
 | Phase | Name | Command | Purpose |
 |-------|------|---------|---------|
 | 1 | Start | `/flow:flow-start` | Create worktree, PR, state file, configure workspace |
-| 2 | Plan | `/flow:flow-plan` | Invoke decompose plugin for DAG analysis, explore codebase, create implementation plan |
+| 2 | Plan | `/flow:flow-plan` | Invoke decompose plugin, explore codebase, create implementation plan |
 | 3 | Code | `/flow:flow-code` | Execute plan tasks one at a time with TDD |
-| 4 | Code Review | `/flow:flow-code-review` | Six tenants assessed by four cognitively isolated agents (reviewer, pre-mortem, adversarial, documentation) launched in parallel. Parent gathers, triages, and fixes. |
-| 5 | Learn | `/flow:flow-learn` | Review mistakes, capture learnings, route to permanent homes |
+| 4 | Code Review | `/flow:flow-code-review` | Six tenants assessed by four cognitively isolated agents (reviewer, pre-mortem, adversarial, documentation). Parent triages and fixes. |
+| 5 | Learn | `/flow:flow-learn` | Capture learnings, route to permanent homes |
 | 6 | Complete | `/flow:flow-complete` | Merge PR, remove worktree, delete state file |
 
-Phase gates are enforced by `bin/flow check-phase` (`src/check_phase.rs`) — there is no instruction path to skip a phase. Back-transitions (e.g., Code Review can return to Code or Plan) are defined in `flow-phases.json`.
+Phase gates enforced by `bin/flow check-phase` (`src/check_phase.rs`). Back-transitions defined in `flow-phases.json`.
 
 ## When You Must Update Docs and Tests
 
@@ -41,17 +34,15 @@ Phase gates are enforced by `bin/flow check-phase` (`src/check_phase.rs`) — th
 
 ### Structural sync (CI-enforced by `tests/docs_sync.rs`)
 
-CI will fail if these are missing:
-
 - New/renamed skill — `docs/skills/<name>.md`, `docs/skills/index.md`, `README.md`
 - New/renamed phase — `docs/phases/phase-<N>-<name>.md`, `docs/skills/index.md`, `README.md`, `docs/index.html`
 - New feature/capability — `README.md` and `docs/index.html` must mention required keywords (see `required_features()` in `tests/docs_sync.rs`)
 
-### Content sync (convention-enforced — no test catches this)
+### Content sync (convention-enforced)
 
-- Changed skill behavior (new flag, changed steps, different workflow) — update `docs/skills/<name>.md` and the Description column in `docs/skills/index.md` to match
-- Changed phase behavior — update `docs/phases/phase-<N>-<name>.md` and the Description column in `docs/skills/index.md` to match
-- Changed architecture or capabilities — update `README.md` and `docs/index.html` if the change affects how FLOW is described to users
+- Changed skill behavior → `docs/skills/<name>.md` and Description column in `docs/skills/index.md`
+- Changed phase behavior → `docs/phases/phase-<N>-<name>.md` and `docs/skills/index.md`
+- Changed architecture → `README.md` and `docs/index.html`
 
 ### Test requirements
 
@@ -60,216 +51,220 @@ CI will fail if these are missing:
 
 ## Key Files
 
-- `config.json` — plugin-level maintainer config: `claude_code_audited` tracks the last Claude Code version audited
+- `config.json` — plugin-level maintainer config (`claude_code_audited` tracks last audited Claude Code version)
 - `flow-phases.json` — state machine: phase names, commands, valid back-transitions
 - `skills/<name>/SKILL.md` — each skill's Markdown instructions
-- `hooks/hooks.json` — hook registration (SessionStart, PreToolUse, PermissionRequest, PostToolUse, PostCompact, Stop, StopFailure)
-- `hooks/session-start.sh` — writes terminal tab colors
+- `hooks/hooks.json` — hook registration
 - `.claude/settings.json` — project permissions (git rebase denied)
-- `docs/` — GitHub Pages site (static HTML); `docs/reference/flow-state-schema.md` for state file schema
-- `agents/*.md` — six custom plugin sub-agents: ci-fixer, reviewer, pre-mortem, adversarial, learn-analyst, documentation
-- `src/*.rs` — Rust source implementing all `bin/flow` subcommands
-- `src/plan_deviation.rs` — pure detector module for plan signature deviations (plan-named test fixture values drifting in the staged diff). Runs as a post-CI, pre-commit gate inside `src/finalize_commit.rs::run_impl` and blocks the commit when a drift is unacknowledged by a matching `bin/flow log` entry
-- `src/dispatch.rs` — centralized dispatch helpers (`dispatch_json`, `dispatch_text`) for `main.rs` match arms that delegate to module-level `run_impl_main` functions; both helpers print their result and then call `process::exit`
-- `src/base_branch_cmd.rs` — `bin/flow base-branch` subcommand. Skill-side single source of truth for the integration branch the flow coordinates against — reads `state["base_branch"]` via `git::read_base_branch` and prints the value (no silent fallback). Skills shell into this subcommand instead of hardcoding `origin/main` so non-main-trunk repos coordinate against their actual integration branch.
-- `src/tui.rs` — interactive TUI (`flow tui`) — ratatui app with keyboard-driven navigation over local state files. Subprocess surface (open, osascript, bin/flow, $HOME) is injected via `TuiAppPlatform` so unit tests exercise real `Command::new()` chains against a no-op `true` binary
-- `src/tui_data.rs` — state-file loaders and pure display helpers for the TUI (phase timeline, flow summaries, orchestration, account metrics, per-phase token table). No IO in the helpers — `phase_timeline`, `phase_token_table`, and friends are deterministic given state JSON + clock
-- `src/tui_terminal.rs` — crossterm glue for the production TUI entry point. Hosts `run_tui_arm` (returns `!`, owns the `process::exit` dispatch so main.rs's Tui arm is a single fully-covered expression), `run_tui_arm_impl` (seam-injected variant accepting `is_tty_fn` and `run_terminal_fn` closures for unit tests), `run_terminal` (the crossterm event loop), and `TerminalGuard<F>` (RAII guard parameterized over a `release_fn` closure so unit tests verify Drop runs via `panic::catch_unwind`). See `.claude/rules/rust-patterns.md` "Seam-injection variant for externally-coupled code" and `.claude/rules/panic-safe-cleanup.md`.
-- `src/window_snapshot.rs` — pure capture function reading `~/.claude/rate-limits.json`, transcript JSONL, and the per-session cost file to produce a `WindowSnapshot` of account-window pcts, session token totals (with per-model split), session cost, turn/tool counts, and most-recent-turn context utilization. Every numeric field is `Option<...>` for fail-open semantics — missing inputs produce `None`, never panics. Called by every state-mutating producer (`start_init`, `phase_enter`, `phase_finalize`, `phase_transition`, `set_timestamp` step counters, `complete_finalize`) to land snapshots at `state.window_at_start`, `phases.<n>.window_at_enter` / `window_at_complete`, `phases.<n>.step_snapshots[]`, and `state.window_at_complete`.
-- `src/window_deltas.rs` — pure delta + by-model rollup helper consuming `WindowSnapshot` data captured in state. Three public functions: `phase_delta(phase: &PhaseState) -> Option<DeltaReport>` for per-phase deltas, `flow_total(state: &FlowState) -> DeltaReport` for flow-level sums, and `by_model_rollup(state: &FlowState) -> IndexMap<String, ModelTokens>`. Cross-session math is load-bearing: snapshots are grouped by `session_id`, deltas summed within each group, then summed across groups so multi-session flows (resume, hand-off after compaction) report non-negative deltas. Window resets (curr pct < prev pct) produce `None` pct deltas and set `window_reset_observed`. Consumed by `format_complete_summary` (Token Cost section), `format_status` (Tokens block), and `tui_data::phase_token_table` (TUI per-phase table).
-- `src/write_rule.rs` — `bin/flow write-rule` subcommand. Reads an intermediate content file and writes its bytes to a target path via `fs::write`, bypassing Claude Code's Write-tool preflight so monitored persistent paths (`plan.md`, `dag.md`, `commit-msg.txt`, `.flow-issue-body`, `orchestrate-queue.json`) can be re-routed without preflight blocks. Hosts the **CLI-layer canonicalization gate**: `classify_path` matches `--path` by basename against the FLOW-managed artifact set, `canonical_path` derives the canonical destination from `(project_root, branch)` via `FlowPaths`, and `run_impl_main` rejects any provided path that doesn't normalize (resolving `..`) to the canonical destination — returning `{"status": "error", "step": "path_canonicalization", ...}` with the canonical path named in the response. The gate runs BEFORE `read_content_file` so a rejection does not destroy the caller's input, and writes the resolved absolute path so a relative `--path` cannot silently re-resolve against the process cwd at write time. See `.claude/rules/file-tool-preflights.md` "Managed-Artifact Canonicalization Gate (CLI Layer)".
-- `bin/flow` — Rust dispatcher: resolves the Rust binary (`target/release/flow-rs` or `target/debug/flow-rs`), auto-rebuilds when source is newer than binary
-- `bin/{format,lint,build,test}` — FLOW's own dogfood scripts; each repo gets its own copies installed by `/flow:flow-prime` from `assets/bin-stubs/`
+- `docs/` — GitHub Pages site; `docs/reference/flow-state-schema.md` for state file schema
+- `agents/*.md` — six custom plugin sub-agents (ci-fixer, reviewer, pre-mortem, adversarial, learn-analyst, documentation)
+- `src/*.rs` — Rust source for all `bin/flow` subcommands. Per-module purpose lives in module doc comments.
+- `bin/flow` — Rust dispatcher (auto-rebuilds when source is newer than binary)
+- `bin/{format,lint,build,test}` — FLOW's own dogfood scripts
 - `assets/bin-stubs/` — self-documenting bash stubs that prime copies into target projects when absent
 - `.claude-plugin/marketplace.json` — marketplace registry (version must match plugin.json)
 
 ## Development Environment
 
 - Run tests with `bin/flow ci` only — never invoke cargo directly
-- `bin/flow ci` runs `./bin/format`, `./bin/lint`, `./bin/build`, `./bin/test` in sequence (format first for fail-fast). In THIS repo, `bin/build` is a no-op that exits 0 with an informational stderr message — compilation happens inside `bin/test` via `cargo-llvm-cov nextest`, so a separate build step would duplicate work. Target projects that need a real build step implement their own `bin/build`.
-- `bin/flow ci --format`/`--lint`/`--build`/`--test` runs only that single phase. Single-phase runs disable both sentinel read and write — one tool passing does not satisfy the all-four-passed contract the sentinel encodes.
-- `bin/flow ci --force` runs all four AND bypasses the sentinel skip
-- **For single-file coverage iteration, use `bin/test tests/<name>.rs`** — runs only that test binary and asserts 100/100/100 against the mirrored `src/<name>.rs`. Completes in seconds vs ~3 minutes for full CI. Use full `bin/flow ci` (or `bin/flow ci --test`) only for final cross-file verification before commit. See `.claude/rules/per-file-coverage-iteration.md`.
-- **Use `bin/flow ci --test -- <filter>` for targeted test runs across the full workspace** — `bin/flow ci --test -- hooks` runs every test name-matching `hooks` across all test binaries. This still compiles the whole workspace, so prefer `bin/test tests/<name>.rs` when the target is a single file. Never call cargo directly — always go through `bin/test` or `bin/flow ci`.
-- **`bin/test` sweeps `*.profraw` recursively under `target/llvm-cov-target/` at the start of every invocation** (full-suite, filtered, forced). llvm-cov's report draws only from the profraws produced by THIS run, so stale instrumented binaries in `target/llvm-cov-target/debug/deps/` contribute no execution counts regardless of `--no-clean`. `bin/flow ci --clean` is the user-facing reset for a full fresh-clone experience when a deeper purge is wanted.
-- **Stale instrumented binaries can produce phantom coverage misses.** The profraw sweep removes execution-count data, but the binaries themselves stay in `target/llvm-cov-target/debug/deps/` and their function-instantiation maps remain in cargo-llvm-cov's report denominator. A file can read e.g. `92.31% / 95.54% / 96.15%` with mysterious "missed functions" that resist every test you add — those are stale crate hashes' empty entries, not real source-level gaps. **Diagnostic: when adding tests doesn't move coverage at all, run `bin/flow ci --clean` once** (12s reset + ~45s next-test cold compile), then re-run the per-file gate. See `.claude/rules/per-file-coverage-iteration.md` "Phantom Misses" for the full diagnostic procedure including `bin/test --funcs <file>` for confirmation.
-- **`bin/test --show <file>`** renders annotated source coverage for ONE source file. Pass basename (`start_init.rs`) or path (`src/start_init.rs`). **`bin/test --funcs <file>`** lists every function instantiation with its execution count and mangled name — the way to confirm phantom-miss diagnosis (multiple crate hashes for the same demangled name).
-- Dependencies managed via `bin/dependencies` (runs `cargo update`)
+- `bin/flow ci` runs `./bin/format`, `./bin/lint`, `./bin/build`, `./bin/test` in sequence (format first for fail-fast). In THIS repo, `bin/build` is a no-op — compilation happens inside `bin/test` via `cargo-llvm-cov nextest`.
+- `bin/flow ci --format`/`--lint`/`--build`/`--test` runs only that single phase. Single-phase runs disable both sentinel read and write.
+- `bin/flow ci --force` runs all four AND bypasses the sentinel skip.
+- `bin/flow ci --clean` is the user-facing deep-reset (wipes sentinel, profraws, `target/llvm-cov-target/debug/`).
+- **For single-file coverage iteration, use `bin/test tests/<name>.rs`** — runs only that test binary and asserts 100/100/100 against the mirrored `src/<name>.rs`. Seconds vs ~3 minutes for full CI. See `.claude/rules/per-file-coverage-iteration.md`.
+- **Use `bin/flow ci --test -- <filter>` for targeted test runs across the workspace.**
+- **`bin/test` sweeps `*.profraw` recursively under `target/llvm-cov-target/` at the start of every invocation** to keep coverage measurement scoped to the current run.
+- **`bin/test --show <file>`** renders annotated source coverage. **`bin/test --funcs <file>`** lists every function instantiation with its execution count (used to confirm phantom-miss diagnosis from stale instrumented binaries).
+- Dependencies managed via `bin/dependencies` (runs `cargo update`).
 
 ## Architecture
 
 ### Plugin vs Target Project
 
-This repo is the plugin source. When installed, skills and hooks run in the target project's working directory. State files live in the target project's `.flow-states/`. Worktrees are created in the target project. Hooks must be tested in the context of a target project directory structure, not this repo.
+Skills and hooks run in the target project's working directory, not the plugin source. State files live in the target project's `.flow-states/`. Hooks must be tested against a target project layout, not this repo.
 
 ### Skills Are Markdown, Not Code
 
-Skills are pure Markdown instructions (`skills/<name>/SKILL.md`). The only executable code is `bin/flow` (dispatcher) and `src/*.rs` (Rust source). Everything else is instructions that Claude reads and follows.
+Skills are pure Markdown (`skills/<name>/SKILL.md`). The only executable code is `bin/flow` (dispatcher) and `src/*.rs` (Rust source).
 
 ### Repo-Local Tool Delegation
 
-`bin/flow ci` (and its single-phase variants `--format`/`--lint`/`--build`/`--test`) spawns `./bin/<tool>` from cwd. The user's `bin/<tool>` script owns the actual command (cargo, pytest, go test, etc.). FLOW contributes:
+`bin/flow ci` (and `--format`/`--lint`/`--build`/`--test`) spawns `./bin/<tool>` from cwd. The user's `bin/<tool>` script owns the actual command. FLOW contributes:
 
-- Sentinel-based dirty-check optimization (`tree_snapshot` SHA-256 over HEAD + diff + untracked)
+- Sentinel-based dirty-check (`tree_snapshot` SHA-256 over HEAD + diff + untracked)
 - Retry/flaky classification (test only)
 - `FLOW_CI_RUNNING=1` recursion guard
 - Fail-fast tool ordering (format → lint → build → test)
 - Stable JSON output contract
-- Cwd-drift guard via `cwd_scope::enforce` so subdirectory-scoped flows can't be run from the wrong directory
+- Cwd-drift guard via `cwd_scope::enforce`
 
-`bin/flow ci` always invokes the **worktree-root** `./bin/<tool>` scripts, not the agent's cwd. When a mono-repo flow is started from a service subdirectory (e.g., `cortex/`), `ci::run_impl` normalizes cwd to the worktree root via `flow_paths::compute_worktree_root` before scanning for `bin/<tool>` scripts. This lets a project ship a single set of root-level scripts that dispatch by diff to per-service runners (the full-harvest pattern), so per-service CI logic lives in one place and stays consistent across every entry point. Per-service iteration uses the project's own per-service `bin/test` directly, not `bin/flow ci`.
+`bin/flow ci` always invokes the **worktree-root** scripts. For mono-repo flows started inside a service subdirectory, `ci::run_impl` normalizes cwd to the worktree root before scanning for `bin/<tool>` scripts. A repo with no `bin/{format,lint,build,test}` scripts is a hard error.
 
-The four `bin/*` stubs are installed by `/flow:flow-prime` from `assets/bin-stubs/<tool>.sh` when absent. Pre-existing user scripts are never overwritten. Each stub carries a `# FLOW-STUB-UNCONFIGURED` marker and defaults to `exit 0` with a stderr reminder so a fresh prime never blocks CI. `bin/flow ci` detects the marker in each script's source and refuses to write the sentinel when any tool is still a stub — that way the stderr reminder surfaces on every CI run until the user configures a real command. A repo with no `bin/{format,lint,build,test}` scripts at all (e.g. a subdirectory where prime hasn't run) is a hard error, not a skip: `bin/flow ci` returns `{"status": "error"}` with an actionable message.
+The four `bin/*` stubs are installed by `/flow:flow-prime` from `assets/bin-stubs/` when absent. Each stub carries a `# FLOW-STUB-UNCONFIGURED` marker; `bin/flow ci` refuses to write the sentinel when any tool is still a stub.
 
-The `bin/test` stub additionally accepts a `bin/test --adversarial-path` invocation that prints the canonical Code Review adversarial probe test path on stdout. The path lives inside the project's test tree so the language test runner can discover and execute the probe; worktree removal at Phase 6 Complete then disposes of the file as a side effect of removing the worktree directory. Exit code 0 with a single-line stdout = configured; exit 2 with a stderr message = unconfigured stub (Code Review halts before the adversarial agent launches). The recommended per-language values ship as comments in `assets/bin-stubs/test.sh` (`tests/test_adversarial_flow.rs` for cargo nextest, `tests/test_adversarial_flow.py` for pytest, `test/adversarial_flow_test.rb` for Rails Minitest, etc.). The `EXCLUDE_ENTRIES` constant in `src/prime_check.rs` lists the basename glob patterns (`test_adversarial_flow.*`, `*_adversarial_flow_test.rb`) that prime adds to `.git/info/exclude` so the throwaway probe never appears in `git status` output.
+The `bin/test` stub additionally accepts `bin/test --adversarial-path` which prints the canonical Code Review adversarial probe test path. Exit 0 with single-line stdout = configured; exit 2 = unconfigured. The `EXCLUDE_ENTRIES` constant in `src/prime_check.rs` lists patterns prime adds to `.git/info/exclude` so the throwaway probe never appears in `git status`.
 
 ### Subdirectory Context
 
-State files capture `relative_cwd` at flow-start time — the path inside the project root where the user invoked `/flow:flow-start`. For root-level flows this is the empty string and behavior is unchanged. For mono-repo flows started inside `api/` (or `packages/api/`), `start-workspace` returns a `worktree_cwd` that includes the suffix so the agent lands in `.worktrees/<branch>/api/` after the worktree is created. `worktree_cwd` is an **absolute path** so the skill's `cd <worktree_cwd>` lands correctly regardless of where the bash tool's cwd is at the moment of the cd — the user can launch Claude at the repo root and `cd <app>` before `/flow:flow-start`, or launch Claude directly inside the app subdir; both produce the same downstream behavior. `prime_check` reads `.flow.json` from the project root (not from cwd), so a mono-repo primed at the root passes prime-check from any app subdirectory.
+State files capture `relative_cwd` at flow-start time — the path inside the project root where `/flow:flow-start` was invoked. Empty string for root-level flows. For mono-repo flows started inside `api/`, `start-workspace` returns an absolute `worktree_cwd` that includes the suffix so the agent lands in `.worktrees/<branch>/api/`. `prime_check` reads `.flow.json` from the project root, so a mono-repo primed at the root passes prime-check from any app subdirectory.
 
-Worktree creation also mirrors every `.venv` discovered under the project root into the new worktree as a relative symlink — root-level `.venv` plus every subdirectory `.venv` (`cortex/.venv`, `packages/api/.venv`, etc.). The walker skips dotted directories other than `.venv` itself, a small named-skip list (`node_modules`, `target`, `vendor`, `build`, `dist`), and directory symlinks (cycle protection); pre-existing committed content at a link path is preserved, never overwritten. See `src/start_workspace.rs::link_venvs`.
+Worktree creation mirrors every `.venv` discovered under the project root into the new worktree as a relative symlink (`src/start_workspace.rs::link_venvs`). The walker skips dotted directories other than `.venv`, a small named-skip list (`node_modules`, `target`, `vendor`, `build`, `dist`), and directory symlinks.
 
-`cwd_scope::enforce` runs as the first action in every subcommand that either runs tools or mutates state: `ci`, `build`, `lint`, `format`, `test` (tool runners) and `phase-enter`, `phase-finalize`, `phase-transition`, `set-timestamp`, `add-finding` (state mutators). Read-only subcommands (e.g. `format-status`, `tombstone-audit`, `plan-check`, `base-branch`) do not enforce because they cannot drift the flow. The guard compares the canonicalized cwd against `<worktree_root>/<relative_cwd>` as a prefix match: cwd must be equal to or a descendant of the expected directory, so agents can cd into sub-modules of `api/` without tripping the guard, but cannot cd into a sibling `ios/` subdirectory. The mechanism is additive: empty `relative_cwd` preserves all pre-existing behavior.
+`cwd_scope::enforce` runs as the first action in every subcommand that runs tools or mutates state: `ci`, `build`, `lint`, `format`, `test`, `phase-enter`, `phase-finalize`, `phase-transition`, `set-timestamp`, `add-finding`. Read-only subcommands (`format-status`, `tombstone-audit`, `plan-check`, `base-branch`) do not enforce.
 
 ### State File
 
-The state file (`.flow-states/<branch>/state.json`) is the backbone. Schema reference: `docs/reference/flow-state-schema.md`. Test fixtures: `tests/common/mod.rs` helpers (`create_git_repo_with_remote`, state JSON builders).
+The state file (`.flow-states/<branch>/state.json`) is the backbone. Schema reference: `docs/reference/flow-state-schema.md`. Test fixtures: `tests/common/mod.rs` helpers.
 
 ### Local vs Shared State
 
 | Domain | Scope | Examples | Coordination |
 |--------|-------|----------|--------------|
-| Local | Per-machine | `.flow-states/`, worktrees, `.flow.json` | None needed — each machine has its own |
-| Shared | All engineers | PRs, issues, labels, branches | GitHub is the API — never assume local knowledge of other engineers' state |
+| Local | Per-machine | `.flow-states/`, worktrees, `.flow.json` | None needed |
+| Shared | All engineers | PRs, issues, labels, branches | GitHub is the API |
 
-The "Flow In-Progress" label on issues is the cross-engineer WIP detection mechanism. See `.claude/rules/concurrency-model.md` for the developer checklist.
+The "Flow In-Progress" label on issues is the cross-engineer WIP detection mechanism. See `.claude/rules/concurrency-model.md`.
 
 ### Start-Gate CI on the Base Branch as Serialization Point
 
-`start-gate` runs `bin/flow ci` on the integration branch (the `base_branch` value captured at flow-start by `init_state` from `git symbolic-ref --short refs/remotes/origin/HEAD` — `main` for standard repos, `staging`/`develop`/etc. for non-main-trunk repos), under the start lock, by design. This is not a safety check that could live in a worktree — it is the coordination surface for dependency-maintenance work across all concurrent flows.
+`start-gate` runs `bin/flow ci` on the integration branch (`base_branch` captured at flow-start by `init_state` from `git symbolic-ref --short refs/remotes/origin/HEAD`), under the start lock. This is the coordination surface for dependency-maintenance work across all concurrent flows: the first flow-start of the day acquires the lock, runs CI on the base branch, and if a dependency upgrade broke something, `ci-fixer` repairs it once. Subsequent flow-starts queue behind the lock; when they acquire, the CI sentinel (`.flow-states/<base_branch>/ci-passed`) lets them pass through without re-running CI. Dependency churn costs O(1), not O(N).
 
-The pattern: the first flow-start of the day acquires the lock, runs CI on the base branch, and if a dependency upgrade broke something, `ci-fixer` repairs it once, under the lock, with its fix committed to the base branch. Subsequent flow-starts queue behind the lock; when they acquire, the base branch is already repaired, and the CI sentinel (`.flow-states/<base_branch>/ci-passed`, branch-keyed via `ci::sentinel_path(repo, base_branch)`) lets them pass through without re-running CI. Dependency churn costs O(1) human/agent time, not O(N). Running CI in a disposable worktree instead would defeat this: every concurrent flow would independently discover the breakage and independently repair it, producing duplicate fixes, merge conflicts, and wasted cycles.
+The base-branch sentinel is also written by `complete-finalize` at the end of every flow that pulled cleanly, fired only when `--pull` was passed AND `cleanup_map["git_pull"] == "pulled"`.
 
-The base-branch sentinel is also written by `complete-finalize` at the end of every flow that pulled cleanly. With the working_tree_dirty gate inside `finalize_commit::run_impl`, the post-merge tree on local `<base_branch>` is byte-identical to the feature-branch tip whose CI just passed — same bytes ran CI, same bytes landed via squash merge, same bytes are now on local main. Writing `<root>/.flow-states/<base_branch>/ci-passed` from `ci::tree_snapshot(&root, None)` lets the next `start-gate` see the snapshot match and skip CI entirely. The write fires only when `--pull` was passed AND `cleanup_map["git_pull"] == "pulled"`; failed pulls or unset `--pull` skip the write so a stale or unknown integration-branch state never produces a falsely-fresh sentinel.
-
-Consequence: **the base branch's `target/` is a long-lived build surface that spans many source generations as PRs merge over time.** Any tool that writes artifacts under `target/` on the base branch must stay coherent across those generations. `bin/test` enforces coherence by sweeping every `*.profraw` under `target/llvm-cov-target/` at the start of every invocation: llvm-cov's report is scoped to the profraws produced by THIS run, so stale instrumented binaries left behind in `deps/` from prior generations produce no execution-count contributions. `bin/flow ci --clean` is the user-facing deep-reset when a full fresh-clone experience is wanted.
+The base branch's `target/` is a long-lived build surface across many source generations. Tools that write artifacts there must stay coherent — `bin/test`'s profraw sweep is the mechanism.
 
 ### Sub-Agents
 
 <!-- duplicate-test-coverage: not-a-new-test -->
-Six custom plugin sub-agents in `agents/*.md` — tiered by task complexity: opus (ci-fixer, adversarial), sonnet (reviewer, pre-mortem), haiku (learn-analyst, documentation). Agent frontmatter must only use supported keys (`name`, `description`, `model`, `effort`, `maxTurns`, `tools`, `disallowedTools`, `skills`, `memory`, `background`, `isolation`) — `test_agent_frontmatter_only_supported_keys` enforces this. The global `PreToolUse` hook (`bin/flow hook validate-pretool`) enforces Bash and Agent tool restrictions across all agents. See `.claude/rules/cognitive-isolation.md` for the two-tier context model and debiasing rationale.
+Six custom plugin sub-agents in `agents/*.md` — tiered by task complexity: opus (ci-fixer, adversarial), sonnet (reviewer, pre-mortem), haiku (learn-analyst, documentation). Agent frontmatter must only use supported keys (`name`, `description`, `model`, `effort`, `maxTurns`, `tools`, `disallowedTools`, `skills`, `memory`, `background`, `isolation`) — `test_agent_frontmatter_only_supported_keys` enforces this. The global `PreToolUse` hook (`bin/flow hook validate-pretool`) enforces Bash and Agent tool restrictions across all agents. See `.claude/rules/cognitive-isolation.md`.
 
-Agent `maxTurns` budgets are set in each agent's frontmatter. When adding or modifying an agent's budget, read peer agents' frontmatter to maintain parity between agents with similar scope (e.g. context-rich read-only agents should have comparable budgets).
+When adding or modifying an agent's `maxTurns` budget, read peer agents' frontmatter to maintain parity.
 
 ### Orchestration
 
-`/flow:flow-orchestrate` is a meta-skill that processes decomposed issues overnight. It fetches open issues labeled "Decomposed", filters out "Flow In-Progress" issues, and runs each sequentially via `flow-start --auto`. State is tracked in `.flow-states/orchestrate.json` (a machine-level singleton, not branch-scoped). Only one orchestration runs per machine at a time.
+`/flow:flow-orchestrate` processes decomposed issues overnight. Fetches open issues labeled "Decomposed", filters out "Flow In-Progress", runs each sequentially via `flow-start --auto`. State tracked in `.flow-states/orchestrate.json` (machine-level singleton). Only one orchestration runs per machine at a time.
 
 ### Memory and Learning System
 
 Auto-memory is shared across git worktrees of the same repository (since Claude Code 2.1.63).
 
-Learn routes learnings to project CLAUDE.md and `.claude/rules/`. Also files GitHub issues for process gaps. All filed issues recorded via `bin/flow add-issue`. All triage findings recorded via `bin/flow add-finding`.
+Learn routes learnings to project CLAUDE.md and `.claude/rules/`. Files GitHub issues for process gaps via `bin/flow add-issue`. Records triage findings via `bin/flow add-finding`.
 
-CI is enforced inside `finalize-commit` itself — `run_impl` calls `ci::run_impl()` before `git commit`, so every commit path (including direct `bin/flow finalize-commit` calls) runs CI mechanically. The sentinel skip optimization means zero overhead when CI already passed. The `commit_format` preference is copied from `.flow.json` into the state file by `/flow-start`; the commit skill reads it from the state file. After `finalize-commit` succeeds and `git pull` did not introduce new content (`pull_merged == false`), the CI sentinel is automatically refreshed so the next `bin/flow ci` run skips when the working tree hasn't changed.
+### Commit Path Gates
 
-A working-tree-dirty gate runs ahead of the CI gate inside `finalize_commit::run_impl`. `git diff --quiet` checks whether the working tree differs from the index; when it does, the call returns `{"status":"error","step":"working_tree_dirty"}` without invoking CI or `git commit`. The gate exists because CI tools read the working tree but `git commit -F` commits the index — when the two diverge (e.g., a file edited after `git add`), CI tests one set of bytes and the commit lands a different set. The gate refuses the commit and instructs the user to either `git add` the unstaged edits (commit them) or `git restore <file>` (drop them), preserving the user's choice. Auto-staging via `git add -A` would erase the `git restore` option, so the gate is refuse-not-resolve. After this gate, every subsequent git call inside `finalize_commit()` uses `.expect()` per `.claude/rules/testability-means-simplicity.md` because git was proven alive.
+CI is enforced inside `finalize-commit` itself — `run_impl` calls `ci::run_impl()` before `git commit`, so every commit path runs CI mechanically. The `commit_format` preference is copied from `.flow.json` into the state file by `/flow-start`. After `finalize-commit` succeeds and `git pull` did not introduce new content, the CI sentinel auto-refreshes.
 
-Plan signature deviations are enforced the same way. After `ci::run_impl()` succeeds and before the `git commit` call, `run_impl` invokes `crate::plan_deviation::run_impl` which reads the plan file's `## Tasks` section, collects `(test_name, fixture_key, plan_value)` triples from eligible fenced code blocks, and cross-references each plan value against the string literals found in the corresponding diff-added test function's body. A deviation is reported when a plan-named test appears in `git diff --cached` but the plan's fixture value is absent from the test's added lines. When drift is detected and not acknowledged by a matching `bin/flow log` entry (a log line containing both the test name and the plan value as substrings), `finalize-commit` blocks with `{"status": "error", "step": "plan_deviation"}` on stdout and a structured stderr message naming each deviation and the exact `bin/flow log` command the user should run to acknowledge it. See `.claude/rules/plan-commit-atomicity.md` "Mechanical Enforcement" for the full gate design.
+Three gates run inside `finalize_commit::run_impl` before `git commit`:
+
+1. **Working-tree-dirty gate** — `git diff --quiet` checks whether the working tree differs from the index. When it does, returns `{"status":"error","step":"working_tree_dirty"}`. CI tools read the working tree but `git commit -F` commits the index — when they diverge, CI tests one set of bytes and the commit lands a different set. Refuse-not-resolve: user must `git add` (commit) or `git restore` (drop).
+2. **CI gate** — `ci::run_impl()` runs the four-tool dispatch.
+3. **Plan deviation gate** — `crate::plan_deviation::run_impl` reads the plan's `## Tasks` section, collects `(test_name, fixture_key, plan_value)` triples, and cross-references each plan value against string literals in the diff-added test function's body. Drift not acknowledged by a matching `bin/flow log` entry blocks with `{"status":"error","step":"plan_deviation"}`. See `.claude/rules/plan-commit-atomicity.md`.
 
 ### Logging
 
-Phase skills log completion events to `.flow-states/<branch>/log` using a command-first pattern (no START timestamps). Logging goes to `.flow-states/`, never `/tmp/`.
+Phase skills log completion events to `.flow-states/<branch>/log` using a command-first pattern. Logging goes to `.flow-states/`, never `/tmp/`.
 
-All 6 phases produce log entries. Phase 1 (Start) logs via its four consolidated commands (`start-init`, `start-gate`, `start-workspace`, `phase-finalize`). Phases 2–5 log via skill-level `bin/flow log` calls and Rust-tier `append_log` calls in `phase_enter.rs` and `finalize_commit.rs`. Phase 6 (Complete) logs via `complete_finalize.rs`, `complete_post_merge.rs`, and `cleanup.rs`. Most log entries use `[Phase N] module — step (status)` format. Phase-transition logs include the action and target phase: `[Phase N] phase-transition --action <action> --phase <phase> ("<status>")`. N is derived from `phase_number()` in `phase_config.rs`. `finalize_commit.rs` reads `current_phase` from the state file to derive the correct phase number across all calling phases. Phase 6 modules use guarded logging to avoid creating `.flow-states/` in test fixtures: `complete_post_merge.rs` and `complete_finalize.rs` check `.flow-states/` directory existence before calling `append_log`; `cleanup.rs` checks log file existence before its final log entry (which is written before the log file deletion step).
+All 6 phases produce log entries. Most use `[Phase N] module — step (status)` format. N is derived from `phase_number()` in `phase_config.rs`. `finalize_commit.rs` reads `current_phase` from the state file. Phase 6 modules use guarded logging to avoid creating `.flow-states/` in test fixtures.
 
 ### Version Locations
 
-The version lives in 3 places (across 2 files), all must match: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (top-level metadata), `.claude-plugin/marketplace.json` (plugins array entry). `tests/structural.rs` enforces consistency.
+Version lives in 3 places (across 2 files), all must match: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` top-level, `.claude-plugin/marketplace.json` plugins array. `tests/structural.rs` enforces consistency.
 
 ### Checksum → Version Invariant
 
-`config_hash` covers permission structure (allow/deny lists, defaultMode, exclude entries). `setup_hash` is a SHA-256 of `src/prime_setup.rs`, covering all installation artifacts (hooks, excludes, launcher, bin/* stub installer). Both hashes are stored in `.flow.json` and compared by `prime_check.rs` when a version mismatch is detected. Matching hashes allow auto-upgrade (just update the version in `.flow.json`); mismatching hashes force a full `/flow:flow-prime` re-run. Hash changes during development do not require version bumps — version bumps are a release decision via `/flow-release`. The hashes ensure that users get the right upgrade path when they update to a new release.
+`config_hash` covers permission structure (allow/deny lists, defaultMode, exclude entries). `setup_hash` is a SHA-256 of `src/prime_setup.rs`. Both stored in `.flow.json`, compared by `prime_check.rs` on version mismatch. Matching hashes allow auto-upgrade; mismatching hashes force a full `/flow:flow-prime` re-run.
 
 ### State Mutations
 
-Claude never computes timestamps, time differences, or counter increments. All standard state mutations go through `bin/flow` commands: `phase-enter` for phase entry (gate check + enter + step counters + state data return — used by Code, Code Review, Learn), `phase-finalize` for phase completion (complete + Slack + notification record — used by Start, Code, Code Review, Learn), `phase-transition` for phases not yet migrated (Plan entry, Complete), `set-timestamp` for mid-phase fields, and `add-finding` for recording triage findings to `findings[]` (used by Code Review and Learn — captures finding description, outcome, reasoning, and optional issue_url or rule path). Exception: `plan-extract` writes Plan phase step fields (`plan_step`, `plan_steps_total`, `files.dag`, `files.plan`, `code_tasks_total`) directly via `mutate_state` when handling the extracted path — these fields are set in the same process that runs phase enter and phase complete. `code_task` can only be incremented by 1 per `--set` argument — `apply_updates` validates each `--set code_task=N` sequentially against the in-memory state mutated by preceding args, so `--set code_task=2 --set code_task=3` in a single CLI call succeeds (each step is +1). For atomic commit groups, batch all counter advances in one call instead of N separate invocations. The plan file lives at `.flow-states/<branch>/plan.md` and its path is stored in `state["files"]["plan"]`. The DAG file (from decompose plugin) lives at `.flow-states/<branch>/dag.md` and is stored in `state["files"]["dag"]`. Legacy state files may still use top-level `state["plan_file"]` and `state["dag_file"]` — consumers should check `files` first with fallback to the top-level keys.
+Claude never computes timestamps, time differences, or counter increments. All standard state mutations go through `bin/flow` commands:
 
-Account-window snapshots are captured at every state-mutating transition by `src/window_snapshot.rs::capture` — at flow start (`state.window_at_start`), at every phase enter and phase complete (`phases.<n>.window_at_enter` / `window_at_complete`), at every step counter increment (`phases.<n>.step_snapshots[]`), and at flow complete (`state.window_at_complete`). Each snapshot records account-window pcts (5h, 7d), session token totals with per-model split, session cost, turn/tool counts, and most-recent-turn context utilization. Every numeric field is `Option<...>` for fail-open semantics — missing or unreadable inputs produce `None` rather than failing the surrounding state mutation. Consumers (`format_complete_summary` Token Cost section, `format_status` Tokens block, `tui_data::phase_token_table`) read the snapshots through `src/window_deltas.rs` which groups by `session_id` so multi-session flows (resume, hand-off after compaction) report non-negative deltas.
+- `phase-enter` — phase entry (gate check + enter + step counters + state data return)
+- `phase-finalize` — phase completion (complete + Slack + notification record)
+- `phase-transition` — phases not yet migrated (Plan entry, Complete)
+- `set-timestamp` — mid-phase fields
+- `add-finding` — recording triage findings to `findings[]`
+
+Exception: `plan-extract` writes Plan phase step fields directly via `mutate_state` when handling the extracted path.
+
+`code_task` can only be incremented by 1 per `--set` argument — `apply_updates` validates each `--set code_task=N` sequentially. Batch counter advances in one call for atomic commit groups.
+
+Plan file: `.flow-states/<branch>/plan.md`, stored in `state["files"]["plan"]`. DAG file: `.flow-states/<branch>/dag.md`, stored in `state["files"]["dag"]`. Legacy state files may still use top-level `state["plan_file"]` and `state["dag_file"]`.
+
+Account-window snapshots are captured at every state-mutating transition by `src/window_snapshot.rs::capture` — at flow start, every phase enter/complete, every step counter increment, and flow complete. Each snapshot records account-window pcts (5h, 7d), session token totals with per-model split, session cost, turn/tool counts, and most-recent-turn context utilization. Every numeric field is `Option<...>` for fail-open semantics. Consumers read snapshots through `src/window_deltas.rs` which groups by `session_id`.
 
 ### Start-Init → Init-State Contract
 
-`start-init` derives the canonical branch name (issue-aware via `fetch_issue_info` + `branch_name`) BEFORE acquiring the start lock. It also computes `relative_cwd` from `cwd.canonicalize().strip_prefix(project_root.canonicalize())` so the captured subdirectory is symlink-stable. It then passes `--branch <canonical> --relative-cwd <rel>` to the `init-state` subprocess, which skips its own derivation and uses the provided values directly. This two-step design ensures the lock is acquired and released under the same name (the canonical branch name). `init-state` retains its full derivation path for backwards compatibility when called directly via `bin/flow init-state` without `--branch`.
+`start-init` derives the canonical branch name (issue-aware via `fetch_issue_info` + `branch_name`) BEFORE acquiring the start lock. It computes `relative_cwd` from `cwd.canonicalize().strip_prefix(project_root.canonicalize())`. It then passes `--branch <canonical> --relative-cwd <rel>` to the `init-state` subprocess, which uses the provided values directly. This ensures the lock is acquired and released under the same name.
 
 ### Auto-Advance Architecture
 
-Phase auto-advance uses two layers. Layer 1: the phase completion command (`phase-finalize` for phases 1, 3, 4, 5; `phase-transition --action complete` for phase 2; `complete-finalize` for phase 6) returns `continue_action` (`"invoke"` or `"ask"`) and optionally `continue_target` (the next phase command) in its JSON output. Skill HARD-GATEs parse `continue_action` to decide whether to auto-invoke the next phase or prompt the user. Layer 2: `phase_complete()` writes `_auto_continue` to the state file when `continue_action` is `"invoke"`. The `bin/flow hook validate-ask-user` PreToolUse hook reads `_auto_continue` and auto-answers any `AskUserQuestion` that fires — this is a safety net for cases where the model ignores the HARD-GATE and prompts anyway. Block-first ordering: when the current phase's `phases.<current_phase>.status == "in_progress"` AND the skills config marks it autonomous (`skills.<current_phase>.continue == "auto"`), the same `validate-ask-user` hook returns exit 2 with a rejection message instead of auto-answering — the block path precedes the auto-answer path so the user's explicit continue=auto config wins over any transient boundary state (see `.claude/rules/autonomous-phase-discipline.md`). The `in_progress` scope is load-bearing: after `phase_complete()` advances `current_phase` to the next phase, the next phase's status is still `"pending"` until `phase_enter()` runs, so the completing skill's HARD-GATE prompt to approve the transition is NOT blocked even when the next phase is auto. `phase_enter()` clears `_auto_continue`, `_continue_pending`, and `_continue_context` when the next phase starts. The `continue_target` field is provided for diagnostic consumers; skills use hardcoded successor commands for reliability.
+Two layers:
+
+1. The phase completion command returns `continue_action` (`"invoke"` or `"ask"`) and optionally `continue_target` in its JSON. Skill HARD-GATEs parse `continue_action` to decide whether to auto-invoke the next phase or prompt the user.
+2. `phase_complete()` writes `_auto_continue` to the state file when `continue_action` is `"invoke"`. The `validate-ask-user` PreToolUse hook reads this and auto-answers any `AskUserQuestion` that fires — safety net for cases where the model ignores the HARD-GATE.
+
+Block-first ordering: when the current phase's `phases.<current_phase>.status == "in_progress"` AND `skills.<current_phase>.continue == "auto"`, `validate-ask-user` returns exit 2 instead of auto-answering. The block path precedes the auto-answer path. The `in_progress` scope is load-bearing: the next phase's status is still `"pending"` until `phase_enter()` runs, so the completing skill's HARD-GATE prompt to approve transitions is NOT blocked even when the next phase is auto. `phase_enter()` clears `_auto_continue`, `_continue_pending`, `_continue_context`. See `.claude/rules/autonomous-phase-discipline.md`.
 
 ### Permission Invariant
 
-Every bash block in every skill must run without triggering a permission prompt. `tests/permissions.rs` enforces at test time (placeholder substitution, allow/deny matching); `bin/flow hook validate-pretool` enforces at runtime via global PreToolUse hook (compound commands, command substitution, redirection, and file-read commands blocked — the compound and redirect matchers are quote-aware, so operator characters inside single- or double-quoted arguments pass through, and unclosed quotes are pessimistically blocked; whitelist enforced when a flow is active; `general-purpose` sub-agents blocked during active FLOW phases). The same hook's Layer 10 mechanically blocks direct commit invocations (`git ... commit`, `bin/flow ... finalize-commit`, with first-token dequoting, `bash -c`/`sh -c` unwrapping, and skip-past `git -c k=v` / `git -C path` flags) when the hook's effective cwd or any `-C` target either resolves to the integration branch named by `default_branch_in` OR resolves to a feature branch with an active FLOW state file at `.flow-states/<branch>/state.json`. The active-flow context carries a skill-commit carve-out: `bin/flow ... finalize-commit` (and only that shape — never `git commit`) passes through when the state file has `_continue_pending == "commit"`, the marker the flow-code, flow-code-review, and flow-learn skills set immediately before invoking `/flow:flow-commit`. The integration-branch context is NOT carved out. See `.claude/rules/concurrency-model.md` "Mechanical Enforcement" for the bypasses defeated, the active-flow trigger, the carve-out's trust contract, and the documented v1 gaps (env-var indirection, git aliases, `xargs`-style indirection, and other unknown launchers). `bin/flow hook validate-ask-user` additionally blocks `AskUserQuestion` tool calls with exit 2 when the current phase is both in-progress (`phases.<current_phase>.status == "in_progress"`) and autonomous (`skills.<current_phase>.continue == "auto"`) — see `.claude/rules/autonomous-phase-discipline.md` for the motivating incidents and the intentional transition-boundary carve-out. See `.claude/rules/permissions.md` for the pattern-adding protocol.
+Every bash block in every skill must run without triggering a permission prompt. `tests/permissions.rs` enforces at test time; `bin/flow hook validate-pretool` enforces at runtime via global PreToolUse hook (compound commands, command substitution, redirection, file-read commands blocked; whitelist enforced when a flow is active; `general-purpose` sub-agents blocked during active phases).
+
+Layer 10 mechanically blocks direct commit invocations (`git ... commit`, `bin/flow ... finalize-commit`) when the effective cwd resolves to the integration branch OR to a feature branch with an active state file. The active-flow context carries a skill-commit carve-out: `bin/flow ... finalize-commit` (only that shape, never `git commit`) passes through when the state file has `_continue_pending == "commit"`. The integration-branch context is NOT carved out.
+
+`validate-ask-user` blocks `AskUserQuestion` calls with exit 2 when the current phase is both in-progress AND autonomous.
+
+See `.claude/rules/concurrency-model.md` "Mechanical Enforcement" and `.claude/rules/permissions.md`.
 
 ### Plan-Phase Gates
 
-Phase 2 (Plan) gates completion on three scanners that share `bin/flow plan-check`: `src/scope_enumeration.rs::scan` (universal-coverage prose without a named sibling list), `src/external_input_audit.rs::scan` (panic/assert tightening proposals without a paired callsite source-classification audit table), and `src/duplicate_test_coverage.rs::scan` (proposed test names that normalize — strip `test_` prefix, lowercase — to an existing test in the repo's test corpus from `tests/**/*.rs` only; `src/*.rs` inline tests are prohibited by `.claude/rules/test-placement.md`). All three scanners run at three callsites — the standard path (`src/plan_check.rs::run_impl`), the pre-decomposed extracted path (`src/plan_extract.rs` extracted), and the resume path (`src/plan_extract.rs` resume) — so the gate cannot be bypassed by routing through an alternative phase entry. Each violation in the JSON response carries a `rule` field (`"scope-enumeration"`, `"external-input-audit"`, or `"duplicate-test-coverage"`) tying it to the rule file (`.claude/rules/scope-enumeration.md`, `.claude/rules/external-input-audit-gate.md`, or `.claude/rules/duplicate-test-coverage.md`) the author should consult for the fix. Duplicate-test-coverage violations additionally carry `existing_test` and `existing_file` fields naming the pre-existing test's location. Contract tests in `tests/scope_enumeration.rs` and `tests/external_input_audit.rs` lock the committed prose corpus (CLAUDE.md, `.claude/rules/*.md`, `skills/**/SKILL.md`, `.claude/skills/**/SKILL.md`) against drift for the scope-enumeration and external-input-audit rules. The duplicate-test-coverage scanner intentionally ships without a corpus contract test — legitimate educational test-name citations in rule files (e.g. `test_agent_frontmatter_only_supported_keys` above in the Sub-Agents section) would false-positive, and the Plan-phase gate already catches the real regression (a plan that names an existing test is rejected at plan-check time regardless of where the name appeared in committed prose). See `tests/duplicate_test_coverage.rs` for the rationale.
+Phase 2 gates completion on three scanners that share `bin/flow plan-check`:
+
+- `src/scope_enumeration.rs::scan` — universal-coverage prose without a named sibling list
+- `src/external_input_audit.rs::scan` — panic/assert tightening proposals without a paired callsite source-classification audit table
+- `src/duplicate_test_coverage.rs::scan` — proposed test names that normalize to an existing test in `tests/**/*.rs`
+
+All three run at three callsites: standard path (`src/plan_check.rs`), pre-decomposed extracted path, and resume path (both in `src/plan_extract.rs`). Each violation carries a `rule` field tying it to its rule file. Contract tests in `tests/scope_enumeration.rs` and `tests/external_input_audit.rs` lock the committed prose corpus against drift.
 
 ### Tombstone Lifecycle
 
-Tombstone tests prevent merge conflicts from silently resurrecting deleted code. The lifecycle has two halves: creation (`.claude/rules/tombstone-tests.md`) and removal (`bin/flow tombstone-audit`). Standalone tombstones (file-existence, source-content checks) live in `tests/tombstones.rs`. Topical tombstones that are integral to a test domain (skill_contracts, structural, dispatcher) stay in their respective test files. The `tombstone-audit` subcommand scans ALL `tests/*.rs` files for PR references, queries GitHub for merge dates, and classifies each as stale or current. Code Review Step 1 runs the audit; Step 4 removes stale tombstones.
+Tombstone tests prevent merge conflicts from silently resurrecting deleted code. Standalone tombstones live in `tests/tombstones.rs`; topical tombstones integral to a test domain stay in their respective test files. `bin/flow tombstone-audit` scans all `tests/*.rs` for PR references, queries GitHub for merge dates, and classifies each as stale or current. Code Review Step 1 runs the audit; Step 4 removes stale tombstones. See `.claude/rules/tombstone-tests.md`.
 
 ### 100% Coverage Is Enforced
 
-Every production line in `src/*.rs` must be exercised by a named
-test. The gate is `bin/test` itself — on full-suite runs it passes
-`--fail-under-lines <L>`, `--fail-under-regions <R>`, and
-`--fail-under-functions <F>` to `cargo llvm-cov nextest`. When any
-aggregate falls below its threshold, CI exits non-zero and
-`finalize-commit` blocks the commit.
+Every production line in `src/*.rs` must be exercised by a named test. The gate is `bin/test` itself — full-suite runs pass `--fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100` to `cargo llvm-cov nextest`. When any aggregate falls below threshold, CI exits non-zero and `finalize-commit` blocks the commit.
 
-The thresholds are pinned at 100/100/100. They are never lowered —
-a regression is a CI-blocking failure, not grounds to relax the
-gate.
-
-The 100/100/100 gate is the load-bearing mechanism. `.claude/rules/no-waivers.md`
-forbids per-line waiver files and the "measurement-only task"
-antipattern that lets a session declare victory at <100%. The Code
-Review reviewer agent treats any uncovered line as a Real finding
-per `.claude/rules/code-review-scope.md`. Coverage-required tests —
-tests whose only purpose is to exercise a branch — are explicitly
-sanctioned by `.claude/rules/tests-guard-real-regressions.md`
-"Coverage-Required Tests" because the gate itself names their
-consumer.
+Thresholds are pinned at 100/100/100 — never lowered. `.claude/rules/no-waivers.md` forbids per-line waiver files. Coverage-required tests are sanctioned by `.claude/rules/tests-guard-real-regressions.md`.
 
 ## Test Architecture
 
-All tests are Rust integration tests in `tests/*.rs`. Shared helpers in `tests/common/mod.rs` provide `repo_root()`, `bin_dir()`, `hooks_dir()`, `skills_dir()`, `docs_dir()`, `agents_dir()`, `load_phases()`, `load_hooks()`, `plugin_version()`, `phase_order()`, `utility_skills()`, `read_skill()`, `collect_md_files()`, and `create_git_repo_with_remote()`.
+All tests are Rust integration tests in `tests/*.rs`. Shared helpers in `tests/common/mod.rs`: `repo_root()`, `bin_dir()`, `hooks_dir()`, `skills_dir()`, `docs_dir()`, `agents_dir()`, `load_phases()`, `load_hooks()`, `plugin_version()`, `phase_order()`, `utility_skills()`, `read_skill()`, `collect_md_files()`, `create_git_repo_with_remote()`.
 
 <!-- duplicate-test-coverage: not-a-new-test -->
-Key test files: `tests/structural.rs` (config invariants, version consistency), `tests/skill_contracts.rs` (SKILL.md content via glob-based discovery — new skills auto-covered; `phase_skills_no_inline_time_computation` blocks skills that instruct Claude to compute values), `tests/permissions.rs` (allow/deny simulation, placeholder validation), `tests/docs_sync.rs` (docs completeness), `tests/concurrency.rs` (real-process concurrency).
+Key test files: `tests/structural.rs` (config invariants, version consistency), `tests/skill_contracts.rs` (SKILL.md content via glob-based discovery — `phase_skills_no_inline_time_computation` blocks skills that instruct Claude to compute values), `tests/permissions.rs`, `tests/docs_sync.rs`, `tests/concurrency.rs`.
 
 ## Maintainer Skills (private to this repo)
 
 - `/flow-release` — `.claude/skills/flow-release/SKILL.md` — bump version, tag, push, create GitHub Release
-- `/flow-changelog-audit` — `.claude/skills/flow-changelog-audit/SKILL.md` — audit Claude Code CHANGELOG.md for plugin-relevant changes, categorize as Adopt/Remove/Adapt, file issues
+- `/flow-changelog-audit` — audit Claude Code CHANGELOG.md for plugin-relevant changes
 
-When developing FLOW itself, point Claude Code at the local plugin source via `claude --plugin-dir=$HOME/code/flow` (or the worktree path you are working in). The installed marketplace plugin enforces phase counts and skill gates from the released version, which conflict with in-progress source changes; `--plugin-dir` overrides the installed version for the duration of the session so source-level edits take effect on the next session start.
+When developing FLOW itself, point Claude Code at the local plugin source via `claude --plugin-dir=$HOME/code/flow`. The installed marketplace plugin enforces phase counts and skill gates from the released version, which conflict with in-progress source changes; `--plugin-dir` overrides for the session.
 
 ## Conventions
 
-- **Never invoke `/flow-release` unless the user explicitly runs it** — fixing a bug does not authorize a release. Committing a fix and releasing it are separate decisions. The user decides when to ship.
-- All commits via `/flow:flow-commit` skill — no exceptions, no shortcuts, no "just this once". The commit skill's `git diff --cached` check handles empty diffs via its "Nothing to commit" return path, so a session that only needs to verify CI never needs a shortcut. Infrastructure commits during `start-gate` (e.g., `commit_deps` for dependency lock files) are the sole carve-out: they commit directly via Rust under the start lock, before any worktree exists.
-- All changes require `bin/flow ci` green before committing — tests are the gate
-- New skills are automatically covered by `tests/skill_contracts.rs` (glob-based discovery)
-- Namespace is `flow:` — plugin.json name is `"flow"`
-- Never rebase — merge only (denied in `.claude/settings.json`)
-- **Skills must never instruct Claude to compute values** — no timestamp generation, no time arithmetic, no counter increments, no `date -u`. All computation goes through `bin/flow` subcommands. Skills say "run this command", never "calculate this value". `tests/skill_contracts.rs` enforces this: `phase_skills_no_inline_time_computation` fails if any phase skill contains computational instruction patterns.
-- **All timestamps use Pacific Time** — `src/utils.rs` provides `now()` which returns Pacific Time ISO 8601 timestamps. All Rust code uses this function — never generate timestamps via other means.
-- **Prefer dedicated tools over Bash** — see `.claude/rules/worktree-commands.md`
-- **Issue filing** — see `.claude/rules/filing-issues.md`
-- **Repo-level targets only** — see `.claude/rules/repo-level-only.md`
-- **Scope enumeration for universal-coverage claims** — see `.claude/rules/scope-enumeration.md`
-- **External-input audit for panic/assert tightenings** — see `.claude/rules/external-input-audit-gate.md`
-- **Extract-helper branch enumeration for refactor plans** — see `.claude/rules/extract-helper-refactor.md`
-- **Duplicate test coverage for proposed test names** — see `.claude/rules/duplicate-test-coverage.md`
-- **No `run_in_background` during FLOW phases**; `bin/flow` (any subcommand) is never allowed in the background regardless of mode — see `.claude/rules/ci-is-a-gate.md`. Enforced by `bin/flow hook validate-pretool`.
-- **User evidence is ground truth** — when a user provides screenshots, error output, or logs that contradict your code analysis, trust the evidence. Your code reading is a hypothesis; the user's evidence is an observation. Never explain away evidence to preserve your analysis.
+- **Never invoke `/flow-release` unless the user explicitly runs it** — fixing a bug does not authorize a release.
+- All commits via `/flow:flow-commit` skill — no exceptions, no shortcuts. Infrastructure commits during `start-gate` (e.g., `commit_deps` for dependency lock files) are the sole carve-out: they commit directly via Rust under the start lock, before any worktree exists.
+- All changes require `bin/flow ci` green before committing — tests are the gate.
+- New skills are automatically covered by `tests/skill_contracts.rs`.
+- Namespace is `flow:` — plugin.json name is `"flow"`.
+- Never rebase — merge only.
+- **Skills must never instruct Claude to compute values** — no timestamp generation, no time arithmetic, no counter increments. All computation goes through `bin/flow` subcommands.
+- **All timestamps use Pacific Time** — `src/utils.rs::now()` returns Pacific Time ISO 8601. All Rust code uses this function.
+- **Prefer dedicated tools over Bash** — see `.claude/rules/worktree-commands.md`.
+- **Issue filing** — see `.claude/rules/filing-issues.md`.
+- **Repo-level targets only** — see `.claude/rules/repo-level-only.md`.
+- **Scope enumeration for universal-coverage claims** — see `.claude/rules/scope-enumeration.md`.
+- **External-input audit for panic/assert tightenings** — see `.claude/rules/external-input-audit-gate.md`.
+- **Extract-helper branch enumeration for refactor plans** — see `.claude/rules/extract-helper-refactor.md`.
+- **Duplicate test coverage for proposed test names** — see `.claude/rules/duplicate-test-coverage.md`.
+- **No `run_in_background` during FLOW phases**; `bin/flow` is never allowed in the background — see `.claude/rules/ci-is-a-gate.md`.
+- **User evidence is ground truth** — when a user provides screenshots or logs that contradict your code analysis, trust the evidence. Your code reading is a hypothesis; the user's evidence is an observation.

--- a/tests/opt_out_inventory.rs
+++ b/tests/opt_out_inventory.rs
@@ -1,0 +1,174 @@
+//! Frozen inventory of opt-out comments in the rule corpus.
+//!
+//! Opt-out comments (`<!-- scope-enumeration: imperative -->`,
+//! `<!-- external-input-audit: not-a-tightening -->`, etc.) disable
+//! specific lint scanners on adjacent prose. Each one is a sanctioned
+//! bypass — but it is still a bypass, and the project's discipline is
+//! that bypasses should be rare and visible.
+//!
+//! This test pins the exact set of opt-out occurrences in the rule
+//! corpus. Adding a new opt-out fails the test until the EXPECTED
+//! constant is updated in the same diff — making every new bypass a
+//! deliberate, reviewable change rather than something a session can
+//! sneak in to make CI green.
+//!
+//! When the test fails:
+//! - Removed opt-out: confirm the prose was reworded to drop the
+//!   trigger (not just the comment) and remove the entry from EXPECTED.
+//! - Added opt-out: prefer rewording the prose to avoid the trigger
+//!   instead. Adding an opt-out is the wrong fix for most cases.
+//!   When an opt-out is genuinely warranted, add it to EXPECTED and
+//!   justify the bypass in the commit message.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+mod common;
+
+/// One entry per active opt-out comment in the corpus, sorted.
+/// Format: `<relative_path>::<kind>::<variant>`.
+///
+/// "Active" means the comment is not inside a fenced code block (those
+/// are documentation examples) and not wrapped in backticks (those are
+/// prose references to the comment, not active bypasses).
+const EXPECTED: &[&str] = &[
+    "CLAUDE.md::duplicate-test-coverage::not-a-new-test",
+    "CLAUDE.md::duplicate-test-coverage::not-a-new-test",
+    ".claude/rules/branch-path-safety.md::scope-enumeration::imperative",
+    ".claude/rules/branch-path-safety.md::scope-enumeration::imperative",
+    ".claude/rules/rust-patterns.md::scope-enumeration::imperative",
+    ".claude/rules/verify-runtime-path.md::scope-enumeration::imperative",
+    ".claude/rules/verify-runtime-path.md::scope-enumeration::imperative",
+    ".claude/rules/verify-runtime-path.md::scope-enumeration::imperative",
+    ".claude/rules/verify-runtime-path.md::scope-enumeration::imperative",
+    ".claude/rules/verify-runtime-path.md::scope-enumeration::imperative",
+    ".claude/rules/verify-runtime-path.md::scope-enumeration::imperative",
+];
+
+#[test]
+fn opt_out_inventory_is_frozen() {
+    let repo_root = common::repo_root();
+    let mut actual = collect(&repo_root);
+    actual.sort();
+    let mut expected: Vec<String> = EXPECTED.iter().map(|s| s.to_string()).collect();
+    expected.sort();
+
+    if actual == expected {
+        return;
+    }
+
+    let mut msg = String::from("Opt-out inventory drift in CLAUDE.md / .claude/rules/:\n\n");
+    for entry in &expected {
+        if count(&actual, entry) < count(&expected, entry)
+            && !msg.contains(&format!("REMOVED: {}", entry))
+        {
+            msg.push_str(&format!("  REMOVED: {}\n", entry));
+        }
+    }
+    for entry in &actual {
+        if count(&expected, entry) < count(&actual, entry)
+            && !msg.contains(&format!("ADDED:   {}", entry))
+        {
+            msg.push_str(&format!("  ADDED:   {}\n", entry));
+        }
+    }
+    msg.push_str(
+        "\nOpt-out comments are sanctioned bypasses for prose that would otherwise\n\
+         trip a corpus scanner (scope-enumeration, external-input-audit,\n\
+         duplicate-test-coverage, extract-helper-refactor). Every entry in this\n\
+         inventory is a deliberate exception. To resolve drift:\n\n\
+         - REMOVED entries: verify the underlying prose was actually reworded to\n\
+           drop the scanner trigger (not just the bypass comment). If yes, remove\n\
+           the entry from EXPECTED in tests/opt_out_inventory.rs.\n\n\
+         - ADDED entries: prefer rewording the prose to avoid the scanner trigger.\n\
+           Adding an opt-out is the wrong fix for most cases. When an opt-out is\n\
+           genuinely warranted (the prose is imperative or the family is\n\
+           open-ended), add the entry to EXPECTED and justify the bypass in the\n\
+           commit message body.\n",
+    );
+    panic!("{}", msg);
+}
+
+fn count<S: AsRef<str> + PartialEq>(haystack: &[S], needle: &S) -> usize {
+    haystack.iter().filter(|x| *x == needle).count()
+}
+
+fn collect(repo_root: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+
+    let mut paths: Vec<PathBuf> = vec![repo_root.join("CLAUDE.md")];
+    let rules_dir = repo_root.join(".claude").join("rules");
+    let mut rule_files: Vec<PathBuf> = fs::read_dir(&rules_dir)
+        .expect("read .claude/rules/")
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("md") {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+    rule_files.sort();
+    paths.extend(rule_files);
+
+    for path in paths {
+        let rel = path
+            .strip_prefix(repo_root)
+            .expect("path under repo_root")
+            .to_string_lossy()
+            .to_string();
+        let content = fs::read_to_string(&path).expect("read corpus file");
+        scan_file(&rel, &content, &mut out);
+    }
+
+    out
+}
+
+fn scan_file(rel_path: &str, content: &str, out: &mut Vec<String>) {
+    let mut in_fence = false;
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        if let Some((kind, variant)) = extract_optout(line) {
+            out.push(format!("{}::{}::{}", rel_path, kind, variant));
+        }
+    }
+}
+
+/// Extract the first active opt-out comment on a line.
+/// Returns `None` for lines with no opt-out, or where the opt-out is
+/// wrapped in backticks (a prose reference, not an active bypass).
+fn extract_optout(line: &str) -> Option<(String, String)> {
+    const KINDS: &[&str] = &[
+        "scope-enumeration",
+        "external-input-audit",
+        "duplicate-test-coverage",
+        "extract-helper-refactor",
+    ];
+    let mut best: Option<(usize, String, String)> = None;
+    for kind in KINDS {
+        let needle = format!("<!-- {}: ", kind);
+        if let Some(start) = line.find(&needle) {
+            // Skip if inside a backtick span (odd count of backticks before).
+            let backticks_before = line[..start].chars().filter(|c| *c == '`').count();
+            if backticks_before % 2 == 1 {
+                continue;
+            }
+            let after_kind = &line[start + needle.len()..];
+            if let Some(end) = after_kind.find(" -->") {
+                let variant = after_kind[..end].to_string();
+                if best.as_ref().is_none_or(|(s, _, _)| start < *s) {
+                    best = Some((start, kind.to_string(), variant));
+                }
+            }
+        }
+    }
+    best.map(|(_, k, v)| (k, v))
+}

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -660,10 +660,8 @@ fn phase_skills_no_inline_time_computation() {
 /// above each opening ```bash fence. The backward walk stops at any
 /// prior fenced block — each CI-invoking block must have its own
 /// adjacent preamble, and inheritance across unrelated blocks is
-/// prohibited. This closes the adjacent-block inheritance gap found
-/// by Code Review's adversarial agent (PR #1183, finding A10) at the
-/// cost of requiring each adjacent variant in the same section to
-/// carry its own preamble.
+/// prohibited. Adjacent variants in the same section each carry their
+/// own preamble.
 #[test]
 fn skill_ci_invocations_specify_long_timeout() {
     // CI-running subcommand family. Each entry runs `ci::run_impl()`
@@ -3236,11 +3234,11 @@ fn flow_plan_skill_has_extract_helper_branch_enumeration() {
 fn extract_helper_refactor_rule_has_expected_structure() {
     // The SKILL.md Extract-Helper Branch Enumeration subsection
     // cross-references .claude/rules/extract-helper-refactor.md for the
-    // full trigger vocabulary, the three classifications, the opt-out
-    // grammar, and the motivating PR #1155 incident. This test asserts
-    // that rule file exists and contains the canonical elements the
-    // SKILL.md cross-reference promises, so a broken cross-reference
-    // or a missing section fails CI instead of silently shipping.
+    // full trigger vocabulary, the three classifications, and the
+    // opt-out grammar. This test asserts that rule file exists and
+    // contains the canonical elements the SKILL.md cross-reference
+    // promises, so a broken cross-reference or a missing section fails
+    // CI instead of silently shipping.
     let path = common::repo_root()
         .join(".claude")
         .join("rules")
@@ -3265,11 +3263,6 @@ fn extract_helper_refactor_rule_has_expected_structure() {
          'extract-helper-refactor: not-an-extraction'"
     );
 
-    assert!(
-        content.contains("PR #1155"),
-        "extract-helper-refactor.md must cite the motivating PR #1155 incident"
-    );
-
     // The rule file must carry the canonical section structure the
     // SKILL.md cross-reference promises. A future edit that removes
     // Why, The Rule, The Three Classifications, or Enforcement
@@ -3283,7 +3276,6 @@ fn extract_helper_refactor_rule_has_expected_structure() {
         "## Enforcement",
         "## Opt-Out Grammar",
         "## How to Apply",
-        "## Motivating Incident",
     ] {
         assert!(
             content.contains(section),


### PR DESCRIPTION
tl;dr

CLAUDE.md was 45.7k chars (over the 40k performance threshold) and
the .claude/rules/ corpus had accumulated ~30 explicit "Motivating
Incident" sections plus inline "PR #NNNN surfaced..." narratives
that forward-facing-authoring.md itself prohibits. This audit
strips that backward-facing prose, collapses verbose Why sections
that just restated the rule, and removes per-file src/*.rs
paragraphs from CLAUDE.md (those belong in module doc comments).
A new tests/opt_out_inventory.rs freezes the exact set of
scope-enumeration / external-input-audit / duplicate-test-coverage /
extract-helper-refactor opt-out comments — adding or dropping a
bypass now fails CI until the EXPECTED constant is bumped, making
every new bypass a deliberate, reviewable change.

- CLAUDE.md: drop verbose src/*.rs Key Files paragraphs, tighten architectural sections; 45.7k to 23.9k.
- tests/opt_out_inventory.rs: new meta-test pinning the inventory of bypass comments in CLAUDE.md and .claude/rules/; fails CI on any addition, removal, or movement.
- .claude/rules/test-placement.md: add tests/opt_out_inventory.rs to the meta-test exception list.
- .claude/rules/rust-patterns.md: trim verbose pattern explanations; remove backward-facing prose; preserve <!-- scope-enumeration: imperative --> opt-out on the saturating_add directive; 30k to 24k.
- .claude/rules/extract-helper-refactor.md: remove Motivating Incident section; trim Why; 16k to 7.8k.
- .claude/rules/plan-commit-atomicity.md: remove two Motivating Incident sections; tighten Plan Signature Deviations; 15k to 9.8k.
- .claude/rules/permissions.md: remove The Anti-Pattern PR narrative; tighten enforcement prose; 15k to 10.1k.
- .claude/rules/testing-gotchas.md: remove Subsection-Local Assertions incident reference; tighten verbose subsections.
- .claude/rules/tests-guard-real-regressions.md: remove Motivating Incident; trim Why.
- .claude/rules/tombstone-tests.md: remove PR-citation-laden examples; tighten lifecycle prose.
- .claude/rules/file-tool-preflights.md: tighten Why and intermediate-file lifecycle sections.
- .claude/rules/concurrency-model.md: tighten Mechanical Enforcement subsections.
- .claude/rules/security-gates.md: tighten Why and Gate-Action Atomicity narrative.
- .claude/rules/test-placement.md: tighten Why; remove duplicated testable-via-seam content.
- .claude/rules/skill-authoring.md: trim each subsection's Why; remove PR-anchored examples; 30k to 26k.
- .claude/rules/code-review-scope.md: tighten Value-vs-Bureaucracy section.
- .claude/rules/external-input-validation.md: remove issue-narrative anchors; tighten codebase-wide rule prose.
- .claude/rules/external-input-audit-gate.md: tighten Why; remove incident citations.
- .claude/rules/external-input-path-construction.md: tighten Why and Reference Implementation sections.
- .claude/rules/scope-enumeration.md: tighten Why; remove incident references.
- .claude/rules/duplicate-test-coverage.md: trim Why; remove issue narrative.
- .claude/rules/autonomous-phase-discipline.md: remove PR #1046 reference; tighten Why.
- .claude/rules/branch-path-safety.md: tighten How to Apply section.
- .claude/rules/code-task-counter.md: remove PR #1156 references; tighten Why.
- .claude/rules/comment-quality.md: tighten Enforcement section.
- .claude/rules/forward-facing-authoring.md: remove How Code Review Applies This narrative; tighten.
- .claude/rules/hook-state-timing.md: remove PR #1053 narrative; tighten Why.
- .claude/rules/no-waivers.md: tighten Forbidden Plan Prose subsections.
- .claude/rules/panic-safe-cleanup.md: remove issue/PR refs; tighten Why and Reference Implementation.
- .claude/rules/subprocess-argument-escaping.md: remove PR #1154 narrative; tighten Why.
- .claude/rules/permission-blocked-workarounds.md: remove PR #1166 incident anchor; tighten Pattern.
- .claude/rules/tool-dispatch.md: tighten Why subsections; remove PR #1333 reference.
- .claude/rules/cli-output-contracts.md: tighten Required Plan-Phase Contract.
- .claude/rules/config-source-mapping.md: tighten How to Apply.
- .claude/rules/gate-consumer-enumeration.md: tighten Why and How to Apply.
- .claude/rules/per-file-coverage-iteration.md: tighten Why and Phantom Misses sections.
- .claude/rules/reachable-is-testable.md: tighten "Covered elsewhere" subsection.
- .claude/rules/subprocess-test-hygiene.md: tighten Why subsections.
- .claude/rules/supersession.md: tighten Cascading Deletion Analysis.
- .claude/rules/testability-means-simplicity.md: tighten Cross-references.
- .claude/rules/adversarial-probe-lifecycle.md: tighten The Rule and How to Apply.
- .claude/rules/docs-with-behavior.md: tighten Feature-Configurable Prose Generalization.
- .claude/rules/ci-is-a-gate.md: drop "as of issue #1182" reference in CI-running family list.
