### PR TITLE
Block Model Invocation Of User

### DIFF
--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -94,9 +94,18 @@ window, `_auto_continue` behaves unchanged.
 The blocked tool call returns the rejection message to the
 model via stderr so the session adapts instead of stalling.
 
-**Known limitation.** `/flow:flow-abort --manual` calls
-`AskUserQuestion` for its destructive-operation confirmation. If
-the user invokes it during an in-progress autonomous phase, the
-hook blocks that confirmation. Workaround: invoke with `--auto`
-to skip the confirmation, or accept the block by switching the
-current phase to `manual` before aborting.
+## User-Only Skill Carve-Out
+
+When a user types `/flow:flow-abort`, `/flow:flow-reset`,
+`/flow:flow-release`, or `/flow:flow-prime` mid-flow, the resulting
+skill invocation often fires an `AskUserQuestion` for
+destructive-operation confirmation. The autonomous-phase block
+above would otherwise reject that confirmation, deadlocking the
+abort. `validate-ask-user::user_only_skill_carve_out_applies`
+suppresses the block when the most recent assistant Skill tool_use
+call (since the most recent user turn) targets a skill in
+`crate::hooks::transcript_walker::USER_ONLY_SKILLS`. The carve-out
+is the user-direction signal — a Skill call to a user-only skill
+can only have arrived because the user typed the slash command,
+which `validate-skill` Layer 1 enforces. See
+`.claude/rules/user-only-skills.md` Layer 2 for the full design.

--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -96,16 +96,21 @@ model via stderr so the session adapts instead of stalling.
 
 ## User-Only Skill Carve-Out
 
-When a user types `/flow:flow-abort`, `/flow:flow-reset`,
-`/flow:flow-release`, or `/flow:flow-prime` mid-flow, the resulting
-skill invocation often fires an `AskUserQuestion` for
-destructive-operation confirmation. The autonomous-phase block
-above would otherwise reject that confirmation, deadlocking the
-abort. `validate-ask-user::user_only_skill_carve_out_applies`
-suppresses the block when the most recent assistant Skill tool_use
-call (since the most recent user turn) targets a skill in
-`crate::hooks::transcript_walker::USER_ONLY_SKILLS`. The carve-out
-is the user-direction signal — a Skill call to a user-only skill
-can only have arrived because the user typed the slash command,
-which `validate-skill` Layer 1 enforces. See
-`.claude/rules/user-only-skills.md` Layer 2 for the full design.
+The autonomous-phase block above protects against model-initiated
+prompts. When a user types `/flow:flow-abort`, `/flow:flow-reset`,
+`/flow:flow-release`, or `/flow:flow-prime` mid-flow, the
+resulting skill invocation fires an `AskUserQuestion` for
+destructive-operation confirmation — and that prompt is
+user-initiated, not model-initiated, so it should fire even
+during in-progress autonomous phases.
+
+`validate-ask-user::user_only_skill_carve_out_applies` recognizes
+this case and allows the AskUserQuestion through. The check
+inspects the persisted transcript: when the most recent assistant
+Skill tool_use call (since the most recent user turn) targets a
+skill in `crate::hooks::transcript_walker::USER_ONLY_SKILLS`, the
+prompt fires. The presence of an assistant Skill call to a user-
+only skill is the user-direction signal — `validate-skill` Layer
+1 ensures the model can only reach that Skill call after the user
+typed the slash command. See `.claude/rules/user-only-skills.md`
+Layer 2 for the full design.

--- a/.claude/rules/flow-requires-user-initiative.md
+++ b/.claude/rules/flow-requires-user-initiative.md
@@ -1,7 +1,38 @@
 # Flow Requires User Initiative
 
-Never invoke `/flow:flow-start` or `/flow:flow-create-issue` unless
-the user explicitly asks for it. If you believe a change should go
-through the FLOW lifecycle, say so — but let the user decide.
-Never auto-start a flow because you think the change is big enough
-to warrant one.
+FLOW skills divide into two authorization tiers based on the action
+they perform.
+
+## User-Only Skills (model must never invoke)
+
+Four skills must be invoked directly by the user — the model never
+proposes them and never invokes them, even after hypothetical
+approval. See `.claude/rules/user-only-skills.md` for the full set
+and the three-layer mechanical enforcement chain
+(`validate-skill`, `validate-ask-user` carve-out, transcript root
+lockdown).
+
+The user-only set:
+
+- `/flow:flow-abort`
+- `/flow:flow-reset`
+- `/flow:flow-release`
+- `/flow:flow-prime`
+
+## Ask-First Skills (model may invoke after user agreement)
+
+The remaining lifecycle-initiating skills follow an ask-first
+pattern: never invoke unless the user explicitly asks. If you
+believe a change should go through the FLOW lifecycle, say so —
+but let the user decide. Never auto-start a flow because you think
+the change is big enough to warrant one.
+
+The ask-first family includes:
+
+- `/flow:flow-start`
+- `/flow:flow-create-issue`
+
+Distinguishing test: would the model proposing the action embarrass
+or surprise the user if their answer were "no"? If the answer is
+"yes, this would be lost work or a public artifact" → user-only.
+If the answer is "no, it would be a wasted prompt" → ask-first.

--- a/.claude/rules/hook-error-diagnosis.md
+++ b/.claude/rules/hook-error-diagnosis.md
@@ -14,6 +14,7 @@ anything.
 - `PreToolUse:Read`, `PreToolUse:Glob`, `PreToolUse:Grep` →
   `validate-worktree-paths`
 - `PreToolUse:AskUserQuestion` → `validate-ask-user`
+- `PreToolUse:Skill` → `validate-skill`
 
 ## Procedure
 

--- a/.claude/rules/hook-vs-instruction.md
+++ b/.claude/rules/hook-vs-instruction.md
@@ -74,11 +74,30 @@ insufficient:
 - **`AskUserQuestion` during an autonomous in-progress phase**
   — `validate-ask-user` rejects with exit 2 when
   `phases.<current_phase>.status == "in_progress"` AND
-  `skills.<current_phase>.continue == "auto"`.
+  `skills.<current_phase>.continue == "auto"`. Carve-out: when
+  the most recent assistant Skill tool_use call (since the most
+  recent user turn) targets a skill in
+  `crate::hooks::transcript_walker::USER_ONLY_SKILLS`, the
+  block is suppressed so user-only skills' confirmation prompts
+  fire mid-autonomous. See `.claude/rules/user-only-skills.md`
+  Layer 2.
+- **Model invocation of user-only skills** —
+  `validate-skill` rejects Skill tool calls naming
+  `flow:flow-abort`, `flow:flow-reset`, `flow:flow-release`, or
+  `flow:flow-prime` when the most recent user-role turn in the
+  persisted transcript does NOT contain a matching
+  `<command-name>/<skill></command-name>` substring. See
+  `.claude/rules/user-only-skills.md` Layer 1.
 - **Edit/Write on `.claude/` paths during a flow** —
   `validate-claude-paths` redirects to
   `bin/flow write-rule` for `CLAUDE.md`,
   `.claude/rules/`, and `.claude/skills/`.
+- **Edit/Write on `~/.claude/projects/` (transcript root) in
+  any context** — `validate-claude-paths` rejects Edit/Write
+  regardless of flow state. The transcript file backs Layer 1's
+  user-invocation check; tampering would defeat
+  `validate-skill`. Read access is preserved for the walker
+  itself. See `.claude/rules/user-only-skills.md` Layer 3.
 - **Edit/Write on shared config files inside a worktree** —
   `validate-worktree-paths` rejects modifications to
   `.gitignore`, `.gitattributes`, `Makefile`, etc., without

--- a/.claude/rules/user-only-skills.md
+++ b/.claude/rules/user-only-skills.md
@@ -1,0 +1,115 @@
+# User-Only Skills
+
+Four FLOW skills are reserved for direct user invocation. The model
+must never invoke them — neither via the Skill tool, nor by
+suggesting that an `AskUserQuestion` answer should be "yes, run
+`/flow:flow-X`". Each skill performs an action whose authorization
+must come from explicit user intent (the user typing the slash
+command) rather than from inferred context.
+
+## The Set
+
+| Skill | Action | Reason for the gate |
+|---|---|---|
+| `/flow:flow-abort` | Closes the PR, deletes the remote branch, removes the worktree, deletes the state file. | Destructive — losing in-flight work. |
+| `/flow:flow-reset` | Same destructive shape but applied across every active flow on the machine. | Destructive — losing in-flight work across multiple flows. |
+| `/flow:flow-release` | Bumps version, tags, pushes, and creates a public GitHub Release. | Resource-shipping — visible to plugin marketplace consumers. |
+| `/flow:flow-prime` | Writes `.claude/settings.json` and the four `bin/*` stubs into the project. | Environment-mutating — modifies shared config the project has not yet reviewed. |
+
+The criterion is "model must never propose." This is stricter than
+the sibling "ask-first" pattern (`/flow:flow-create-issue`,
+`/flow:flow-start`, etc.) where the model may ask the user whether
+to proceed but the user then answers and the model invokes. For
+user-only skills the model does NOT invoke even after a
+hypothetical "yes" answer — the user types the slash command
+directly.
+
+## Three-Layer Enforcement Chain
+
+The four skills are protected by three independent mechanical
+gates so a single bypass does not defeat the discipline.
+
+### Layer 1: `validate-skill` (PreToolUse:Skill)
+
+`src/hooks/validate_skill.rs` runs on every Skill tool call. When
+`tool_input.skill` is in the user-only set AND the persisted
+transcript at `transcript_path` does NOT contain a matching
+`<command-name>/<skill></command-name>` substring in the most
+recent user-role turn, the hook exits 2 and Claude Code rejects
+the tool call. The block message names the skill and points to
+this rule file.
+
+The walker
+(`src/hooks/transcript_walker.rs::last_user_message_invokes_skill`)
+scans backward through the transcript JSONL, stops at the first
+user-role turn, and checks that turn for the matching tag. The
+read is capped at `TRANSCRIPT_BYTE_CAP` (50 MB) per
+`.claude/rules/external-input-path-construction.md`.
+
+### Layer 2: `validate-ask-user` carve-out
+
+`src/hooks/validate_ask_user.rs::user_only_skill_carve_out_applies`
+allows `AskUserQuestion` to fire even during in-progress
+autonomous phases when the most recent assistant Skill tool_use
+call (since the most recent user turn) targets a user-only skill.
+Without this carve-out, a user typing `/flow:flow-abort` during
+an in-progress autonomous Code phase would deadlock — the abort
+skill's destructive-confirmation prompt would be blocked by the
+existing autonomous-phase-discipline gate.
+
+The carve-out fires after `validate` would have returned a block
+and overrides it. The walker function
+(`most_recent_skill_in_user_only_set`) stops at the most recent
+user turn going backward — older Skill calls outside that window
+are invisible.
+
+### Layer 3: `validate-claude-paths` transcript root lockdown
+
+`src/hooks/validate_claude_paths.rs::is_transcript_path` blocks
+Edit/Write on `~/.claude/projects/<project>/<session>.jsonl` —
+the persisted transcript root. The block fires regardless of
+flow state because transcript tampering can subvert Layer 1: a
+hand-injected fake user `<command-name>` line in an old
+transcript would bypass the user-invocation check.
+
+Read access is preserved because Layer 1 and Layer 2 walkers
+themselves need to scan the file. The hook is registered for the
+Edit and Write matchers only in `hooks/hooks.json`.
+
+Residual surface: Bash file-mutation commands beyond redirect
+(`cp`, `mv`, `dd`) are not blocked by this layer — `validate-pretool`
+covers redirect (`>`, `>>`, `tee`). A future tightening could add
+those tokens to `validate-pretool`'s deny list when the target
+resolves under `~/.claude/projects/`.
+
+## How to Add a Skill to the User-Only Set
+
+1. Add the skill name (`flow:flow-<name>`) to `USER_ONLY_SKILLS` in
+   `src/hooks/transcript_walker.rs`.
+2. Add the skill row to the table in this rule file with action
+   description and threat-shape rationale.
+3. Add a `validate_user_only_skill_<name>_is_in_set` test in
+   `tests/validate_skill.rs`.
+4. Confirm the skill's `SKILL.md` has a HARD-GATE that prompts the
+   user before performing the destructive / resource-shipping
+   action.
+
+## How to Apply (Skill Authoring)
+
+When designing a new skill that performs a destructive,
+resource-shipping, or environment-mutating action, decide whether
+it belongs in the user-only set or the ask-first set:
+
+- **User-only** — the action's authorization must come from
+  explicit user intent. Adding the skill name to
+  `USER_ONLY_SKILLS` enables Layer 1 enforcement automatically.
+- **Ask-first** — the model may invoke after asking the user via
+  `AskUserQuestion`. No mechanical block; the discipline is
+  documented in `.claude/rules/flow-requires-user-initiative.md`.
+
+Default to user-only when the action's blast radius spans
+shared resources (PRs, branches, releases, project config).
+Reserve ask-first for scoped actions whose error path is local
+recovery (`/flow:flow-create-issue` files an issue but the user
+can close it; `/flow:flow-start` opens a worktree but the user
+can abort).

--- a/.claude/rules/user-only-skills.md
+++ b/.claude/rules/user-only-skills.md
@@ -29,39 +29,85 @@ directly.
 The four skills are protected by three independent mechanical
 gates so a single bypass does not defeat the discipline.
 
+### Layer threat mapping
+
+Each layer addresses a specific bypass surface:
+
+- **Layer 1 (`validate-skill`)** — defends against *direct model
+  invocation* of a user-only skill via the Skill tool. The hook
+  fires PreToolUse:Skill and blocks unless the most recent user-
+  role transcript turn typed the matching slash command.
+- **Layer 2 (`validate-ask-user` carve-out)** — defends against
+  *autonomous-phase deadlock* when a user typing
+  `/flow:flow-abort` mid-autonomous-flow needs the
+  destructive-confirmation prompt to fire. The carve-out
+  suppresses the autonomous-phase block on AskUserQuestion when
+  the most recent assistant Skill tool_use call fired a user-only
+  skill — meaning the user just typed the slash command and Layer
+  1 already verified it.
+- **Layer 3 (`validate-claude-paths` transcript root)** — defends
+  against *transcript tampering* that would defeat Layer 1's user-
+  invocation check. Blocks Edit/Write on `~/.claude/projects/`
+  regardless of flow state. Reads remain allowed because Layer 1
+  and Layer 2 walkers themselves need them.
+
+If Layer 1's substring or membership check has a bypass, Layers 2
+and 3 cannot independently catch the bypass — they are defense in
+depth around Layer 1's correctness, not redundant gates over the
+same surface. The Layer 1 gate's `normalize_gate_input`
+(NUL strip + trim + ASCII lowercase) and slash-command anchoring
+are therefore the load-bearing checks; the other two layers
+extend the protection but do not replace it.
+
 ### Layer 1: `validate-skill` (PreToolUse:Skill)
 
 `src/hooks/validate_skill.rs` runs on every Skill tool call. When
-`tool_input.skill` is in the user-only set AND the persisted
-transcript at `transcript_path` does NOT contain a matching
-`<command-name>/<skill></command-name>` substring in the most
-recent user-role turn, the hook exits 2 and Claude Code rejects
-the tool call. The block message names the skill and points to
-this rule file.
+`tool_input.skill` (after normalization) is in the user-only set
+AND the persisted transcript at `transcript_path` does NOT carry
+a matching `<command-name>/<skill></command-name>` substring AT
+THE START of the most recent user-role turn's `message.content`
+string, the hook exits 2 and Claude Code rejects the tool call.
+The block message names the skill (in canonical lowercased form)
+and points to this rule file.
 
 The walker
 (`src/hooks/transcript_walker.rs::last_user_message_invokes_skill`)
 scans backward through the transcript JSONL, stops at the first
-user-role turn, and checks that turn for the matching tag. The
-read is capped at `TRANSCRIPT_BYTE_CAP` (50 MB) per
-`.claude/rules/external-input-path-construction.md`.
+user-role turn, and requires the marker at the START of trimmed
+content (slash-command anchoring). User prose mentioning the
+literal marker mid-text, and tool_result-wrapped user turns whose
+content is an array of blocks (carrying assistant-echoed text),
+are explicitly rejected.
+
+The walker reads the LAST `TRANSCRIPT_BYTE_CAP` bytes of the
+file (50 MB) so the most recent turns are always visible
+regardless of total transcript size. Per
+`.claude/rules/external-input-path-construction.md`, the
+`transcript_path` is validated through
+`crate::window_snapshot::is_safe_transcript_path` — which rejects
+empty, NUL-byte, relative, ParentDir-component, and
+prefix-escaping paths.
 
 ### Layer 2: `validate-ask-user` carve-out
 
 `src/hooks/validate_ask_user.rs::user_only_skill_carve_out_applies`
 allows `AskUserQuestion` to fire even during in-progress
-autonomous phases when the most recent assistant Skill tool_use
-call (since the most recent user turn) targets a user-only skill.
-Without this carve-out, a user typing `/flow:flow-abort` during
-an in-progress autonomous Code phase would deadlock — the abort
-skill's destructive-confirmation prompt would be blocked by the
-existing autonomous-phase-discipline gate.
+autonomous phases when the most recent assistant turn fires at
+least one Skill tool_use whose `input.skill` (after normalization)
+is in `USER_ONLY_SKILLS`. Without this carve-out, a user typing
+`/flow:flow-abort` during an in-progress autonomous Code phase
+would deadlock — the abort skill's destructive-confirmation
+prompt would be blocked by the existing autonomous-phase-
+discipline gate.
 
 The carve-out fires after `validate` would have returned a block
 and overrides it. The walker function
 (`most_recent_skill_in_user_only_set`) stops at the most recent
 user turn going backward — older Skill calls outside that window
-are invisible.
+are invisible. Multi-tool assistant turns are scanned in full
+(extract_skill_invocations returns all Skill names), so a user-
+only Skill appearing second or later in the turn's content
+array still satisfies the carve-out.
 
 ### Layer 3: `validate-claude-paths` transcript root lockdown
 
@@ -113,3 +159,6 @@ Reserve ask-first for scoped actions whose error path is local
 recovery (`/flow:flow-create-issue` files an issue but the user
 can close it; `/flow:flow-start` opens a worktree but the user
 can abort).
+
+See `.claude/rules/autonomous-phase-discipline.md` "User-Only
+Skill Carve-Out" for the interaction with autonomous phases.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,16 @@ Layer 9 mechanically blocks direct commit invocations (`git ... commit`, `bin/fl
 
 See `.claude/rules/concurrency-model.md` "Mechanical Enforcement" and `.claude/rules/permissions.md`.
 
+### User-Only Skill Enforcement
+
+Four FLOW skills are reserved for direct user invocation: `/flow:flow-abort`, `/flow:flow-reset`, `/flow:flow-release`, and `/flow:flow-prime`. The model must never invoke them. Three independent mechanical layers enforce this:
+
+1. **Layer 1 — `validate-skill` (PreToolUse:Skill)**. `src/hooks/validate_skill.rs` blocks Skill tool calls naming a user-only skill unless the persisted transcript at `transcript_path` shows the most recent user-role turn typed `<command-name>/<skill></command-name>`. Backed by `src/hooks/transcript_walker.rs::last_user_message_invokes_skill`.
+2. **Layer 2 — `validate-ask-user` carve-out**. `src/hooks/validate_ask_user.rs::user_only_skill_carve_out_applies` allows `AskUserQuestion` to fire even during in-progress autonomous phases when the most recent assistant Skill tool_use call (since the most recent user turn) targets a user-only skill. Resolves the abort-during-autonomous-flow deadlock.
+3. **Layer 3 — `validate-claude-paths` transcript root lockdown**. `src/hooks/validate_claude_paths.rs::is_transcript_path` blocks Edit/Write on `~/.claude/projects/` regardless of flow state. Tampering with the persisted transcript would subvert Layer 1's user-invocation check.
+
+The transcript walker (`src/hooks/transcript_walker.rs`) is shared infrastructure between Layer 1 and Layer 2. `USER_ONLY_SKILLS` is the authoritative list. Reads are capped at `TRANSCRIPT_BYTE_CAP` (50 MB) per `.claude/rules/external-input-path-construction.md`. See `.claude/rules/user-only-skills.md` for the full design and the per-skill threat-shape rationale.
+
 ### Plan-Phase Gates
 
 Phase 2 gates completion on seven scanners that share `bin/flow plan-check`:
@@ -277,4 +287,5 @@ When developing FLOW itself, point Claude Code at the local plugin source via `c
 - **Tombstone five-item checklist for tombstone proposals** — see `.claude/rules/tombstone-tests.md` "Plan-phase responsibility".
 - **Verify cited identifiers exist as `fn` definitions** — see `.claude/rules/skill-authoring.md` "Verify Test Function References in Issues".
 - **No `run_in_background` during FLOW phases**; `bin/flow` is never allowed in the background — see `.claude/rules/ci-is-a-gate.md`.
+- **User-only skills (model must never invoke)** — see `.claude/rules/user-only-skills.md`. The model must not invoke `/flow:flow-abort`, `/flow:flow-reset`, `/flow:flow-release`, or `/flow:flow-prime`; the user types these directly.
 - **User evidence is ground truth** — when a user provides screenshots or logs that contradict your code analysis, trust the evidence. Your code reading is a hypothesis; the user's evidence is an observation.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -65,6 +65,15 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/bin/flow hook validate-ask-user"
           }
         ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/flow hook validate-skill"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -172,7 +172,9 @@ pub fn read_hook_input() -> Option<Value> {
 pub mod post_compact;
 pub mod stop_continue;
 pub mod stop_failure;
+pub mod transcript_walker;
 pub mod validate_ask_user;
 pub mod validate_claude_paths;
 pub mod validate_pretool;
+pub mod validate_skill;
 pub mod validate_worktree_paths;

--- a/src/hooks/transcript_walker.rs
+++ b/src/hooks/transcript_walker.rs
@@ -3,15 +3,15 @@
 //!
 //! 1. `src/hooks/validate_skill.rs` — Layer 1 of the user-only skill
 //!    enforcement chain. Calls
-//!    `last_user_message_invokes_skill(transcript_path, skill)` to
-//!    decide whether the most recent user turn typed the matching
+//!    `last_user_message_invokes_skill(transcript_path, skill, home)`
+//!    to decide whether the most recent user turn typed the matching
 //!    `<command-name>/<skill></command-name>` slash command. Without
 //!    a match, the model invocation of a user-only skill is blocked.
 //! 2. `src/hooks/validate_ask_user.rs` — Layer 2 carve-out. Calls
-//!    `most_recent_skill_in_user_only_set(transcript_path)` to allow
-//!    `AskUserQuestion` confirmation prompts during in-progress
-//!    autonomous phases when the most recent assistant Skill tool
-//!    invocation targets a user-only skill (`/flow:flow-abort` etc.).
+//!    `most_recent_skill_in_user_only_set(transcript_path, home)` to
+//!    allow `AskUserQuestion` confirmation prompts during in-progress
+//!    autonomous phases when the most recent assistant turn fires a
+//!    Skill tool_use targeting a user-only skill.
 //!
 //! Both helpers are read-only over a JSONL transcript file. They
 //! never mutate state, never spawn subprocesses, and fail-open
@@ -26,21 +26,51 @@
 //! `path` argument is validated through
 //! `crate::window_snapshot::is_safe_transcript_path` before any
 //! filesystem read. The validator rejects empty paths, NUL-byte
-//! paths, relative paths, and paths that do not normalize under
-//! `<home>/.claude/projects/`. Reads are capped at
-//! `TRANSCRIPT_BYTE_CAP` bytes via `BufReader::new(file.take(cap))`
-//! so a hand-crafted oversized transcript cannot exhaust process
-//! memory mid-session.
+//! paths, relative paths, paths containing a `..` component, and
+//! paths that do not normalize under `<home>/.claude/projects/`.
+//!
+//! ## Tail-bounded read
+//!
+//! `read_capped` seeks to the LAST `TRANSCRIPT_BYTE_CAP` bytes of
+//! the file and reads forward to EOF. The walker iterates the
+//! resulting buffer in reverse line order, so the file's tail (the
+//! most recent turns) is always visible regardless of total file
+//! size. Reading from the head would silently omit the most recent
+//! turns on transcripts larger than the cap, defeating the entire
+//! enforcement chain on long autonomous flows.
+//!
+//! ## Gate normalization
+//!
+//! Per `.claude/rules/security-gates.md` "Normalize Before
+//! Comparing", every gate-relevant string input is normalized
+//! through `normalize_gate_input` (NUL strip + trim + ASCII
+//! lowercase) before comparison. This applies to `skill` values,
+//! transcript-extracted skill names, and turn-type discriminants.
+//! Both sides of every comparison run through the same normalizer.
+//!
+//! ## Slash-command anchoring
+//!
+//! Layer 1's user-turn check parses `message.content` as a string
+//! and requires the `<command-name>/<skill></command-name>`
+//! marker at the START of the trimmed content. A user typing
+//! "what does <command-name>/flow:flow-abort</command-name> do?"
+//! produces a content string where the marker appears mid-text —
+//! that is prose mention, not a slash-command invocation, and is
+//! rejected. Tool-result-wrapped user turns (where `content` is an
+//! array of blocks rather than a string) are also rejected
+//! because echoed assistant text in a tool_result would otherwise
+//! authorize invocation of a user-only skill.
 //!
 //! ## JSONL turn shape
 //!
 //! Mirrors `crate::window_snapshot::read_transcript`. Each line is
 //! a JSON object with a top-level `type` field whose value is
 //! `"user"` or `"assistant"`. The line's payload lives under
-//! `message.content` — a string for user turns, an array of
+//! `message.content` — a string for user-typed turns, an array of
 //! content blocks (`{"type": "tool_use", "name": "Skill",
-//! "input": {"skill": "..."}}`, etc.) for assistant turns. Lines
-//! that fail to parse as JSON are skipped silently.
+//! "input": {"skill": "..."}}`, etc.) for assistant turns and
+//! tool_result-wrapped user turns. Lines that fail to parse as
+//! JSON are skipped silently.
 //!
 //! Tests live at `tests/transcript_walker.rs` (top-level rather
 //! than the mirror `tests/hooks/transcript_walker.rs`) per the
@@ -49,7 +79,7 @@
 //! validate-worktree-paths shared-config hook in autonomous mode.
 
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use serde_json::Value;
@@ -65,6 +95,9 @@ use crate::window_snapshot::is_safe_transcript_path;
 /// Re-exported by `validate_skill` and `validate_ask_user` so a
 /// single authoritative list governs both Layer 1 (block model
 /// invocation) and Layer 2 (carve-out for confirmation prompts).
+/// Entries are stored ASCII-lowercased; gate comparisons normalize
+/// caller input through `normalize_gate_input` before checking
+/// membership.
 pub const USER_ONLY_SKILLS: &[&str] = &[
     "flow:flow-abort",
     "flow:flow-reset",
@@ -72,22 +105,36 @@ pub const USER_ONLY_SKILLS: &[&str] = &[
     "flow:flow-prime",
 ];
 
-/// Maximum bytes read from the transcript file. Mirrors
-/// `crate::window_snapshot::TRANSCRIPT_BYTE_CAP` (50 MB) so the
-/// walker bounds I/O the same way the snapshot reader does. A
-/// long-autonomous-flow transcript can exceed 100 MB; reading
-/// every byte on every Skill / AskUserQuestion tool call would
-/// dominate session latency. Capping at 50 MB still covers more
-/// than the most recent ~10,000 turns of a typical session,
-/// which is far more than the lookback the predicates need.
+/// Maximum bytes read from the transcript file (50 MB). Bounds I/O
+/// across long autonomous flows — a session transcript can exceed
+/// 100 MB, and reading every byte on every Skill /
+/// AskUserQuestion tool call would dominate session latency.
+/// `read_capped` reads the LAST `TRANSCRIPT_BYTE_CAP` bytes (not
+/// the first), so the most recent ~10,000 turns are always
+/// reachable regardless of total file size.
 pub const TRANSCRIPT_BYTE_CAP: u64 = 50 * 1024 * 1024;
 
+/// Normalize a gate-relevant string for comparison: strip NUL
+/// bytes, trim leading/trailing whitespace, and ASCII-lowercase.
+/// Per `.claude/rules/security-gates.md` "Normalize Before
+/// Comparing", every gate input runs through this helper before
+/// comparison so a NUL-padded, whitespace-padded, or case-variant
+/// caller cannot bypass the membership check.
+pub fn normalize_gate_input(s: &str) -> String {
+    s.replace('\0', "").trim().to_ascii_lowercase()
+}
+
 /// Return `true` when the most recent user-role turn in the
-/// transcript at `path` contains a `<command-name>/<skill></command-name>`
-/// substring. Returns `false` on any read, parse, or validation
-/// failure (fail-open). Skips assistant turns until a user turn is
-/// found; checks ONLY that user turn — older user turns do not
-/// count.
+/// transcript at `path` invokes `skill` as a Claude Code slash
+/// command. Returns `false` on any read, parse, or validation
+/// failure (fail-open).
+///
+/// Slash-command anchoring: the marker
+/// `<command-name>/<skill></command-name>` must appear at the
+/// START of the trimmed `message.content` string. A user typing
+/// the marker mid-prose, or a tool_result-wrapped user turn whose
+/// content is an array of blocks (containing assistant-echoed
+/// text), does NOT satisfy the check.
 ///
 /// `home` is passed in (rather than read from `$HOME` internally)
 /// so the validator can run against a fixture-controlled prefix in
@@ -99,11 +146,15 @@ pub fn last_user_message_invokes_skill(path: &Path, skill: &str, home: &Path) ->
     if !is_safe_transcript_path(path, home) {
         return false;
     }
+    let skill_norm = normalize_gate_input(skill);
+    if skill_norm.is_empty() {
+        return false;
+    }
     let lines = match read_capped(path) {
         Some(s) => s,
         None => return false,
     };
-    let needle = format!("<command-name>/{}</command-name>", skill);
+    let needle = format!("<command-name>/{}</command-name>", skill_norm);
     for line in lines.lines().rev() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -113,26 +164,44 @@ pub fn last_user_message_invokes_skill(path: &Path, skill: &str, home: &Path) ->
             Ok(v) => v,
             Err(_) => continue,
         };
-        let turn_type = turn.get("type").and_then(|v| v.as_str()).unwrap_or("");
-        if turn_type == "user" {
-            return trimmed.contains(&needle);
+        let turn_type =
+            normalize_gate_input(turn.get("type").and_then(|v| v.as_str()).unwrap_or(""));
+        if turn_type != "user" {
+            continue;
         }
+        // Stop at the most recent user turn. Older user turns are
+        // invisible regardless of what they contain.
+        let content = match turn.get("message").and_then(|m| m.get("content")) {
+            Some(c) => c,
+            None => return false,
+        };
+        // Only string content authorizes — tool_result-wrapped user
+        // turns (content as array) carry assistant-generated text
+        // that must not be treated as user intent.
+        let content_str = match content.as_str() {
+            Some(s) => s,
+            None => return false,
+        };
+        let content_norm = content_str.trim_start().to_ascii_lowercase();
+        return content_norm.starts_with(&needle);
     }
     false
 }
 
-/// Return `true` when the most recent assistant tool_use Skill
-/// invocation BEFORE the next-younger user turn targets a skill in
-/// `USER_ONLY_SKILLS`. Returns `false` when no Skill invocation
-/// occurred since the most recent user turn, when the most recent
-/// Skill invocation targets a non-user-only skill, or on any read /
-/// parse / validation failure (fail-open).
+/// Return `true` when the most recent assistant turn in the
+/// transcript fires at least one Skill tool_use whose `input.skill`
+/// (after normalization) is in `USER_ONLY_SKILLS`. Returns `false`
+/// when the most recent turn is a user turn, when the most recent
+/// assistant turn carries no user-only Skill invocations, or on
+/// any read / parse / validation failure (fail-open).
 ///
-/// "Before the next-younger user turn" means: walking backward from
-/// the file's tail, the walker stops the moment it encounters a
-/// user turn. Older Skill invocations beyond that boundary are
-/// invisible — only Skill calls fired since the most recent user
-/// turn count.
+/// Walking backward from the file's tail, the walker stops at the
+/// first user turn or the first assistant turn that carries any
+/// Skill tool_use. Older turns beyond either boundary are
+/// invisible. Multi-tool assistant turns are scanned in full — a
+/// turn fires `[Bash, Skill(flow:flow-status), Skill(flow:flow-abort)]`
+/// satisfies the check because the user-only Skill is present in
+/// the same turn.
 ///
 /// `home` is passed in for the same testability reason as
 /// `last_user_message_invokes_skill`.
@@ -153,42 +222,82 @@ pub fn most_recent_skill_in_user_only_set(path: &Path, home: &Path) -> bool {
             Ok(v) => v,
             Err(_) => continue,
         };
-        let turn_type = turn.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let turn_type =
+            normalize_gate_input(turn.get("type").and_then(|v| v.as_str()).unwrap_or(""));
         if turn_type == "user" {
             return false;
         }
         if turn_type != "assistant" {
             continue;
         }
-        if let Some(skill) = extract_skill_invocation(&turn) {
-            return USER_ONLY_SKILLS.contains(&skill.as_str());
+        let skills = extract_skill_invocations(&turn);
+        if skills.is_empty() {
+            // Assistant turn produced no Skill tool_use — keep
+            // walking backward toward an older Skill call or the
+            // user boundary.
+            continue;
         }
-        // Assistant turn produced no Skill tool_use — keep walking
-        // backward toward an older Skill call or the user boundary.
+        return skills
+            .iter()
+            .map(|s| normalize_gate_input(s))
+            .any(|s| USER_ONLY_SKILLS.contains(&s.as_str()));
     }
     false
 }
 
-/// Read up to `TRANSCRIPT_BYTE_CAP` bytes from `path` as a UTF-8
+/// Read the LAST `TRANSCRIPT_BYTE_CAP` bytes of `path` as a UTF-8
 /// String. Returns `None` on `File::open` error or non-UTF-8
-/// content. Caps the read via `BufReader::new(file.take(cap))` per
-/// `.claude/rules/external-input-path-construction.md` Rule 3 so a
-/// hand-crafted oversized transcript cannot OOM the process.
+/// content.
+///
+/// The function seeks to `max(0, file_len - TRANSCRIPT_BYTE_CAP)`
+/// and reads forward to EOF. The buffer is the file's tail, which
+/// is what the backward walker needs — reading from the head
+/// silently omits recent turns on transcripts larger than the cap.
+/// A partial JSONL line at the buffer's start (mid-line truncation
+/// at the seek point) fails to parse and is silently skipped by
+/// the walker's `Err(_) => continue` branch.
+///
+/// `metadata()` and `seek()` on a freshly-opened regular file are
+/// genuinely TOCTOU-only failure modes per the
+/// `.claude/rules/external-input-path-construction.md` "No `.expect()`
+/// on Filesystem Reads" carve-out — `.expect()` is acceptable here
+/// because the `.ok()?` branch above on `File::open` is the only
+/// reachable failure surface for the open-file-then-stat-then-seek
+/// sequence. A test cannot reproduce metadata or seek failure on a
+/// freshly-opened regular file without root-level interference.
 fn read_capped(path: &Path) -> Option<String> {
-    let file = File::open(path).ok()?;
-    let mut reader = BufReader::new(file.take(TRANSCRIPT_BYTE_CAP));
+    let mut file = File::open(path).ok()?;
+    let file_len = file
+        .metadata()
+        .expect("metadata succeeds on freshly-opened regular file (TOCTOU-only)")
+        .len();
+    let start = file_len.saturating_sub(TRANSCRIPT_BYTE_CAP);
+    file.seek(SeekFrom::Start(start))
+        .expect("seek to non-negative absolute offset succeeds on regular file (TOCTOU-only)");
+    let mut reader = BufReader::new(file);
     let mut buf = String::new();
     reader.read_to_string(&mut buf).ok()?;
     Some(buf)
 }
 
-/// Walk an assistant turn's `message.content` array and return the
-/// first `tool_use` block whose `name == "Skill"`. The block's
-/// `input.skill` is returned as a String. Returns `None` when the
-/// content array is missing, non-array, contains no Skill tool_use,
-/// or the Skill block lacks an `input.skill` string.
-fn extract_skill_invocation(turn: &Value) -> Option<String> {
-    let content = turn.get("message")?.get("content")?.as_array()?;
+/// Walk an assistant turn's `message.content` array and return
+/// every `tool_use` block whose `name == "Skill"` — extracted from
+/// `input.skill` as a String. The walker examines all blocks (not
+/// just the first), so a multi-tool turn whose user-only Skill
+/// appears second or later is still visible to the caller. Returns
+/// an empty Vec when the content array is missing, non-array,
+/// contains no Skill tool_use, or every Skill block lacks an
+/// `input.skill` string.
+fn extract_skill_invocations(turn: &Value) -> Vec<String> {
+    let content = match turn
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())
+    {
+        Some(c) => c,
+        None => return Vec::new(),
+    };
+    let mut skills = Vec::new();
     for block in content {
         let block_type = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
         if block_type != "tool_use" {
@@ -198,11 +307,13 @@ fn extract_skill_invocation(turn: &Value) -> Option<String> {
         if name != "Skill" {
             continue;
         }
-        let skill = block
+        if let Some(skill) = block
             .get("input")
             .and_then(|v| v.get("skill"))
-            .and_then(|v| v.as_str())?;
-        return Some(skill.to_string());
+            .and_then(|v| v.as_str())
+        {
+            skills.push(skill.to_string());
+        }
     }
-    None
+    skills
 }

--- a/src/hooks/transcript_walker.rs
+++ b/src/hooks/transcript_walker.rs
@@ -1,0 +1,208 @@
+//! Shared backward walker over the persisted Claude Code transcript
+//! JSONL. Two consumers share this module:
+//!
+//! 1. `src/hooks/validate_skill.rs` — Layer 1 of the user-only skill
+//!    enforcement chain. Calls
+//!    `last_user_message_invokes_skill(transcript_path, skill)` to
+//!    decide whether the most recent user turn typed the matching
+//!    `<command-name>/<skill></command-name>` slash command. Without
+//!    a match, the model invocation of a user-only skill is blocked.
+//! 2. `src/hooks/validate_ask_user.rs` — Layer 2 carve-out. Calls
+//!    `most_recent_skill_in_user_only_set(transcript_path)` to allow
+//!    `AskUserQuestion` confirmation prompts during in-progress
+//!    autonomous phases when the most recent assistant Skill tool
+//!    invocation targets a user-only skill (`/flow:flow-abort` etc.).
+//!
+//! Both helpers are read-only over a JSONL transcript file. They
+//! never mutate state, never spawn subprocesses, and fail-open
+//! (return `false`) on any I/O, parse, or validation error. The
+//! `false` return surfaces as "no match" at every consumer, which
+//! routes through to the consumer's safe default (block for Layer
+//! 1, fall through to existing autonomous block for Layer 2).
+//!
+//! ## Validation contract
+//!
+//! Per `.claude/rules/external-input-path-construction.md`, the
+//! `path` argument is validated through
+//! `crate::window_snapshot::is_safe_transcript_path` before any
+//! filesystem read. The validator rejects empty paths, NUL-byte
+//! paths, relative paths, and paths that do not normalize under
+//! `<home>/.claude/projects/`. Reads are capped at
+//! `TRANSCRIPT_BYTE_CAP` bytes via `BufReader::new(file.take(cap))`
+//! so a hand-crafted oversized transcript cannot exhaust process
+//! memory mid-session.
+//!
+//! ## JSONL turn shape
+//!
+//! Mirrors `crate::window_snapshot::read_transcript`. Each line is
+//! a JSON object with a top-level `type` field whose value is
+//! `"user"` or `"assistant"`. The line's payload lives under
+//! `message.content` — a string for user turns, an array of
+//! content blocks (`{"type": "tool_use", "name": "Skill",
+//! "input": {"skill": "..."}}`, etc.) for assistant turns. Lines
+//! that fail to parse as JSON are skipped silently.
+//!
+//! Tests live at `tests/transcript_walker.rs` (top-level rather
+//! than the mirror `tests/hooks/transcript_walker.rs`) per the
+//! deviation log entry on this branch — adding a `[[test]]`
+//! stanza for the subdirectory test was blocked by the
+//! validate-worktree-paths shared-config hook in autonomous mode.
+
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::window_snapshot::is_safe_transcript_path;
+
+/// The four FLOW skills the model must never invoke. Each requires
+/// explicit user initiative — typing `/flow:flow-<name>` directly —
+/// because the action is destructive (`flow-abort`, `flow-reset`),
+/// resource-shipping (`flow-release`), or environment-mutating
+/// (`flow-prime`).
+///
+/// Re-exported by `validate_skill` and `validate_ask_user` so a
+/// single authoritative list governs both Layer 1 (block model
+/// invocation) and Layer 2 (carve-out for confirmation prompts).
+pub const USER_ONLY_SKILLS: &[&str] = &[
+    "flow:flow-abort",
+    "flow:flow-reset",
+    "flow:flow-release",
+    "flow:flow-prime",
+];
+
+/// Maximum bytes read from the transcript file. Mirrors
+/// `crate::window_snapshot::TRANSCRIPT_BYTE_CAP` (50 MB) so the
+/// walker bounds I/O the same way the snapshot reader does. A
+/// long-autonomous-flow transcript can exceed 100 MB; reading
+/// every byte on every Skill / AskUserQuestion tool call would
+/// dominate session latency. Capping at 50 MB still covers more
+/// than the most recent ~10,000 turns of a typical session,
+/// which is far more than the lookback the predicates need.
+pub const TRANSCRIPT_BYTE_CAP: u64 = 50 * 1024 * 1024;
+
+/// Return `true` when the most recent user-role turn in the
+/// transcript at `path` contains a `<command-name>/<skill></command-name>`
+/// substring. Returns `false` on any read, parse, or validation
+/// failure (fail-open). Skips assistant turns until a user turn is
+/// found; checks ONLY that user turn — older user turns do not
+/// count.
+///
+/// `home` is passed in (rather than read from `$HOME` internally)
+/// so the validator can run against a fixture-controlled prefix in
+/// tests without `set_var` env races. Hook callers
+/// (`validate_skill::run`, `validate_ask_user::run`) read `$HOME`
+/// via `crate::window_snapshot::home_dir_or_empty()` and pass it
+/// through.
+pub fn last_user_message_invokes_skill(path: &Path, skill: &str, home: &Path) -> bool {
+    if !is_safe_transcript_path(path, home) {
+        return false;
+    }
+    let lines = match read_capped(path) {
+        Some(s) => s,
+        None => return false,
+    };
+    let needle = format!("<command-name>/{}</command-name>", skill);
+    for line in lines.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let turn: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let turn_type = turn.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if turn_type == "user" {
+            return trimmed.contains(&needle);
+        }
+    }
+    false
+}
+
+/// Return `true` when the most recent assistant tool_use Skill
+/// invocation BEFORE the next-younger user turn targets a skill in
+/// `USER_ONLY_SKILLS`. Returns `false` when no Skill invocation
+/// occurred since the most recent user turn, when the most recent
+/// Skill invocation targets a non-user-only skill, or on any read /
+/// parse / validation failure (fail-open).
+///
+/// "Before the next-younger user turn" means: walking backward from
+/// the file's tail, the walker stops the moment it encounters a
+/// user turn. Older Skill invocations beyond that boundary are
+/// invisible — only Skill calls fired since the most recent user
+/// turn count.
+///
+/// `home` is passed in for the same testability reason as
+/// `last_user_message_invokes_skill`.
+pub fn most_recent_skill_in_user_only_set(path: &Path, home: &Path) -> bool {
+    if !is_safe_transcript_path(path, home) {
+        return false;
+    }
+    let lines = match read_capped(path) {
+        Some(s) => s,
+        None => return false,
+    };
+    for line in lines.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let turn: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let turn_type = turn.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if turn_type == "user" {
+            return false;
+        }
+        if turn_type != "assistant" {
+            continue;
+        }
+        if let Some(skill) = extract_skill_invocation(&turn) {
+            return USER_ONLY_SKILLS.contains(&skill.as_str());
+        }
+        // Assistant turn produced no Skill tool_use — keep walking
+        // backward toward an older Skill call or the user boundary.
+    }
+    false
+}
+
+/// Read up to `TRANSCRIPT_BYTE_CAP` bytes from `path` as a UTF-8
+/// String. Returns `None` on `File::open` error or non-UTF-8
+/// content. Caps the read via `BufReader::new(file.take(cap))` per
+/// `.claude/rules/external-input-path-construction.md` Rule 3 so a
+/// hand-crafted oversized transcript cannot OOM the process.
+fn read_capped(path: &Path) -> Option<String> {
+    let file = File::open(path).ok()?;
+    let mut reader = BufReader::new(file.take(TRANSCRIPT_BYTE_CAP));
+    let mut buf = String::new();
+    reader.read_to_string(&mut buf).ok()?;
+    Some(buf)
+}
+
+/// Walk an assistant turn's `message.content` array and return the
+/// first `tool_use` block whose `name == "Skill"`. The block's
+/// `input.skill` is returned as a String. Returns `None` when the
+/// content array is missing, non-array, contains no Skill tool_use,
+/// or the Skill block lacks an `input.skill` string.
+fn extract_skill_invocation(turn: &Value) -> Option<String> {
+    let content = turn.get("message")?.get("content")?.as_array()?;
+    for block in content {
+        let block_type = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if block_type != "tool_use" {
+            continue;
+        }
+        let name = block.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        if name != "Skill" {
+            continue;
+        }
+        let skill = block
+            .get("input")
+            .and_then(|v| v.get("skill"))
+            .and_then(|v| v.as_str())?;
+        return Some(skill.to_string());
+    }
+    None
+}

--- a/src/hooks/validate_ask_user.rs
+++ b/src/hooks/validate_ask_user.rs
@@ -1,6 +1,6 @@
 //! PreToolUse hook for AskUserQuestion — enforces autonomous-phase discipline.
 //!
-//! Three outcomes, evaluated in order:
+//! Four outcomes, evaluated in order:
 //!
 //! 1. **Block** (exit 2, stderr message) — when the current phase is
 //!    mid-execution (`phases.<current_phase>.status == "in_progress"`)
@@ -11,22 +11,32 @@
 //!    `phase_complete()` advances `current_phase` but before
 //!    `phase_enter()` sets the next phase to in_progress) are not
 //!    blocked.
-//! 2. **Auto-answer** (exit 0, JSON on stdout) — when `_auto_continue`
+//! 2. **User-only skill carve-out** — when `validate` would have
+//!    blocked the prompt but the persisted transcript shows the most
+//!    recent assistant Skill tool_use targets a skill in
+//!    `crate::hooks::transcript_walker::USER_ONLY_SKILLS`
+//!    (`flow:flow-abort`, `flow:flow-reset`, `flow:flow-release`,
+//!    `flow:flow-prime`). Allows the confirmation prompt to fire so
+//!    user-only skills' destructive-operation gates do not deadlock
+//!    when invoked from inside an in-progress autonomous phase.
+//! 3. **Auto-answer** (exit 0, JSON on stdout) — when `_auto_continue`
 //!    is set and the block did not fire. Answers the AskUserQuestion
 //!    with the successor skill command so phase transitions advance
 //!    even if the skill's HARD-GATE was ignored.
-//! 3. **Allow** (exit 0, no stdout) — otherwise. The tool call passes
+//! 4. **Allow** (exit 0, no stdout) — otherwise. The tool call passes
 //!    through to Claude Code's normal permission system.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
 use super::read_hook_input;
 use crate::flow_paths::FlowPaths;
 use crate::git::{current_branch, project_root};
+use crate::hooks::transcript_walker::most_recent_skill_in_user_only_set;
 use crate::lock::mutate_state;
 use crate::utils::now;
+use crate::window_snapshot::home_dir_or_empty;
 
 /// Write `_blocked` timestamp to the state file.
 ///
@@ -145,6 +155,25 @@ pub fn validate(state_path: Option<&Path>) -> (bool, String, Option<Value>) {
     )
 }
 
+/// Returns `true` when the most recent assistant tool_use Skill
+/// invocation in the transcript at `transcript_path` targets a
+/// skill in `crate::hooks::transcript_walker::USER_ONLY_SKILLS`.
+/// Returns `false` when `transcript_path` is `None`, when the
+/// validator rejects the path (not under `<home>/.claude/projects/`,
+/// NUL-byte, relative), or when no Skill tool_use is found before
+/// the most recent user turn.
+///
+/// Companion to `run_impl_main`: when validate would have blocked
+/// the AskUserQuestion under autonomous-phase discipline and this
+/// helper returns `true`, the block is suppressed so user-only
+/// skills can fire their confirmation prompts mid-autonomous-flow.
+pub fn user_only_skill_carve_out_applies(transcript_path: Option<&Path>, home: &Path) -> bool {
+    match transcript_path {
+        Some(p) => most_recent_skill_in_user_only_set(p, home),
+        None => false,
+    }
+}
+
 /// Decision produced by `run_impl_main` — translates to exit code +
 /// side effect in `run()`.
 #[derive(Debug)]
@@ -161,19 +190,21 @@ enum HookAction {
 }
 
 /// Pure decision core for the validate-ask-user hook. Accepts the
-/// parsed stdin payload, current git branch, and project root as
-/// parameters. Called from `run()` with live inputs; integration
-/// tests drive the decision tree by spawning the hook subprocess
-/// with controlled state fixtures.
+/// parsed stdin payload, current git branch, project root, and
+/// `$HOME` as parameters. Called from `run()` with live inputs;
+/// integration tests drive the decision tree by spawning the hook
+/// subprocess with controlled state fixtures.
 fn run_impl_main(
     hook_input: Option<Value>,
     branch: Option<String>,
     project_root: &Path,
+    home: &Path,
 ) -> HookAction {
     // No stdin input — nothing to gate on.
-    if hook_input.is_none() {
-        return HookAction::Allow;
-    }
+    let input = match hook_input {
+        Some(v) => v,
+        None => return HookAction::Allow,
+    };
 
     let branch = match branch {
         Some(b) => b,
@@ -187,12 +218,27 @@ fn run_impl_main(
         None => return HookAction::Allow,
     };
 
+    let transcript_path: Option<PathBuf> = input
+        .get("transcript_path")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from);
+
     let (allowed, message, hook_response) = validate(Some(&state_path));
-    // Block path: `set_blocked` is intentionally not called — the
-    // hook refused the tool call at the gate, so there is no
-    // "blocked-while-executing" timestamp to record. `_blocked` is
-    // only written when an AskUserQuestion was actually delivered.
     if !allowed {
+        // Carve-out: user-only skills' confirmation prompts fire
+        // even during in_progress + auto. Only fires when the
+        // transcript walker confirms the most recent assistant
+        // Skill tool_use call targets a user-only skill — meaning
+        // the user just typed the slash command and the resulting
+        // confirmation prompt is part of that user-initiated flow.
+        if user_only_skill_carve_out_applies(transcript_path.as_deref(), home) {
+            return HookAction::AllowWithMark(state_path);
+        }
+        // `set_blocked` is intentionally not called — the hook
+        // refused the tool call at the gate, so there is no
+        // "blocked-while-executing" timestamp to record. `_blocked`
+        // is only written when an AskUserQuestion was actually
+        // delivered.
         return HookAction::Block(message);
     }
     if let Some(response) = hook_response {
@@ -207,7 +253,8 @@ pub fn run() {
     let hook_input = read_hook_input();
     let branch = current_branch();
     let root = project_root();
-    match run_impl_main(hook_input, branch, &root) {
+    let home = home_dir_or_empty();
+    match run_impl_main(hook_input, branch, &root, &home) {
         HookAction::Allow => std::process::exit(0),
         HookAction::Block(msg) => {
             eprintln!("{}", msg);

--- a/src/hooks/validate_claude_paths.rs
+++ b/src/hooks/validate_claude_paths.rs
@@ -1,10 +1,21 @@
-//! PreToolUse hook that blocks Edit/Write on .claude/rules/, .claude/skills/,
-//! and CLAUDE.md during active FLOW phases, redirecting to bin/flow write-rule.
+//! PreToolUse hook that blocks Edit/Write on:
+//!
+//! 1. `.claude/rules/`, `.claude/skills/`, and `CLAUDE.md` — only during
+//!    active FLOW phases. Redirects to `bin/flow write-rule`.
+//! 2. `~/.claude/projects/` (the Claude Code persisted transcript root)
+//!    — in ALL contexts, not just active flows. Transcript tampering
+//!    could subvert `validate-skill`'s user-only block by injecting a
+//!    fake user `<command-name>` line, so the block fires regardless of
+//!    flow state. Reads remain allowed because the transcript walkers in
+//!    `validate-skill` and `validate-ask-user` need to scan the file
+//!    themselves; the hook is registered for Edit/Write tools only in
+//!    `hooks/hooks.json`.
 //!
 //! Fires on Edit and Write tool calls.
 //!
-//! Exit 0 — allow (path is not protected, or no FLOW phase active)
-//! Exit 2 — block (path is protected and FLOW phase is active)
+//! Exit 0 — allow (path is not protected, or no FLOW phase active and
+//!          path is not in the always-protected transcript root)
+//! Exit 2 — block
 
 use std::path::Path;
 
@@ -12,12 +23,56 @@ use super::{detect_branch_from_path, is_flow_active, read_hook_input, resolve_ma
 use crate::flow_paths::FlowStatesDir;
 use crate::protected_paths::is_protected_path;
 
+/// Returns `true` when `file_path` passes through a `.claude/projects/`
+/// directory at any depth. The Claude Code harness persists session
+/// transcripts under `<home>/.claude/projects/<project_id>/<session>.jsonl`;
+/// any Edit/Write to that family of paths is a tampering vector for
+/// `validate-skill`'s user-only-skill block, so blocked across all
+/// contexts (not just active flows).
+///
+/// Matching is ASCII-case-insensitive for `.claude` and `projects` so a
+/// caller on a case-insensitive filesystem (macOS APFS/HFS+ by default)
+/// cannot bypass the gate by writing to `.CLAUDE/Projects/...` —
+/// matches the same discipline used by `is_protected_path`.
+fn is_transcript_path(file_path: &str) -> bool {
+    let path = Path::new(file_path);
+    let components: Vec<&str> = path
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect();
+    for (i, comp) in components.iter().enumerate() {
+        if comp.eq_ignore_ascii_case(".claude") && i + 1 < components.len() {
+            let next = components[i + 1];
+            if next.eq_ignore_ascii_case("projects") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Validate that an Edit/Write on this path is allowed.
 ///
 /// Returns `(allowed, message)`.
 pub fn validate(file_path: &str, flow_active: bool) -> (bool, String) {
     if file_path.is_empty() {
         return (true, String::new());
+    }
+
+    // Transcript paths blocked regardless of flow_active. Tampering
+    // with the persisted transcript can subvert validate-skill's
+    // user-only block by injecting a fake user `<command-name>`
+    // line; the block must fire even pre-flow / post-flow.
+    if is_transcript_path(file_path) {
+        return (
+            false,
+            "BLOCKED: `~/.claude/projects/` is the persisted Claude Code \
+             transcript root. Edit/Write is forbidden because tampering \
+             with the transcript can subvert validate-skill's user-only \
+             skill block. Read access is preserved for the transcript \
+             walkers."
+                .to_string(),
+        );
     }
 
     if !flow_active {

--- a/src/hooks/validate_skill.rs
+++ b/src/hooks/validate_skill.rs
@@ -1,0 +1,111 @@
+//! PreToolUse hook for the Skill tool — Layer 1 of the user-only
+//! skill enforcement chain. Blocks model invocations of the four
+//! `USER_ONLY_SKILLS` (`flow:flow-abort`, `flow:flow-reset`,
+//! `flow:flow-release`, `flow:flow-prime`) unless the most recent
+//! user-role turn in the persisted transcript carries a matching
+//! `<command-name>/<skill></command-name>` substring (i.e. the user
+//! typed the slash command directly).
+//!
+//! Exit semantics:
+//! - Exit 0, no stdout / stderr — allow (skill not user-only, or
+//!   user-only and a matching user invocation found, or stdin
+//!   missing / malformed)
+//! - Exit 2, stderr message — block (skill is user-only and the
+//!   transcript walker found no matching user invocation in the
+//!   most recent user turn)
+//!
+//! Companion to `validate_ask_user`'s Layer 2 carve-out: when the
+//! same Skill tool call would fire an `AskUserQuestion` for user
+//! confirmation, the carve-out allows the prompt to fire even
+//! during in-progress autonomous phases — resolving the
+//! autonomous-deadlock the `--auto` bypass on `/flow:flow-abort`
+//! and `/flow:flow-release` previously worked around.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::read_hook_input;
+use crate::hooks::transcript_walker::{last_user_message_invokes_skill, USER_ONLY_SKILLS};
+use crate::window_snapshot::home_dir_or_empty;
+
+/// Decide whether to allow or block a Skill tool invocation.
+///
+/// Returns `(allowed, message)`:
+/// - `(true, "")` — allow the tool call (silent)
+/// - `(false, msg)` — block; caller writes `msg` to stderr and exits 2
+///
+/// `tool_input` is the parsed JSON payload Claude Code passes for
+/// the Skill tool — its `skill` field carries the name being
+/// invoked. `transcript_path` is the persisted JSONL session log
+/// (when present in the hook stdin); `home` is `$HOME` (passed in
+/// rather than read from the env so tests can drive a tempdir
+/// fixture without `set_var` env races per
+/// `.claude/rules/testing-gotchas.md` "Rust Parallel Test Env Var
+/// Races").
+pub fn validate(tool_input: &Value, transcript_path: Option<&Path>, home: &Path) -> (bool, String) {
+    let skill = tool_input
+        .get("skill")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if !USER_ONLY_SKILLS.contains(&skill) {
+        return (true, String::new());
+    }
+    if let Some(path) = transcript_path {
+        if last_user_message_invokes_skill(path, skill, home) {
+            return (true, String::new());
+        }
+    }
+    (
+        false,
+        format!(
+            "BLOCKED: `{}` is a user-only skill. The model cannot invoke it. \
+             Ask the user to type `/{}` directly. This skill performs a \
+             destructive or initiating action that requires explicit user \
+             intent — see .claude/rules/user-only-skills.md.",
+            skill, skill,
+        ),
+    )
+}
+
+/// Pure decision core. Accepts the parsed stdin payload and `home`
+/// as injected dependencies so unit tests drive every branch with a
+/// `TempDir` fixture. Mirrors the `run_impl_main` pattern documented
+/// in `.claude/rules/rust-patterns.md` "Main-arm dispatch."
+///
+/// Return contract:
+/// - `(0, None)` → allow silently (exit 0, no stderr)
+/// - `(2, Some(message))` → block (stderr the message, exit 2)
+pub fn run_impl_main(hook_input: Option<Value>, home: &Path) -> (i32, Option<String>) {
+    let hook_input = match hook_input {
+        Some(v) => v,
+        None => return (0, None),
+    };
+    let tool_input = hook_input
+        .get("tool_input")
+        .cloned()
+        .unwrap_or(Value::Object(Default::default()));
+    let transcript_path: Option<PathBuf> = hook_input
+        .get("transcript_path")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from);
+    let (allowed, msg) = validate(&tool_input, transcript_path.as_deref(), home);
+    if !allowed {
+        return (2, Some(msg));
+    }
+    (0, None)
+}
+
+/// Run the validate-skill hook (entry point from CLI). Reads stdin,
+/// resolves `$HOME` via `home_dir_or_empty()`, calls
+/// `run_impl_main`, writes any block message to stderr, and exits
+/// with the returned code.
+pub fn run() {
+    let input = read_hook_input();
+    let home = home_dir_or_empty();
+    let (code, message) = run_impl_main(input, &home);
+    if let Some(m) = message {
+        eprintln!("{}", m);
+    }
+    std::process::exit(code);
+}

--- a/src/hooks/validate_skill.rs
+++ b/src/hooks/validate_skill.rs
@@ -26,7 +26,9 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use super::read_hook_input;
-use crate::hooks::transcript_walker::{last_user_message_invokes_skill, USER_ONLY_SKILLS};
+use crate::hooks::transcript_walker::{
+    last_user_message_invokes_skill, normalize_gate_input, USER_ONLY_SKILLS,
+};
 use crate::window_snapshot::home_dir_or_empty;
 
 /// Decide whether to allow or block a Skill tool invocation.
@@ -34,6 +36,13 @@ use crate::window_snapshot::home_dir_or_empty;
 /// Returns `(allowed, message)`:
 /// - `(true, "")` — allow the tool call (silent)
 /// - `(false, msg)` — block; caller writes `msg` to stderr and exits 2
+///
+/// The `skill` field is normalized through `normalize_gate_input`
+/// (NUL strip + trim + ASCII lowercase) before the membership check
+/// per `.claude/rules/security-gates.md` "Normalize Before
+/// Comparing", so case-variant (`flow:Flow-Abort`),
+/// whitespace-padded (`"flow:flow-abort "`), and NUL-padded inputs
+/// all match the canonical entries in `USER_ONLY_SKILLS`.
 ///
 /// `tool_input` is the parsed JSON payload Claude Code passes for
 /// the Skill tool — its `skill` field carries the name being
@@ -44,15 +53,16 @@ use crate::window_snapshot::home_dir_or_empty;
 /// `.claude/rules/testing-gotchas.md` "Rust Parallel Test Env Var
 /// Races").
 pub fn validate(tool_input: &Value, transcript_path: Option<&Path>, home: &Path) -> (bool, String) {
-    let skill = tool_input
+    let skill_raw = tool_input
         .get("skill")
         .and_then(|v| v.as_str())
         .unwrap_or("");
-    if !USER_ONLY_SKILLS.contains(&skill) {
+    let skill_norm = normalize_gate_input(skill_raw);
+    if !USER_ONLY_SKILLS.contains(&skill_norm.as_str()) {
         return (true, String::new());
     }
     if let Some(path) = transcript_path {
-        if last_user_message_invokes_skill(path, skill, home) {
+        if last_user_message_invokes_skill(path, &skill_norm, home) {
             return (true, String::new());
         }
     }
@@ -63,7 +73,7 @@ pub fn validate(tool_input: &Value, transcript_path: Option<&Path>, home: &Path)
              Ask the user to type `/{}` directly. This skill performs a \
              destructive or initiating action that requires explicit user \
              intent — see .claude/rules/user-only-skills.md.",
-            skill, skill,
+            skill_norm, skill_norm,
         ),
     )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -435,6 +435,10 @@ enum HookCommands {
     /// Enforce auto-continue for AskUserQuestion prompts.
     #[command(name = "validate-ask-user")]
     ValidateAskUser,
+    /// Block model invocation of user-only Skill tool calls
+    /// (flow-abort, flow-reset, flow-release, flow-prime).
+    #[command(name = "validate-skill")]
+    ValidateSkill,
     /// Stop hook: continuation gating, blocked-flag management, tab color.
     #[command(name = "stop-continue")]
     StopContinue,
@@ -832,6 +836,7 @@ fn main() {
             HookCommands::ValidateClaudePaths => hooks::validate_claude_paths::run(),
             HookCommands::ValidateWorktreePaths => hooks::validate_worktree_paths::run(),
             HookCommands::ValidateAskUser => hooks::validate_ask_user::run(),
+            HookCommands::ValidateSkill => hooks::validate_skill::run(),
             HookCommands::StopContinue => hooks::stop_continue::run(),
             HookCommands::StopFailure => hooks::stop_failure::run(),
             HookCommands::PostCompact => hooks::post_compact::run(),

--- a/src/window_snapshot.rs
+++ b/src/window_snapshot.rs
@@ -165,6 +165,18 @@ pub fn is_safe_transcript_path(path: &Path, home: &Path) -> bool {
     if !path.is_absolute() {
         return false;
     }
+    // Reject any ParentDir (`..`) component. `Path::starts_with` is a
+    // lexical component-wise prefix check that does NOT canonicalize
+    // `..` segments — `<home>/.claude/projects/../../etc/passwd`
+    // passes `starts_with(<home>/.claude/projects)` even though
+    // `File::open` resolves it to `<home>/etc/passwd`. Refusing
+    // ParentDir components closes the traversal-bypass surface
+    // without paying the canonicalize() syscall cost on every call.
+    for component in path.components() {
+        if matches!(component, std::path::Component::ParentDir) {
+            return false;
+        }
+    }
     let expected_prefix = home.join(".claude").join("projects");
     path.starts_with(&expected_prefix)
 }

--- a/src/window_snapshot.rs
+++ b/src/window_snapshot.rs
@@ -147,7 +147,15 @@ fn is_safe_session_id(s: &str) -> bool {
 /// transcripts always live under that directory; values pointing
 /// elsewhere are corrupted state and read attempts could leak
 /// arbitrary file contents into snapshot fields.
-fn is_safe_transcript_path(path: &Path, home: &Path) -> bool {
+///
+/// Cross-module consumer: `src/hooks/transcript_walker.rs` validates
+/// the same `transcript_path` string before reading the JSONL
+/// session log to gate user-only skill invocations and the
+/// validate-ask-user carve-out. Per
+/// `.claude/rules/external-input-path-construction.md`, the same
+/// validator runs at every state-derived path-construction site so
+/// the prefix-containment contract is enforced once.
+pub fn is_safe_transcript_path(path: &Path, home: &Path) -> bool {
     if path.as_os_str().is_empty() {
         return false;
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -460,3 +460,16 @@ pub fn add_phase_snapshots(state: &mut Value, key: &str, enter_n: i64, complete_
     state["phases"][key]["window_at_complete"] =
         snapshot_value("S1", complete_n, "claude-opus-4-7");
 }
+
+/// Write a transcript JSONL fixture under
+/// `<home>/.claude/projects/<project_id>/session.jsonl` so the path
+/// satisfies `is_safe_transcript_path` validation. Used by
+/// `transcript_walker` and `validate_skill` tests to build controlled
+/// JSONL content with arbitrary user/assistant turns.
+pub fn transcript_fixture(home: &Path, project_id: &str, jsonl: &str) -> PathBuf {
+    let dir = home.join(".claude").join("projects").join(project_id);
+    fs::create_dir_all(&dir).expect("create transcript fixture dir");
+    let path = dir.join("session.jsonl");
+    fs::write(&path, jsonl).expect("write transcript fixture");
+    path
+}

--- a/tests/hooks/transcript_walker.rs
+++ b/tests/hooks/transcript_walker.rs
@@ -1,0 +1,6 @@
+//! Placeholder. Tests live at `tests/transcript_walker.rs` (top-level).
+//!
+//! See the deviation log entry in `.flow-states/<branch>/log` for context:
+//! Cargo.toml stanza addition was blocked by validate-worktree-paths in
+//! autonomous mode, so the test file was relocated to a top-level path
+//! where Cargo's auto-discovery handles registration.

--- a/tests/hooks/validate_ask_user.rs
+++ b/tests/hooks/validate_ask_user.rs
@@ -5,8 +5,23 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-use flow_rs::hooks::validate_ask_user::{set_blocked, validate};
+use flow_rs::hooks::validate_ask_user::{set_blocked, user_only_skill_carve_out_applies, validate};
 use serde_json::{json, Value};
+
+/// Build a JSONL transcript fixture under
+/// `<home>/.claude/projects/p/session.jsonl`. Returns the path.
+/// Inlined here rather than imported from `tests/common/mod.rs`
+/// because subdirectory tests use `#[path = "../common/mod.rs"]
+/// mod common;` and we already have `mod common;` indirectly via
+/// other tests in this module — keeping this helper self-contained
+/// avoids the import dance.
+fn carve_out_transcript_fixture(home: &Path, jsonl: &str) -> std::path::PathBuf {
+    let dir = home.join(".claude").join("projects").join("p");
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("session.jsonl");
+    fs::write(&path, jsonl).unwrap();
+    path
+}
 
 fn write_state(dir: &Path, branch: &str, state: &Value) -> std::path::PathBuf {
     let branch_dir = dir.join(".flow-states").join(branch);
@@ -589,4 +604,193 @@ fn run_subprocess_sets_blocked_on_allow_path() {
     assert_eq!(code, 0);
     let updated: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert!(updated.get("_blocked").is_some(), "state: {:?}", updated);
+}
+
+// --- user_only_skill_carve_out_applies ---
+
+#[test]
+fn validate_ask_user_carve_out_allows_when_user_only_skill_in_transcript_during_in_progress_auto() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"do something\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n";
+    let path = carve_out_transcript_fixture(home, jsonl);
+    assert!(user_only_skill_carve_out_applies(Some(&path), home));
+}
+
+#[test]
+fn validate_ask_user_carve_out_does_not_apply_when_skill_not_user_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"check\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-create-issue\"}}]}}\n";
+    let path = carve_out_transcript_fixture(home, jsonl);
+    assert!(!user_only_skill_carve_out_applies(Some(&path), home));
+}
+
+#[test]
+fn validate_ask_user_carve_out_does_not_apply_when_no_recent_skill_invocation() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Transcript contains only a user turn — walker hits the user
+    // turn without finding any Skill tool_use call. Carve-out
+    // returns false; existing block stands.
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hello\"}}\n";
+    let path = carve_out_transcript_fixture(home, jsonl);
+    assert!(!user_only_skill_carve_out_applies(Some(&path), home));
+}
+
+#[test]
+fn validate_ask_user_carve_out_does_not_apply_when_transcript_path_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // No transcript path at all — carve-out cannot fire. Existing
+    // block stands.
+    assert!(!user_only_skill_carve_out_applies(None, home));
+}
+
+#[test]
+fn validate_ask_user_unaffected_when_phase_not_in_progress_auto() {
+    // Pre-existing behavior preserved: when validate would NOT have
+    // blocked (manual phase), the carve-out is irrelevant. Verify
+    // the existing validate path returns allow without invoking the
+    // carve-out helper.
+    let dir = tempfile::tempdir().unwrap();
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "manual"}},
+    });
+    let path = write_state(dir.path(), "test", &state);
+    let (allowed, _msg, _resp) = validate(Some(&path));
+    assert!(allowed);
+}
+
+#[test]
+fn validate_ask_user_carve_out_subprocess_allows_during_in_progress_auto() {
+    // Subprocess test for the integrated carve-out behavior:
+    // state file has in_progress + auto, transcript has assistant
+    // Skill invocation of flow:flow-abort. The hook would normally
+    // block, but the carve-out fires and allows.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+    Command::new("git")
+        .args(["init", "--initial-branch=test", "."])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "x@y.z"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "X"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "auto"}},
+    });
+    write_state(&root, "test", &state);
+
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n";
+    let transcript = carve_out_transcript_fixture(&root, jsonl);
+    let payload = json!({"transcript_path": transcript.to_string_lossy()});
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["hook", "validate-ask-user"])
+        .current_dir(&root)
+        .env_remove("FLOW_CI_RUNNING")
+        .env("HOME", &root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(payload.to_string().as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    // Without the carve-out the in_progress + auto block would
+    // exit 2. Verify it exited 0 and stderr is empty.
+    assert_eq!(
+        output.status.code().unwrap_or(-1),
+        0,
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_ask_user_block_persists_when_no_carve_out_during_in_progress_auto() {
+    // Subprocess test: state file has in_progress + auto and the
+    // transcript has NO Skill tool_use. The hook should still
+    // block — carve-out does not fire.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+    Command::new("git")
+        .args(["init", "--initial-branch=test", "."])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "x@y.z"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "X"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "auto"}},
+    });
+    write_state(&root, "test", &state);
+
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hello\"}}\n";
+    let transcript = carve_out_transcript_fixture(&root, jsonl);
+    let payload = json!({"transcript_path": transcript.to_string_lossy()});
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["hook", "validate-ask-user"])
+        .current_dir(&root)
+        .env_remove("FLOW_CI_RUNNING")
+        .env("HOME", &root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(payload.to_string().as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code().unwrap_or(-1), 2);
+    assert!(String::from_utf8_lossy(&output.stderr).contains("BLOCKED"));
 }

--- a/tests/hooks/validate_claude_paths.rs
+++ b/tests/hooks/validate_claude_paths.rs
@@ -134,6 +134,74 @@ fn test_error_message_mentions_write_rule() {
     assert!(msg.contains("--content-file"));
 }
 
+// --- ~/.claude/projects/ transcript path block ---
+//
+// The block fires regardless of flow_active because transcript
+// tampering can subvert validate-skill's user-only block.
+
+#[test]
+fn validate_claude_paths_blocks_edit_in_claude_projects() {
+    let (allowed, msg) = validate("/Users/ben/.claude/projects/abc/session.jsonl", true);
+    assert!(!allowed);
+    assert!(msg.contains("BLOCKED"));
+    assert!(msg.contains("transcript"));
+}
+
+#[test]
+fn validate_claude_paths_blocks_write_in_claude_projects() {
+    // Same path family — validate doesn't distinguish Edit vs Write
+    // (the hook is registered for both matchers separately in
+    // hooks.json). Test asserts the block fires for either tool.
+    let (allowed, msg) = validate("/Users/ben/.claude/projects/abc/session.jsonl", true);
+    assert!(!allowed);
+    assert!(msg.contains("BLOCKED"));
+}
+
+#[test]
+fn validate_claude_paths_blocks_in_claude_projects_when_no_flow_active() {
+    // Distinguishing property: unlike .claude/rules, the transcript
+    // block fires even when no flow is active. Pre-flow and
+    // post-flow tampering must be blocked too.
+    let (allowed, msg) = validate("/Users/ben/.claude/projects/abc/session.jsonl", false);
+    assert!(!allowed);
+    assert!(msg.contains("BLOCKED"));
+    assert!(msg.contains("transcript"));
+}
+
+#[test]
+fn validate_claude_paths_allows_edit_in_other_paths_under_home() {
+    // .claude/rules pre-existing behavior preserved — without an
+    // active flow, .claude/rules edits pass through.
+    let (allowed, msg) = validate("/Users/ben/.claude/rules/foo.md", false);
+    assert!(allowed);
+    assert!(msg.is_empty());
+}
+
+#[test]
+fn validate_claude_paths_blocks_nested_claude_projects() {
+    let (allowed, msg) = validate("/Users/ben/.claude/projects/abc/subdir/deep.jsonl", false);
+    assert!(!allowed);
+    assert!(msg.contains("BLOCKED"));
+}
+
+#[test]
+fn validate_claude_paths_case_insensitive_claude_projects_match() {
+    // macOS APFS is case-insensitive — `.CLAUDE/Projects/` resolves
+    // to the same inode as `.claude/projects/`. The block matches
+    // both casings.
+    let (allowed, msg) = validate("/Users/ben/.CLAUDE/Projects/abc/session.jsonl", false);
+    assert!(!allowed);
+    assert!(msg.contains("BLOCKED"));
+}
+
+#[test]
+fn validate_claude_paths_allows_claude_projects_substring_in_filename() {
+    // `.claude_projects` (no separator) is not the transcript
+    // family — must not match.
+    let (allowed, _msg) = validate("/Users/ben/foo/.claude_projects/x", true);
+    assert!(allowed);
+}
+
 // --- run_impl_main tests (drive find_project_root_in branches) ---
 
 fn seed_active_flow_fixture(root: &Path, branch: &str) -> std::path::PathBuf {

--- a/tests/transcript_walker.rs
+++ b/tests/transcript_walker.rs
@@ -1,0 +1,396 @@
+//! Integration tests for `src/hooks/transcript_walker.rs`.
+//!
+//! Drives `last_user_message_invokes_skill` and
+//! `most_recent_skill_in_user_only_set` through controlled JSONL
+//! fixtures via `transcript_fixture` (in tests/common/mod.rs). Each
+//! line in the fixture is a Claude Code transcript turn whose
+//! top-level `type` field carries the `user`/`assistant` role
+//! (matching `src/window_snapshot.rs::read_transcript`).
+//!
+//! Lives at the top-level `tests/` path rather than the mirrored
+//! `tests/hooks/transcript_walker.rs` because the `[[test]]` stanza
+//! addition required for subdirectory tests was blocked by the
+//! validate-worktree-paths shared-config hook in autonomous mode and
+//! `AskUserQuestion` was blocked by validate-ask-user. Top-level
+//! placement is functionally equivalent — Cargo auto-discovers
+//! `tests/*.rs`. See the deviation log entry on this branch.
+
+mod common;
+
+use std::fs;
+
+use flow_rs::hooks::transcript_walker::{
+    last_user_message_invokes_skill, most_recent_skill_in_user_only_set, TRANSCRIPT_BYTE_CAP,
+    USER_ONLY_SKILLS,
+};
+
+// --- last_user_message_invokes_skill ---
+
+#[test]
+fn walker_returns_false_when_path_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let missing = home
+        .join(".claude")
+        .join("projects")
+        .join("p")
+        .join("nonexistent.jsonl");
+    assert!(!last_user_message_invokes_skill(
+        &missing,
+        "flow:flow-abort",
+        home,
+    ));
+    assert!(!most_recent_skill_in_user_only_set(&missing, home));
+}
+
+#[test]
+fn walker_returns_false_when_path_unparseable_jsonl() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let path = common::transcript_fixture(home, "p", "not json\nstill not json\n");
+    assert!(!last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+    assert!(!most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn walker_returns_false_when_oversized() {
+    // Fixture sized just past TRANSCRIPT_BYTE_CAP with the matching
+    // `<command-name>` tag positioned beyond the cap. The reader
+    // truncates at the cap so the matching content is unreadable and
+    // the predicate returns false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let proj = home.join(".claude").join("projects").join("p");
+    fs::create_dir_all(&proj).unwrap();
+    let path = proj.join("oversized.jsonl");
+    let padding_size = (TRANSCRIPT_BYTE_CAP as usize) + 1024;
+    let mut content = vec![b'\n'; padding_size];
+    let trailing = "\n{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n";
+    content.extend_from_slice(trailing.as_bytes());
+    fs::write(&path, &content).unwrap();
+    assert!(!last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+}
+
+#[test]
+fn last_user_invokes_finds_match_on_most_recent_user_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+}
+
+#[test]
+fn last_user_invokes_returns_false_when_user_turn_has_different_command() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-status</command-name>\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+}
+
+#[test]
+fn last_user_invokes_returns_false_when_command_in_older_user_turn_not_most_recent() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"please continue\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+}
+
+#[test]
+fn last_user_invokes_ignores_command_in_assistant_text() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Assistant turn discusses the literal `<command-name>/flow:flow-abort` substring.
+    // The most recent user turn has different content. The walker stops at
+    // the user turn so the assistant text is never queried — returns false.
+    let jsonl = "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"<command-name>/flow:flow-abort</command-name>\"}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"please continue\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+}
+
+// --- most_recent_skill_in_user_only_set ---
+
+#[test]
+fn most_recent_skill_in_user_only_set_finds_assistant_skill_call() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"do something\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn most_recent_skill_in_user_only_set_returns_false_when_skill_not_user_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"check status\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-status\"}}]}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn most_recent_skill_in_user_only_set_stops_at_user_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Older assistant Skill call to a user-only skill, then a user
+    // turn, then a more recent assistant Skill call to a non-user-only
+    // skill. The walker scans from the end, hits the recent
+    // non-user-only call first, returns false. Stopping at the user
+    // turn ensures the older user-only call is never reached.
+    let jsonl = "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"now do something else\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-status\"}}]}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn user_only_skills_constant_lists_four_skills() {
+    let names: Vec<&str> = USER_ONLY_SKILLS.to_vec();
+    assert!(names.contains(&"flow:flow-abort"));
+    assert!(names.contains(&"flow:flow-reset"));
+    assert!(names.contains(&"flow:flow-release"));
+    assert!(names.contains(&"flow:flow-prime"));
+    assert_eq!(names.len(), 4);
+}
+
+#[test]
+fn walker_skips_empty_lines_in_fixture() {
+    // Empty / whitespace-only lines must be skipped without parsing.
+    // Placing blank lines between real turns exercises the
+    // `trimmed.is_empty()` continue branch in the walker.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "\n   \n{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"do something\"}}\n\
+\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n\
+\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn most_recent_skill_walker_continues_past_assistant_turn_without_skill_call() {
+    // Assistant turn has only a text block (no tool_use) — walker
+    // continues past it. Then a user turn — walker stops, returns
+    // false. Exercises the
+    // `extract_skill_invocation -> None` branch when the assistant
+    // turn yields no Skill invocation.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hello\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"thinking\"}]}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    // Walking from end: assistant turn (no Skill) → continue.
+    // Next: user turn → return false.
+    assert!(!most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn most_recent_skill_walker_skips_non_skill_tool_use() {
+    // Assistant turn has a tool_use block whose name is "Bash"
+    // (not "Skill"). extract_skill_invocation skips the Bash block
+    // and continues. Then no further blocks → returns None →
+    // walker continues past the assistant turn → eventually
+    // returns false at the user turn.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"do it\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}]}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn most_recent_skill_walker_skips_text_block_then_finds_skill() {
+    // Assistant turn has BOTH a text block (continue) AND a Skill
+    // tool_use block. The walker iterates through the content
+    // array, skips the text block, finds the Skill block.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"abort please\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"OK, aborting.\"},{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn most_recent_skill_walker_handles_skill_block_without_input_skill_string() {
+    // Skill tool_use whose input.skill field is missing OR not a
+    // string. extract_skill_invocation returns None — walker
+    // continues past the block, finds nothing else, returns false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":42}}]}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn most_recent_skill_walker_handles_assistant_turn_without_message_field() {
+    // Assistant turn with no `message` field at all.
+    // extract_skill_invocation returns None at the first `?` ->
+    // walker continues, hits user turn, returns false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n\
+{\"type\":\"assistant\"}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn most_recent_skill_walker_handles_assistant_message_without_content_field() {
+    // Assistant turn has `message` but no `content` field —
+    // `get("content")?` short-circuits to None, walker continues
+    // and returns false at the user turn.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn most_recent_skill_walker_handles_content_not_array() {
+    // Assistant turn has `message.content` as a STRING (not array).
+    // `as_array()?` short-circuits to None.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"plain text response\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn last_user_invokes_iterates_past_trailing_assistant_to_older_user_turn() {
+    // Fixture has an assistant turn AFTER the most recent user
+    // turn (assistant is last in file). Walking backward: hit
+    // assistant first → not user → continue past it. Next: user
+    // turn → match check returns. Exercises the iterate-past-
+    // assistant branch in `last_user_message_invokes_skill`.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"OK.\"}]}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+}
+
+#[test]
+fn most_recent_skill_walker_skips_turns_with_unknown_type() {
+    // A turn whose `type` is neither "user" nor "assistant" (e.g.,
+    // a future role like "system" or a malformed/unknown type)
+    // is skipped via continue — walker keeps iterating to find
+    // either a user or assistant turn.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n\
+{\"type\":\"system\",\"message\":{\"role\":\"system\",\"content\":\"compaction summary\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    // Walk reverse: assistant Skill (user-only) → returns true.
+    // The system turn would be skipped if it appeared before the
+    // assistant turn in reverse order. Place the system turn
+    // BETWEEN assistant and user to ensure walker skips it on its
+    // way to the user boundary.
+    assert!(most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn most_recent_skill_walker_skips_unknown_type_before_reaching_user() {
+    // Unknown-type turn (e.g., "system") appears as the LAST turn.
+    // Walker hits it first, sees neither user nor assistant,
+    // continues to the next iteration. Eventually reaches the
+    // user boundary and returns false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n\
+{\"type\":\"system\",\"message\":{\"role\":\"system\",\"content\":\"compaction summary\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    // Walking reverse: system turn → unknown type → continue.
+    // Then user turn → return false.
+    assert!(!most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn walker_returns_false_when_file_contains_non_utf8_bytes() {
+    // File opens but `read_to_string` fails with InvalidData
+    // because the bytes don't form valid UTF-8. Walker fails open
+    // and returns false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let proj = home.join(".claude").join("projects").join("p");
+    fs::create_dir_all(&proj).unwrap();
+    let path = proj.join("invalid.jsonl");
+    // 0xC3 starts a 2-byte UTF-8 sequence; 0x28 is `(` (not a
+    // valid continuation byte), so the pair is invalid UTF-8.
+    fs::write(&path, [0xC3u8, 0x28u8]).unwrap();
+    assert!(!last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+    assert!(!most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn walker_rejects_path_outside_home_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Write a valid transcript at a path that does NOT live under
+    // `<home>/.claude/projects/`. The validator rejects the path
+    // even though the JSONL content is well-formed and would
+    // otherwise match. Defense-in-depth: a hand-edited
+    // `transcript_path` cannot redirect the walker outside the
+    // canonical Claude Code transcript root.
+    let stray = home.join("malicious").join("session.jsonl");
+    fs::create_dir_all(stray.parent().unwrap()).unwrap();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n";
+    fs::write(&stray, jsonl).unwrap();
+    assert!(!last_user_message_invokes_skill(
+        &stray,
+        "flow:flow-abort",
+        home
+    ));
+    assert!(!most_recent_skill_in_user_only_set(&stray, home));
+}

--- a/tests/transcript_walker.rs
+++ b/tests/transcript_walker.rs
@@ -57,22 +57,48 @@ fn walker_returns_false_when_path_unparseable_jsonl() {
 }
 
 #[test]
-fn walker_returns_false_when_oversized() {
-    // Fixture sized just past TRANSCRIPT_BYTE_CAP with the matching
-    // `<command-name>` tag positioned beyond the cap. The reader
-    // truncates at the cap so the matching content is unreadable and
-    // the predicate returns false.
+fn walker_returns_false_when_command_falls_off_tail_cap() {
+    // Tail-read fixture: a valid user turn with the matching command
+    // is written at the file's HEAD, then > TRANSCRIPT_BYTE_CAP bytes
+    // of padding follow. `read_capped` reads the LAST cap bytes, so
+    // the head-positioned command is invisible and the walker
+    // returns false. Verifies the byte cap bounds backward visibility
+    // when the most recent content has buried older user turns far
+    // enough back that they no longer fit in the cap.
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path();
     let proj = home.join(".claude").join("projects").join("p");
     fs::create_dir_all(&proj).unwrap();
     let path = proj.join("oversized.jsonl");
+    let leading = b"{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n";
+    let mut content: Vec<u8> = leading.to_vec();
     let padding_size = (TRANSCRIPT_BYTE_CAP as usize) + 1024;
-    let mut content = vec![b'\n'; padding_size];
-    let trailing = "\n{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n";
-    content.extend_from_slice(trailing.as_bytes());
+    content.extend(std::iter::repeat_n(b'\n', padding_size));
     fs::write(&path, &content).unwrap();
     assert!(!last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+}
+
+#[test]
+fn walker_finds_command_when_tail_within_cap() {
+    // Inverse of walker_returns_false_when_command_falls_off_tail_cap:
+    // padding precedes the command, then a valid user turn at the
+    // tail fits within the last TRANSCRIPT_BYTE_CAP bytes. The
+    // tail-read sees the command and the predicate returns true.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let proj = home.join(".claude").join("projects").join("p");
+    fs::create_dir_all(&proj).unwrap();
+    let path = proj.join("tail-within-cap.jsonl");
+    let padding_size = 1024usize;
+    let mut content: Vec<u8> = std::iter::repeat_n(b'\n', padding_size).collect();
+    let trailing = b"{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n";
+    content.extend_from_slice(trailing);
+    fs::write(&path, &content).unwrap();
+    assert!(last_user_message_invokes_skill(
         &path,
         "flow:flow-abort",
         home
@@ -393,4 +419,157 @@ fn walker_rejects_path_outside_home_prefix() {
         home
     ));
     assert!(!most_recent_skill_in_user_only_set(&stray, home));
+}
+
+// --- Adversarial regression tests ---
+//
+// Each test below locks in a fix surfaced by the Code Review
+// adversarial / pre-mortem agents. Adding the test here protects
+// against future regression.
+
+#[test]
+fn walker_rejects_path_traversal_via_dotdot_components() {
+    // `Path::starts_with(<home>/.claude/projects)` is a lexical
+    // prefix check that does NOT canonicalize `..` segments. A path
+    // like `<home>/.claude/projects/../../evil.jsonl` passes the
+    // prefix check but `File::open` resolves it OUT of the canonical
+    // root. The validator must reject any ParentDir component before
+    // the prefix check.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let evil = home.join("evil.jsonl");
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n";
+    fs::write(&evil, jsonl).unwrap();
+    fs::create_dir_all(home.join(".claude").join("projects").join("p")).unwrap();
+    let traversal = home
+        .join(".claude")
+        .join("projects")
+        .join("..")
+        .join("..")
+        .join("evil.jsonl");
+    assert!(!last_user_message_invokes_skill(
+        &traversal,
+        "flow:flow-abort",
+        home
+    ));
+    assert!(!most_recent_skill_in_user_only_set(&traversal, home));
+}
+
+#[test]
+fn last_user_invokes_rejects_command_mention_in_user_prose() {
+    // A user typing "what does <command-name>/flow:flow-abort</command-name>
+    // do?" — the marker appears mid-string. The walker must require
+    // the marker at the START of the trimmed content (slash-command
+    // anchoring), not anywhere in the line.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"what does <command-name>/flow:flow-abort</command-name> do?\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+}
+
+#[test]
+fn last_user_invokes_returns_false_when_user_turn_missing_content_field() {
+    // Most recent user turn has a `message` field but no `content`
+    // sub-field — the walker hits the user boundary and the
+    // content-extraction match arm returns false. Exercises the
+    // None branch of the content lookup.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+}
+
+#[test]
+fn last_user_invokes_rejects_tool_result_wrapped_user_turn() {
+    // Claude Code wraps tool results inside user-role turns whose
+    // `content` is an array (not a string) of blocks. The
+    // assistant-generated tool_result text inside such a turn must
+    // NOT authorize a user-only skill invocation. Only string-
+    // valued user content (direct user input) qualifies as a
+    // slash-command invocation.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"tu_1\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}]}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!last_user_message_invokes_skill(
+        &path,
+        "flow:flow-abort",
+        home
+    ));
+}
+
+#[test]
+fn last_user_invokes_lowercases_skill_name_for_anchor_match() {
+    // The walker normalizes the input skill via normalize_gate_input
+    // (lowercase + trim + NUL-strip). Mixed-case input must still
+    // match a properly-typed slash command in the transcript.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    // Mixed-case input — should match because both sides normalize.
+    assert!(last_user_message_invokes_skill(
+        &path,
+        "Flow:Flow-Abort",
+        home
+    ));
+}
+
+#[test]
+fn last_user_invokes_rejects_empty_skill_after_normalization() {
+    // A `skill` argument that is purely whitespace, NULs, or empty
+    // becomes an empty string after `normalize_gate_input`. Such a
+    // value must not authorize anything — return false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(!last_user_message_invokes_skill(&path, "  \0  ", home));
+    assert!(!last_user_message_invokes_skill(&path, "", home));
+}
+
+#[test]
+fn most_recent_skill_walker_finds_user_only_in_multi_skill_turn() {
+    // Assistant turn fires multiple Skill tool_use calls in the same
+    // content array — first a non-user-only skill, then a user-only
+    // one. The walker must scan ALL Skill blocks in the turn
+    // (extract_skill_invocations returns a Vec), not return on the
+    // first match. Otherwise the carve-out would miss the user-only
+    // call when it appears after a non-user-only one.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"do things\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[\
+{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-status\"}},\
+{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    assert!(most_recent_skill_in_user_only_set(&path, home));
+}
+
+#[test]
+fn normalize_gate_input_strips_nul_trims_and_lowercases() {
+    use flow_rs::hooks::transcript_walker::normalize_gate_input;
+    assert_eq!(normalize_gate_input("flow:flow-abort"), "flow:flow-abort");
+    assert_eq!(
+        normalize_gate_input("  flow:flow-abort  "),
+        "flow:flow-abort"
+    );
+    assert_eq!(normalize_gate_input("Flow:Flow-Abort"), "flow:flow-abort");
+    assert_eq!(normalize_gate_input("flow:flow-abort\0"), "flow:flow-abort");
+    assert_eq!(
+        normalize_gate_input("\0  Flow:flow-Abort  \0"),
+        "flow:flow-abort"
+    );
+    assert_eq!(normalize_gate_input(""), "");
+    assert_eq!(normalize_gate_input("   "), "");
 }

--- a/tests/validate_skill.rs
+++ b/tests/validate_skill.rs
@@ -144,6 +144,80 @@ fn validate_blocks_when_user_only_skill_and_no_transcript_path() {
     assert!(msg.contains("BLOCKED"));
 }
 
+// --- Adversarial regression tests for gate normalization ---
+//
+// Each test below locks in a Code Review fix that closed a Layer 1
+// bypass — case variation, trailing whitespace, NUL padding. The
+// `normalize_gate_input` helper now strips all three before the
+// `USER_ONLY_SKILLS` membership check.
+
+#[test]
+fn validate_blocks_case_variant_user_only_skill_name() {
+    // `Flow:Flow-Abort` previously bypassed `USER_ONLY_SKILLS.contains`
+    // because the membership check was exact-string. With
+    // `normalize_gate_input`, both sides lowercase before comparison.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let tool_input = json!({"skill": "Flow:Flow-Abort"});
+    let (allowed, msg) = validate(&tool_input, None, home);
+    assert!(!allowed);
+    assert!(msg.contains("BLOCKED"));
+}
+
+#[test]
+fn validate_blocks_whitespace_padded_user_only_skill_name() {
+    // `flow:flow-abort ` (trailing space) previously bypassed the
+    // membership check. Normalization trims whitespace.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let tool_input = json!({"skill": "  flow:flow-abort  "});
+    let (allowed, msg) = validate(&tool_input, None, home);
+    assert!(!allowed);
+    assert!(msg.contains("BLOCKED"));
+}
+
+#[test]
+fn validate_blocks_nul_padded_user_only_skill_name() {
+    // `flow:flow-abort\0` previously bypassed the membership check.
+    // Normalization strips NUL bytes.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let tool_input = json!({"skill": "flow:flow-abort\0"});
+    let (allowed, msg) = validate(&tool_input, None, home);
+    assert!(!allowed);
+    assert!(msg.contains("BLOCKED"));
+}
+
+#[test]
+fn validate_block_message_uses_normalized_skill_name() {
+    // The block message echoes the normalized skill name so the
+    // user always sees the canonical form regardless of how the
+    // model phrased the bypass attempt.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let tool_input = json!({"skill": "  Flow:FLOW-Abort\0"});
+    let (allowed, msg) = validate(&tool_input, None, home);
+    assert!(!allowed);
+    assert!(msg.contains("`flow:flow-abort`"));
+}
+
+#[test]
+fn validate_blocks_user_prose_mention_of_command_marker() {
+    // A user message that mentions the literal
+    // `<command-name>/flow:flow-abort</command-name>` substring
+    // mid-text is NOT a slash-command invocation. The walker
+    // requires the marker at the START of the trimmed content,
+    // so this case must block.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"can you describe what <command-name>/flow:flow-abort</command-name> does?\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    let tool_input = json!({"skill": "flow:flow-abort"});
+    let (allowed, msg) = validate(&tool_input, Some(&path), home);
+    assert!(!allowed);
+    assert!(msg.contains("BLOCKED"));
+}
+
 // --- subprocess integration tests ---
 
 fn run_hook_subprocess(stdin_input: &str) -> (i32, String, String) {

--- a/tests/validate_skill.rs
+++ b/tests/validate_skill.rs
@@ -1,0 +1,280 @@
+//! Integration tests for `src/hooks/validate_skill.rs`.
+//!
+//! Drives the `validate` decision core directly with controlled
+//! `tool_input`, `transcript_path`, and `home` fixtures. Subprocess
+//! integration test (`subprocess_validate_skill_blocks_user_only_invocation_without_user_command`
+//! and siblings) lives below the unit tests and exercises the
+//! compiled binary.
+//!
+//! Lives at the top-level `tests/` path rather than the mirrored
+//! `tests/hooks/validate_skill.rs` because the `[[test]]` stanza
+//! addition required for subdirectory tests was blocked by the
+//! validate-worktree-paths shared-config hook in autonomous mode.
+//! See the deviation log entry on this branch.
+
+mod common;
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use flow_rs::hooks::transcript_walker::USER_ONLY_SKILLS;
+use flow_rs::hooks::validate_skill::validate;
+use serde_json::json;
+
+// --- validate (decision core) ---
+
+#[test]
+fn validate_allows_when_skill_not_in_user_only_set() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let tool_input = json!({"skill": "flow:flow-status"});
+    let (allowed, msg) = validate(&tool_input, None, home);
+    assert!(allowed);
+    assert!(msg.is_empty());
+}
+
+#[test]
+fn validate_allows_when_skill_not_in_user_only_set_even_if_transcript_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let missing = home
+        .join(".claude")
+        .join("projects")
+        .join("p")
+        .join("nonexistent.jsonl");
+    let tool_input = json!({"skill": "flow:flow-status"});
+    let (allowed, msg) = validate(&tool_input, Some(&missing), home);
+    assert!(allowed);
+    assert!(msg.is_empty());
+}
+
+#[test]
+fn validate_blocks_when_user_only_skill_lacks_user_invocation() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Transcript exists and is well-formed but has no matching
+    // `<command-name>` tag. Layer 1 must block.
+    let jsonl =
+        "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"unrelated message\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    let tool_input = json!({"skill": "flow:flow-abort"});
+    let (allowed, msg) = validate(&tool_input, Some(&path), home);
+    assert!(!allowed);
+    assert!(msg.contains("BLOCKED"));
+}
+
+#[test]
+fn validate_allows_when_user_only_skill_has_user_invocation() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    let tool_input = json!({"skill": "flow:flow-abort"});
+    let (allowed, msg) = validate(&tool_input, Some(&path), home);
+    assert!(allowed);
+    assert!(msg.is_empty());
+}
+
+#[test]
+fn validate_block_message_names_skill() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"unrelated\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    let tool_input = json!({"skill": "flow:flow-abort"});
+    let (_, msg) = validate(&tool_input, Some(&path), home);
+    assert!(msg.contains("`flow:flow-abort`"));
+}
+
+#[test]
+fn validate_block_message_references_rule_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"unrelated\"}}\n";
+    let path = common::transcript_fixture(home, "p", jsonl);
+    let tool_input = json!({"skill": "flow:flow-abort"});
+    let (_, msg) = validate(&tool_input, Some(&path), home);
+    assert!(msg.contains(".claude/rules/user-only-skills.md"));
+}
+
+// One test per user-only skill — verifies each is in the set.
+#[test]
+fn validate_user_only_skill_flow_abort_is_in_set() {
+    assert!(USER_ONLY_SKILLS.contains(&"flow:flow-abort"));
+}
+
+#[test]
+fn validate_user_only_skill_flow_reset_is_in_set() {
+    assert!(USER_ONLY_SKILLS.contains(&"flow:flow-reset"));
+}
+
+#[test]
+fn validate_user_only_skill_flow_release_is_in_set() {
+    assert!(USER_ONLY_SKILLS.contains(&"flow:flow-release"));
+}
+
+#[test]
+fn validate_user_only_skill_flow_prime_is_in_set() {
+    assert!(USER_ONLY_SKILLS.contains(&"flow:flow-prime"));
+}
+
+#[test]
+fn validate_fail_open_when_tool_input_missing_skill_field() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // tool_input has no `skill` field. Treat as non-user-only and
+    // allow. Defense in depth: the absent field is not a synthetic
+    // block trigger.
+    let tool_input = json!({});
+    let (allowed, msg) = validate(&tool_input, None, home);
+    assert!(allowed);
+    assert!(msg.is_empty());
+}
+
+#[test]
+fn validate_blocks_when_user_only_skill_and_no_transcript_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // No transcript path — walker can't verify user invocation, so
+    // the user-only skill is blocked by default.
+    let tool_input = json!({"skill": "flow:flow-abort"});
+    let (allowed, msg) = validate(&tool_input, None, home);
+    assert!(!allowed);
+    assert!(msg.contains("BLOCKED"));
+}
+
+// --- subprocess integration tests ---
+
+fn run_hook_subprocess(stdin_input: &str) -> (i32, String, String) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["hook", "validate-skill"])
+        .env_remove("FLOW_CI_RUNNING")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn flow-rs");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(stdin_input.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().expect("wait");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+fn write_jsonl_fixture(home: &Path, jsonl: &str) -> std::path::PathBuf {
+    common::transcript_fixture(home, "p", jsonl)
+}
+
+#[test]
+fn subprocess_validate_skill_blocks_user_only_invocation_without_user_command() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n";
+    let path = write_jsonl_fixture(home, jsonl);
+    let payload = json!({
+        "tool_input": {"skill": "flow:flow-abort"},
+        "transcript_path": path.to_string_lossy(),
+    });
+    // Override HOME for the subprocess so is_safe_transcript_path
+    // accepts the tempdir-rooted fixture.
+    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["hook", "validate-skill"])
+        .env_remove("FLOW_CI_RUNNING")
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn flow-rs");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(payload.to_string().as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().expect("wait");
+    assert_eq!(output.status.code().unwrap_or(-1), 2);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("BLOCKED"), "stderr: {}", stderr);
+    assert!(
+        stderr.contains("flow:flow-abort"),
+        "stderr should name skill: {}",
+        stderr
+    );
+}
+
+#[test]
+fn subprocess_validate_skill_allows_when_user_invocation_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n";
+    let path = write_jsonl_fixture(home, jsonl);
+    let payload = json!({
+        "tool_input": {"skill": "flow:flow-abort"},
+        "transcript_path": path.to_string_lossy(),
+    });
+    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["hook", "validate-skill"])
+        .env_remove("FLOW_CI_RUNNING")
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn flow-rs");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(payload.to_string().as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().expect("wait");
+    assert_eq!(output.status.code().unwrap_or(-1), 0);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.is_empty(), "stderr should be empty: {}", stderr);
+}
+
+#[test]
+fn subprocess_validate_skill_allows_when_skill_not_user_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"unrelated\"}}\n";
+    let path = write_jsonl_fixture(home, jsonl);
+    let payload = json!({
+        "tool_input": {"skill": "flow:flow-status"},
+        "transcript_path": path.to_string_lossy(),
+    });
+    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["hook", "validate-skill"])
+        .env_remove("FLOW_CI_RUNNING")
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn flow-rs");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(payload.to_string().as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().expect("wait");
+    assert_eq!(output.status.code().unwrap_or(-1), 0);
+}
+
+#[test]
+fn subprocess_validate_skill_allows_when_no_stdin() {
+    // No stdin payload — hook silently allows (exit 0, no stderr).
+    let (code, _stdout, stderr) = run_hook_subprocess("");
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty(), "stderr should be empty: {}", stderr);
+}


### PR DESCRIPTION
## What

work on issue: Block model invocation of user-only flow- skills (PreToolUse:Skill hook) #1366.

Closes #1366

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/block-model-invocation-of-user/plan.md` |
| DAG | `.flow-states/block-model-invocation-of-user/dag.md` |
| Log | `.flow-states/block-model-invocation-of-user/log` |
| State | `.flow-states/block-model-invocation-of-user/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | 6m |
| Code | 1h 3m |
| Code Review | 44m |
| Learn | 18m |
| Complete | <1m |
| **Total** | **2h 12m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/block-model-invocation-of-user.json</summary>

```json
{
  "schema_version": 1,
  "branch": "block-model-invocation-of-user",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1367,
  "pr_url": "https://github.com/benkruger/flow/pull/1367",
  "started_at": "2026-05-07T09:37:23-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/block-model-invocation-of-user/plan.md",
    "dag": ".flow-states/block-model-invocation-of-user/dag.md",
    "log": ".flow-states/block-model-invocation-of-user/log",
    "state": ".flow-states/block-model-invocation-of-user/state.json"
  },
  "session_tty": "/dev/ttys009",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "work on issue: Block model invocation of user-only flow- skills (PreToolUse:Skill hook) #1366",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-07T09:37:23-07:00",
      "completed_at": "2026-05-07T09:38:08-07:00",
      "session_started_at": null,
      "cumulative_seconds": 45,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-07T09:38:08-07:00",
        "five_hour_pct": 22,
        "seven_day_pct": 85
      }
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-05-07T09:38:22-07:00",
      "completed_at": "2026-05-07T09:44:31-07:00",
      "session_started_at": null,
      "cumulative_seconds": 369,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-07T09:44:31-07:00",
        "five_hour_pct": 24,
        "seven_day_pct": 85
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-07T09:45:57-07:00",
      "completed_at": "2026-05-07T10:49:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 3788,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-07T09:45:57-07:00",
        "five_hour_pct": 24,
        "seven_day_pct": 85
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-07T10:41:59-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 87
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-07T10:41:59-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 87
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-07T10:41:59-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 87
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-07T10:41:59-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 87
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-07T10:41:59-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 87
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-07T10:41:59-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 87
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-07T10:41:59-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 87
        },
        {
          "step": 8,
          "field": "code_task",
          "captured_at": "2026-05-07T10:41:59-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 87
        },
        {
          "step": 9,
          "field": "code_task",
          "captured_at": "2026-05-07T10:41:59-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 87
        },
        {
          "step": 10,
          "field": "code_task",
          "captured_at": "2026-05-07T10:41:59-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 87
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-07T10:49:05-07:00",
        "five_hour_pct": 30,
        "seven_day_pct": 87
      }
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-05-07T10:49:16-07:00",
      "completed_at": "2026-05-07T11:33:35-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2659,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-07T10:49:16-07:00",
        "five_hour_pct": 30,
        "seven_day_pct": 87
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_review_step",
          "captured_at": "2026-05-07T10:51:09-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 87
        },
        {
          "step": 2,
          "field": "code_review_step",
          "captured_at": "2026-05-07T11:03:06-07:00",
          "five_hour_pct": 34,
          "seven_day_pct": 88
        },
        {
          "step": 3,
          "field": "code_review_step",
          "captured_at": "2026-05-07T11:03:12-07:00",
          "five_hour_pct": 35,
          "seven_day_pct": 88
        },
        {
          "step": 4,
          "field": "code_review_step",
          "captured_at": "2026-05-07T11:33:19-07:00",
          "five_hour_pct": 1,
          "seven_day_pct": 88
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-07T11:33:35-07:00",
        "five_hour_pct": 1,
        "seven_day_pct": 88
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-07T11:33:50-07:00",
      "completed_at": "2026-05-07T11:51:51-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1081,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-07T11:33:50-07:00",
        "five_hour_pct": 1,
        "seven_day_pct": 88
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-07T11:47:54-07:00",
          "five_hour_pct": 3,
          "seven_day_pct": 89
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-07T11:49:05-07:00",
          "five_hour_pct": 3,
          "seven_day_pct": 89
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-07T11:49:13-07:00",
          "five_hour_pct": 3,
          "seven_day_pct": 89
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-07T11:49:29-07:00",
          "five_hour_pct": 3,
          "seven_day_pct": 89
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-07T11:49:36-07:00",
          "five_hour_pct": 3,
          "seven_day_pct": 89
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-07T11:51:32-07:00",
          "five_hour_pct": 3,
          "seven_day_pct": 89
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-07T11:51:51-07:00",
        "five_hour_pct": 3,
        "seven_day_pct": 89
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-07T11:54:18-07:00",
      "completed_at": "2026-05-07T11:54:50-07:00",
      "session_started_at": null,
      "cumulative_seconds": 32,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-07T11:54:50-07:00",
        "five_hour_pct": 5,
        "seven_day_pct": 89
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-05-07T09:38:22-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-07T09:45:57-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-05-07T10:49:16-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-07T11:33:50-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-07T11:54:18-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-07T09:37:23-07:00",
    "five_hour_pct": 21,
    "seven_day_pct": 85
  },
  "plan_steps_total": 4,
  "plan_step": 3,
  "code_tasks_total": 10,
  "code_task_name": "Doc updates: rules + CLAUDE.md",
  "code_task": 10,
  "diff_stats": {
    "files_changed": 19,
    "insertions": 1631,
    "deletions": 34,
    "captured_at": "2026-05-07T10:49:05-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "compact_summary": "<analysis>\nThe user invoked /flow:flow-complete to begin Phase 6 of the FLOW lifecycle. The skill prompt was loaded but the system has now requested a summary of the entire conversation history (a context-compaction operation). I need to produce a thorough summary covering the entire FLOW workflow that was executed: Start, Plan, Code, Code Review, Learn, and now entering Complete.\n\nLet me chronologically reconstruct the conversation:\n\n**Phase 1 — Start (issue #1366)**: User invoked `/flow:flow-start work on issue: Block model invocation of user-only flow- skills (PreToolUse:Skill hook) #1366`. The branch `block-model-invocation-of-user` was created, PR #1367 opened, state file initialized. All autonomous mode (commit=auto, continue=auto for every phase).\n\n**Phase 2 — Plan**: The plan was extracted from issue #1366 (pre-decomposed). 28 verify-references violations were caught by `bin/flow plan-check` because the plan named NEW test functions that don't yet exist in the codebase. Added `<!-- verify-references: prose-citation -->` opt-out comments to all 28 trigger lines. Then 4 more violations surfaced (scanner caps at 30 identifiers per run), added 4 more opt-outs. Plan-check passed. 10 implementation tasks landed; marked as a single atomic commit group.\n\n**Phase 3 — Code (atomic group, 10 tasks, 1 commit)**: Implemented:\n- `src/hooks/transcript_walker.rs` (NEW) — shared backward walker with `USER_ONLY_SKILLS`, `last_user_message_invokes_skill`, `most_recent_skill_in_user_only_set`, `TRANSCRIPT_BYTE_CAP=50MB`\n- `src/hooks/validate_skill.rs` (NEW) — Layer 1 PreToolUse:Skill hook\n- `src/hooks/validate_ask_user.rs` — Added `user_only_skill_carve_out_applies` helper for Layer 2\n- `src/hooks/validate_claude_paths.rs` — Added `is_transcript_path` predicate for Layer 3\n- `hooks/hooks.json` — Added PreToolUse:Skill matcher\n- `src/window_snapshot.rs` — Made `is_safe_transcript_path` pub\n- 4 doc updates: NEW `.claude/rules/user-only-skills.md`, restructured `flow-requires-user-initiative.md`, extended `hook-vs-instruction.md`, replaced \"Known limitation\" para in `autonomous-phase-discipline.md`, added \"User-Only Skill Enforcement\" subsection to CLAUDE.md\n- Tests at top-level `tests/transcript_walker.rs` and `tests/validate_skill.rs` (NOT mirrored to `tests/hooks/` due to Cargo.toml stanza addition being blocked by validate-worktree-paths shared-config hook in autonomous mode — this is a real deadlock that recurred)\n- Plan signature deviations logged: walker functions take `home: &Path` parameter; carve-out implemented as separate helper\n\nCommit SHA `f638e5b5`, 100/100/100 across 4193 tests.\n\n**Phase 4 — Code Review**: 4 cognitively isolated agents launched:\n- Reviewer found 4 findings (hook-error-diagnosis.md missing entry, test placement, normalization gap, orphan placeholder)\n- Pre-mortem found 5 critical findings (Layer 1 substring bypass via tool_result, read_capped reads file BEGINNING, cp/mv/dd Layer 3 gap, race condition, extract_skill_invocation returns first only)\n- Adversarial wrote tests that proved 5 critical bypasses with passing failure tests (user-prose echo, path traversal via `..`, case-variant skill, whitespace skill, Layer 2 trusts assistant alone)\n- Documentation found 6 findings (transcript persistence contract, orphan exception, cross-references, forward-facing prose, layer threat mapping, is_transcript_path doc)\n\nTriaged: 11 Real, 6 False positive. Fixed:\n- `is_safe_transcript_path` now rejects `..` components\n- `read_capped` now reads LAST cap bytes (tail read)\n- Added `normalize_gate_input` helper (NUL strip + trim + ASCII lowercase)\n- Layer 1 now parses `message.content` as string and requires marker at START of trimmed content (slash-command anchoring); rejects tool_result-wrapped user turns\n- `extract_skill_invocation` renamed to `extract_skill_invocations` returns Vec of all Skill names\n- 4 doc fixes (hook-error-diagnosis.md PreToolUse:Skill row, autonomous-phase-discipline.md forward-facing prose, user-only-skills.md layer threat mapping)\n- Restored `tests/test_adversarial_flow.rs` to integration-branch doc-comment-only stub per `.claude/rules/adversarial-probe-lifecycle.md`\n- Added 16+ regression tests (11 in transcript_walker, 5 in validate_skill)\n\nLint failure on `repeat().take()` → fixed with `repeat_n()`. Coverage gap on user-turn-without-content → added test. .expect with TOCTOU rationale on read_capped's metadata/seek (per external-input-path-construction.md carve-out).\n\nCommit SHA `9780b24f`, 100/100/100 across 4207 tests.\n\n**Phase 5 — Learn**: Launched learn-analyst agent. 8 findings returned across 3 tenants. After verifying against current rule corpus, 6 findings dismissed as already-addressed (USER_ONLY_SKILLS doc comment present, sole-registry callsite enumerated, plan deviation logs followed format, env-var home path validation already in external-input-path-construction.md Rule 5, byte cap rule already there, add-a-skill checklist already in user-only-skills.md). 2 real findings filed as GitHub issues:\n- benkruger/flow#1368: Cargo.toml shared-config edit deadlocks during autonomous Code phase (same root cause as #1366)\n- benkruger/flow#1369: Plan-phase scanner gap — security-gate code without normalization passes plan-check\n\nNo rule edits needed (all recommendations already covered). Promoted permissions (no local file). Phase finalized in 18m, continue_action: invoke.\n\n**Phase 6 — Complete (current)**: Skill loaded. Now I'm being asked to summarize before executing Step 1 (run complete-fast).\n\nKey state:\n- Branch: `block-model-invocation-of-user`\n- Project root: `/Users/ben/code/flow`\n- Worktree: `/Users/ben/code/flow/.worktrees/block-model-invocation-of-user`\n- PR: #1367 (https://github.com/benkruger/flow/pull/1367)\n- Mode: auto (commit=auto, continue=auto from state file skills config)\n- All phases complete except flow-complete (currently in_progress)\n- Two issues filed: benkruger/flow#1368 and #1369\n\nThe user's request was the original /flow:flow-start invocation. Everything since has been executing the autonomous lifecycle.\n\nNow let me write the structured summary.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user invoked `/flow:flow-start work on issue: Block model invocation of user-only flow- skills (PreToolUse:Skill hook) #1366` to start an autonomous FLOW lifecycle on issue #1366. The issue requested adding a three-layer mechanical chain to block model invocation of four user-only FLOW skills (`flow:flow-abort`, `flow:flow-reset`, `flow:flow-release`, `flow:flow-prime`) via a new PreToolUse:Skill hook (`validate-skill`), a sibling carve-out in `validate-ask-user`, and a transcript root lockdown in `validate-claude-paths`. The flow has now reached Phase 6 (Complete) after auto-progressing through Start, Plan, Code, Code Review, and Learn phases.\n\n2. Key Technical Concepts:\n   - PreToolUse:Skill hook (new matcher in `hooks/hooks.json`)\n   - Three-layer enforcement: Layer 1 `validate-skill`, Layer 2 `validate-ask-user` carve-out, Layer 3 `validate-claude-paths` transcript root block\n   - Shared transcript walker (`src/hooks/transcript_walker.rs`) over Claude Code persisted JSONL transcript\n   - `USER_ONLY_SKILLS` const (4 skills, ASCII-lowercased)\n   - `TRANSCRIPT_BYTE_CAP = 50 MB` with TAIL read (seek to file_len - cap, not BEGINNING)\n   - `normalize_gate_input` helper (NUL strip + trim + ASCII lowercase) per `.claude/rules/security-gates.md`\n   - Slash-command anchoring (marker at START of `message.content` string, not substring on raw line)\n   - `is_safe_transcript_path` validator in `src/window_snapshot.rs` (now public; rejects `..` components)\n   - Cognitively isolated review agents (reviewer, pre-mortem, adversarial, documentation, learn-analyst)\n   - Adversarial probe lifecycle (`tests/test_adversarial_flow.rs`)\n   - Plan deviation logging via `bin/flow log`\n   - Shared-config protection via `validate-worktree-paths` hook (Cargo.toml is in the canonical list)\n\n3. Files and Code Sections:\n   - **NEW `src/hooks/transcript_walker.rs`**: Shared backward walker. Final form has `normalize_gate_input` pub fn, `last_user_message_invokes_skill(path, skill, home)` (slash-command anchored, parses message.content as string), `most_recent_skill_in_user_only_set(path, home)` (uses Vec from `extract_skill_invocations`), `read_capped` (tail-read with .expect TOCTOU rationale on metadata/seek per `.claude/rules/external-input-path-construction.md` carve-out), `extract_skill_invocations` (returns Vec of all Skill names).\n   - **NEW `src/hooks/validate_skill.rs`**: Layer 1 hook. `validate(tool_input, transcript_path, home)` normalizes skill via `normalize_gate_input` before USER_ONLY_SKILLS membership; block message echoes canonical lowercased name.\n   - **MODIFIED `src/hooks/validate_ask_user.rs`**: Added `user_only_skill_carve_out_applies(transcript_path, home)`. `run_impl_main` extended with `home: &Path`; carve-out fires after `validate` returns block.\n   - **MODIFIED `src/hooks/validate_claude_paths.rs`**: Added `is_transcript_path` predicate (case-insensitive `.claude/projects/` match); blocks Edit/Write regardless of flow_active.\n   - **MODIFIED `src/window_snapshot.rs`**: `is_safe_transcript_path` made pub; rejects any `Component::ParentDir` before lexical starts_with check.\n   - **MODIFIED `hooks/hooks.json`**: Added PreToolUse:Skill matcher pointing at `bin/flow hook validate-skill`.\n   - **MODIFIED `src/main.rs`**: Added `ValidateSkill` HookCommands variant + dispatch arm.\n   - **MODIFIED `src/hooks/mod.rs`**: Added `pub mod transcript_walker; pub mod validate_skill;`.\n   - **NEW `.claude/rules/user-only-skills.md`**: 4-skill set, threat shapes, 3-layer enforcement chain with Layer threat mapping subsection (added in Code Review).\n   - **MODIFIED `.claude/rules/flow-requires-user-initiative.md`**: Restructured into User-Only vs Ask-First tiers.\n   - **MODIFIED `.claude/rules/hook-vs-instruction.md`**: Added Layer 1, 2, 3 entries to Mechanically-Enforced Gates list.\n   - **MODIFIED `.claude/rules/autonomous-phase-discipline.md`**: Replaced \"Known limitation\" paragraph with forward-facing User-Only Skill Carve-Out subsection.\n   - **MODIFIED `.claude/rules/hook-error-diagnosis.md`**: Added PreToolUse:Skill → validate-skill row.\n   - **MODIFIED `CLAUDE.md`**: Added User-Only Skill Enforcement subsection under Permission Invariant + Conventions entry.\n   - **NEW `tests/transcript_walker.rs`**: 32 tests including 11 regression tests for adversarial bypasses (path traversal, prose mention, tool_result wrapping, case-variant skill, multi-skill extraction, tail-cap behavior).\n   - **NEW `tests/validate_skill.rs`**: 21 tests including 5 normalization regression tests.\n   - **MODIFIED `tests/hooks/validate_ask_user.rs`** + `tests/hooks/validate_claude_paths.rs`: Extended with carve-out / transcript-block tests.\n   - **NEW `tests/common/mod.rs::transcript_fixture`**: Helper writing JSONL under `<home>/.claude/projects/<id>/session.jsonl`.\n   - **PLACEHOLDER `tests/hooks/transcript_walker.rs`**: Doc-comment-only stub (orphan from Cargo.toml stanza block).\n\n4. Errors and fixes:\n   - **Cargo.toml stanza addition blocked** by validate-worktree-paths shared-config hook in autonomous mode → relocated tests to top-level paths and logged the deviation. Filed as benkruger/flow#1368.\n   - **AskUserQuestion blocked** by validate-ask-user when needing user permission for Cargo.toml → same deadlock as the user-only-skills issue itself. Documented in deviation log.\n   - **Plan-check verify-references violations (28 + 4)** for proposed new test names → added `<!-- verify-references: prose-citation -->` opt-outs.\n   - **Test failure: home parameter validation** — `is_safe_transcript_path` rejected fixture paths because it read real $HOME → added `home: &Path` parameter to walker functions (logged as plan signature deviation).\n   - **5 critical security bypasses** surfaced by adversarial agent in Code Review (substring match, path traversal, normalization, tail-read, multi-skill extraction) → all fixed with regression tests.\n   - **Adversarial probe test failed CI** after Step 4 fixes → restored `tests/test_adversarial_flow.rs` to integration-branch stub per `.claude/rules/adversarial-probe-lifecycle.md`.\n   - **Clippy lint** on `std::iter::repeat().take()` → replaced with `std::iter::repeat_n()`.\n   - **Coverage gap** on user-turn-without-content branch and read_capped TOCTOU branches → added test for missing-content + used `.expect` with TOCTOU rationale on read_capped per the carve-out.\n\n5. Problem Solving:\n   - Resolved Cargo.toml + AskUserQuestion deadlock by deferring test relocation to a follow-up issue (#1368) and proceeding with top-level tests + orphan placeholder.\n   - Resolved security-gate normalization gap by introducing `normalize_gate_input` and applying it on both sides of every gate comparison (skill input, transcript-extracted skill, turn_type).\n   - Resolved tail-read coverage by using `.expect()` with TOCTOU rationale per the rule's carve-out.\n   - Generated regression tests for every adversarial-discovered bypass to prevent recurrence.\n\n6. All user messages:\n   - `/flow:flow-start work on issue: Block model invocation of user-only flow- skills (PreToolUse:Skill hook) #1366` (the only direct user message; everything else was autonomous skill self-invocation).\n\n7. Pending Tasks:\n   - Complete Phase 6 (merge PR #1367 and clean up worktree). Specifically: run `bin/flow complete-fast --branch block-model-invocation-of-user --auto` (10-minute Bash timeout), then dispatch on JSON `path` field; for `merged` or `already_merged` skip to Step 6; otherwise handle ci_stale, ci_failed, ci_pending, conflict, max_retries, or error.\n\n8. Current Work:\n   Phase 6 (Complete) just started via auto-advance from Phase 5 Learn (formatted_time: 18m). The flow-complete skill has been loaded with --auto resolved (mode is auto from `skills.flow-complete = \"auto\"` in state). The SOFT-GATE preflight needs to run to read state values, then Step 1 invokes `bin/flow complete-fast --branch block-model-invocation-of-user --auto` with 10-minute timeout. State values: branch=`block-model-invocation-of-user`, project_root=`/Users/ben/code/flow`, worktree=`/Users/ben/code/flow/.worktrees/block-model-invocation-of-user`, pr_number=1367, pr_url=`https://github.com/benkruger/flow/pull/1367`. Phase 5 status is \"complete\". Two issues were filed during Learn (#1368, #1369) which will appear in the issues_links section of the final summary.\n\n9. Optional Next Step:\n   Run the Phase 6 SOFT-GATE preflight (read state file, check `phases.flow-learn.status == \"complete\"`, capture `feature`/`branch`/`worktree`/`pr_number`/`pr_url`/`cumulative_seconds`), output the Phase 6 STARTING banner, then proceed to Step 1 by invoking `/Users/ben/code/flow/bin/flow complete-fast --branch block-model-invocation-of-user --auto` with `timeout: 600000` (10-minute Bash tool timeout per `.claude/rules/ci-is-a-gate.md`). The expected happy path returns `\"path\": \"merged\"` since CI was green at the end of Code Review and no work has happened on main since (the only commits on this branch are `f638e5b5` and `9780b24f`). Per the skill: \"If `\\\"path\\\": \\\"merged\\\"` — the PR is merged (auto mode happy path). Skip directly to Step 6 (finalize).\"\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/block-model-invocation-of-user",
  "compact_count": 7,
  "findings": [
    {
      "finding": "Layer 1 substring match on raw JSON line allowed user-prose echo bypass",
      "reason": "Walker now parses message.content as a string and requires marker at START of trimmed content; tool_result-wrapped user turns rejected",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T11:30:20-07:00"
    },
    {
      "finding": "is_safe_transcript_path bypassable via .. components",
      "reason": "Validator now rejects any path containing a ParentDir component before the prefix check",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T11:30:27-07:00"
    },
    {
      "finding": "read_capped read file BEGINNING — tail invisible on transcripts >50MB",
      "reason": "read_capped now seeks to file_len - TRANSCRIPT_BYTE_CAP before reading; the tail is always visible. metadata/seek wrapped in .expect with TOCTOU rationale per the .claude/rules/external-input-path-construction.md carve-out",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T11:30:38-07:00"
    },
    {
      "finding": "Gate normalization missing — case-variant / whitespace-padded / NUL-padded skill names bypass USER_ONLY_SKILLS membership check",
      "reason": "Added normalize_gate_input helper (NUL strip + trim + ASCII lowercase) and applied to skill input on both validate-skill and the walker. USER_ONLY_SKILLS entries already lowercased; now both sides normalize",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T11:30:47-07:00"
    },
    {
      "finding": "extract_skill_invocation returned only first Skill — multi-tool turns with user-only Skill in second position bypass Layer 2 carve-out",
      "reason": "Renamed to extract_skill_invocations; returns Vec of all Skill names in the turn. Carve-out check uses .any() over the normalized names",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T11:30:54-07:00"
    },
    {
      "finding": "hook-error-diagnosis.md missing PreToolUse:Skill matcher entry",
      "reason": "Added Skill -> validate-skill row to the Matcher to hook mapping table",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T11:31:02-07:00"
    },
    {
      "finding": "autonomous-phase-discipline.md User-Only Skill Carve-Out used backward-facing 'would otherwise' prose",
      "reason": "Rewrote subsection forward-facing: describes what the carve-out DOES, not what would happen without it",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T11:31:09-07:00"
    },
    {
      "finding": "user-only-skills.md missing layer threat mapping subsection",
      "reason": "Added 'Layer threat mapping' subsection naming the specific bypass surface each layer addresses; added cross-reference to autonomous-phase-discipline.md",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T11:31:17-07:00"
    },
    {
      "finding": "Test placement deviation — tests/transcript_walker.rs and tests/validate_skill.rs at top-level instead of mirrored tests/hooks/",
      "reason": "Already documented as a deviation in the Phase 3 log. Cargo.toml stanza addition required for subdirectory tests is mechanically blocked by validate-worktree-paths shared-config hook in autonomous mode (the deadlock this PR fixes). Top-level placement is functionally equivalent. Deferring relocation as a follow-up that requires either a manual mode session or a future enhancement to the shared-config hook",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T11:31:26-07:00"
    },
    {
      "finding": "Orphan placeholder file at tests/hooks/transcript_walker.rs (doc-comment-only)",
      "reason": "Same root cause as the test placement deviation — the placeholder marks where the mirrored test would live. Cargo ignores it (no [[test]] stanza). Removing it requires Bash rm or Cargo.toml edit, both blocked. Leaving the placeholder + deviation log entry so a future manual-mode session can complete the relocation",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T11:31:35-07:00"
    },
    {
      "finding": "Asymmetric normalization of USER_ONLY_SKILLS",
      "reason": "Already addressed: USER_ONLY_SKILLS const has doc comment 'Entries are stored ASCII-lowercased; gate comparisons normalize caller input through normalize_gate_input before checking membership' added in Code Review Step 4",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T11:48:04-07:00"
    },
    {
      "finding": "USER_ONLY_SKILLS sole-registry caller enumeration missing",
      "reason": "Already addressed: .claude/rules/user-only-skills.md 'How to Add a Skill to the User-Only Set' lists USER_ONLY_SKILLS in src/hooks/transcript_walker.rs as the registry and enumerates the four-step add-a-skill checklist",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T11:48:14-07:00"
    },
    {
      "finding": "Plan deviation logs missing parenthetical rationale",
      "reason": "False positive — all three Phase 3 deviation log entries on this branch followed the format <what changed> (<why>) per .claude/rules/plan-commit-atomicity.md 'Plan Signature Deviations Must Be Logged'. Verified by reading the log file",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T11:48:26-07:00"
    },
    {
      "finding": "Env-var-derived home path validation rule missing",
      "reason": "False positive — .claude/rules/external-input-path-construction.md 'Validate env-var-derived paths as absolute' (Rule 5) already covers this exact pattern",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T11:48:33-07:00"
    },
    {
      "finding": "Transcript byte-cap rule for hooks missing",
      "reason": "False positive — .claude/rules/external-input-path-construction.md 'Enforce a documented size cap on every external read' (Rule 3) already covers this. TRANSCRIPT_BYTE_CAP is implemented in src/hooks/transcript_walker.rs and verified by the walker_returns_false_when_command_falls_off_tail_cap test",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T11:48:41-07:00"
    },
    {
      "finding": "User-only-skill add-checklist subsection missing",
      "reason": "False positive — .claude/rules/user-only-skills.md 'How to Add a Skill to the User-Only Set' subsection already provides the four-item checklist (USER_ONLY_SKILLS const, table row, validate_user_only_skill_*_is_in_set test, SKILL.md HARD-GATE confirmation)",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T11:48:48-07:00"
    },
    {
      "finding": "Hook-context introspection cross-hook table",
      "reason": "Already partially addressed — .claude/rules/user-only-skills.md added a 'Layer threat mapping' subsection in Code Review Step 4 that names each layer's bypass surface and load-bearing role. Adding a separate file/function/exit-code table would duplicate information already discoverable via grep + the rule prose",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T11:48:58-07:00"
    },
    {
      "finding": "Cargo.toml shared-config autonomous-mode deadlock — sibling of #1366",
      "reason": "Same autonomous-deadlock pattern recurs for shared-config edits. Filed as benkruger/flow#1368",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T11:50:30-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1368"
    },
    {
      "finding": "Plan phase missed security-gates.md normalization discipline for Layer 1 gate code; 5 critical bypasses surfaced in Code Review",
      "reason": "Filed as benkruger/flow#1369 — recommends a new plan-check scanner that flags security-gate pseudocode lacking normalization rationale",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T11:51:25-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1369"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "issues_filed": [
    {
      "label": "Flow",
      "title": "Cargo.toml shared-config edit deadlocks during autonomous Code phase (same root cause as #1366)",
      "url": "https://github.com/benkruger/flow/issues/1368",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T11:50:22-07:00"
    },
    {
      "label": "Flow",
      "title": "Plan-phase scanner gap: security-gate code without normalization passes plan-check",
      "url": "https://github.com/benkruger/flow/issues/1369",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T11:51:16-07:00"
    }
  ],
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-07T11:54:50-07:00",
    "five_hour_pct": 5,
    "seven_day_pct": 89
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Flow | Cargo.toml shared-config edit deadlocks during autonomous Code phase (same root cause as #1366) | Learn | #1368 |
| Flow | Plan-phase scanner gap: security-gate code without normalization passes plan-check | Learn | #1369 |

<!-- end:Issues Filed -->