### PR TITLE
Autonomous Flows Can Be Silently

### DIFF
--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -21,6 +21,12 @@ During any phase with `continue: auto`:
 - Never unilaterally decide the flow is "too big" and ask whether
   to continue — autonomy means the user already answered that
   question when they chose `--auto`.
+- Never end the turn voluntarily without producing a tool call.
+  When context is exhausted, commit the in-flight work at a natural
+  boundary; the Stop-hook predicate
+  (`stop_continue::check_autonomous_in_progress`) refuses a turn-end
+  during an in-progress autonomous phase, so a model that "stops
+  with text" gets blocked into continuing.
 
 If Claude feels the urge to pause because of context pressure, a
 long-running task, or uncertainty about scope: commit the in-flight
@@ -61,7 +67,9 @@ response.
 
 ## Enforcement
 
-The prose rule above is backed by a mechanical PreToolUse hook.
+The prose rule above is backed by two mechanical hooks. The first
+gates `AskUserQuestion`; the second gates the Stop event itself.
+
 The `validate-ask-user` hook
 (`src/hooks/validate_ask_user.rs::validate()`) refuses
 `AskUserQuestion` tool calls with exit 2 when the state file
@@ -93,6 +101,20 @@ window, `_auto_continue` behaves unchanged.
 
 The blocked tool call returns the rejection message to the
 model via stderr so the session adapts instead of stalling.
+
+The Stop hook (`stop_continue::run()`) refuses a voluntary
+turn-end with `{"decision":"block"}` when
+`phases.<current_phase>.status == "in_progress"` AND
+`skills.<current_phase>.continue == "auto"` (Simple `"auto"` and
+Detailed `{"continue":"auto"}` shapes both recognized) AND
+`_continue_pending` is empty. The block runs after
+`check_first_stop` and `check_continue` so discussion mode and
+multi-child-skill chains keep their semantics. The block reason
+instructs user stop intent to route through `/flow:flow-abort`
+or `/flow:flow-note`. PreToolUse hooks cannot observe a turn-end
+with no tool call — only a Stop hook can — so this predicate
+closes the text-only-stop hole that `validate-ask-user` cannot
+reach.
 
 ## User-Only Skill Carve-Out
 

--- a/.claude/rules/hook-vs-instruction.md
+++ b/.claude/rules/hook-vs-instruction.md
@@ -81,6 +81,16 @@ insufficient:
   block is suppressed so user-only skills' confirmation prompts
   fire mid-autonomous. See `.claude/rules/user-only-skills.md`
   Layer 2.
+- **Voluntary turn-end during autonomous in-progress phases** —
+  `stop_continue::check_autonomous_in_progress` refuses the Stop
+  event with `{"decision":"block"}` and an autonomous-mode reason
+  when the current phase is in-progress AND configured `auto` AND
+  `_continue_pending` is empty. Closes the text-only-stop hole
+  that PreToolUse hooks cannot reach: a model that ends the turn
+  with prose alone (no tool call) is invisible to PreToolUse, but
+  the Stop hook fires and refuses the turn-end. The block runs
+  AFTER `check_first_stop` and `check_continue` so discussion
+  mode and multi-child-skill chains keep their semantics.
 - **Model invocation of user-only skills** —
   `validate-skill` rejects Skill tool calls naming
   `flow:flow-abort`, `flow:flow-reset`, `flow:flow-release`, or

--- a/.claude/rules/mirror-pattern-rule-audit.md
+++ b/.claude/rules/mirror-pattern-rule-audit.md
@@ -1,0 +1,134 @@
+# Mirror-Pattern Rule Audit
+
+When a plan's Exploration or Approach section says the new code will
+"mirror sibling X exactly" — copying the field reads, gate
+comparisons, fail-open posture, or any other pattern from an existing
+function — the plan must also enumerate whether sibling X currently
+complies with every applicable rule. A literal mirror inherits any
+pre-existing rule violations as new code, and Code Review will flag
+them in the new file even though they were copied verbatim from an
+older one.
+
+## Why
+
+"Mirror sibling X exactly" is a shortcut for "the existing pattern
+works, do that." It saves Plan-phase exploration time and produces
+internally consistent code. But the shortcut has a hidden cost: it
+copies whatever the sibling does, including any latent rule
+violations the sibling has accumulated while rules tightened around
+it.
+
+Two failure modes recur:
+
+1. **Inherited violation.** Sibling X uses raw `==` comparisons on
+   state-derived strings; `security-gates.md` "Normalize Before
+   Comparing" was added after X was written. The new function
+   mirrors X, so it inherits the un-normalized comparison. Code
+   Review flags it. The fix lands in the new function only,
+   leaving X out of date.
+2. **Drift on rule update.** A future rule change tightens
+   `security-gates.md`. The author updates X. The mirror in the
+   new function is forgotten because nothing tied them together.
+   The two predicates silently diverge.
+
+The Plan-phase audit catches both: by listing the sibling's
+applicable rules at planning time, the author either fixes both
+together (extracting a shared helper, planning a second commit) or
+explicitly accepts the inheritance (logging the gap and filing tech
+debt for the sibling).
+
+## The Rule
+
+When a plan task description, Exploration entry, or Approach prose
+contains any of these mirror-pattern phrasings:
+
+- "mirror sibling X exactly"
+- "matches sibling X's pattern"
+- "follow X's convention"
+- "use the same pattern as X"
+- "copy from X"
+- "parallels the implementation of X"
+
+…the plan must include a **Mirror Audit Table** within a few lines
+of the trigger. The table has three columns:
+
+| Sibling pattern | Applicable rules | Compliance |
+|---|---|---|
+| `validate_ask_user::validate` — reads `phases.<phase>.status`, `skills.<phase>` and compares to literal strings | `security-gates.md` "Normalize Before Comparing"; `external-input-path-construction.md` "Enforce a documented size cap" | UN-NORMALIZED — `== Some("auto")` raw byte equality (gap). NO BYTE CAP — uses `mutate_state` which has internal bounds. |
+| `check_first_stop` — fail-open on parse error | `security-gates.md` "Fail Closed When State Is Unreliable" | TENSION — module doc commits to fail-open across the hook family for user-recovery; rule's fail-closed posture would deadlock under corrupt state. Documented exception. |
+
+Column definitions:
+
+- **Sibling pattern** — file:function and the specific behavior the
+  new code will mirror.
+- **Applicable rules** — every `.claude/rules/*.md` file whose
+  trigger conditions match this pattern. Cite the rule's relevant
+  section heading.
+- **Compliance** — one of:
+  - *Compliant* — sibling X follows the rule. Mirror inherits the
+    compliant pattern.
+  - *Gap* — sibling X violates the rule. Mirroring inherits the
+    violation. The plan must decide: extract a shared helper that
+    fixes both, OR mirror the violation in the new code AND file
+    a Tech Debt issue for the sibling, AND add the new code's fix
+    to the same PR.
+  - *Tension* — sibling X follows a pattern that contradicts the
+    rule, but for a documented reason. The plan must reference the
+    documenting source (module doc, prior rule clarification) so
+    the new code can adopt the same exception.
+
+## How to Find Applicable Rules
+
+For each pattern the plan is about to mirror, run a targeted grep
+of `.claude/rules/` for keywords describing the pattern:
+
+```text
+grep -l "Normalize Before Comparing" .claude/rules/
+grep -l "BYTE_CAP\|byte cap\|Enforce a documented size cap" .claude/rules/
+grep -l "fail-open\|Fail Closed" .claude/rules/
+grep -l "panic.*assert\|invariant check" .claude/rules/
+```
+
+Every matching rule is a candidate; read each match and decide if
+the rule's trigger conditions match the pattern being mirrored.
+
+## How to Apply
+
+**Plan phase.** When writing Exploration prose, watch for
+mirror-pattern phrasings. For each one, build the audit table.
+Include the table in the plan's Exploration or Approach section
+before Code phase begins.
+
+**Code phase.** When implementing a mirror, follow the audit
+table's compliance column:
+
+- **Compliant** rows: copy the pattern verbatim.
+- **Gap** rows: do not copy the violation. Implement the new code
+  with the rule-compliant pattern. File the Tech Debt issue for
+  the sibling.
+- **Tension** rows: copy the documented exception. Reference the
+  documenting source in a code comment so future readers see the
+  rule tension explicitly.
+
+**Code Review phase.** The reviewer agent cross-checks the audit
+table against the landed code. A finding tagged "mirror inherited
+a known violation" routed to Step 4 either fixes the new code or
+records a Plan-phase gap (the audit was missing or incomplete).
+
+## Plan-Phase Trigger
+
+This rule is enforcement-light: no mechanical scanner currently
+catches missing audit tables, because mirror-pattern phrasings
+are too common in legitimate prose ("mirror this in tests" is
+not the same as "mirror sibling X exactly"). The Plan-phase
+exploration is where the audit happens; the Code Review reviewer
+agent is the safety net.
+
+## Cross-References
+
+- `.claude/rules/security-gates.md` — the canonical gate-input
+  rules that mirror audits most often surface.
+- `.claude/rules/external-input-path-construction.md` — the
+  byte-cap rule for filesystem reads.
+- `.claude/rules/external-input-validation.md` — the parent
+  prose discipline for fallible constructors.

--- a/.claude/rules/plan-commit-atomicity.md
+++ b/.claude/rules/plan-commit-atomicity.md
@@ -164,6 +164,20 @@ It is NOT required for:
 - **Whitespace or formatting adjustments** to code the plan sketched
   as pseudocode.
 - **Test-function renames** that stay within the plan's stated scope.
+- **Implementation-detail changes within an unchanged signature** —
+  selecting a different filesystem syscall (e.g., `Path::exists()`
+  versus `Path::symlink_metadata().is_err()`) when both produce
+  identical fail-open semantics, restructuring `match` arms into
+  `.ok().and_then(...)` chains, swapping equivalent standard-library
+  primitives, or other refactorings that leave the public signature,
+  return type, and observable behavior unchanged. These are routine
+  Code-phase implementation choices — not "interface prototype"
+  deviations. Code Review may still flag them as architecture or
+  simplicity findings, but they do not require a `bin/flow log`
+  entry to satisfy this rule. The trigger for logging is a change
+  the Plan phase would have written differently if it had known —
+  not a change the Plan phase happened to sketch in pseudocode that
+  Code phase polished into idiomatic Rust.
 
 ### How to Apply (Deviation Logging)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,10 +198,11 @@ Account-window snapshots are captured at every state-mutating transition by `src
 
 ### Auto-Advance Architecture
 
-Two layers:
+Three layers:
 
 1. The phase completion command returns `continue_action` (`"invoke"` or `"ask"`) and optionally `continue_target` in its JSON. Skill HARD-GATEs parse `continue_action` to decide whether to auto-invoke the next phase or prompt the user.
 2. `phase_complete()` writes `_auto_continue` to the state file when `continue_action` is `"invoke"`. The `validate-ask-user` PreToolUse hook reads this and auto-answers any `AskUserQuestion` that fires — safety net for cases where the model ignores the HARD-GATE.
+3. **Autonomous Stop Enforcement.** The Stop hook (`stop_continue::run()`) refuses voluntary turn-end via `check_autonomous_in_progress` when the current phase is `in_progress` AND configured `auto` AND `_continue_pending` is empty — closing the text-only-stop hole that PreToolUse hooks cannot reach. PreToolUse fires on tool calls, so a model that ends the turn with prose alone (no tool call) is invisible to it; the Stop hook fires on the Stop event itself. Composed AFTER `check_first_stop` and `check_continue` so discussion-mode and multi-child-skill chains keep their semantics. See `.claude/rules/autonomous-phase-discipline.md` Enforcement section.
 
 Block-first ordering: when the current phase's `phases.<current_phase>.status == "in_progress"` AND `skills.<current_phase>.continue == "auto"`, `validate-ask-user` returns exit 2 instead of auto-answering. The block path precedes the auto-answer path. The `in_progress` scope is load-bearing: the next phase's status is still `"pending"` until `phase_enter()` runs, so the completing skill's HARD-GATE prompt to approve transitions is NOT blocked even when the next phase is auto. `phase_enter()` clears `_auto_continue`, `_continue_pending`, `_continue_context`. See `.claude/rules/autonomous-phase-discipline.md`.
 

--- a/src/hooks/stop_continue.rs
+++ b/src/hooks/stop_continue.rs
@@ -1,10 +1,17 @@
-//! Stop hook that forces continuation when `_continue_pending` is set.
+//! Stop hook composed of three predicates that may refuse a turn-end.
 //!
-//! When a phase skill sets `_continue_pending=<skill_name>` in the state
-//! file before invoking a child skill, this hook fires when the model
-//! tries to end its turn. If the flag is non-empty, the hook clears it
-//! and blocks the stop, forcing Claude to continue generating and follow
-//! the parent skill's remaining instructions.
+//! `run()` evaluates them in order:
+//!
+//! 1. `check_first_stop` — on the first Stop event of a session,
+//!    enters discussion mode (or consumes a pending continuation
+//!    with a conditional message).
+//! 2. `check_continue` — on subsequent stops, forces continuation
+//!    when `_continue_pending=<skill_name>` is set, supporting
+//!    multi-child-skill chains.
+//! 3. `check_autonomous_in_progress` — when the current phase is
+//!    in-progress AND configured `auto` AND `_continue_pending` is
+//!    empty, refuses a voluntary turn-end. Closes the
+//!    text-only-stop hole that PreToolUse hooks cannot reach.
 //!
 //! Fail-open with error reporting: any error allows the stop (exit 0,
 //! no block output), but writes a diagnostic to stderr and attempts to
@@ -519,6 +526,95 @@ pub fn format_conditional_continue_reason(skill: &str, context: Option<&str>) ->
     )
 }
 
+/// Refuse a voluntary turn-end when the current phase is in-progress,
+/// configured autonomous, and no `_continue_pending` marker is set.
+///
+/// PreToolUse hooks cannot observe a turn-end with no tool call —
+/// only a Stop hook can. When a phase is configured `auto`, the user
+/// has authorized continuous execution; allowing the model to end
+/// the turn voluntarily silently breaks that contract. This predicate
+/// converts the contract from advisory prose into a mechanical block.
+///
+/// Composed into `run()` AFTER `check_first_stop` and `check_continue`
+/// so discussion mode and multi-child-skill chains keep their
+/// semantics. Reordering would let `_continue_pending` paths get
+/// caught by the autonomous block.
+///
+/// Recognizes both skill-config shapes: bare `"auto"` string
+/// (`SkillConfig::Simple`) and `{"continue": "auto", ...}` object
+/// (`SkillConfig::Detailed`). Mirrors `validate_ask_user::validate`'s
+/// scoping precisely.
+///
+/// Fail-open on every error class: missing state file, unparseable
+/// JSON, wrong root type, missing `current_phase`. The Stop hook must
+/// never panic — a hook crash terminates the user's session.
+pub fn check_autonomous_in_progress(state_path: &Path) -> ContinueResult {
+    let no_block = || ContinueResult {
+        should_block: false,
+        skill: None,
+        context: None,
+    };
+    if !state_path.exists() {
+        return no_block();
+    }
+    // Fold read-Err and parse-Err through the same `None` arm: a chmod-000
+    // file (read-Err), a malformed JSON file (parse-Err), and a missing
+    // file (handled above) all behave identically — fail-open with no
+    // block. Collapsing into one branch keeps the surface testable
+    // through the parse-Err path without requiring a chmod fixture per
+    // `.claude/rules/reachable-is-testable.md`.
+    let state: Value = match std::fs::read_to_string(state_path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<Value>(&c).ok())
+    {
+        Some(v) => v,
+        None => return no_block(),
+    };
+
+    let current_phase = state
+        .get("current_phase")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if current_phase.is_empty() {
+        return no_block();
+    }
+
+    let in_progress = state
+        .get("phases")
+        .and_then(|p| p.get(current_phase))
+        .and_then(|p| p.get("status"))
+        .and_then(|v| v.as_str())
+        == Some("in_progress");
+    if !in_progress {
+        return no_block();
+    }
+
+    let skill_entry = state.get("skills").and_then(|s| s.get(current_phase));
+    let is_auto = match skill_entry {
+        Some(v) if v.as_str() == Some("auto") => true,
+        Some(v) => v.get("continue").and_then(|c| c.as_str()) == Some("auto"),
+        None => false,
+    };
+    if !is_auto {
+        return no_block();
+    }
+
+    ContinueResult {
+        should_block: true,
+        skill: Some("autonomous-stop-refused".to_string()),
+        context: Some(format!(
+            "Autonomous mode in phase `{}`. Stop refused.\n\n\
+             Autonomous flows must not end the turn voluntarily. \
+             Continue with the next plan task. If context is exhausted, \
+             commit in-flight work at a natural boundary, then continue.\n\n\
+             If the user has expressed stop intent, route through \
+             /flow:flow-abort (to end the flow) or /flow:flow-note (to \
+             capture a correction without ending). Do not stop on text alone.",
+            current_phase
+        )),
+    }
+}
+
 /// Run the stop-continue hook (entry point).
 ///
 /// Uses `resolve_branch` for `--branch` override support. Calls
@@ -553,6 +649,15 @@ pub fn run() {
         result = check_continue(&hook_input, &state_path);
     }
 
+    // Autonomous-stop refusal: when the current phase is in-progress
+    // and configured `auto`, refuse a voluntary turn-end. Composed
+    // AFTER check_continue so multi-child-skill chains route through
+    // check_continue first; reordering would let `_continue_pending`
+    // paths get caught here.
+    if !result.should_block {
+        result = check_autonomous_in_progress(&state_path);
+    }
+
     capture_session_id(&hook_input, &state_path);
 
     // Blocked flag: CLEAR when session is continuing (blocking),
@@ -567,11 +672,14 @@ pub fn run() {
 
     if result.should_block {
         let skill_name = result.skill.as_deref().unwrap_or("");
-        // Discussion mode and discussion-with-pending both use their context
-        // directly as the reason — not the "child skill returned" framing
-        // from format_block_output, which is designed for multi-child-skill
-        // check_continue continuations.
-        let output = if skill_name == "discussion" || skill_name == "discussion-with-pending" {
+        // Discussion mode, discussion-with-pending, and autonomous-stop-refused
+        // all use their context directly as the reason — not the "child
+        // skill returned" framing from format_block_output, which is
+        // designed for multi-child-skill check_continue continuations.
+        let output = if skill_name == "discussion"
+            || skill_name == "discussion-with-pending"
+            || skill_name == "autonomous-stop-refused"
+        {
             json!({"decision": "block", "reason": result.context.as_deref().unwrap_or(DISCUSSION_BLOCK_REASON)})
         } else {
             format_block_output(skill_name, result.context.as_deref())

--- a/src/hooks/stop_continue.rs
+++ b/src/hooks/stop_continue.rs
@@ -17,8 +17,8 @@
 //! no block output), but writes a diagnostic to stderr and attempts to
 //! log to `.flow-states/<branch>.log` for post-mortem visibility.
 
-use std::fs::OpenOptions;
-use std::io::{Read, Write};
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
@@ -526,6 +526,24 @@ pub fn format_conditional_continue_reason(skill: &str, context: Option<&str>) ->
     )
 }
 
+/// State file size cap for the direct read in
+/// `check_autonomous_in_progress`. The state file is FLOW-managed and
+/// branch-scoped, but a corrupted or hostile state file could grow
+/// without bound (account-window snapshots, findings array, log
+/// entries) and an unbounded read at every Stop event would scale
+/// O(turns × file_size). 4 MB is comfortably above the largest
+/// observed legitimate state file and bounds adversarial input.
+const STATE_FILE_BYTE_CAP: u64 = 4 * 1024 * 1024;
+
+/// Normalize a state-file string before comparing in a gate per
+/// `.claude/rules/security-gates.md` "Normalize Before Comparing":
+/// strip embedded NULs (defeat-byte-equality from truncated writes),
+/// trim whitespace (state-file padding, hand edits), and ASCII-
+/// lowercase (case-insensitive intent across `auto`/`Auto`/`AUTO`).
+fn normalize_gate_input(s: &str) -> String {
+    s.replace('\0', "").trim().to_ascii_lowercase()
+}
+
 /// Refuse a voluntary turn-end when the current phase is in-progress,
 /// configured autonomous, and no `_continue_pending` marker is set.
 ///
@@ -557,16 +575,25 @@ pub fn check_autonomous_in_progress(state_path: &Path) -> ContinueResult {
     if !state_path.exists() {
         return no_block();
     }
-    // Fold read-Err and parse-Err through the same `None` arm: a chmod-000
-    // file (read-Err), a malformed JSON file (parse-Err), and a missing
-    // file (handled above) all behave identically — fail-open with no
-    // block. Collapsing into one branch keeps the surface testable
-    // through the parse-Err path without requiring a chmod fixture per
-    // `.claude/rules/reachable-is-testable.md`.
-    let state: Value = match std::fs::read_to_string(state_path)
-        .ok()
-        .and_then(|c| serde_json::from_str::<Value>(&c).ok())
-    {
+    // Read with a byte cap per `.claude/rules/external-input-path-construction.md`
+    // — bounds the read so a corrupted or hostile state file cannot OOM the
+    // hook on a long autonomous flow where this fires at every Stop. Fold
+    // read-Err and parse-Err through the same `None` arm: a chmod-000 file,
+    // a malformed JSON file, and a missing file (handled above) all behave
+    // identically — fail-open with no block. Collapsing into one branch
+    // keeps the surface testable through the parse-Err path without
+    // requiring a chmod fixture per `.claude/rules/reachable-is-testable.md`.
+    let state: Value = match File::open(state_path).ok().and_then(|f| {
+        let mut buf = String::new();
+        // Discard the read-Err arm: any read failure (chmod-000 mid-read,
+        // transient I/O) leaves `buf` empty or partial, which then fails the
+        // JSON parse below. Funnelling both error paths through the parse-Err
+        // arm avoids an unreachable branch — see
+        // `.claude/rules/reachable-is-testable.md` "When the test resists
+        // the real production path."
+        let _ = BufReader::new(f.take(STATE_FILE_BYTE_CAP)).read_to_string(&mut buf);
+        serde_json::from_str::<Value>(&buf).ok()
+    }) {
         Some(v) => v,
         None => return no_block(),
     };
@@ -579,11 +606,16 @@ pub fn check_autonomous_in_progress(state_path: &Path) -> ContinueResult {
         return no_block();
     }
 
+    // Normalize before comparing per `.claude/rules/security-gates.md` so
+    // hand-edited padding (whitespace, NUL), case variants, and BOM-ish
+    // remnants do not silently disable the gate.
     let in_progress = state
         .get("phases")
         .and_then(|p| p.get(current_phase))
         .and_then(|p| p.get("status"))
         .and_then(|v| v.as_str())
+        .map(normalize_gate_input)
+        .as_deref()
         == Some("in_progress");
     if !in_progress {
         return no_block();
@@ -591,8 +623,14 @@ pub fn check_autonomous_in_progress(state_path: &Path) -> ContinueResult {
 
     let skill_entry = state.get("skills").and_then(|s| s.get(current_phase));
     let is_auto = match skill_entry {
-        Some(v) if v.as_str() == Some("auto") => true,
-        Some(v) => v.get("continue").and_then(|c| c.as_str()) == Some("auto"),
+        Some(v) if v.as_str().map(normalize_gate_input).as_deref() == Some("auto") => true,
+        Some(v) => {
+            v.get("continue")
+                .and_then(|c| c.as_str())
+                .map(normalize_gate_input)
+                .as_deref()
+                == Some("auto")
+        }
         None => false,
     };
     if !is_auto {

--- a/tests/hooks/stop_continue.rs
+++ b/tests/hooks/stop_continue.rs
@@ -1433,3 +1433,148 @@ fn subprocess_stop_hook_blocks_voluntary_stop_in_autonomous_in_progress_phase() 
         reason
     );
 }
+
+// --- check_autonomous_in_progress normalization (security-gates.md) ---
+//
+// Each test below asserts the gate still blocks under a state-file value
+// that defeats raw byte equality: trailing/leading whitespace, mixed case,
+// embedded NUL. Without normalization a hand-edited or hostile state file
+// could silently bypass the autonomous-stop gate per security-gates.md
+// "Normalize Before Comparing".
+
+fn write_state(path: &std::path::Path, status: Value, skill: Value) {
+    let state = json!({
+        "current_phase": "flow-code",
+        "phases": {"flow-code": {"status": status}},
+        "skills": {"flow-code": skill},
+    });
+    fs::write(path, serde_json::to_string(&state).unwrap()).unwrap();
+}
+
+#[test]
+fn check_autonomous_in_progress_blocks_when_status_has_trailing_whitespace() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    write_state(&path, json!("in_progress "), json!("auto"));
+    assert!(
+        check_autonomous_in_progress(&path).should_block,
+        "trailing-whitespace status must normalize and still block"
+    );
+}
+
+#[test]
+fn check_autonomous_in_progress_blocks_when_status_has_leading_whitespace() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    write_state(&path, json!(" in_progress"), json!("auto"));
+    assert!(
+        check_autonomous_in_progress(&path).should_block,
+        "leading-whitespace status must normalize and still block"
+    );
+}
+
+#[test]
+fn check_autonomous_in_progress_blocks_when_status_is_mixed_case() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    write_state(&path, json!("In_Progress"), json!("auto"));
+    assert!(
+        check_autonomous_in_progress(&path).should_block,
+        "mixed-case status must normalize (case-fold) and still block"
+    );
+}
+
+#[test]
+fn check_autonomous_in_progress_blocks_when_status_has_embedded_nul() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    write_state(&path, json!("in_progress\u{0000}"), json!("auto"));
+    assert!(
+        check_autonomous_in_progress(&path).should_block,
+        "NUL-padded status must normalize and still block"
+    );
+}
+
+#[test]
+fn check_autonomous_in_progress_blocks_when_simple_skill_has_trailing_whitespace() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    write_state(&path, json!("in_progress"), json!("auto "));
+    assert!(
+        check_autonomous_in_progress(&path).should_block,
+        "trailing-whitespace Simple skill must normalize and still block"
+    );
+}
+
+#[test]
+fn check_autonomous_in_progress_blocks_when_simple_skill_is_uppercase() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    write_state(&path, json!("in_progress"), json!("AUTO"));
+    assert!(
+        check_autonomous_in_progress(&path).should_block,
+        "uppercase Simple skill must normalize and still block"
+    );
+}
+
+#[test]
+fn check_autonomous_in_progress_blocks_when_simple_skill_has_embedded_nul() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    write_state(&path, json!("in_progress"), json!("auto\u{0000}"));
+    assert!(
+        check_autonomous_in_progress(&path).should_block,
+        "NUL-padded Simple skill must normalize and still block"
+    );
+}
+
+#[test]
+fn check_autonomous_in_progress_blocks_when_detailed_skill_continue_is_uppercase() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    write_state(&path, json!("in_progress"), json!({"continue": "AUTO"}));
+    assert!(
+        check_autonomous_in_progress(&path).should_block,
+        "uppercase Detailed-form continue must normalize and still block"
+    );
+}
+
+#[test]
+fn check_autonomous_in_progress_blocks_when_detailed_skill_continue_has_trailing_whitespace() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    write_state(&path, json!("in_progress"), json!({"continue": "auto "}));
+    assert!(
+        check_autonomous_in_progress(&path).should_block,
+        "trailing-whitespace Detailed-form continue must normalize and still block"
+    );
+}
+
+// --- check_autonomous_in_progress oversized state file (byte cap) ---
+
+#[test]
+fn check_autonomous_in_progress_no_block_when_state_file_exceeds_byte_cap() {
+    // Write a state file that exceeds STATE_FILE_BYTE_CAP (4 MB). The
+    // capped read truncates mid-string, the JSON parse fails, and the
+    // function fails open (no block). This proves the cap actually
+    // bounds the read — without it, the read would consume the full
+    // 5 MB and only fail at parse time after a successful unbounded
+    // allocation.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    // 5 MB padding inside a string field, wrapping a state otherwise
+    // valid for blocking. The padding pushes the file past the 4 MB cap.
+    let padding = "x".repeat(5 * 1024 * 1024);
+    let state = json!({
+        "current_phase": "flow-code",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": "auto"},
+        "padding": padding,
+    });
+    fs::write(&path, serde_json::to_string(&state).unwrap()).unwrap();
+    let result = check_autonomous_in_progress(&path);
+    assert!(
+        !result.should_block,
+        "state file exceeding byte cap must fail-open (truncated read produces malformed JSON)"
+    );
+}

--- a/tests/hooks/stop_continue.rs
+++ b/tests/hooks/stop_continue.rs
@@ -11,9 +11,9 @@ use std::process::{Command, Stdio};
 
 use flow_rs::commands::clear_blocked::clear_blocked;
 use flow_rs::hooks::stop_continue::{
-    capture_session_id, check_continue, check_discussion_mode, check_first_stop,
-    format_block_output, format_conditional_continue_reason, set_blocked_idle, set_tab_color,
-    DISCUSSION_BLOCK_REASON,
+    capture_session_id, check_autonomous_in_progress, check_continue, check_discussion_mode,
+    check_first_stop, format_block_output, format_conditional_continue_reason, set_blocked_idle,
+    set_tab_color, DISCUSSION_BLOCK_REASON,
 };
 use serde_json::{json, Value};
 
@@ -1173,6 +1173,263 @@ fn run_subprocess_continue_pending_uses_format_block_output() {
     assert!(
         reason.contains("child skill 'flow-commit' has returned"),
         "format_block_output reason must name the pending skill: {}",
+        reason
+    );
+}
+
+// --- check_autonomous_in_progress ---
+
+#[test]
+fn check_autonomous_in_progress_returns_no_block_when_state_file_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("nonexistent.json");
+    let result = check_autonomous_in_progress(&path);
+    assert!(!result.should_block);
+    assert!(result.skill.is_none());
+    assert!(result.context.is_none());
+}
+
+#[test]
+fn check_autonomous_in_progress_returns_no_block_when_state_unparseable() {
+    let dir = tempfile::tempdir().unwrap();
+    // Empty file
+    let empty = dir.path().join("empty.json");
+    fs::write(&empty, "").unwrap();
+    assert!(!check_autonomous_in_progress(&empty).should_block);
+
+    // Invalid JSON
+    let invalid = dir.path().join("invalid.json");
+    fs::write(&invalid, "{not json").unwrap();
+    assert!(!check_autonomous_in_progress(&invalid).should_block);
+
+    // Wrong root type (array)
+    let array = dir.path().join("array.json");
+    fs::write(&array, "[1, 2, 3]").unwrap();
+    assert!(!check_autonomous_in_progress(&array).should_block);
+}
+
+#[test]
+fn check_autonomous_in_progress_returns_no_block_when_current_phase_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    // Empty current_phase string
+    let empty_phase = dir.path().join("empty_phase.json");
+    let state = json!({"current_phase": ""});
+    fs::write(&empty_phase, serde_json::to_string(&state).unwrap()).unwrap();
+    assert!(!check_autonomous_in_progress(&empty_phase).should_block);
+
+    // Missing current_phase key
+    let missing_phase = dir.path().join("missing_phase.json");
+    let state = json!({"branch": "feat"});
+    fs::write(&missing_phase, serde_json::to_string(&state).unwrap()).unwrap();
+    assert!(!check_autonomous_in_progress(&missing_phase).should_block);
+}
+
+#[test]
+fn check_autonomous_in_progress_returns_no_block_when_phase_status_pending() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    // Transition window: current_phase advanced but phase_enter not yet
+    // run, so status is still "pending".
+    let state = json!({
+        "current_phase": "flow-code",
+        "phases": {"flow-code": {"status": "pending"}},
+        "skills": {"flow-code": "auto"}
+    });
+    fs::write(&path, serde_json::to_string(&state).unwrap()).unwrap();
+    assert!(!check_autonomous_in_progress(&path).should_block);
+}
+
+#[test]
+fn check_autonomous_in_progress_returns_no_block_when_phase_status_complete() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    let state = json!({
+        "current_phase": "flow-code",
+        "phases": {"flow-code": {"status": "complete"}},
+        "skills": {"flow-code": "auto"}
+    });
+    fs::write(&path, serde_json::to_string(&state).unwrap()).unwrap();
+    assert!(!check_autonomous_in_progress(&path).should_block);
+}
+
+#[test]
+fn check_autonomous_in_progress_returns_no_block_when_skill_config_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    let state = json!({
+        "current_phase": "flow-code",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {}
+    });
+    fs::write(&path, serde_json::to_string(&state).unwrap()).unwrap();
+    assert!(!check_autonomous_in_progress(&path).should_block);
+}
+
+#[test]
+fn check_autonomous_in_progress_returns_no_block_when_skill_simple_manual() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    let state = json!({
+        "current_phase": "flow-code",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": "manual"}
+    });
+    fs::write(&path, serde_json::to_string(&state).unwrap()).unwrap();
+    assert!(!check_autonomous_in_progress(&path).should_block);
+}
+
+#[test]
+fn check_autonomous_in_progress_returns_no_block_when_skill_detailed_manual() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    let state = json!({
+        "current_phase": "flow-code",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "manual"}}
+    });
+    fs::write(&path, serde_json::to_string(&state).unwrap()).unwrap();
+    assert!(!check_autonomous_in_progress(&path).should_block);
+}
+
+#[test]
+fn check_autonomous_in_progress_blocks_when_in_progress_and_skill_simple_auto() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    let state = json!({
+        "current_phase": "flow-code",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": "auto"}
+    });
+    fs::write(&path, serde_json::to_string(&state).unwrap()).unwrap();
+    let result = check_autonomous_in_progress(&path);
+    assert!(result.should_block);
+    assert_eq!(result.skill.as_deref(), Some("autonomous-stop-refused"));
+    assert!(result.context.is_some());
+}
+
+#[test]
+fn check_autonomous_in_progress_blocks_when_in_progress_and_skill_detailed_auto() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    let state = json!({
+        "current_phase": "flow-code",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "auto", "commit": "auto"}}
+    });
+    fs::write(&path, serde_json::to_string(&state).unwrap()).unwrap();
+    let result = check_autonomous_in_progress(&path);
+    assert!(result.should_block);
+    assert_eq!(result.skill.as_deref(), Some("autonomous-stop-refused"));
+    assert!(result.context.is_some());
+}
+
+#[test]
+fn check_autonomous_in_progress_block_message_names_current_phase() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    let state = json!({
+        "current_phase": "flow-code",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": "auto"}
+    });
+    fs::write(&path, serde_json::to_string(&state).unwrap()).unwrap();
+    let result = check_autonomous_in_progress(&path);
+    let context = result.context.expect("context present");
+    assert!(
+        context.contains("flow-code"),
+        "context must name current phase: {}",
+        context
+    );
+}
+
+#[test]
+fn check_autonomous_in_progress_block_message_mentions_flow_abort() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("state.json");
+    let state = json!({
+        "current_phase": "flow-plan",
+        "phases": {"flow-plan": {"status": "in_progress"}},
+        "skills": {"flow-plan": "auto"}
+    });
+    fs::write(&path, serde_json::to_string(&state).unwrap()).unwrap();
+    let result = check_autonomous_in_progress(&path);
+    let context = result.context.expect("context present");
+    assert!(
+        context.contains("/flow:flow-abort"),
+        "context must mention /flow:flow-abort: {}",
+        context
+    );
+}
+
+// State file with current_phase=flow-code, status=in_progress,
+// skills.flow-code="auto", _stop_instructed=true (so check_first_stop
+// falls through), no _continue_pending → run() invokes
+// check_autonomous_in_progress which blocks with skill
+// "autonomous-stop-refused". The output-formatting matcher routes the
+// block context directly as the reason (bypass format_block_output).
+#[test]
+fn subprocess_stop_hook_blocks_voluntary_stop_in_autonomous_in_progress_phase() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    Command::new("git")
+        .args(["init", "--initial-branch", "main"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "t@t"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "t"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    fs::write(root.join("README.md"), "x").unwrap();
+    Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+
+    let state_dir = root.join(".flow-states");
+    fs::create_dir_all(state_dir.join("main")).unwrap();
+    let state = json!({
+        "branch": "main",
+        "current_phase": "flow-code",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": "auto"},
+        "_stop_instructed": true
+    });
+    fs::write(
+        state_dir.join("main").join("state.json"),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+
+    let (code, stdout, _stderr) = run_hook(&root, r#"{"session_id": "s1"}"#);
+    assert_eq!(code, 0);
+    let last = stdout
+        .lines()
+        .rfind(|l| l.trim_start().starts_with('{'))
+        .unwrap_or_else(|| panic!("no JSON in stdout: {}", stdout));
+    let json: Value = serde_json::from_str(last).unwrap();
+    assert_eq!(json["decision"], "block");
+    let reason = json["reason"].as_str().unwrap_or("");
+    assert!(
+        reason.contains("Autonomous mode"),
+        "reason must say `Autonomous mode`: {}",
+        reason
+    );
+    assert!(
+        reason.contains("/flow:flow-abort"),
+        "reason must mention /flow:flow-abort: {}",
         reason
     );
 }


### PR DESCRIPTION
## What

work on issue: Autonomous flows can be silently terminated by text-only voluntary stops #1365.

Closes #1365

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/autonomous-flows-can-be-silently/plan.md` |
| DAG | `.flow-states/autonomous-flows-can-be-silently/dag.md` |
| Log | `.flow-states/autonomous-flows-can-be-silently/log` |
| State | `.flow-states/autonomous-flows-can-be-silently/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/1b9014c0-4668-4113-8985-2bc17bd3ef92.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | <1m |
| Code | 32m |
| Code Review | 38m |
| Learn | 1h 32m |
| Complete | <1m |
| **Total** | **2h 44m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/autonomous-flows-can-be-silently.json</summary>

```json
{
  "schema_version": 1,
  "branch": "autonomous-flows-can-be-silently",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1371,
  "pr_url": "https://github.com/benkruger/flow/pull/1371",
  "started_at": "2026-05-07T12:35:15-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/autonomous-flows-can-be-silently/plan.md",
    "dag": ".flow-states/autonomous-flows-can-be-silently/dag.md",
    "log": ".flow-states/autonomous-flows-can-be-silently/log",
    "state": ".flow-states/autonomous-flows-can-be-silently/state.json"
  },
  "session_tty": "/dev/ttys009",
  "session_id": "1b9014c0-4668-4113-8985-2bc17bd3ef92",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/1b9014c0-4668-4113-8985-2bc17bd3ef92.jsonl",
  "notes": [],
  "prompt": "work on issue: Autonomous flows can be silently terminated by text-only voluntary stops #1365",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-07T12:35:15-07:00",
      "completed_at": "2026-05-07T12:36:01-07:00",
      "session_started_at": null,
      "cumulative_seconds": 46,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-07T12:36:01-07:00",
        "five_hour_pct": 9,
        "seven_day_pct": 91
      }
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-05-07T12:36:21-07:00",
      "completed_at": "2026-05-07T12:45:02-07:00",
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 2,
      "window_at_complete": {
        "captured_at": "2026-05-07T12:45:02-07:00",
        "five_hour_pct": 11,
        "seven_day_pct": 91
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-07T12:45:15-07:00",
      "completed_at": "2026-05-07T13:17:15-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1920,
      "visit_count": 1,
      "step_snapshots": [
        {
          "step": 4,
          "field": "plan_step",
          "captured_at": "2026-05-07T12:44:47-07:00",
          "five_hour_pct": 10,
          "seven_day_pct": 91
        },
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-07T13:14:41-07:00",
          "five_hour_pct": 12,
          "seven_day_pct": 91
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-07T13:14:41-07:00",
          "five_hour_pct": 12,
          "seven_day_pct": 91
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-07T13:14:41-07:00",
          "five_hour_pct": 12,
          "seven_day_pct": 91
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-07T13:14:41-07:00",
          "five_hour_pct": 12,
          "seven_day_pct": 91
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-07T13:14:41-07:00",
          "five_hour_pct": 12,
          "seven_day_pct": 91
        }
      ],
      "window_at_enter": {
        "captured_at": "2026-05-07T12:45:15-07:00",
        "five_hour_pct": 11,
        "seven_day_pct": 91
      },
      "window_at_complete": {
        "captured_at": "2026-05-07T13:17:15-07:00",
        "five_hour_pct": 12,
        "seven_day_pct": 91
      }
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-05-07T13:17:29-07:00",
      "completed_at": "2026-05-07T13:56:23-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2334,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-07T13:17:29-07:00",
        "five_hour_pct": 12,
        "seven_day_pct": 91
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_review_step",
          "captured_at": "2026-05-07T13:21:00-07:00",
          "five_hour_pct": 12,
          "seven_day_pct": 91
        },
        {
          "step": 2,
          "field": "code_review_step",
          "captured_at": "2026-05-07T13:36:25-07:00",
          "five_hour_pct": 16,
          "seven_day_pct": 93
        },
        {
          "step": 3,
          "field": "code_review_step",
          "captured_at": "2026-05-07T13:38:57-07:00",
          "five_hour_pct": 17,
          "seven_day_pct": 93
        },
        {
          "step": 4,
          "field": "code_review_step",
          "captured_at": "2026-05-07T13:56:11-07:00",
          "five_hour_pct": 17,
          "seven_day_pct": 93
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-07T13:56:23-07:00",
        "five_hour_pct": 17,
        "seven_day_pct": 93
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-07T13:56:38-07:00",
      "completed_at": "2026-05-07T15:29:19-07:00",
      "session_started_at": null,
      "cumulative_seconds": 5561,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-07T13:56:38-07:00",
        "five_hour_pct": 17,
        "seven_day_pct": 93
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-07T14:01:08-07:00",
          "five_hour_pct": 18,
          "seven_day_pct": 93
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-07T14:02:42-07:00",
          "five_hour_pct": 18,
          "seven_day_pct": 93
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-07T14:07:30-07:00",
          "five_hour_pct": 18,
          "seven_day_pct": 93
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-07T14:08:07-07:00",
          "five_hour_pct": 18,
          "seven_day_pct": 93
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-07T15:26:08-07:00",
          "session_id": "1b9014c0-4668-4113-8985-2bc17bd3ef92",
          "model": "claude-opus-4-7",
          "five_hour_pct": 23,
          "seven_day_pct": 94,
          "session_input_tokens": 629,
          "session_output_tokens": 334008,
          "session_cache_creation_tokens": 4112250,
          "session_cache_read_tokens": 219745746,
          "by_model": {
            "claude-opus-4-7": {
              "input": 629,
              "output": 334008,
              "cache_create": 4112250,
              "cache_read": 219745746
            }
          },
          "turn_count": 393,
          "tool_call_count": 217,
          "context_at_last_turn_tokens": 760380,
          "context_window_pct": 380.19
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-07T15:29:01-07:00",
          "session_id": "1b9014c0-4668-4113-8985-2bc17bd3ef92",
          "model": "claude-opus-4-7",
          "five_hour_pct": 23,
          "seven_day_pct": 94,
          "session_input_tokens": 662,
          "session_output_tokens": 344147,
          "session_cache_creation_tokens": 4148543,
          "session_cache_read_tokens": 233633965,
          "by_model": {
            "claude-opus-4-7": {
              "input": 662,
              "output": 344147,
              "cache_create": 4148543,
              "cache_read": 233633965
            }
          },
          "turn_count": 411,
          "tool_call_count": 231,
          "context_at_last_turn_tokens": 777026,
          "context_window_pct": 388.513
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-07T15:29:19-07:00",
        "session_id": "1b9014c0-4668-4113-8985-2bc17bd3ef92",
        "model": "claude-opus-4-7",
        "five_hour_pct": 23,
        "seven_day_pct": 94,
        "session_input_tokens": 664,
        "session_output_tokens": 346081,
        "session_cache_creation_tokens": 4148889,
        "session_cache_read_tokens": 235188015,
        "by_model": {
          "claude-opus-4-7": {
            "input": 664,
            "output": 346081,
            "cache_create": 4148889,
            "cache_read": 235188015
          }
        },
        "turn_count": 413,
        "tool_call_count": 232,
        "context_at_last_turn_tokens": 777199,
        "context_window_pct": 388.5995
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-07T15:29:36-07:00",
      "completed_at": "2026-05-07T15:30:00-07:00",
      "session_started_at": null,
      "cumulative_seconds": 24,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-07T15:30:00-07:00",
        "session_id": "1b9014c0-4668-4113-8985-2bc17bd3ef92",
        "model": "claude-opus-4-7",
        "five_hour_pct": 23,
        "seven_day_pct": 94,
        "session_input_tokens": 679,
        "session_output_tokens": 347722,
        "session_cache_creation_tokens": 4172430,
        "session_cache_read_tokens": 240665024,
        "by_model": {
          "claude-opus-4-7": {
            "input": 679,
            "output": 347722,
            "cache_create": 4172430,
            "cache_read": 240665024
          }
        },
        "turn_count": 420,
        "tool_call_count": 236,
        "context_at_last_turn_tokens": 789047,
        "context_window_pct": 394.5235
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-05-07T12:36:21-07:00"
    },
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-05-07T12:43:38-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-07T12:45:15-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-05-07T13:17:29-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-07T13:56:38-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-07T15:29:36-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-07T12:35:15-07:00",
    "five_hour_pct": 9,
    "seven_day_pct": 91
  },
  "plan_steps_total": 4,
  "plan_step": 4,
  "code_tasks_total": 5,
  "code_task_name": "Atomic group: tests + check_autonomous_in_progress + wiring + docs",
  "code_task": 5,
  "diff_stats": {
    "files_changed": 5,
    "insertions": 414,
    "deletions": 16,
    "captured_at": "2026-05-07T13:17:15-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "compact_summary": "<analysis>\nThe user's primary request is to audit a FLOW PR (#1371) for process gaps, rule compliance violations, and missing rules. The user provided detailed context about a worktree, branch, and specific artifacts to read (diff, state file, log, plan, CLAUDE.md, and rule files).\n\nThe user explicitly stated they receive \"only persisted artifacts — no conversation history\" and want findings keyed to Process Gap / Rule Compliance / Missing Rule, with each finding following a Premise → Trace → Conclude structure.\n\nLooking at the conversation chronologically:\n\n1. First message: User provides explicit audit instructions with the prompt to examine a PR and identify three categories of findings (process gaps, rule compliance violations, missing rules). They list specific artifacts to read and provide a diff summary highlighting 615 lines added across 5 files.\n\n2. The user then provides extensive system reminders containing the FLOW project's complete rule corpus (~100+ rule files covering topics like autonomy-phase discipline, hook patterns, external input validation, testing patterns, etc.).\n\n3. The user's most recent (and only) explicit directive message states: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools... Your task is to create a detailed summary of the conversation so far...\"\n\nKey observations:\n- The user has NOT yet asked me to run the actual audit (even though it was the initial request)\n- Instead, they've now asked for a summary of the conversation\n- I was in the process of reading artifacts (made Read calls for state.json, plan.md, stop_continue.rs) but did not complete the full audit analysis\n- No errors were encountered in my tool calls\n- No user feedback was given on my approach yet\n- The user's latest message is asking for a summary, which seems to be a pivot from the original audit request\n\nThe user is now asking me to summarize what we've discussed so far, not to continue with the audit work.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user requested an audit of FLOW PR #1371 (which adds a `check_autonomous_in_progress` Stop-hook predicate) for:\n   - (1) Process gaps\n   - (2) Rule compliance violations  \n   - (3) Missing rules\n   \n   The user specified that findings should be keyed to these three categories, with each finding following a Premise → Trace → Conclude structure where applicable. The user stated they receive \"only persisted artifacts — no conversation history\" and provided a detailed diff summary showing 615 lines added/18 deleted across 5 files (stop_continue.rs, tests/hooks/stop_continue.rs, autonomous-phase-discipline.md, hook-vs-instruction.md, CLAUDE.md).\n\n2. Key Technical Concepts:\n   - FLOW plugin architecture (6-phase development lifecycle)\n   - Autonomous phase execution (`continue: auto` configuration)\n   - Stop-hook predicates (check_first_stop, check_continue, check_autonomous_in_progress)\n   - PreToolUse hooks (validate-ask-user, validate-skill, validate-pretool, validate-claude-paths)\n   - State file schema and concurrency model\n   - Security gates and input normalization\n   - Rule-based enforcement vs instruction-based guidance\n   - Hook state-read timing and transition windows\n   - Mechanical vs advisory enforcement mechanisms\n\n3. Files and Code Sections:\n   - `/Users/ben/code/flow/.flow-states/autonomous-flows-can-be-silently/state.json`\n     - Contains full FLOW session state including phases, phase transitions, skills config, findings array, and log references\n     - Shows the workflow visited Plan (2 visits), Code (1920s), Code Review (2334s), and Learn phases\n     - Includes 8 findings records with outcomes (dismissed/fixed)\n   \n   - `/Users/ben/code/flow/.flow-states/autonomous-flows-can-be-silently/plan.md`\n     - 395-line plan document detailing the implementation of check_autonomous_in_progress\n     - Context section explains the feature (refuse Stop event when phase mid-execution AND autonomous AND no pending-continuation marker)\n     - Exploration section maps source files: stop_continue.rs, validate_ask_user.rs, state.rs, tests/hooks/stop_continue.rs, CLAUDE.md, rule files\n     - Risks section enumerates 6 detailed risks including hook state-read window, deadlock potential, race conditions, fail-open semantics, ordering invariant, and user stop intent\n     - Approach section provides pseudocode and wiring strategy\n     - Dependency Graph marks tasks 1-5 as atomic group (all land in single commit)\n     - Tasks 1-5: unit tests, implementation+wiring+output matcher, subprocess test, rule updates, CLAUDE.md update\n   \n   - `/Users/ben/code/flow/.worktrees/autonomous-flows-can-be-silently/src/hooks/stop_continue.rs`\n     - 728-line module implementing Stop hook with three predicates\n     - Module doc rewritten from \"two predicates\" to \"three predicates\" (added check_autonomous_in_progress)\n     - New const STATE_FILE_BYTE_CAP = 4 * 1024 * 1024 for capped state-file read\n     - New normalize_gate_input(s: &str) helper that strips NULs, trims whitespace, and ASCII-lowercases\n     - New check_autonomous_in_progress(state_path: &Path) -> ContinueResult function (lines 569-654):\n       - Reads state file with byte cap via BufReader::new(f.take(STATE_FILE_BYTE_CAP))\n       - Checks: file exists, JSON parses, current_phase non-empty, phases.<phase>.status == \"in_progress\", skills.<phase>.continue == \"auto\" (both Simple and Detailed shapes)\n       - Returns no_block (early) for missing file, parse error, wrong type, missing phase, non-in-progress status, manual skill config\n       - Returns blocking result with skill=\"autonomous-stop-refused\" when all conditions met\n       - Block message instructs user to route stop intent through /flow:flow-abort or /flow:flow-note\n     - Wired into run() function at lines 695-697, AFTER check_continue\n     - Output matcher extended (lines 717-724) to recognize \"autonomous-stop-refused\" alongside \"discussion\" and \"discussion-with-pending\"\n   \n   - `/Users/ben/code/flow/.worktrees/autonomous-flows-can-be-silently/.claude/rules/autonomous-phase-discipline.md`\n     - Added \"never end turn voluntarily\" bullet to rule\n     - Added Enforcement paragraph documenting the Stop hook predicate with detailed behavior description\n     - Documents ordering: runs AFTER check_first_stop and check_continue\n     - Documents that _continue_pending empty is the guard condition\n   \n   - `/Users/ben/code/flow/.worktrees/autonomous-flows-can-be-silently/.claude/rules/hook-vs-instruction.md`\n     - Added \"Voluntary turn-end during autonomous in-progress phases\" bullet to Mechanically-Enforced Gates list\n     - References stop_continue::check_autonomous_in_progress with decision block behavior\n\n   - `/Users/ben/code/flow/.worktrees/autonomous-flows-can-be-silently/CLAUDE.md`\n     - Changed Auto-Advance Architecture from \"Two layers\" to \"Three layers\"\n     - Added new section: \"3. **Autonomous Stop Enforcement.**\" describing the Stop hook predicate\n\n4. Errors and fixes:\n   - No errors were encountered during artifact reading\n   - No user feedback was provided on approach or methodology\n   - All Read tool calls succeeded and returned expected content\n\n5. Problem Solving:\n   No problems have been solved yet. The audit analysis was not performed. The user's latest message pivoted from requesting the audit to requesting a summary of the conversation.\n\n6. All user messages:\n   - Message 1: \"Audit the FLOW Code/Code Review work on this PR for: (1) process gaps, (2) rule compliance violations, and (3) missing rules. You receive only persisted artifacts — no conversation history. [Detailed instructions with artifact paths and diff summary]\"\n   - Message 2: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools... Your task is to create a detailed summary of the conversation so far...\"\n\n7. Pending Tasks:\n   - Complete the PR audit (the original request) once this summary is delivered, IF the user requests it\n   - Provide findings keyed to Process Gap / Rule Compliance / Missing Rule categories\n   - Use Premise → Trace → Conclude structure for findings that depend on code behavior tracing\n   - Address the specific process events the user highlighted: Plan-extract phase verify-references violations, Code-phase plan deviation logging, Code Review rule violations discovery, pre-existing validate_ask_user violations, and adversarial probe coverage gaps\n\n8. Current Work:\n   Currently working on summarizing the conversation as explicitly requested in the most recent user message. The user provided extensive system reminders containing the full FLOW rule corpus and context, then asked for a text-only summary before any audit analysis was performed. The user stated: \"Your task is to create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions.\"\n\n9. Optional Next Step:\n   Once this summary is complete and acknowledged, the next step should be to perform the actual PR audit as requested in the user's first message: \"Audit the FLOW Code/Code Review work on this PR for: (1) process gaps, (2) rule compliance violations, and (3) missing rules.\" This should include analysis of the four key process events the user highlighted:\n   - Plan-extract phase verify-references violations and opt-out comment friction\n   - Code-phase plan deviation (symlink_metadata vs exists() guard) not logged at commit time\n   - Code Review findings on missing normalization and byte cap that Plan/Code should have caught\n   - Pre-existing validate_ask_user violations in parallel code\n   - Adversarial probe coverage gap in read+parse error handling\n   \n   The findings should be routed as \"Step 6 issue, rule clarification, or new rule\" per the user's routing framework.\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/autonomous-flows-can-be-silently",
  "compact_count": 5,
  "findings": [
    {
      "finding": "Pre-mortem: context-exhaustion deadlock when validate-ask-user and check_autonomous_in_progress both block",
      "reason": "Already considered in plan Risks: 'Bounded by user keystroke interrupt + /flow:flow-abort. Acceptable for v1: loop with evidence > silent surrender.' The block message itself surfaces /flow:flow-abort and /flow:flow-note as the escape routes. The user-only skill carve-out in validate-ask-user permits abort even mid-autonomous.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T13:37:57-07:00"
    },
    {
      "finding": "Documentation: _continue_pending lifecycle missing from check_autonomous_in_progress doc comment",
      "reason": "The field's set/clear lifecycle is documented in concurrency-model.md Skill-commit carve-out. A reader who needs the lifecycle finds it via grep on _continue_pending; duplicating it in the function's doc comment adds no signal an informed reader cannot derive.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T13:38:06-07:00"
    },
    {
      "finding": "Documentation: hook-state-timing.md missing positive example for check_autonomous_in_progress",
      "reason": "The rule already has Good and Bad examples illustrating the in_progress-status guard pattern. The new function follows the existing documented pattern correctly. Adding a third example is record-keeping that does not unblock a future reader.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T13:38:14-07:00"
    },
    {
      "finding": "Documentation: inconsistent phrasing of blocking condition across rule files",
      "reason": "The three rule files describe the same condition with slightly different phrasings, all correct. The exact precise condition is in the function's doc comment and the test names. Standardizing prose phrasing across rule files is bureaucracy that does not change behavior or prevent regressions.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T13:38:23-07:00"
    },
    {
      "finding": "Documentation: layer ordering justification missing from run() doc comment",
      "reason": "Each composition site in run() already has an inline comment explaining why that ordering matters (check_first_stop establishes discussion-mode boundary, check_continue handles multi-child-skill chains, check_autonomous_in_progress runs last so _continue_pending paths are not caught). The agent missed the existing inline justifications.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T13:38:31-07:00"
    },
    {
      "finding": "Plan signature deviation not logged (reviewer T1 Architecture)",
      "reason": "Plan task 2 specified std::fs::symlink_metadata(state_path).is_err() as the missing-file guard; landed code uses !state_path.exists() to match sibling validate_ask_user convention. Fixed by adding bin/flow log entry per plan-commit-atomicity.md so Learn-phase audit has the deviation context.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T13:39:30-07:00"
    },
    {
      "finding": "Unnormalized state-file gate comparisons (reviewer T4 + pre-mortem F3 + 9 adversarial probe failures)",
      "reason": "check_autonomous_in_progress did raw byte equality on phases.<phase>.status and skills.<phase>.continue, so trailing/leading whitespace, mixed case, and embedded NUL silently bypassed the gate. Fixed by adding normalize_gate_input helper (NUL strip, trim, ASCII lowercase) per security-gates.md Normalize Before Comparing, applied to both gate sites. Added 9 unit tests covering each variant family.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T13:41:25-07:00"
    },
    {
      "finding": "Unbounded state file read in hook hot path (pre-mortem F2)",
      "reason": "check_autonomous_in_progress used std::fs::read_to_string with no size cap, violating external-input-path-construction.md Enforce a documented size cap on every external read. Fixed by adding STATE_FILE_BYTE_CAP=4MB module const and switching to BufReader::new(File::open(...)?.take(CAP)).read_to_string. Added test asserting an oversized state file (5MB padding) truncates and fails-open instead of OOM.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-07T13:41:34-07:00"
    },
    {
      "finding": "Learn-analyst F1: state-read timing not enumerated",
      "reason": "False positive — plan Risks section explicitly enumerated current_phase, phases.<phase>.status, skills.<phase>.continue, _continue_pending with their writers AND the transition-window read window. Agent did not reach the relevant section of the plan.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T14:01:36-07:00"
    },
    {
      "finding": "Learn-analyst F4: parse-error path should fail closed not fail open",
      "reason": "Borderline — security-gates.md says fail-closed on state-file gates, but stop_continue.rs module doc commits to fail-open across all three predicates because a Stop-hook crash terminates the user session. Reversing to fail-closed on corrupt state would deadlock the user without recourse (validate-ask-user blocks, AskUserQuestion can't fire). The existing fail-open pattern is user-recovery-correct for this hook family. No concrete bug class to fix; would require a rule clarification rather than code change.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T14:01:54-07:00"
    },
    {
      "finding": "Learn-analyst F5: missing rule on Stop-hook decision predictability under conflicting fields",
      "reason": "Speculative — names no concrete bug class. The existing predicate has a clear linear gate sequence (current_phase → status==in_progress → skill==auto). A future hook with genuinely conflicting fields could file this rule then; today no such hook exists.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T14:02:14-07:00"
    },
    {
      "finding": "plan-commit-atomicity.md What Counts list missed an entry for implementation-detail changes within an unchanged signature, leading reviewer agents to flag exists() vs symlink_metadata().is_err() as a signature deviation requiring bin/flow log",
      "reason": "Added a fourth item to the 'NOT required for' list: implementation-detail changes within an unchanged signature. This clarifies that swapping equivalent standard-library primitives (Path::exists vs symlink_metadata().is_err) is a routine implementation choice, not a plan-prototype deviation, so future reviewer agents and Code phases scope the rule correctly.",
      "outcome": "rule_clarified",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T14:05:29-07:00",
      "path": ".claude/rules/plan-commit-atomicity.md"
    },
    {
      "finding": "No rule existed for auditing 'mirror sibling X exactly' patterns against current applicable rules; literal mirrors silently inherited pre-existing violations (un-normalized gates, missing byte caps in validate_ask_user) into the new check_autonomous_in_progress",
      "reason": "Created .claude/rules/mirror-pattern-rule-audit.md requiring plans that cite mirror-pattern phrasings to include a Mirror Audit Table enumerating sibling, applicable rules, and compliance status. Forces the Plan phase to either extract a shared helper, mirror with violation acceptance plus tech-debt filing for the sibling, or document the documented-exception case. Code Review reviewer agent serves as the safety net.",
      "outcome": "rule_written",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T14:07:14-07:00",
      "path": ".claude/rules/mirror-pattern-rule-audit.md"
    },
    {
      "finding": "Plan-phase scanners missing for unbounded state-file reads (external-input-path-construction.md trigger) and unnormalized state-derived gate comparisons (security-gates.md Normalize Before Comparing)",
      "reason": "Both rules have explicit Plan-phase triggers but no mechanical enforcer. Code Review pre-mortem and adversarial agents catch the violations after Code phase ships, costing a fix cycle the Plan phase should have prevented.",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T15:28:34-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1372"
    },
    {
      "finding": "verify-references scanner over-fires on forward-looking test names this PR proposes to create",
      "reason": "Plans citing N new tests trigger N opt-out comments. PR #1371 generated 16 violations on first plan-check, requiring two repair rounds. Block-level opt-out or scanner awareness of plan-introduced names would reduce friction.",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T15:28:45-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1373"
    },
    {
      "finding": "validate_ask_user::validate has the same un-normalized gate comparisons that this PR fixed in check_autonomous_in_progress",
      "reason": "The two hooks share an autonomous-phase contract; mixed coverage produces inconsistent enforcement. Fix: apply normalize_gate_input from check_autonomous_in_progress to validate_ask_user::validate's two gate sites + bypass-variant tests. Filed as Tech Debt rather than fixed in this PR per code-review-scope.md supersession rule (validate_ask_user is not superseded, just analogous).",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T15:28:54-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1374"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "issues_filed": [
    {
      "label": "Flow",
      "title": "Plan-phase scanners missing for unbounded state-file reads and unnormalized gate comparisons",
      "url": "https://github.com/benkruger/flow/issues/1372",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T15:28:10-07:00"
    },
    {
      "label": "Flow",
      "title": "verify-references scanner over-fires on forward-looking test names in plan Tasks blocks",
      "url": "https://github.com/benkruger/flow/issues/1373",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T15:28:18-07:00"
    },
    {
      "label": "Tech Debt",
      "title": "validate_ask_user::validate uses unnormalized gate comparisons (mirror of fixed check_autonomous_in_progress)",
      "url": "https://github.com/benkruger/flow/issues/1374",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-07T15:28:24-07:00"
    }
  ],
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-07T15:29:59-07:00",
    "session_id": "1b9014c0-4668-4113-8985-2bc17bd3ef92",
    "model": "claude-opus-4-7",
    "five_hour_pct": 23,
    "seven_day_pct": 94,
    "session_input_tokens": 679,
    "session_output_tokens": 347722,
    "session_cache_creation_tokens": 4172430,
    "session_cache_read_tokens": 240665024,
    "by_model": {
      "claude-opus-4-7": {
        "input": 679,
        "output": 347722,
        "cache_create": 4172430,
        "cache_read": 240665024
      }
    },
    "turn_count": 420,
    "tool_call_count": 236,
    "context_at_last_turn_tokens": 789047,
    "context_window_pct": 394.5235
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Flow | Plan-phase scanners missing for unbounded state-file reads and unnormalized gate comparisons | Learn | #1372 |
| Flow | verify-references scanner over-fires on forward-looking test names in plan Tasks blocks | Learn | #1373 |
| Tech Debt | validate_ask_user::validate uses unnormalized gate comparisons (mirror of fixed check_autonomous_in_progress) | Learn | #1374 |

<!-- end:Issues Filed -->