### PR TITLE
Add Flowflow Triage Issues Skill

### DIFF
--- a/.claude/rules/assess-issues.md
+++ b/.claude/rules/assess-issues.md
@@ -17,6 +17,24 @@ confirming the issue's assertions. Grep snippets show fragments
 but miss surrounding changes that may have already addressed
 the problem.
 
+## When the Issue Names No Files
+
+If the issue names no files, search the codebase for the behavior
+described, then read the implementation. The grep is to locate
+code, not to confirm the issue. After locating the relevant code,
+return to step 3 of Required Steps and compare current behavior
+against the issue's claims independently.
+
+## Check for Already-Shipped Work
+
+Before assessing relevance, check `gh pr list --search "<issue
+number>"` and `git log --all --grep "#<issue number>"` for
+already-shipped work. A merged PR that referenced the issue
+without closing it is strong evidence the work shipped — verify
+by reading the cited code rather than trusting the PR title alone.
+If the work shipped but the issue remained open, the issue may
+describe a follow-up gap or may be ready to close.
+
 ## Existing Code Does Not Mean "Already Done"
 
 When DAG analysis or codebase exploration reveals code that

--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -185,6 +185,69 @@ advisory — the prose rule above is the primary instrument and
 the targeted guard is the merge-conflict trip-wire for the
 specific shape the conversation surfaces most often.
 
+## Explicit User Pause Directives
+
+The autonomous-mode block above protects against model-initiated
+pauses — interruptions the user did not ask for. It does NOT
+override **explicit user directives** to pause. When the user
+types a pause instruction in plain English ("pause until I get
+back", "stop here and wait", "pause after the next agent
+returns"), the directive overrides the autonomous configuration
+for the scope the user named. The model honors the pause at the
+next natural boundary the user identified and stays halted until
+the user explicitly says to continue.
+
+The two surfaces are not in conflict. The autonomous-mode rule
+forbids self-imposed pauses ("want me to continue?"). The user-
+directive rule honors user-imposed pauses ("pause and wait"). The
+distinguishing test: did the user type the pause instruction in
+the conversation, or is the model imagining a pause point on its
+own?
+
+### Mechanical interaction with the Stop hook
+
+`stop_continue::check_autonomous_in_progress` refuses a voluntary
+turn-end during in-progress autonomous phases regardless of why
+the model wants to stop. The hook cannot distinguish a user-
+directed pause from a self-imposed pause — both surface as
+"voluntary stop with no `_continue_pending`." When the hook
+refuses, the model has three sanctioned responses:
+
+1. **Capture the user's correction via `/flow:flow-note`.** The
+   note records the directive without ending the flow. After
+   capture, hold position by responding to the user's message
+   directly; do NOT advance to the next skill instruction. The
+   conversational pause IS the honored pause — Stop-hook
+   refusals do not require the model to keep advancing past the
+   user's directive. Once the model emits prose acknowledging
+   the pause and the user replies (continue or otherwise), the
+   model resumes per the user's reply.
+2. **Continue at the lowest-side-effect boundary.** When the
+   user has named a future boundary ("pause AFTER X returns"),
+   complete the work up to that boundary, then capture and
+   acknowledge. Do not skip ahead to a later boundary just
+   because the hook refused; the user's named boundary is the
+   commitment.
+3. **Treat `/flow:flow-abort` as the escape hatch only when the
+   user explicitly asks to abort.** The hook's block message
+   suggests `/flow:flow-abort` as the route for stop intent,
+   but abort is destructive — closes the PR, deletes the
+   branch, removes the worktree. Never invoke it for a pause.
+
+Per `.claude/rules/user-only-skills.md`, the user types
+`/flow:flow-abort` themselves; the model never invokes it.
+
+### Resumption discipline
+
+When the user says "continue" or otherwise indicates resumption,
+proceed from where the pause halted. Do not re-survey the
+landscape, do not re-summarize what would be done, do not ask
+"sure?" — the user has answered. The directive that ended the
+pause is also the directive that re-authorizes the autonomous
+configuration; the model is back in the same `continue: auto`
+state it was in before the pause, and the same discipline
+applies (no self-imposed pauses, commit at natural boundaries).
+
 ## User-Only Skill Carve-Out
 
 The autonomous-phase block above protects against model-initiated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Phase gates enforced by `bin/flow check-phase` (`src/check_phase.rs`). Back-tran
 - `hooks/hooks.json` — hook registration
 - `.claude/settings.json` — project permissions (git rebase denied)
 - `docs/` — GitHub Pages site; `docs/reference/flow-state-schema.md` for state file schema
-- `agents/*.md` — six custom plugin sub-agents (ci-fixer, reviewer, pre-mortem, adversarial, learn-analyst, documentation)
+- `agents/*.md` — seven custom plugin sub-agents (ci-fixer, reviewer, pre-mortem, adversarial, learn-analyst, documentation, issue-triage)
 - `src/*.rs` — Rust source for all `bin/flow` subcommands. Per-module purpose lives in module doc comments.
 - `bin/flow` — Rust dispatcher (auto-rebuilds when source is newer than binary)
 - `bin/{format,lint,build,test}` — FLOW's own dogfood scripts
@@ -136,7 +136,7 @@ The base branch's `target/` is a long-lived build surface across many source gen
 ### Sub-Agents
 
 <!-- duplicate-test-coverage: not-a-new-test -->
-Six custom plugin sub-agents in `agents/*.md` — tiered by task complexity: opus (ci-fixer, adversarial), sonnet (reviewer, pre-mortem), haiku (learn-analyst, documentation). Agent frontmatter must only use supported keys (`name`, `description`, `model`, `effort`, `maxTurns`, `tools`, `disallowedTools`, `skills`, `memory`, `background`, `isolation`) — `test_agent_frontmatter_only_supported_keys` enforces this. The global `PreToolUse` hook (`bin/flow hook validate-pretool`) enforces Bash and Agent tool restrictions across all agents. See `.claude/rules/cognitive-isolation.md`.
+Seven custom plugin sub-agents in `agents/*.md` — tiered by task complexity: opus (ci-fixer, adversarial), sonnet (reviewer, pre-mortem, issue-triage), haiku (learn-analyst, documentation). Agent frontmatter must only use supported keys (`name`, `description`, `model`, `effort`, `maxTurns`, `tools`, `disallowedTools`, `skills`, `memory`, `background`, `isolation`) — `test_agent_frontmatter_only_supported_keys` enforces this. The global `PreToolUse` hook (`bin/flow hook validate-pretool`) enforces Bash and Agent tool restrictions across all agents. See `.claude/rules/cognitive-isolation.md`.
 
 When adding or modifying an agent's `maxTurns` budget, read peer agents' frontmatter to maintain parity.
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Available at any point in the workflow:
 | `/flow-create-issue` | Explore a design question or decompose a concrete problem, iterate until work-ready, then file it |
 | `/flow-decompose-project` | Decompose a large project into linked GitHub issues with sub-issue relationships, blocked-by dependencies, and milestones |
 | `/flow-orchestrate` | Process decomposed issues overnight — batch orchestration via flow-start --auto |
+| `/flow-triage-issues` | Triage a single open GitHub issue from a PM lens — reads code, checks for already-shipped work, returns a verdict in {close, decompose, keep-open, fix-now} |
 
 ### Standalone Tools
 

--- a/agents/issue-triage.md
+++ b/agents/issue-triage.md
@@ -1,0 +1,177 @@
+---
+name: issue-triage
+description: "PM-lens issue triage. Receives an issue number, fetches via gh, reads referenced code (or searches for behavior when unreferenced), checks for already-shipped work, and produces a verdict in {close, decompose, keep-open, fix-now} with confidence and a flip-condition."
+model: sonnet
+tools: Read, Glob, Grep, Bash
+disallowedTools: Edit, Write
+maxTurns: 40
+---
+
+# PM-Lens Issue Triage
+
+You are a senior PM with engineering literacy. You read code before
+judging an issue's claims (per `.claude/rules/assess-issues.md`), but
+you answer in user/business terms. The PM consuming your verdict has
+not seen the issue or the code — your output must stand alone.
+
+## Input
+
+Your prompt contains a single labeled section:
+
+- **ISSUE_NUMBER** — the GitHub issue number to triage (e.g. `1379`)
+
+You have no other context. The issue body, referenced files,
+shipped-work history — every artifact you need — must be fetched and
+read by you during this run.
+
+## Scope
+
+This agent is **v1: open issues only**. Refuse closed issues with a
+structured "out-of-scope" envelope (see Output Format below). A future
+phase may add reopen-triage; not in v1.
+
+The agent **never** mutates GitHub state. No `gh issue close`, no
+`gh issue edit`, no `gh issue comment`, no labels, no PR creation.
+Read-only investigation only. The `disallowedTools: Edit, Write`
+frontmatter enforces this for filesystem mutations; the absence of
+mutating `gh` calls in your investigation enforces it for shared
+state.
+
+## Process
+
+Follow these steps in order. Each step builds on the previous one.
+
+1. **Fetch the issue.** Run:
+
+   ```bash
+   gh issue view <ISSUE_NUMBER> --json title,body,labels,state,createdAt,updatedAt,comments,author
+   ```
+
+   If `state` is `CLOSED`, return the out-of-scope envelope and stop.
+   If the fetch fails (404, auth error), return a structured error
+   envelope and stop.
+
+2. **Read referenced code.** Scan the issue body for backtick-quoted
+   file paths and `path:line` references. Read every file referenced
+   in the body via the Read tool. If the body names no files, search
+   the codebase for the behavior described, then read the
+   implementation. Per `.claude/rules/assess-issues.md` "When the
+   Issue Names No Files," the grep is to locate code, not to confirm
+   the issue.
+
+3. **Check for already-shipped work.** Per
+   `.claude/rules/assess-issues.md` "Check for Already-Shipped Work,"
+   run:
+
+   ```bash
+   gh pr list --search "<ISSUE_NUMBER>" --state merged --json number,title,mergedAt,url
+   gh pr list --search "<ISSUE_NUMBER>" --state open --json number,title,url
+   git log --all --grep "#<ISSUE_NUMBER>" --oneline
+   ```
+
+   For every merged PR that referenced the issue, read the cited
+   code to verify what shipped. A merged PR that referenced the
+   issue without closing it is strong evidence the work shipped —
+   verify by reading the cited code rather than trusting the PR
+   title alone.
+
+4. **Answer all 10 questions.** Use plain English. Cite `file:line`
+   for every code claim. The 10 questions are listed under Output
+   Format below — answer in order, one heading per question.
+
+5. **Produce the verdict card.** Pick a disposition from the closed
+   set `{close, decompose, keep-open, fix-now}`, write a one-paragraph
+   summary, list evidence as `file:line` bullets, declare a confidence
+   level, and name the flip-condition (what would change the
+   disposition).
+
+## Reasoning Discipline
+
+Per `.claude/rules/semi-formal-reasoning.md`, every claim about code
+behavior follows the **Premise → Trace → Conclude** template:
+
+- **Premise** — state the claim and cite specific file paths and
+  line ranges.
+- **Trace** — walk the execution path step by step, verifying each
+  step with Read or Grep.
+- **Conclude** — confirm or refute the premise based on the trace.
+
+Findings with incomplete traces must be discarded, not reported with
+caveats. If you cannot complete the trace (network failure, file
+inaccessible, ambiguous semantics), say so explicitly in the answer
+to question 2 ("Still real?") and lower the confidence level
+accordingly.
+
+## Output Format
+
+The parent skill renders your output verbatim. Use the exact heading
+shapes below — the 10 question markers and the 5 verdict-card fields
+are locked in by contract tests.
+
+```text
+### 1. Real?  [answer + evidence]
+### 2. Still real?  [answer + current code state]
+### 3. Framing  [actual problem or symptom]
+### 4. What (plain English)
+### 5. Why care (plain English)
+### 6. Who's affected + severity
+### 7. Urgency
+### 8. How would this be fixed
+### 9. What success looks like
+### 10. Risk of the fix
+
+### Verdict
+- **Disposition:** {close | decompose | keep-open | fix-now}
+- **Summary:** [one paragraph]
+- **Evidence:** [bulleted file:line refs]
+- **Confidence:** {low | medium | high} — [one-line rationale]
+- **This flips if:** [what would change the disposition]
+```
+
+### Out-of-scope envelope (closed issues, fetch failures)
+
+When the issue cannot be triaged because it is closed or the fetch
+failed, replace the 10-question lens with a single section:
+
+```text
+### Out of scope
+- **Reason:** {closed | fetch_failed | not_found}
+- **Detail:** [one-line explanation]
+- **Next step for the PM:** [what the PM can type or do next]
+```
+
+Do NOT produce a verdict card in this case. The skill detects the
+absence of the `### Verdict` marker and reports that the
+investigation did not produce a triage decision.
+
+## Disposition Semantics
+
+The closed set is `{close, decompose, keep-open, fix-now}`. Pick
+exactly one:
+
+- **close** — the issue is no longer a real problem (already shipped,
+  framing was wrong, behavior changed). The PM should run
+  `gh issue close <num>` after reading your evidence.
+- **decompose** — the issue is real and substantial enough to need an
+  Implementation Plan section before any code lands. The PM should
+  invoke `/flow:flow-create-issue` to draft a pre-decomposed
+  replacement, then close the original.
+- **keep-open** — the issue is real but not yet ready for work
+  (blocked by upstream, awaiting design, low priority right now). The
+  PM should leave it open and revisit later.
+- **fix-now** — the issue is real, scoped, and ready for
+  implementation. The PM should invoke `/flow:flow-start <issue
+  number>` to begin a flow.
+
+## Hard Rules
+
+- Read code before judging an issue's claims, never the other way
+  around (per `.claude/rules/assess-issues.md`).
+- Cite `file:line` for every code claim. A claim without a citation
+  is speculation.
+- Pick a disposition from the closed set above. Never invent
+  `wontfix`, `duplicate`, `stale`, or any other value.
+- Refuse closed issues — return the out-of-scope envelope and stop.
+- Never mutate GitHub state — read-only investigation only.
+- When in doubt, lower confidence and name the flip-condition
+  explicitly.

--- a/agents/issue-triage.md
+++ b/agents/issue-triage.md
@@ -169,9 +169,36 @@ exactly one:
   around (per `.claude/rules/assess-issues.md`).
 - Cite `file:line` for every code claim. A claim without a citation
   is speculation.
-- Pick a disposition from the closed set above. Never invent
-  `wontfix`, `duplicate`, `stale`, or any other value.
+- Pick a disposition from the closed set above. The four canonical
+  values are the entire allowed set; never invent additional values.
 - Refuse closed issues — return the out-of-scope envelope and stop.
 - Never mutate GitHub state — read-only investigation only.
+  **Enforcement boundary:** the `disallowedTools: Edit, Write`
+  frontmatter blocks filesystem mutations through Claude Code's
+  file tools, but the `Bash` tool remains available for read-only
+  `gh` and `git` calls. The "no GitHub state mutation" constraint
+  is a discipline this prompt enforces — `Bash` would technically
+  permit `gh issue close`, `gh issue edit`, `gh issue comment`,
+  and `gh label add` if a future model invoked them. Never run any
+  `gh` subcommand outside the read-only set named in the Process
+  section above. The `validate-pretool` hook's allow-list
+  enforcement during active flows is the additional mechanical
+  backstop, but during non-flow invocations of this skill that
+  backstop does not fire — the discipline alone protects shared
+  state.
 - When in doubt, lower confidence and name the flip-condition
   explicitly.
+
+## Completion Marker
+
+End your response with the literal completion marker
+`## END-OF-FINDINGS` on its own line as the final structural
+element, after the verdict card or out-of-scope envelope. The
+parent skill checks for this marker (per
+`.claude/rules/cognitive-isolation.md` "Context Budget +
+Truncation Recovery") to detect natural completion versus
+mid-investigation truncation. A response without this marker is
+treated as truncated and the parent skill will report
+"investigation incomplete" rather than render partial output.
+
+## END-OF-FINDINGS

--- a/docs/index.html
+++ b/docs/index.html
@@ -859,6 +859,7 @@ Duration: <span class="t-accent">6h 27m</span>
         <tr><td><code>/flow-hygiene</code></td><td>Audit instruction corpus health &mdash; CLAUDE.md, rules, and memory for staleness, misplacement, duplication, and contradictions</td></tr>
         <tr><td><code>/flow-decompose-project</code></td><td>Decompose a project into a linked GitHub issue graph &mdash; epic, milestones, sub-issues, blocked-by dependencies</td></tr>
         <tr><td><code>/flow-orchestrate</code></td><td>Batch orchestration &mdash; process decomposed issues overnight via flow-start --auto</td></tr>
+        <tr><td><code>/flow-triage-issues</code></td><td>Triage a single open GitHub issue from a PM lens &mdash; reads code, checks for already-shipped work, returns a verdict in {close, decompose, keep-open, fix-now}</td></tr>
       </tbody>
     </table>
 

--- a/docs/skills/flow-triage-issues.md
+++ b/docs/skills/flow-triage-issues.md
@@ -1,0 +1,98 @@
+---
+title: /flow-triage-issues
+nav_order: 16
+parent: Skills
+---
+
+# /flow-triage-issues
+
+**Phase:** Any
+
+**Usage:**
+
+```text
+/flow-triage-issues <issue-number>
+```
+
+Triage a single open GitHub issue from a senior-PM-with-engineering-literacy
+lens. Dispatches the `issue-triage` sub-agent in the foreground. The agent
+fetches the issue, reads referenced code (or grep-locates behavior when
+the issue body names no files), checks `gh pr list --search "<num>"` and
+`git log --all --grep "#<num>"` for already-shipped work, answers ten
+triage questions, and produces a verdict in `{close, decompose, keep-open,
+fix-now}` with confidence and a flip-condition. The skill renders the
+verdict verbatim and stops — no auto-actions.
+
+---
+
+## What It Does
+
+1. Parses the argument as a positive integer issue number; rejects
+   non-numeric input and prompts when the argument is missing.
+2. Dispatches the `issue-triage` sub-agent (model: `sonnet`,
+   read-only tools, no `Edit`/`Write`).
+3. Checks the agent's output for a `### Verdict` or `### Out of scope`
+   structural marker. If neither is present, the agent ran out of turns
+   mid-investigation; the skill reports "investigation incomplete" and
+   stops without rendering the partial output.
+4. Renders the agent's full output inline — every heading, bullet, and
+   `file:line` citation, exactly as the agent produced it.
+5. Prints a one-line hint pointing at the next manual step based on the
+   disposition (e.g. `gh issue close <num>` for `close`,
+   `/flow:flow-start` for `fix-now`).
+
+---
+
+## The 10-Question Lens
+
+The agent answers ten questions in plain English, citing `file:line` for
+every code claim:
+
+1. Real? (evidence-grounded)
+2. Still real? (current code state)
+3. Framing — actual problem or symptom?
+4. What (plain English)
+5. Why care (plain English)
+6. Who's affected and how severely?
+7. How urgent?
+8. How would this be fixed?
+9. What does success look like?
+10. Risk of the fix.
+
+---
+
+## The 4-Disposition Verdict
+
+| Disposition | Meaning | Next manual step |
+|---|---|---|
+| `close` | No longer a real problem (already shipped, framing wrong, behavior changed) | `gh issue close <num>` after reading evidence |
+| `decompose` | Real and substantial; needs an Implementation Plan before code lands | `/flow:flow-create-issue` to draft a pre-decomposed replacement |
+| `keep-open` | Real but not yet ready for work (blocked, awaiting design, low priority) | Leave open; revisit later |
+| `fix-now` | Real, scoped, and ready for implementation | `/flow:flow-start <feature words>` |
+
+The set is closed in v1. Adding new dispositions requires a separate
+design conversation.
+
+---
+
+## What This Skill Does NOT Do
+
+- **Never closes issues.** No `gh issue close`. The PM closes manually
+  after reading the evidence.
+- **Never adds labels.** No `gh issue edit --add-label`.
+- **Never comments.** No `gh issue comment`.
+- **Never auto-invokes follow-on skills.** Render the verdict, stop,
+  print the next-step hint. The PM types the next command.
+- **Never triages closed issues.** v1 refuses closed issues with an
+  out-of-scope envelope.
+- **Never triages PRs.** PR review is `/code-review:code-review`'s
+  domain.
+
+---
+
+## Gates
+
+- Read-only on GitHub state — no mutations
+- Display-only after the agent returns — no auto-actions
+- The `### Verdict` / `### Out of scope` structural marker is required;
+  partial output (sub-agent truncation) is not rendered as if complete

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -45,3 +45,4 @@ These skills are available at any point in the workflow, regardless of phase.
 | [`/flow-create-issue`](flow-create-issue.md) | Capture a brainstormed solution as a pre-planned issue with an Implementation Plan for fast-tracking through Plan |
 | [`/flow-decompose-project`](flow-decompose-project.md) | Decompose a large project into linked GitHub issues with sub-issue relationships, blocked-by dependencies, and milestones |
 | [`/flow-orchestrate`](flow-orchestrate.md) | Process decomposed issues sequentially overnight via flow-start --auto |
+| [`/flow-triage-issues`](flow-triage-issues.md) | Triage a single open GitHub issue from a PM lens. Reads code, checks for already-shipped work, returns a verdict in `{close, decompose, keep-open, fix-now}` |

--- a/skills/flow-triage-issues/SKILL.md
+++ b/skills/flow-triage-issues/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: flow-triage-issues
+description: "Triage a single open GitHub issue from a PM lens. Reads code, checks for already-shipped work, returns a verdict in {close, decompose, keep-open, fix-now} with confidence and a flip-condition. Renders and stops — no side effects."
+---
+
+# FLOW Triage Issues
+
+Run a structured per-issue triage from a PM-with-engineering-literacy
+lens. Dispatches the `issue-triage` sub-agent in the foreground, which
+fetches the issue, reads referenced code (or grep-locates behavior when
+unreferenced), checks for already-shipped work via
+`gh pr list --search` and `git log --all --grep`, and answers 10
+triage questions plus a verdict card. The skill renders the verdict
+verbatim and STOPS — the PM acts manually.
+
+## Usage
+
+```text
+/flow:flow-triage-issues <issue-number>
+```
+
+The argument is a positive integer issue number in the current
+repository (whichever repo `gh` resolves to). v1 is open issues
+only — closed issues are refused with an out-of-scope envelope.
+
+## Concurrency
+
+This skill is read-only with respect to GitHub state. It never
+closes, labels, comments on, or otherwise mutates issues.
+Concurrent invocations from different sessions cannot collide on
+shared state. The sub-agent's `gh issue view` and `gh pr list`
+calls are read-only; multiple parallel triages on different issues
+are safe.
+
+## Announce
+
+At the very start, output the following banner in your response (not via Bash) inside a fenced code block:
+
+````markdown
+```text
+──────────────────────────────────────────────────
+  FLOW v1.1.0 — flow:flow-triage-issues — STARTING
+──────────────────────────────────────────────────
+```
+````
+
+## Steps
+
+### Step 1 — Parse argument
+
+Read the argument string. Strip surrounding whitespace.
+
+- If empty (no argument): use AskUserQuestion to ask
+  "Which issue number should I triage?" with no preset options. Use
+  the user's reply as the issue number.
+- If non-numeric (after stripping a leading `#` if present): output
+  the following error in your response (not via Bash) inside a fenced
+  code block, then stop:
+
+````markdown
+```text
+Error: /flow:flow-triage-issues requires a positive integer issue number.
+Got: <argument>
+Usage: /flow:flow-triage-issues <issue-number>
+```
+````
+
+- If numeric: keep the number as `<ISSUE_NUMBER>` for Step 2.
+
+### Step 2 — Dispatch the issue-triage sub-agent
+
+Invoke the `issue-triage` sub-agent in the foreground via the Agent
+tool. Pass `<ISSUE_NUMBER>` as the labeled `ISSUE_NUMBER` input.
+
+Wait for the sub-agent to return its full output. The sub-agent does
+all the investigation — gh fetches, code reads, shipped-work checks,
+question answers, verdict construction. The skill performs no `gh`
+or `git` calls itself.
+
+### Step 3 — Check for the structural marker
+
+Before rendering, scan the agent's returned output for the literal
+`### Verdict` heading (or the `### Out of scope` heading for closed-
+issue or fetch-failure cases). The check enforces the silent-truncation
+contract from `.claude/rules/cognitive-isolation.md` "Silent Truncation
+on maxTurns Exhaustion" — without the marker, the agent ran out of
+turns mid-investigation and the partial output is unsafe to render.
+
+- If the agent's output contains `### Verdict` OR `### Out of scope`
+  → proceed to Step 4.
+- If neither marker is present → output the following message in your
+  response (not via Bash) inside a fenced code block, then stop without
+  rendering the partial output:
+
+````markdown
+```text
+Investigation incomplete: the issue-triage sub-agent did not produce a
+`### Verdict` or `### Out of scope` block. The agent likely ran out of
+turns mid-investigation. Try invoking the skill again, or open the issue
+manually and triage it yourself.
+```
+````
+
+### Step 4 — Render the verdict verbatim
+
+Print the agent's complete output inline in your response — every
+heading, every bullet, every citation. Do not summarize, paraphrase,
+re-rank, or trim. The verdict format (5 fields: disposition, summary,
+evidence, confidence, flip-condition) and the 4-disposition closed
+set (`close`, `decompose`, `keep-open`, `fix-now`) are locked by
+contract tests. The PM consuming the verdict must see exactly what
+the agent produced.
+
+### Step 5 — STOP
+
+<HARD-GATE>
+After rendering the verdict, stop. Do NOT take any auto-action based
+on the disposition — no auto-close, no auto-label, no auto-comment,
+no auto-invocation of follow-on skills like `/flow:flow-create-issue`
+or `/flow:flow-start`.
+
+The PM reads the verdict and decides what to do. Print a one-line
+hint pointing at the next manual step based on the disposition,
+inside a fenced code block:
+
+- **close** — `Next: gh issue close <num>` (after reading the
+  evidence to confirm).
+- **decompose** — `Next: /flow:flow-create-issue` (to draft a
+  pre-decomposed replacement, then close the original).
+- **keep-open** — `Next: nothing — leave the issue open and revisit
+  later.`
+- **fix-now** — `Next: /flow:flow-start <feature words>` (to begin
+  a new flow against the issue).
+- **Out of scope** (closed issue or fetch failure) — `Next: open the
+  issue in a browser and triage manually.`
+
+Then output the COMPLETE banner and stop. Do not run any other tool
+or invoke any other skill.
+</HARD-GATE>
+
+## Done
+
+Output the following banner in your response (not via Bash) inside a fenced code block:
+
+````markdown
+```text
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ✓ FLOW v1.1.0 — flow:flow-triage-issues — COMPLETE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+````
+
+## Hard Rules
+
+- Never close issues. The skill is read-only with respect to GitHub
+  state — no `gh issue close`, no `gh issue edit`, no
+  `gh issue comment`, no labels.
+- Never auto-invoke `/flow:flow-create-issue`, `/flow:flow-start`, or
+  any other skill based on the verdict. The PM acts manually.
+- v1: open issues only. The agent refuses closed issues with the
+  out-of-scope envelope; the skill renders that envelope cleanly.
+- Verdict format is exactly the 5-field card produced by
+  `agents/issue-triage.md`. Do not paraphrase, re-rank, summarize, or
+  trim the agent's output.
+- Disposition values are exactly `{close, decompose, keep-open,
+  fix-now}`. The closed set is locked by contract test; never
+  introduce additional values — the agent never produces them.
+- Use the `issue-triage` sub-agent only. Other agents are out of
+  scope for this skill (the contract test enforces this).
+- Render and stop. No auto-actions of any kind.

--- a/skills/flow-triage-issues/SKILL.md
+++ b/skills/flow-triage-issues/SKILL.md
@@ -48,14 +48,24 @@ At the very start, output the following banner in your response (not via Bash) i
 
 ### Step 1 — Parse argument
 
-Read the argument string. Strip surrounding whitespace.
+Read the argument string. Strip surrounding whitespace and a single
+leading `#` if present.
+
+The argument MUST match the regex `^[1-9][0-9]*$` exactly — a
+positive decimal integer with no leading zero, no sign, no decimal
+point, no scientific notation, no whitespace, no quotes, no flags.
+The strict shape rejects argument-injection vectors like
+`42 --repo other/repo`, regex-metacharacter values like `1[23]`,
+floats like `1.5`, and zero/negative values that the GitHub API
+treats as flags.
 
 - If empty (no argument): use AskUserQuestion to ask
   "Which issue number should I triage?" with no preset options. Use
-  the user's reply as the issue number.
-- If non-numeric (after stripping a leading `#` if present): output
-  the following error in your response (not via Bash) inside a fenced
-  code block, then stop:
+  the user's reply as the issue number, then re-validate against
+  the regex above.
+- If the argument does NOT match the regex: output the following
+  error in your response (not via Bash) inside a fenced code block,
+  then stop:
 
 ````markdown
 ```text
@@ -65,7 +75,8 @@ Usage: /flow:flow-triage-issues <issue-number>
 ```
 ````
 
-- If numeric: keep the number as `<ISSUE_NUMBER>` for Step 2.
+- If the argument matches: keep the value as `<ISSUE_NUMBER>` for
+  Step 2.
 
 ### Step 2 — Dispatch the issue-triage sub-agent
 
@@ -80,23 +91,39 @@ or `git` calls itself.
 ### Step 3 — Check for the structural marker
 
 Before rendering, scan the agent's returned output for the literal
-`### Verdict` heading (or the `### Out of scope` heading for closed-
-issue or fetch-failure cases). The check enforces the silent-truncation
-contract from `.claude/rules/cognitive-isolation.md` "Silent Truncation
-on maxTurns Exhaustion" — without the marker, the agent ran out of
+`## END-OF-FINDINGS` completion marker (per
+`.claude/rules/cognitive-isolation.md` "Context Budget +
+Truncation Recovery"). Marker absence means the agent ran out of
 turns mid-investigation and the partial output is unsafe to render.
 
-- If the agent's output contains `### Verdict` OR `### Out of scope`
-  → proceed to Step 4.
-- If neither marker is present → output the following message in your
-  response (not via Bash) inside a fenced code block, then stop without
+When the marker IS present, additionally verify the agent produced
+either a complete verdict card or an out-of-scope envelope:
+
+- A complete verdict card requires a `### Verdict` heading
+  followed by ALL FIVE labels appearing somewhere after the
+  heading: `Disposition`, `Summary`, `Evidence`, `Confidence`,
+  `This flips if`. A response with `### Verdict` but missing any
+  of the five labels is an echo of the agent's own template, not
+  a real verdict — treat as truncated.
+- An out-of-scope envelope requires a `### Out of scope` heading
+  followed by `Reason`, `Detail`, and `Next step for the PM`
+  labels. Same shape.
+
+Decision tree:
+
+- If `## END-OF-FINDINGS` is present AND a complete verdict card
+  OR a complete out-of-scope envelope is present → proceed to
+  Step 4.
+- Otherwise → output the following message in your response (not
+  via Bash) inside a fenced code block, then stop without
   rendering the partial output:
 
 ````markdown
 ```text
-Investigation incomplete: the issue-triage sub-agent did not produce a
-`### Verdict` or `### Out of scope` block. The agent likely ran out of
-turns mid-investigation. Try invoking the skill again, or open the issue
+Investigation incomplete: the issue-triage sub-agent did not produce
+a complete verdict card or out-of-scope envelope followed by the
+`## END-OF-FINDINGS` marker. The agent likely ran out of turns
+mid-investigation. Try invoking the skill again, or open the issue
 manually and triage it yourself.
 ```
 ````
@@ -116,23 +143,36 @@ the agent produced.
 <HARD-GATE>
 After rendering the verdict, stop. Do NOT take any auto-action based
 on the disposition — no auto-close, no auto-label, no auto-comment,
-no auto-invocation of follow-on skills like `/flow:flow-create-issue`
-or `/flow:flow-start`.
+no auto-invocation of follow-on skills.
 
-The PM reads the verdict and decides what to do. Print a one-line
-hint pointing at the next manual step based on the disposition,
-inside a fenced code block:
+This HARD-GATE is mechanical. You must NOT:
 
-- **close** — `Next: gh issue close <num>` (after reading the
-  evidence to confirm).
-- **decompose** — `Next: /flow:flow-create-issue` (to draft a
-  pre-decomposed replacement, then close the original).
-- **keep-open** — `Next: nothing — leave the issue open and revisit
-  later.`
-- **fix-now** — `Next: /flow:flow-start <feature words>` (to begin
-  a new flow against the issue).
-- **Out of scope** (closed issue or fetch failure) — `Next: open the
-  issue in a browser and triage manually.`
+- Invoke any skill via the Skill tool after rendering the verdict
+  (regardless of what the disposition value is)
+- Run `gh issue close`, `gh issue edit`, `gh issue comment`, or any
+  other GitHub-state-mutating subcommand
+- Run any `git` command that writes (commit, push, tag, etc.)
+- Take any action whatsoever based on the disposition value
+
+The PM reads the verdict and decides what to do. Print a brief
+hint describing the next manual step based on the disposition,
+inside a fenced code block. Describe the action in prose — do
+NOT include slash-command literals that the model could be
+tempted to invoke. The PM types the next command themselves.
+
+- **close** — describe the manual step as: "Read the evidence to
+  confirm, then close the issue manually via the GitHub UI or your
+  CLI of choice."
+- **decompose** — describe the manual step as: "The issue needs an
+  Implementation Plan; draft a pre-decomposed replacement
+  yourself, then close the original."
+- **keep-open** — describe the manual step as: "Leave the issue
+  open and revisit later — no action needed now."
+- **fix-now** — describe the manual step as: "Start a new flow
+  against the issue yourself when you are ready to work on it."
+- **Out of scope** (closed issue or fetch failure) — describe the
+  manual step as: "Open the issue in a browser and triage
+  manually."
 
 Then output the COMPLETE banner and stop. Do not run any other tool
 or invoke any other skill.

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -4017,3 +4017,62 @@ fn flow_reset_invokes_cleanup_all_dry_run_and_live() {
         "skills/flow-reset/SKILL.md must invoke `cleanup . --all` without --dry-run (Step 3 execute)"
     );
 }
+
+// --- assess-issues rule content contracts ---
+//
+// `.claude/rules/assess-issues.md` is the rule the issue-triage agent
+// depends on. The three contracts below lock in (a) the canonical
+// "code actually does" phrasing against the historical `issue actually
+// does` typo shape, (b) the unreferenced-files coverage bullet, and
+// (c) the `gh pr list --search` / `git log --grep` shipped-but-not-
+// closed investigation move. Each test guards a distinct regression:
+// a deletion of any of the three lines fails CI immediately.
+
+fn read_assess_issues_rule() -> String {
+    let path = common::repo_root()
+        .join(".claude")
+        .join("rules")
+        .join("assess-issues.md");
+    std::fs::read_to_string(&path).expect(".claude/rules/assess-issues.md must exist")
+}
+
+#[test]
+fn test_assess_issues_rule_has_no_typo() {
+    let content = read_assess_issues_rule();
+    assert!(
+        content.contains("what the existing code\nactually does")
+            || content.contains("what the existing code actually does")
+            || content.contains("the code actually does"),
+        ".claude/rules/assess-issues.md must phrase the comparison as 'what the (existing) code actually does'"
+    );
+    assert!(
+        !content.contains("what the issue actually does"),
+        ".claude/rules/assess-issues.md must NOT contain the typo 'what the issue actually does'"
+    );
+}
+
+#[test]
+fn test_assess_issues_rule_covers_unreferenced_files() {
+    let content = read_assess_issues_rule();
+    assert!(
+        content.contains("If the issue names no files"),
+        ".claude/rules/assess-issues.md must cover the unreferenced-files case starting with 'If the issue names no files'"
+    );
+    assert!(
+        content.contains("search the codebase for the behavior"),
+        ".claude/rules/assess-issues.md must instruct searching the codebase for the described behavior when no files are referenced"
+    );
+}
+
+#[test]
+fn test_assess_issues_rule_includes_pr_search_step() {
+    let content = read_assess_issues_rule();
+    assert!(
+        content.contains("gh pr list --search"),
+        ".claude/rules/assess-issues.md must instruct checking `gh pr list --search` for already-shipped work"
+    );
+    assert!(
+        content.contains("git log --all --grep"),
+        ".claude/rules/assess-issues.md must instruct checking `git log --all --grep` for already-shipped work"
+    );
+}

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -4076,3 +4076,77 @@ fn test_assess_issues_rule_includes_pr_search_step() {
         ".claude/rules/assess-issues.md must instruct checking `git log --all --grep` for already-shipped work"
     );
 }
+
+// --- flow-triage-issues skill content contracts ---
+//
+// `skills/flow-triage-issues/SKILL.md` is a thin dispatcher. The three
+// contracts below lock in (a) the no-side-effects HARD-GATE that
+// forbids auto-close, auto-label, auto-comment, and auto-skill
+// invocation; (b) the canonical 4-disposition closed set; and (c) the
+// dispatch target — the issue-triage sub-agent, never general-purpose
+// or any other agent. Each test guards a distinct regression: a
+// missing HARD-GATE invites side-effect creep, a drifted disposition
+// set invents new outcomes the agent never produces, and a wrong
+// dispatch target sends the model into an unbounded sub-agent.
+
+#[test]
+fn test_flow_triage_issues_skill_has_no_side_effects_hard_gate() {
+    let content = common::read_skill("flow-triage-issues");
+    let lower = content.to_lowercase();
+    assert!(
+        content.contains("HARD-GATE"),
+        "skills/flow-triage-issues/SKILL.md must contain a HARD-GATE block"
+    );
+    for forbidden in ["auto-close", "auto-label", "auto-comment"] {
+        assert!(
+            lower.contains(forbidden),
+            "skills/flow-triage-issues/SKILL.md HARD-GATE must explicitly forbid {forbidden}"
+        );
+    }
+    assert!(
+        lower.contains("never close") || lower.contains("never closes"),
+        "skills/flow-triage-issues/SKILL.md must forbid closing issues"
+    );
+    assert!(
+        lower.contains("never auto-invoke") || lower.contains("never auto-invokes"),
+        "skills/flow-triage-issues/SKILL.md must forbid auto-invocation of follow-on skills"
+    );
+}
+
+#[test]
+fn test_flow_triage_issues_skill_disposition_set_is_canonical() {
+    let content = common::read_skill("flow-triage-issues");
+    for disposition in ["close", "decompose", "keep-open", "fix-now"] {
+        assert!(
+            content.contains(disposition),
+            "skills/flow-triage-issues/SKILL.md must enumerate disposition: {disposition}"
+        );
+    }
+    // Forbid drift toward common alternative dispositions. The
+    // disposition set is closed in v1; expanding it requires a
+    // separate design conversation per the issue body's Out of Scope
+    // section.
+    let lower = content.to_lowercase();
+    for forbidden in ["wontfix", "won't fix", "duplicate", "stale"] {
+        assert!(
+            !lower.contains(forbidden),
+            "skills/flow-triage-issues/SKILL.md must NOT enumerate forbidden disposition: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn test_flow_triage_issues_skill_dispatches_issue_triage_agent() {
+    let content = common::read_skill("flow-triage-issues");
+    assert!(
+        content.contains("issue-triage"),
+        "skills/flow-triage-issues/SKILL.md must dispatch the issue-triage sub-agent"
+    );
+    // The skill must NOT route through general-purpose — that agent
+    // ignores tool restrictions in its prompt and is forbidden during
+    // active flows by .claude/rules/skill-authoring.md "Sub-Agent Safety".
+    assert!(
+        !content.contains("general-purpose"),
+        "skills/flow-triage-issues/SKILL.md must NOT use general-purpose sub-agent"
+    );
+}

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -4089,48 +4089,105 @@ fn test_assess_issues_rule_includes_pr_search_step() {
 // set invents new outcomes the agent never produces, and a wrong
 // dispatch target sends the model into an unbounded sub-agent.
 
+/// Extract the body of the FIRST `<HARD-GATE>...</HARD-GATE>` block
+/// in the SKILL.md so contract assertions about HARD-GATE content
+/// can be bound to the gate scope rather than satisfied by passive
+/// prose anywhere in the file. Returns the inner content of the
+/// block (between the opening and closing tags). Asserts that both
+/// tags exist in the file. Panics if the block is malformed.
+fn extract_hard_gate_block(content: &str) -> String {
+    let open = content
+        .find("<HARD-GATE>")
+        .expect("skills/flow-triage-issues/SKILL.md must contain <HARD-GATE> opening tag");
+    let after_open = open + "<HARD-GATE>".len();
+    let close_offset = content[after_open..]
+        .find("</HARD-GATE>")
+        .expect("skills/flow-triage-issues/SKILL.md must contain </HARD-GATE> closing tag");
+    content[after_open..after_open + close_offset].to_string()
+}
+
 #[test]
 fn test_flow_triage_issues_skill_has_no_side_effects_hard_gate() {
     let content = common::read_skill("flow-triage-issues");
-    let lower = content.to_lowercase();
-    assert!(
-        content.contains("HARD-GATE"),
-        "skills/flow-triage-issues/SKILL.md must contain a HARD-GATE block"
-    );
+    // Bind the assertions to the actual <HARD-GATE>...</HARD-GATE>
+    // block so prose elsewhere in the file cannot satisfy the
+    // checks (per adversarial findings A2/A6/A9/A12/A13/A16).
+    let gate = extract_hard_gate_block(&content);
+    let gate_lower = gate.to_lowercase();
     for forbidden in ["auto-close", "auto-label", "auto-comment"] {
         assert!(
-            lower.contains(forbidden),
-            "skills/flow-triage-issues/SKILL.md HARD-GATE must explicitly forbid {forbidden}"
+            gate_lower.contains(forbidden),
+            "skills/flow-triage-issues/SKILL.md HARD-GATE block must explicitly forbid {forbidden}"
         );
     }
+    // The "never close" prohibition must live inside the HARD-GATE
+    // block so a removed or empty gate fails the test.
     assert!(
-        lower.contains("never close") || lower.contains("never closes"),
-        "skills/flow-triage-issues/SKILL.md must forbid closing issues"
+        gate_lower.contains("close") && gate_lower.contains("not"),
+        "skills/flow-triage-issues/SKILL.md HARD-GATE block must forbid closing issues"
     );
+    // The "no auto-invocation of skills" prohibition must live
+    // inside the HARD-GATE block.
     assert!(
-        lower.contains("never auto-invoke") || lower.contains("never auto-invokes"),
-        "skills/flow-triage-issues/SKILL.md must forbid auto-invocation of follow-on skills"
+        gate_lower.contains("invoke any skill") || gate_lower.contains("auto-invocation"),
+        "skills/flow-triage-issues/SKILL.md HARD-GATE block must forbid Skill tool invocation after rendering the verdict"
     );
 }
 
 #[test]
 fn test_flow_triage_issues_skill_disposition_set_is_canonical() {
     let content = common::read_skill("flow-triage-issues");
+    let lower = content.to_lowercase();
+    // Canonical four must be present.
     for disposition in ["close", "decompose", "keep-open", "fix-now"] {
         assert!(
             content.contains(disposition),
             "skills/flow-triage-issues/SKILL.md must enumerate disposition: {disposition}"
         );
     }
-    // Forbid drift toward common alternative dispositions. The
-    // disposition set is closed in v1; expanding it requires a
-    // separate design conversation per the issue body's Out of Scope
-    // section.
-    let lower = content.to_lowercase();
-    for forbidden in ["wontfix", "won't fix", "duplicate", "stale"] {
+    // Closed-set check: extract every quoted token inside
+    // backticks that follows a `**` disposition-marker pattern in
+    // the Step 5 hint section. The Step 5 hint enumerates one
+    // bullet per allowed disposition (`**close**`, `**decompose**`,
+    // `**keep-open**`, `**fix-now**`, `**Out of scope**`). Any
+    // additional `**<token>**` bullet inside the HARD-GATE
+    // disposition list is an unsanctioned extension. Locks the
+    // closed set to four canonical dispositions plus the
+    // out-of-scope envelope label.
+    let gate = extract_hard_gate_block(&content);
+    let bullet_re = regex::Regex::new(r"(?m)^- \*\*([a-zA-Z][a-zA-Z0-9 -]*)\*\*")
+        .expect("disposition bullet regex");
+    let mut bullet_tokens: Vec<String> = bullet_re
+        .captures_iter(&gate)
+        .map(|cap| cap[1].trim().to_lowercase())
+        .collect();
+    bullet_tokens.sort();
+    bullet_tokens.dedup();
+    let allowed: std::collections::HashSet<&str> =
+        ["close", "decompose", "keep-open", "fix-now", "out of scope"]
+            .into_iter()
+            .collect();
+    for token in &bullet_tokens {
         assert!(
-            !lower.contains(forbidden),
-            "skills/flow-triage-issues/SKILL.md must NOT enumerate forbidden disposition: {forbidden}"
+            allowed.contains(token.as_str()),
+            "skills/flow-triage-issues/SKILL.md HARD-GATE enumerates unsanctioned disposition bullet: {token:?}. The closed set is exactly {{close, decompose, keep-open, fix-now}} plus the Out-of-scope envelope."
+        );
+    }
+    // Defense in depth: forbid common alternative tokens
+    // anywhere outside fenced code blocks. Use word-boundary
+    // shape so legitimate prose like "decompose" doesn't false-
+    // match. Alternative tokens are never names of valid
+    // dispositions in this v1 — their presence in body prose
+    // signals drift even if the test above passed because the
+    // bullet list was unchanged.
+    let forbidden_re = regex::Regex::new(
+        r"(?i)\b(wontfix|won't fix|stale|invalid|reopened|pending|wip|needs[- ]info)\b",
+    )
+    .expect("forbidden disposition regex");
+    if let Some(m) = forbidden_re.find(&lower) {
+        panic!(
+            "skills/flow-triage-issues/SKILL.md must NOT mention forbidden alternative disposition token: {:?}",
+            m.as_str()
         );
     }
 }
@@ -4138,9 +4195,18 @@ fn test_flow_triage_issues_skill_disposition_set_is_canonical() {
 #[test]
 fn test_flow_triage_issues_skill_dispatches_issue_triage_agent() {
     let content = common::read_skill("flow-triage-issues");
+    // The skill MUST dispatch issue-triage in its Step 2 dispatch
+    // instruction. Bind the check to the dispatch-instruction
+    // context (the line containing "Invoke the" + "sub-agent")
+    // so prose mentions of `issue-triage` elsewhere in the file
+    // cannot satisfy the assertion (per reviewer finding R3 and
+    // adversarial test verification).
+    let dispatch_line_present = content
+        .lines()
+        .any(|line| line.contains("issue-triage") && line.contains("sub-agent"));
     assert!(
-        content.contains("issue-triage"),
-        "skills/flow-triage-issues/SKILL.md must dispatch the issue-triage sub-agent"
+        dispatch_line_present,
+        "skills/flow-triage-issues/SKILL.md must contain a dispatch instruction line that names the `issue-triage` sub-agent (e.g. 'Invoke the `issue-triage` sub-agent ...')"
     );
     // The skill must NOT route through general-purpose — that agent
     // ignores tool restrictions in its prompt and is forbidden during
@@ -4148,5 +4214,22 @@ fn test_flow_triage_issues_skill_dispatches_issue_triage_agent() {
     assert!(
         !content.contains("general-purpose"),
         "skills/flow-triage-issues/SKILL.md must NOT use general-purpose sub-agent"
+    );
+}
+
+#[test]
+fn issue_triage_agent_declares_end_of_findings_marker() {
+    // Per .claude/rules/cognitive-isolation.md "Completion-marker
+    // contract": every high-investigation agent must declare
+    // `## END-OF-FINDINGS` as the final structural element of its
+    // Output Format. Adversarial findings A7/A11/A14 demonstrated
+    // that the SKILL.md's `### Verdict` substring check is gameable
+    // by echoed instruction templates; the END-OF-FINDINGS marker
+    // is the canonical truncation signal.
+    let path = common::repo_root().join("agents").join("issue-triage.md");
+    let content = std::fs::read_to_string(&path).expect("agents/issue-triage.md must exist");
+    assert!(
+        content.contains("## END-OF-FINDINGS"),
+        "agents/issue-triage.md must declare the literal `## END-OF-FINDINGS` completion marker"
     );
 }

--- a/tests/structural.rs
+++ b/tests/structural.rs
@@ -643,6 +643,7 @@ fn test_all_agents_specify_model() {
         ("pre-mortem.md", "sonnet"),
         ("learn-analyst.md", "haiku"),
         ("documentation.md", "haiku"),
+        ("issue-triage.md", "sonnet"),
     ]
     .into_iter()
     .collect();
@@ -678,6 +679,123 @@ fn test_all_agents_specify_model() {
             file_name,
             model,
             expected.unwrap()
+        );
+    }
+}
+
+// --- issue-triage agent contract ---
+//
+// `agents/issue-triage.md` is the PM-lens triage agent. The three
+// contracts below lock in (a) frontmatter shape (name, model, tools,
+// disallowedTools), (b) the canonical 10-question lens count and
+// ordering, and (c) the 5-field verdict card. Each test guards a
+// distinct regression: silent model downgrade or permission
+// widening, dropped/added questions, verdict-card field drift.
+
+fn read_issue_triage_agent() -> String {
+    let path = common::agents_dir().join("issue-triage.md");
+    fs::read_to_string(&path).expect("agents/issue-triage.md must exist")
+}
+
+#[test]
+fn test_issue_triage_agent_frontmatter() {
+    let path = common::agents_dir().join("issue-triage.md");
+    let frontmatter = parse_agent_frontmatter(&path);
+    let mapping = frontmatter.as_mapping().unwrap();
+
+    let name = mapping
+        .get(serde_yaml::Value::String("name".to_string()))
+        .and_then(|v| v.as_str())
+        .expect("issue-triage frontmatter missing name");
+    assert_eq!(
+        name, "issue-triage",
+        "issue-triage agent name must be 'issue-triage'"
+    );
+
+    let model = mapping
+        .get(serde_yaml::Value::String("model".to_string()))
+        .and_then(|v| v.as_str())
+        .expect("issue-triage frontmatter missing model");
+    assert_eq!(
+        model, "sonnet",
+        "issue-triage agent must use model=sonnet for parity with reviewer/pre-mortem"
+    );
+
+    let tools = mapping
+        .get(serde_yaml::Value::String("tools".to_string()))
+        .and_then(|v| v.as_str())
+        .expect("issue-triage frontmatter missing tools");
+    for required in ["Read", "Glob", "Grep", "Bash"] {
+        assert!(
+            tools.contains(required),
+            "issue-triage tools must include {required}: got {tools:?}"
+        );
+    }
+
+    let disallowed = mapping
+        .get(serde_yaml::Value::String("disallowedTools".to_string()))
+        .and_then(|v| v.as_str())
+        .expect("issue-triage frontmatter missing disallowedTools — Edit and Write must be explicitly forbidden");
+    for forbidden in ["Edit", "Write"] {
+        assert!(
+            disallowed.contains(forbidden),
+            "issue-triage disallowedTools must include {forbidden}: got {disallowed:?}"
+        );
+    }
+}
+
+#[test]
+fn test_issue_triage_agent_enumerates_ten_questions() {
+    let content = read_issue_triage_agent();
+    // Lock count + ordering of the 10-question lens. Each marker is a
+    // distinct heading or numbered prompt the agent must answer.
+    let markers = [
+        "1. Real",
+        "2. Still real",
+        "3. Framing",
+        "4. What",
+        "5. Why care",
+        "6. Who",
+        "7. Urgency",
+        "8. How would this be fixed",
+        "9. What success looks like",
+        "10. Risk of the fix",
+    ];
+    let mut last_pos: Option<usize> = None;
+    for marker in markers {
+        let pos = content.find(marker).unwrap_or_else(|| {
+            panic!("agents/issue-triage.md must enumerate question marker {marker:?}")
+        });
+        if let Some(prev) = last_pos {
+            assert!(
+                pos > prev,
+                "agents/issue-triage.md question {marker:?} appears out of order"
+            );
+        }
+        last_pos = Some(pos);
+    }
+}
+
+#[test]
+fn test_issue_triage_agent_verdict_card_fields() {
+    let content = read_issue_triage_agent();
+    // Lock the five verdict-card fields and the canonical disposition set.
+    for field in [
+        "Disposition",
+        "Summary",
+        "Evidence",
+        "Confidence",
+        "This flips if",
+    ] {
+        assert!(
+            content.contains(field),
+            "agents/issue-triage.md verdict card must include field: {field}"
+        );
+    }
+    for disposition in ["close", "decompose", "keep-open", "fix-now"] {
+        assert!(
+            content.contains(disposition),
+            "agents/issue-triage.md must enumerate disposition: {disposition}"
         );
     }
 }

--- a/tests/structural.rs
+++ b/tests/structural.rs
@@ -697,6 +697,21 @@ fn read_issue_triage_agent() -> String {
     fs::read_to_string(&path).expect("agents/issue-triage.md must exist")
 }
 
+/// Parse a comma-separated YAML scalar value into a sorted list of
+/// trimmed tokens. The frontmatter `tools` and `disallowedTools`
+/// values are written as YAML comma-separated strings (e.g.
+/// `tools: Read, Glob, Grep, Bash`); `as_str()` returns the
+/// concatenated string, and we split-trim to recover the canonical
+/// list so contract assertions can do exact-equality checks rather
+/// than substring matches (per adversarial findings A4/A5 — a
+/// substring check accepts `Read_Editor` as if it were `Read`).
+fn split_tools(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 #[test]
 fn test_issue_triage_agent_frontmatter() {
     let path = common::agents_dir().join("issue-triage.md");
@@ -721,58 +736,89 @@ fn test_issue_triage_agent_frontmatter() {
         "issue-triage agent must use model=sonnet for parity with reviewer/pre-mortem"
     );
 
-    let tools = mapping
+    // Exact-equality check on each tool token: split on `,`, trim,
+    // require the set to equal {Read, Glob, Grep, Bash}. Substring
+    // matching would accept malformed `Read_Editor` as if it were
+    // `Read` (A4).
+    let tools_raw = mapping
         .get(serde_yaml::Value::String("tools".to_string()))
         .and_then(|v| v.as_str())
         .expect("issue-triage frontmatter missing tools");
-    for required in ["Read", "Glob", "Grep", "Bash"] {
-        assert!(
-            tools.contains(required),
-            "issue-triage tools must include {required}: got {tools:?}"
-        );
-    }
+    let tools = split_tools(tools_raw);
+    let expected_tools: std::collections::HashSet<&str> =
+        ["Read", "Glob", "Grep", "Bash"].into_iter().collect();
+    let actual_tools: std::collections::HashSet<&str> = tools.iter().map(|s| s.as_str()).collect();
+    assert_eq!(
+        actual_tools, expected_tools,
+        "issue-triage tools must be exactly {{Read, Glob, Grep, Bash}}: got {tools_raw:?}"
+    );
 
-    let disallowed = mapping
+    // Same exact-equality discipline for disallowedTools (A5 —
+    // `Edit_Self` would substring-match `Edit` while leaving the
+    // real Edit tool enabled).
+    let disallowed_raw = mapping
         .get(serde_yaml::Value::String("disallowedTools".to_string()))
         .and_then(|v| v.as_str())
         .expect("issue-triage frontmatter missing disallowedTools — Edit and Write must be explicitly forbidden");
-    for forbidden in ["Edit", "Write"] {
-        assert!(
-            disallowed.contains(forbidden),
-            "issue-triage disallowedTools must include {forbidden}: got {disallowed:?}"
-        );
-    }
+    let disallowed = split_tools(disallowed_raw);
+    let expected_disallowed: std::collections::HashSet<&str> =
+        ["Edit", "Write"].into_iter().collect();
+    let actual_disallowed: std::collections::HashSet<&str> =
+        disallowed.iter().map(|s| s.as_str()).collect();
+    assert_eq!(
+        actual_disallowed, expected_disallowed,
+        "issue-triage disallowedTools must be exactly {{Edit, Write}}: got {disallowed_raw:?}"
+    );
 }
 
 #[test]
 fn test_issue_triage_agent_enumerates_ten_questions() {
     let content = read_issue_triage_agent();
-    // Lock count + ordering of the 10-question lens. Each marker is a
-    // distinct heading or numbered prompt the agent must answer.
+    // Each marker must appear as a line whose trimmed prefix
+    // begins with `### N. <heading>`. Line-prefix anchoring
+    // defeats prose-mention bypass (A3) — the previous
+    // `content.find()` accepted matches anywhere in the file
+    // including inside running prose like "answer question 1.
+    // Real?". The line must START with the marker, which
+    // structurally identifies a heading regardless of whether
+    // it lives inside the agent's Output Format fenced
+    // template or in prose elsewhere.
     let markers = [
-        "1. Real",
-        "2. Still real",
-        "3. Framing",
-        "4. What",
-        "5. Why care",
-        "6. Who",
-        "7. Urgency",
-        "8. How would this be fixed",
-        "9. What success looks like",
-        "10. Risk of the fix",
+        "### 1. Real",
+        "### 2. Still real",
+        "### 3. Framing",
+        "### 4. What",
+        "### 5. Why care",
+        "### 6. Who",
+        "### 7. Urgency",
+        "### 8. How would this be fixed",
+        "### 9. What success looks like",
+        "### 10. Risk of the fix",
     ];
-    let mut last_pos: Option<usize> = None;
-    for marker in markers {
-        let pos = content.find(marker).unwrap_or_else(|| {
-            panic!("agents/issue-triage.md must enumerate question marker {marker:?}")
+
+    let mut found: Vec<Option<usize>> = vec![None; markers.len()];
+    for (idx, line) in content.lines().enumerate() {
+        let trimmed = line.trim_start();
+        for (i, marker) in markers.iter().enumerate() {
+            if found[i].is_none() && trimmed.starts_with(marker) {
+                found[i] = Some(idx);
+                break;
+            }
+        }
+    }
+
+    let mut last_line: Option<usize> = None;
+    for (i, marker) in markers.iter().enumerate() {
+        let line = found[i].unwrap_or_else(|| {
+            panic!("agents/issue-triage.md must enumerate question marker {marker:?} as a `### ` line prefix")
         });
-        if let Some(prev) = last_pos {
+        if let Some(prev) = last_line {
             assert!(
-                pos > prev,
-                "agents/issue-triage.md question {marker:?} appears out of order"
+                line > prev,
+                "agents/issue-triage.md question {marker:?} appears out of order (line {line}, previous {prev})"
             );
         }
-        last_pos = Some(pos);
+        last_line = Some(line);
     }
 }
 


### PR DESCRIPTION
## What

work on issue: Add /flow:flow-triage-issues skill for PM-lens issue triage #1379.

Closes #1379

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/add-flowflow-triage-issues-skill/plan.md` |
| DAG | `.flow-states/add-flowflow-triage-issues-skill/dag.md` |
| Log | `.flow-states/add-flowflow-triage-issues-skill/log` |
| State | `.flow-states/add-flowflow-triage-issues-skill/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/0296df33-04e1-4d3e-859f-4e719930ca20.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Plan | <1m |
| Code | 38m |
| Code Review | 42m |
| Learn | 11m |
| Complete | <1m |
| **Total** | **1h 33m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/add-flowflow-triage-issues-skill.json</summary>

````json
{
  "schema_version": 1,
  "branch": "add-flowflow-triage-issues-skill",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1380,
  "pr_url": "https://github.com/benkruger/flow/pull/1380",
  "started_at": "2026-05-08T11:57:14-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/add-flowflow-triage-issues-skill/plan.md",
    "dag": ".flow-states/add-flowflow-triage-issues-skill/dag.md",
    "log": ".flow-states/add-flowflow-triage-issues-skill/log",
    "state": ".flow-states/add-flowflow-triage-issues-skill/state.json"
  },
  "session_tty": "/dev/ttys009",
  "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/0296df33-04e1-4d3e-859f-4e719930ca20.jsonl",
  "notes": [
    {
      "phase": "flow-plan",
      "phase_name": "Plan",
      "timestamp": "2026-05-08T12:08:09-07:00",
      "type": "correction",
      "note": "Mid-flow gate failures with diagnosable root causes: adjust the input the gate names (issue body, plan file, state field) and drive the flow through. Do not present the user with a multi-option menu (fix root cause vs work around vs re-aim flow) — that's surveying, and surveying stalls the flow. The current flow exists to ship the work the user named; underlying-tool bugs file as separate issues. The HARD-GATE that blocks proceeding past a tool error does not block fixing the named input to clear that error."
    },
    {
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:28:45-07:00",
      "type": "correction",
      "note": "When the user signals they are joining a meeting or that machine load may spike, pause the autonomous flow at the next natural boundary they name (e.g. 'pause after the adversarial agent comes back') and stay halted — do not advance to the next step, do not invoke skills, do not run further commands. The autonomous configuration does not override an explicit pause directive from the user. Resume only when they explicitly say to continue."
    }
  ],
  "prompt": "work on issue: Add /flow:flow-triage-issues skill for PM-lens issue triage #1379",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-08T11:57:14-07:00",
      "completed_at": "2026-05-08T11:57:48-07:00",
      "session_started_at": null,
      "cumulative_seconds": 34,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-08T11:57:48-07:00",
        "five_hour_pct": 2,
        "seven_day_pct": 35
      }
    },
    "flow-plan": {
      "name": "Plan",
      "status": "complete",
      "started_at": "2026-05-08T13:27:41-07:00",
      "completed_at": "2026-05-08T13:31:36-07:00",
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 2
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-08T13:32:52-07:00",
      "completed_at": "2026-05-08T14:11:36-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2324,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-08T13:32:52-07:00",
        "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
        "model": "claude-opus-4-7",
        "five_hour_pct": 6,
        "seven_day_pct": 36,
        "session_input_tokens": 182,
        "session_output_tokens": 142730,
        "session_cache_creation_tokens": 2425668,
        "session_cache_read_tokens": 41079934,
        "by_model": {
          "claude-opus-4-7": {
            "input": 182,
            "output": 142730,
            "cache_create": 2425668,
            "cache_read": 41079934
          }
        },
        "turn_count": 106,
        "tool_call_count": 59,
        "context_at_last_turn_tokens": 522572,
        "context_window_pct": 261.286
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-08T13:43:08-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 7,
          "seven_day_pct": 36,
          "session_input_tokens": 222,
          "session_output_tokens": 167664,
          "session_cache_creation_tokens": 2470071,
          "session_cache_read_tokens": 62402355,
          "by_model": {
            "claude-opus-4-7": {
              "input": 222,
              "output": 167664,
              "cache_create": 2470071,
              "cache_read": 62402355
            }
          },
          "turn_count": 146,
          "tool_call_count": 82,
          "context_at_last_turn_tokens": 544963,
          "context_window_pct": 272.4815
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-08T13:43:08-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 7,
          "seven_day_pct": 36,
          "session_input_tokens": 222,
          "session_output_tokens": 167664,
          "session_cache_creation_tokens": 2470071,
          "session_cache_read_tokens": 62402355,
          "by_model": {
            "claude-opus-4-7": {
              "input": 222,
              "output": 167664,
              "cache_create": 2470071,
              "cache_read": 62402355
            }
          },
          "turn_count": 146,
          "tool_call_count": 82,
          "context_at_last_turn_tokens": 544963,
          "context_window_pct": 272.4815
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-08T13:43:08-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 7,
          "seven_day_pct": 36,
          "session_input_tokens": 222,
          "session_output_tokens": 167664,
          "session_cache_creation_tokens": 2470071,
          "session_cache_read_tokens": 62402355,
          "by_model": {
            "claude-opus-4-7": {
              "input": 222,
              "output": 167664,
              "cache_create": 2470071,
              "cache_read": 62402355
            }
          },
          "turn_count": 146,
          "tool_call_count": 82,
          "context_at_last_turn_tokens": 544963,
          "context_window_pct": 272.4815
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-08T13:51:02-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 36,
          "session_input_tokens": 283,
          "session_output_tokens": 189800,
          "session_cache_creation_tokens": 2552080,
          "session_cache_read_tokens": 83759381,
          "by_model": {
            "claude-opus-4-7": {
              "input": 283,
              "output": 189800,
              "cache_create": 2552080,
              "cache_read": 83759381
            }
          },
          "turn_count": 184,
          "tool_call_count": 106,
          "context_at_last_turn_tokens": 583609,
          "context_window_pct": 291.8045
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-08T13:51:02-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 36,
          "session_input_tokens": 283,
          "session_output_tokens": 189800,
          "session_cache_creation_tokens": 2552080,
          "session_cache_read_tokens": 83759381,
          "by_model": {
            "claude-opus-4-7": {
              "input": 283,
              "output": 189800,
              "cache_create": 2552080,
              "cache_read": 83759381
            }
          },
          "turn_count": 184,
          "tool_call_count": 106,
          "context_at_last_turn_tokens": 583609,
          "context_window_pct": 291.8045
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-08T14:05:35-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 37,
          "session_input_tokens": 358,
          "session_output_tokens": 222002,
          "session_cache_creation_tokens": 2643812,
          "session_cache_read_tokens": 118459135,
          "by_model": {
            "claude-opus-4-7": {
              "input": 358,
              "output": 222002,
              "cache_create": 2643812,
              "cache_read": 118459135
            }
          },
          "turn_count": 241,
          "tool_call_count": 142,
          "context_at_last_turn_tokens": 633840,
          "context_window_pct": 316.92
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-08T14:05:35-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 37,
          "session_input_tokens": 358,
          "session_output_tokens": 222002,
          "session_cache_creation_tokens": 2643812,
          "session_cache_read_tokens": 118459135,
          "by_model": {
            "claude-opus-4-7": {
              "input": 358,
              "output": 222002,
              "cache_create": 2643812,
              "cache_read": 118459135
            }
          },
          "turn_count": 241,
          "tool_call_count": 142,
          "context_at_last_turn_tokens": 633840,
          "context_window_pct": 316.92
        },
        {
          "step": 8,
          "field": "code_task",
          "captured_at": "2026-05-08T14:05:35-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 37,
          "session_input_tokens": 358,
          "session_output_tokens": 222002,
          "session_cache_creation_tokens": 2643812,
          "session_cache_read_tokens": 118459135,
          "by_model": {
            "claude-opus-4-7": {
              "input": 358,
              "output": 222002,
              "cache_create": 2643812,
              "cache_read": 118459135
            }
          },
          "turn_count": 241,
          "tool_call_count": 142,
          "context_at_last_turn_tokens": 633840,
          "context_window_pct": 316.92
        },
        {
          "step": 9,
          "field": "code_task",
          "captured_at": "2026-05-08T14:11:01-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 37,
          "session_input_tokens": 402,
          "session_output_tokens": 230899,
          "session_cache_creation_tokens": 2687218,
          "session_cache_read_tokens": 131945738,
          "by_model": {
            "claude-opus-4-7": {
              "input": 402,
              "output": 230899,
              "cache_create": 2687218,
              "cache_read": 131945738
            }
          },
          "turn_count": 262,
          "tool_call_count": 154,
          "context_at_last_turn_tokens": 652469,
          "context_window_pct": 326.2345
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-08T14:11:36-07:00",
        "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 37,
        "session_input_tokens": 434,
        "session_output_tokens": 234116,
        "session_cache_creation_tokens": 2723333,
        "session_cache_read_tokens": 137844035,
        "by_model": {
          "claude-opus-4-7": {
            "input": 434,
            "output": 234116,
            "cache_create": 2723333,
            "cache_read": 137844035
          }
        },
        "turn_count": 271,
        "tool_call_count": 159,
        "context_at_last_turn_tokens": 666133,
        "context_window_pct": 333.0665
      }
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-05-08T14:11:47-07:00",
      "completed_at": "2026-05-08T14:53:57-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2530,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-08T14:11:47-07:00",
        "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 37,
        "session_input_tokens": 446,
        "session_output_tokens": 234990,
        "session_cache_creation_tokens": 2747647,
        "session_cache_read_tokens": 140509977,
        "by_model": {
          "claude-opus-4-7": {
            "input": 446,
            "output": 234990,
            "cache_create": 2747647,
            "cache_read": 140509977
          }
        },
        "turn_count": 275,
        "tool_call_count": 161,
        "context_at_last_turn_tokens": 678289,
        "context_window_pct": 339.1445
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_review_step",
          "captured_at": "2026-05-08T14:13:03-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 37,
          "session_input_tokens": 462,
          "session_output_tokens": 239498,
          "session_cache_creation_tokens": 2770429,
          "session_cache_read_tokens": 151422209,
          "by_model": {
            "claude-opus-4-7": {
              "input": 462,
              "output": 239498,
              "cache_create": 2770429,
              "cache_read": 151422209
            }
          },
          "turn_count": 291,
          "tool_call_count": 172,
          "context_at_last_turn_tokens": 690386,
          "context_window_pct": 345.193
        },
        {
          "step": 3,
          "field": "code_review_step",
          "captured_at": "2026-05-08T14:30:47-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 14,
          "seven_day_pct": 38,
          "session_input_tokens": 531,
          "session_output_tokens": 301354,
          "session_cache_creation_tokens": 2915638,
          "session_cache_read_tokens": 165035523,
          "by_model": {
            "claude-opus-4-7": {
              "input": 531,
              "output": 301354,
              "cache_create": 2915638,
              "cache_read": 165035523
            }
          },
          "turn_count": 310,
          "tool_call_count": 182,
          "context_at_last_turn_tokens": 745518,
          "context_window_pct": 372.759
        },
        {
          "step": 4,
          "field": "code_review_step",
          "captured_at": "2026-05-08T14:53:45-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 15,
          "seven_day_pct": 39,
          "session_input_tokens": 619,
          "session_output_tokens": 378294,
          "session_cache_creation_tokens": 3076247,
          "session_cache_read_tokens": 216915694,
          "by_model": {
            "claude-opus-4-7": {
              "input": 619,
              "output": 378294,
              "cache_create": 3076247,
              "cache_read": 216915694
            }
          },
          "turn_count": 375,
          "tool_call_count": 225,
          "context_at_last_turn_tokens": 832938,
          "context_window_pct": 416.469
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-08T14:53:57-07:00",
        "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
        "model": "claude-opus-4-7",
        "five_hour_pct": 15,
        "seven_day_pct": 39,
        "session_input_tokens": 632,
        "session_output_tokens": 378814,
        "session_cache_creation_tokens": 3099193,
        "session_cache_read_tokens": 219415149,
        "by_model": {
          "claude-opus-4-7": {
            "input": 632,
            "output": 378814,
            "cache_create": 3099193,
            "cache_read": 219415149
          }
        },
        "turn_count": 378,
        "tool_call_count": 227,
        "context_at_last_turn_tokens": 844577,
        "context_window_pct": 422.2885
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-08T14:54:08-07:00",
      "completed_at": "2026-05-08T15:05:29-07:00",
      "session_started_at": null,
      "cumulative_seconds": 681,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-08T14:54:08-07:00",
        "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
        "model": "claude-opus-4-7",
        "five_hour_pct": 16,
        "seven_day_pct": 39,
        "session_input_tokens": 644,
        "session_output_tokens": 379682,
        "session_cache_creation_tokens": 3121575,
        "session_cache_read_tokens": 222794269,
        "by_model": {
          "claude-opus-4-7": {
            "input": 644,
            "output": 379682,
            "cache_create": 3121575,
            "cache_read": 222794269
          }
        },
        "turn_count": 382,
        "tool_call_count": 229,
        "context_at_last_turn_tokens": 855767,
        "context_window_pct": 427.8835
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-08T14:56:28-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 16,
          "seven_day_pct": 39,
          "session_input_tokens": 649,
          "session_output_tokens": 383691,
          "session_cache_creation_tokens": 3131434,
          "session_cache_read_tokens": 227074899,
          "by_model": {
            "claude-opus-4-7": {
              "input": 649,
              "output": 383691,
              "cache_create": 3131434,
              "cache_read": 227074899
            }
          },
          "turn_count": 387,
          "tool_call_count": 232,
          "context_at_last_turn_tokens": 860855,
          "context_window_pct": 430.4275
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-08T14:56:49-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 16,
          "seven_day_pct": 39,
          "session_input_tokens": 653,
          "session_output_tokens": 385241,
          "session_cache_creation_tokens": 3134820,
          "session_cache_read_tokens": 230520057,
          "by_model": {
            "claude-opus-4-7": {
              "input": 653,
              "output": 385241,
              "cache_create": 3134820,
              "cache_read": 230520057
            }
          },
          "turn_count": 391,
          "tool_call_count": 234,
          "context_at_last_turn_tokens": 862548,
          "context_window_pct": 431.274
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-08T14:58:46-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 16,
          "seven_day_pct": 39,
          "session_input_tokens": 664,
          "session_output_tokens": 397138,
          "session_cache_creation_tokens": 3151944,
          "session_cache_read_tokens": 240060223,
          "by_model": {
            "claude-opus-4-7": {
              "input": 664,
              "output": 397138,
              "cache_create": 3151944,
              "cache_read": 240060223
            }
          },
          "turn_count": 402,
          "tool_call_count": 242,
          "context_at_last_turn_tokens": 874135,
          "context_window_pct": 437.0675
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-08T15:04:05-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 16,
          "seven_day_pct": 39,
          "session_input_tokens": 685,
          "session_output_tokens": 401074,
          "session_cache_creation_tokens": 3164651,
          "session_cache_read_tokens": 251465433,
          "by_model": {
            "claude-opus-4-7": {
              "input": 685,
              "output": 401074,
              "cache_create": 3164651,
              "cache_read": 251465433
            }
          },
          "turn_count": 415,
          "tool_call_count": 250,
          "context_at_last_turn_tokens": 881201,
          "context_window_pct": 440.6005
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-08T15:05:14-07:00",
          "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
          "model": "claude-opus-4-7",
          "five_hour_pct": 16,
          "seven_day_pct": 39,
          "session_input_tokens": 710,
          "session_output_tokens": 405976,
          "session_cache_creation_tokens": 3199800,
          "session_cache_read_tokens": 260354029,
          "by_model": {
            "claude-opus-4-7": {
              "input": 710,
              "output": 405976,
              "cache_create": 3199800,
              "cache_read": 260354029
            }
          },
          "turn_count": 425,
          "tool_call_count": 258,
          "context_at_last_turn_tokens": 895062,
          "context_window_pct": 447.531
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-08T15:05:29-07:00",
        "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
        "model": "claude-opus-4-7",
        "five_hour_pct": 16,
        "seven_day_pct": 39,
        "session_input_tokens": 712,
        "session_output_tokens": 407406,
        "session_cache_creation_tokens": 3200126,
        "session_cache_read_tokens": 262144151,
        "by_model": {
          "claude-opus-4-7": {
            "input": 712,
            "output": 407406,
            "cache_create": 3200126,
            "cache_read": 262144151
          }
        },
        "turn_count": 427,
        "tool_call_count": 259,
        "context_at_last_turn_tokens": 895225,
        "context_window_pct": 447.6125
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-08T15:05:43-07:00",
      "completed_at": "2026-05-08T15:06:04-07:00",
      "session_started_at": null,
      "cumulative_seconds": 21,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-08T15:06:04-07:00",
        "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
        "model": "claude-opus-4-7",
        "five_hour_pct": 16,
        "seven_day_pct": 39,
        "session_input_tokens": 727,
        "session_output_tokens": 408891,
        "session_cache_creation_tokens": 3223003,
        "session_cache_read_tokens": 268445366,
        "by_model": {
          "claude-opus-4-7": {
            "input": 727,
            "output": 408891,
            "cache_create": 3223003,
            "cache_read": 268445366
          }
        },
        "turn_count": 434,
        "tool_call_count": 263,
        "context_at_last_turn_tokens": 906819,
        "context_window_pct": 453.4095
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-05-08T13:27:41-07:00"
    },
    {
      "from": "flow-plan",
      "to": "flow-plan",
      "timestamp": "2026-05-08T13:31:36-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-08T13:32:52-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-05-08T14:11:47-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-08T14:54:08-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-08T15:05:43-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-08T11:57:14-07:00",
    "five_hour_pct": 2,
    "seven_day_pct": 35
  },
  "plan_steps_total": 4,
  "plan_step": 3,
  "code_tasks_total": 9,
  "code_task_name": "Task 9: final verification (measurement-only)",
  "code_task": 9,
  "diff_stats": {
    "files_changed": 9,
    "insertions": 717,
    "deletions": 0,
    "captured_at": "2026-05-08T14:11:36-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "compact_summary": "<analysis>\nLet me analyze this conversation chronologically and thoroughly.\n\n## What Happened\n\nThis is a Code Review agent task. The user (via the parent skill) provided:\n1. A DIFF of changes from origin/main..HEAD (commits 0cd4c9bc..23c55587)\n2. A PLAN file\n3. CLAUDE.md and RULES context\n\nThe task was to review the diff for architecture adherence, simplicity, correctness, and security across six tenants.\n\n## The Diff Summary\n\nThe PR adds a new `/flow:flow-triage-issues` skill and supporting infrastructure:\n\n**New/modified files:**\n- `.claude/rules/assess-issues.md` — added two sections: \"When the Issue Names No Files\" and \"Check for Already-Shipped Work\"\n- `agents/issue-triage.md` — new PM-lens triage sub-agent\n- `skills/flow-triage-issues/SKILL.md` — new dispatcher skill (5 steps)\n- `docs/skills/flow-triage-issues.md` — new skill docs page\n- `docs/skills/index.md` — one row added\n- `README.md` — one row added\n- `docs/index.html` — one row added\n- `tests/skill_contracts.rs` — 6 contract tests added\n- `tests/structural.rs` — agent frontmatter + content contract tests added\n\n## Key Technical Review Areas\n\nThe prompt asked me to focus on:\n1. Whether the agent's `disallowedTools: Edit, Write` plus `tools: Read, Glob, Grep, Bash` is correctly enforced\n2. Whether SKILL.md's HARD-GATE genuinely prevents auto-actions (cross-check the contract test)\n3. Whether the contract tests actually trip on regression (not vacuous)\n4. Whether the new docs match the new skill behavior\n5. Whether the new rule sections in `assess-issues.md` are forward-facing\n\n## What I Did\n\nI read:\n1. The full diff via `git -C ... diff`\n2. The plan.md file\n3. The SKILL.md for flow-triage-issues\n4. The agents/issue-triage.md\n\n## Key Findings from My Analysis\n\nLet me trace through each area carefully:\n\n### Architecture\n\n1. **HARD-GATE enforcement**: The SKILL.md has a `<HARD-GATE>` block in Step 5 that explicitly prohibits auto-close, auto-label, auto-comment, and auto-invocation of follow-on skills. The contract test `test_flow_triage_issues_skill_has_no_side_effects_hard_gate` checks for the `HARD-GATE` keyword and several forbidden strings (`auto-close`, `auto-label`, `auto-comment`, `never close`/`never closes`, `never auto-invoke`/`never auto-invokes`). This is correctly implemented.\n\n2. **Agent tools enforcement**: The frontmatter has `disallowedTools: Edit, Write` and `tools: Read, Glob, Grep, Bash`. The contract test `test_issue_triage_agent_frontmatter` in `tests/structural.rs` validates these. However, there's a nuance: the `disallowedTools` list blocks filesystem mutations but the agent's Bash tool still allows `gh` commands that could potentially mutate GitHub state (close issues, edit issues, add labels). The agent prose says \"never mutate GitHub state\" but this is only advisory — there's no mechanical enforcement preventing the agent from calling `gh issue close` via Bash, since Bash is in the allowed tools list. The FLOW permission system blocks this via `validate-pretool` Layer 8 (UNIVERSAL_ALLOW whitelist) but only during active flows.\n\n3. **CLAUDE.md Key Files missing entry**: Per `docs-with-behavior.md` \"What Counts\" — \"New permanent on-main artifact → `CLAUDE.md` 'Key Files' section.\" The new `agents/issue-triage.md` is a permanent on-main artifact, but it's not listed in CLAUDE.md's \"Key Files\" section. However, the existing CLAUDE.md entry already says `agents/*.md` covers \"six custom plugin sub-agents\" — this is now seven. The Key Files entry says \"six\" which drifts. This is borderline per the value-vs-bureaucracy triage in code-review-scope.md.\n\n4. **SKILL.md banner hardcodes version**: The skill's banner says `FLOW v1.1.0`. Per convention, version is maintained in 3 places and must match. But hardcoding a specific version number in a SKILL.md means the banner will show stale version numbers after future version bumps. No contract test locks this. However, I see that other skills also do this (e.g., this is a pattern from peer skills), so this may be an existing convention issue, not unique to this PR.\n\n5. **Plan alignment**: The plan says \"5-step dispatcher\" but the plan's step descriptions describe 4 logical phases (parse → dispatch → check marker → render → STOP). The SKILL.md has Steps 1-5 correctly numbered. Plan and implementation appear aligned.\n\n### Simplicity\n\n1. The dispatcher pattern (skill dispatches to agent, agent investigates) is appropriate and matches the cognitive-isolation architecture. The skill is genuinely thin.\n\n2. The `read_assess_issues_rule` helper function in `tests/skill_contracts.rs` is defined locally rather than using `common::repo_root()` — it manually constructs the path. This is slightly inconsistent with how other test helpers work, but not a correctness issue.\n\n### Correctness\n\n1. **Contract test vacuousness concern — `test_assess_issues_rule_has_no_typo`**: The test asserts `content.contains(\"the code actually does\")` OR similar phrases. Looking at the actual rule text, this assertion is confirmed by reading the actual file: \"Compare what the issue asks for against what the existing code actually does.\" The test should trip if the typo `what the issue actually does` were reintroduced. This is not vacuous.\n\n2. **Contract test `test_flow_triage_issues_skill_dispatches_issue_triage_agent`**: From the diff, this test asserts `content.contains(\"issue-triage\")` — fairly weak since the string could appear in comments or prose. Let me look more carefully at what the diff says the test does... The truncated diff shows the test asserts `issue-triage` appears, but I need to look at whether it's bounded. The test at the end of the diff was truncated, but the description says it asserts the SKILL.md invokes `issue-triage` — the actual test body needs to be checked.\n\n3. **Missing `END-OF-FINDINGS` marker in agent**: Per `.claude/rules/cognitive-isolation.md` \"Completion-marker contract\": \"Every high-investigation agent (reviewer, learn-analyst, documentation) declares a literal `## END-OF-FINDINGS` marker as the final output of its response.\" The `issue-triage` agent does NOT use the `## END-OF-FINDINGS` completion marker pattern. Instead, the skill detects truncation by checking for `### Verdict` or `### Out of scope`. This is a deliberate design choice — the skill uses a domain-specific structural marker rather than the generic `## END-OF-FINDINGS` pattern.\n\n   BUT: The cognitive-isolation rule says \"New high-investigation agents added to `agents/` MUST declare the marker AND extend the contract test with a per-agent sibling.\" The `issue-triage` agent is a high-investigation agent (it walks code, fetches issues, reads multiple files). However, the plan and implementation chose a different truncation detection mechanism (`### Verdict` marker instead of `## END-OF-FINDINGS`).\n\n   This IS a violation of the cognitive-isolation rule: \"New high-investigation agents added to `agents/` MUST declare the marker AND extend the contract test with a per-agent sibling.\" The `issue-triage` agent doesn't declare `## END-OF-FINDINGS` and there's no corresponding `issue_triage_agent_declares_end_of_findings_marker` contract test.\n\n   The plan didn't mention this. The skill uses `### Verdict` for truncation detection instead, which is a different mechanism. This is a Real finding.\n\n4. **`test_issue_triage_agent_enumerates_ten_questions`**: The test from the structural.rs diff asserts 10 questions. Looking at the agent, it has questions 1-10 in its Output Format. The test validates `### 1. Real?` through `### 10. Risk` are present. This seems sound.\n\n5. **`test_issue_triage_agent_verdict_card_fields`**: The test validates 5 fields: Disposition, Summary, Evidence, Confidence, flip-condition (\"This flips if\"). Looking at the agent Output Format, the verdict card contains exactly these 5 fields. Sound.\n\n6. **Non-numeric input handling**: The SKILL.md Step 1 says \"Strip a leading `#` if present\" before numeric check. So `#1234` would be treated as issue number `1234`. This is good UX.\n\n7. **Positive integer validation**: The skill says \"positive integer\" but strips `#` and then checks if numeric. It doesn't explicitly validate that the number is positive (>0). Issue `0` or a very large number would pass. This is a minor edge case — the agent's `gh issue view` call would fail gracefully anyway.\n\n8. **Out-of-scope marker in Step 3 check**: The SKILL.md Step 3 checks for `### Verdict` OR `### Out of scope`. But the agent's out-of-scope envelope uses `### Out of scope` (lowercase 's'). The check is `### Out of scope` — this is case-sensitive in text matching. Let me verify: SKILL.md says `'### Out of scope'` and the agent says `### Out of scope` — these match. Good.\n\n### Security\n\n1. **GitHub mutation via Bash**: The agent has `tools: Bash` which can run arbitrary `gh` commands. The agent prose says \"Never mutate GitHub state\" but this is advisory. The `validate-pretool` hook would enforce UNIVERSAL_ALLOW limits during active flows, but `/flow:flow-triage-issues` is a utility skill that can be invoked outside active flows (explicitly mentioned in the README as available at any time). Outside an active flow, Layer 8 (whitelist enforcement) doesn't apply per the hook's design. This means the agent could potentially call `gh issue close` via Bash without mechanical enforcement. However, `disallowedTools: Edit, Write` only blocks the Edit/Write tools, not Bash gh calls. This is the main security concern: no mechanical enforcement preventing the agent from mutating GitHub state via `gh` CLI commands.\n\n   But tracing this more carefully: `validate-pretool` checks if a flow is active. Outside a flow, the default mode allows many commands. Inside a flow, UNIVERSAL_ALLOW applies. The agent runs as a sub-agent invoked by the skill. The FLOW's `validate-pretool` hook also applies to agent tool calls (per the architecture). So `gh issue close` would need to be in UNIVERSAL_ALLOW. Looking at the plan's Task 3, it audited UNIVERSAL_ALLOW for `gh issue view *` and `gh pr list *` — only read operations. So `gh issue close` would presumably not be in UNIVERSAL_ALLOW and would be blocked during active flows by Layer 8. Outside flows, the whitelist doesn't apply. This is a real gap but may be acceptable given the advisory nature of the constraint.\n\n2. **Issue number injection**: The SKILL.md passes the issue number to the agent as `<ISSUE_NUMBER>`. The issue number is validated as numeric before dispatch. However, the agent directly interpolates it into shell commands like `gh issue view <ISSUE_NUMBER>`. If someone passes `1234; malicious` as an argument... but wait, the skill validates it's numeric first and strips `#`, so it's a clean integer by the time it reaches the agent. No injection risk at the Bash level since pure integers have no shell metacharacters.\n\n### Documentation\n\n1. **`docs/skills/flow-triage-issues.md` — \"What It Does\" count**: The doc says the skill has 5 steps but the step numbering in the doc matches Steps 1-5 in the SKILL.md. This is correct.\n\n2. **CLAUDE.md \"Key Files\" section still says \"six custom plugin sub-agents\"**: Adding `issue-triage.md` makes it seven. The Key Files section lists `agents/*.md — six custom plugin sub-agents (ci-fixer, reviewer, pre-mortem, adversarial, learn-analyst, documentation)` and doesn't mention `issue-triage`. Per `docs-with-behavior.md`, new permanent on-main artifacts need CLAUDE.md Key Files entries. This is a Real finding.\n\n3. **`assess-issues.md` forward-facing check**: The two new sections describe behaviors abstractly:\n   - \"When the Issue Names No Files\" — describes what to do, no historical framing\n   - \"Check for Already-Shipped Work\" — describes what to do, no historical framing\n   Both pass the forward-facing test. Good.\n\n4. **`docs/skills/flow-triage-issues.md` does NOT document the `END-OF-FINDINGS` vs `### Verdict` truncation mechanism difference**: But this is an internal mechanism, not user-facing, so it doesn't need to be in user docs.\n\n## Summary of Findings\n\n### Finding 1 (High): `issue-triage` agent missing `## END-OF-FINDINGS` marker\nPer `.claude/rules/cognitive-isolation.md` \"Completion-marker contract\": new high-investigation agents MUST declare the `## END-OF-FINDINGS` marker. The `issue-triage` agent uses `### Verdict` as its truncation signal instead. The cognitive-isolation rule requires the standard marker AND a corresponding contract test.\n\n### Finding 2 (Medium): CLAUDE.md Key Files says \"six custom plugin sub-agents\" but now there are seven\nPer `docs-with-behavior.md` \"What Counts\": new permanent on-main artifacts require Key Files entries.\n\n### Finding 3 (Low): No mechanical enforcement preventing the agent from mutating GitHub state via Bash during non-flow invocations\nThe `disallowedTools: Edit, Write` only blocks filesystem mutations. The `validate-pretool` Layer 8 whitelist enforcement only applies during active flows. The `issue-triage` agent can be invoked outside active flows (it's a utility skill), where the whitelist doesn't apply, potentially allowing `gh issue close` or other mutating calls.\n\n### Finding 4 (Low): `test_flow_triage_issues_skill_dispatches_issue_triage_agent` may be vacuous\nThe test asserts `issue-triage` appears in the skill content, but \"issue-triage\" appears multiple times in prose throughout the skill (in the description, in Hard Rules, etc.) — the test would pass even if the Agent tool invocation were removed and replaced with general-purpose. A stronger test would check for the Agent tool invocation syntax targeting `issue-triage` specifically.\n\nLet me now write up findings properly...\n\nWait, let me re-examine finding 1 more carefully. The cognitive-isolation rule says:\n\n\"For high-investigation agents (full repo walks, large doc trees), declare the `## END-OF-FINDINGS` completion marker in Output Format AND add a per-agent sibling test in `tests/skill_contracts.rs` per 'Completion-marker contract' above\"\n\nThis is in the \"Checklist for New Consumers\" section. The `issue-triage` agent doesn't walk the full doc tree or do large repo walks in the same way as the reviewer/documentation agents — it investigates a single issue and its referenced code. The cognitive-isolation rule's \"high-investigation\" qualifier seems targeted at agents doing full repo/doc scans. The `issue-triage` agent has bounded investigation scope.\n\nHowever, the rule says explicitly: \"New high-investigation agents added to `agents/` MUST declare the marker AND extend the contract test with a per-agent sibling.\" The issue is whether this agent qualifies as \"high-investigation.\" Given that it does code reads, PR searches, and potentially extensive investigation, and given that it has maxTurns:40, I'd argue it qualifies. The skill uses an alternative truncation mechanism (`### Verdict`) but the rule doesn't provide for alternatives.\n\nThis is a finding worth flagging. The skill's alternative mechanism may be more appropriate for this use case (a verdict marker is semantically richer than a generic END-OF-FINDINGS), but it violates the letter of the cognitive-isolation rule.\n\nLet me also double-check finding 4 more carefully. The truncated diff shows the test structure but was cut off. Let me think about what the test does based on what I saw:\n\n```rust\nfn test_flow_triage_issues_skill_dispatches_issue_triage_agent(\n    ...\n    for disposition in [\"close\", \"decompose\", \"keep-open\", \"fix-now\"] {\n```\n\nThat part is for the disposition test. The dispatch test is described as asserting the SKILL.md invokes `issue-triage` (not `general-purpose` or any other agent). Looking at the SKILL.md, it says \"Invoke the `issue-triage` sub-agent in the foreground via the Agent tool.\" The test should check for `issue-triage` in the content, which it does, but this is a substring check that could be satisfied by prose references alone. The test's described purpose is \"guards against agent redirection\" — the main regression scenario is someone changing the dispatch target to `general-purpose` or another agent. The string `issue-triage` would disappear from the dispatch context if it were changed to a different agent, so the test would correctly fail. Actually the substring check is probably sufficient for this purpose since the agent name appears in the invocation instruction.\n\nNow let me think about whether finding 3 is real. The `validate-pretool` hook fires on all Bash tool calls when a flow is active (Layer 8). Since this is a utility skill that can run outside a flow context, Layer 8 doesn't apply. The question is: does Layer 8 apply to sub-agents invoked from a utility skill that itself runs in a non-flow context?\n\nLooking at the architecture: the global `PreToolUse` hook (`bin/flow hook validate-pretool`) is registered in `hooks/hooks.json` and blocks various operations \"across all agents.\" This fires on every Bash tool call. Layer 8 enforces the whitelist \"when a flow is active.\" So if the triage skill is invoked outside a flow, the agent's `gh issue close` would be allowed by Layer 8 (since no flow is active). This is indeed a gap.\n\nBut is this a real security concern or an acceptable design gap? The agent's instructions say \"never mutate GitHub state\" — if the model follows instructions. The risk is if the model ignores the instructions. Given that this is a triage-focused skill that would normally be invoked by a human to assess issues, the risk seems low in practice.\n\nActually, let me reconsider. The security concern is about what the model COULD do, not what it SHOULD do. The `disallowedTools` list is the mechanical enforcement. If we want to prevent `gh issue close`, we need either: (1) add it to `FLOW_DENY`, or (2) rely on the advisory instruction. Currently the design relies on advisory instruction. This is consistent with how other read-only operations are handled in FLOW — the adversarial agent also has Bash access and relies on advisory \"read-only\" instructions.\n\nGiven the code-review-scope.md value test: \"would the proposed fix add signal that an informed reader cannot already derive from the code, the existing rule files, or the diff?\" — the fact that Bash allows arbitrary `gh` commands is already clear from the frontmatter. The agent's prose explicitly addresses it. This might be a False positive under the value test. But it's still worth flagging as a Medium/Low risk.\n\nLet me finalize my findings:\n\n**Finding 1 (Medium): `issue-triage` agent missing `## END-OF-FINDINGS` completion marker**\n- Cognitive-isolation rule requires high-investigation agents to declare this marker\n- The agent uses `### Verdict` instead (a domain-specific alternative)\n- No corresponding `issue_triage_agent_declares_end_of_findings_marker` contract test\n- Violated per the rule's \"Checklist for New Consumers\"\n\n**Finding 2 (Low): CLAUDE.md \"Key Files\" lists \"six custom plugin sub-agents\" — now seven**\n- New permanent artifact `agents/issue-triage.md` not reflected in Key Files count/list\n- Per docs-with-behavior.md requirement for new permanent on-main artifacts\n\n**Finding 3 (Low): `test_flow_triage_issues_skill_dispatches_issue_triage_agent` is a simple substring check**\n- Asserts `issue-triage` appears in content but doesn't verify the Agent tool invocation syntax\n- Could theoretically be satisfied by prose references even if the dispatch were changed to general-purpose\n- However, the test's primary regression (changing dispatch target) would still be caught since the new agent name would replace `issue-triage`\n\nActually Finding 3 on reflection: if someone changed the Agent tool call to dispatch to `general-purpose`, the string `issue-triage` would still appear in the skill's prose (Hard Rules, description, etc.). The test would PASS even though the dispatch is wrong. This IS a vacuousness issue per the spec.\n\nLet me write up the final findings cleanly now.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user submitted a Code Review agent task. The parent skill invoked this reviewer agent with the diff for commits 0cd4c9bc..23c55587 on branch `add-flowflow-triage-issues-skill`, along with the implementation plan, CLAUDE.md, and all rule files. The review task was to check across six tenants (Architecture, Simplicity, Maintainability, Correctness, Test coverage, Documentation) with specific focus on:\n   - Whether the agent's `disallowedTools: Edit, Write` plus `tools: Read, Glob, Grep, Bash` is correctly enforced\n   - Whether the SKILL.md's HARD-GATE genuinely prevents auto-actions (cross-check the contract test)\n   - Whether the contract tests actually trip on regression (not vacuous)\n   - Whether the new docs match the new skill behavior\n   - Whether the new rule sections in `assess-issues.md` are forward-facing per `.claude/rules/forward-facing-authoring.md`\n\n2. Key Technical Concepts:\n   - FLOW plugin architecture: skills are Markdown dispatcher instructions, agents are sub-agents with constrained tool access\n   - Cognitive isolation: sub-agents receive only persisted artifacts; parent skill renders output verbatim\n   - `## END-OF-FINDINGS` completion marker contract: required by `.claude/rules/cognitive-isolation.md` for high-investigation agents\n   - HARD-GATE blocks in SKILL.md: prevent auto-actions without user approval\n   - `disallowedTools` frontmatter: blocks Edit/Write but does NOT block `gh` CLI mutations via Bash\n   - `validate-pretool` Layer 8 whitelist enforcement: only applies during active flows (state file present)\n   - Contract tests in `tests/skill_contracts.rs` and `tests/structural.rs`: lock content invariants against regression\n   - `docs-with-behavior.md` \"Key Files\" requirement: new permanent on-main artifacts must appear in CLAUDE.md Key Files\n   - Truncation detection via structural markers: `### Verdict` / `### Out of scope` vs the standard `## END-OF-FINDINGS`\n   - Forward-facing authoring: rule sections must describe current behavior, not historical incidents\n\n3. Files and Code Sections:\n   - `/Users/ben/code/flow/.worktrees/add-flowflow-triage-issues-skill/skills/flow-triage-issues/SKILL.md`\n     - New 5-step dispatcher skill\n     - Step 5 contains the HARD-GATE block prohibiting auto-close, auto-label, auto-comment, auto-invocation\n     - Banner hardcodes `FLOW v1.1.0` — will go stale on future version bumps\n     - Step 3 checks for `### Verdict` OR `### Out of scope` as truncation signal\n   - `/Users/ben/code/flow/.worktrees/add-flowflow-triage-issues-skill/agents/issue-triage.md`\n     - Frontmatter: `model: sonnet`, `tools: Read, Glob, Grep, Bash`, `disallowedTools: Edit, Write`, `maxTurns: 40`\n     - Does NOT declare `## END-OF-FINDINGS` completion marker in Output Format\n     - Output Format uses `### Verdict` and `### Out of scope` structural markers instead\n     - Hard Rules section says \"Never mutate GitHub state\" (advisory, not mechanical)\n   - `/Users/ben/code/flow/.worktrees/add-flowflow-triage-issues-skill/tests/skill_contracts.rs`\n     - Added `read_assess_issues_rule()` helper and three rule content tests\n     - `test_flow_triage_issues_skill_has_no_side_effects_hard_gate`: checks for `HARD-GATE` keyword and forbidden strings (`auto-close`, `auto-label`, `auto-comment`, `never close`/`never closes`, `never auto-invoke`)\n     - `test_flow_triage_issues_skill_disposition_set_is_canonical`: verifies all four dispositions present\n     - `test_flow_triage_issues_skill_dispatches_issue_triage_agent`: does a simple substring check for `issue-triage` in skill content — potentially vacuous since `issue-triage` appears in prose references throughout the file (description, Hard Rules, etc.), not only in the Agent tool invocation instruction\n   - `/Users/ben/code/flow/.worktrees/add-flowflow-triage-issues-skill/tests/structural.rs`\n     - `test_issue_triage_agent_frontmatter`: validates `name`, `model`, tools, disallowedTools\n     - `test_issue_triage_agent_enumerates_ten_questions`: validates 10 question headings present\n     - `test_issue_triage_agent_verdict_card_fields`: validates 5 verdict card fields (Disposition, Summary, Evidence, Confidence, flip-condition)\n     - No `issue_triage_agent_declares_end_of_findings_marker` test\n   - `/Users/ben/code/flow/.worktrees/add-flowflow-triage-issues-skill/.claude/rules/assess-issues.md`\n     - Two new sections added: \"When the Issue Names No Files\" and \"Check for Already-Shipped Work\"\n     - Both sections are forward-facing (describe what to do, no historical framing) — pass the forward-facing test\n   - `/Users/ben/code/flow/CLAUDE.md` (main repo)\n     - \"Key Files\" section still reads: `agents/*.md — six custom plugin sub-agents (ci-fixer, reviewer, pre-mortem, adversarial, learn-analyst, documentation)` — does not mention `issue-triage`, count is now wrong (seven agents)\n\n4. Errors and fixes:\n   - No errors in the execution of this review. The review was read-only: fetched the diff, read the plan, read the SKILL.md and agent file directly.\n\n5. Problem Solving:\n   - Identified that the cognitive-isolation rule's \"Checklist for New Consumers\" requires `## END-OF-FINDINGS` for high-investigation agents — the `issue-triage` agent uses an alternative (`### Verdict`) that violates the letter of the rule\n   - Identified that `disallowedTools: Edit, Write` does not mechanically prevent GitHub state mutations via `gh` CLI through the Bash tool, and Layer 8 whitelist only applies during active flows — utility skills like this one can be invoked outside active flows\n   - Identified that the substring check in `test_flow_triage_issues_skill_dispatches_issue_triage_agent` may be vacuous because `issue-triage` appears in multiple prose locations in the skill, not only in the Agent tool dispatch instruction\n   - Confirmed that CLAUDE.md Key Files section count is stale (six vs seven agents)\n   - Confirmed assess-issues.md new sections pass the forward-facing authoring test\n   - Confirmed the HARD-GATE contract test is sound and would detect regressions\n   - Confirmed verdict card and 10-question contract tests are non-vacuous\n\n6. All user messages:\n   - Initial invocation message providing the diff, plan, CLAUDE.md, and rules, requesting a structured code review with specific focus areas (agent tool enforcement, HARD-GATE verification, contract test vacuousness, doc accuracy, forward-facing authoring check).\n\n7. Pending Tasks:\n   - Complete the findings output and emit the `## END-OF-FINDINGS` completion marker so the parent skill can detect natural completion.\n\n8. Current Work:\n   After reading all artifacts (diff, plan, SKILL.md, agent file), the analysis phase is complete. The following findings have been identified:\n\n   **Finding 1 (Medium) — Architecture/Test Coverage**: `issue-triage` agent violates the cognitive-isolation rule's completion-marker contract. Per `.claude/rules/cognitive-isolation.md` \"Checklist for New Consumers\": \"For high-investigation agents (full repo walks, large doc trees), declare the `## END-OF-FINDINGS` completion marker in Output Format AND add a per-agent sibling test in `tests/skill_contracts.rs`.\" The agent uses `### Verdict` as its truncation signal instead, and there is no `issue_triage_agent_declares_end_of_findings_marker` contract test.\n\n   **Finding 2 (Low) — Documentation**: CLAUDE.md \"Key Files\" section says \"six custom plugin sub-agents\" and lists six names — `agents/issue-triage.md` is the seventh permanent agent added on main, but is absent from the Key Files list and count. Per `docs-with-behavior.md`: \"New permanent on-main artifact → `CLAUDE.md` 'Key Files' section.\"\n\n   **Finding 3 (Low) — Test Coverage**: `test_flow_triage_issues_skill_dispatches_issue_triage_agent` performs a simple `content.contains(\"issue-triage\")` check. The string `issue-triage` appears in prose throughout the SKILL.md (the description, the Hard Rules section, the Step 4 mention of the contract tests, etc.) — not only in the Agent tool dispatch instruction. A future author could change the Agent tool call to dispatch to `general-purpose` while the test would still pass because `issue-triage` remains in the surrounding prose. A stronger assertion would check for the Agent-dispatch instruction syntax (e.g., `issue-triage sub-agent in the foreground` appearing specifically in Step 2's text, or checking that the dispatch instruction mentions `issue-triage` as the subagent_type).\n\n   **Finding 4 (Low) — Security**: The `disallowedTools: Edit, Write` frontmatter blocks filesystem mutations but does not mechanically prevent the agent from calling `gh issue close`, `gh issue comment`, or `gh issue edit` via Bash. The `validate-pretool` Layer 8 whitelist only enforces `UNIVERSAL_ALLOW` during active flows. The triage skill is a utility skill explicitly documented as usable at any time, including outside active flows — in that context, no mechanical guard prevents GitHub state mutation. The agent's Hard Rules advisory (\"Never mutate GitHub state\") is the only enforcement. This mirrors the same limitation on the `adversarial` agent, but the adversarial agent runs inside Code Review (always an active flow), while the triage skill can run without an active flow.\n\n9. Optional Next Step:\n   Produce the structured findings output as required by the task, emitting each finding in the prescribed `**Finding N:**` format, then emit `## END-OF-FINDINGS`.\n</summary>\n\nNow producing the actual findings output:\n\n---\n\n**Finding 1: `issue-triage` agent missing `## END-OF-FINDINGS` completion marker**\n\n- **Severity:** Medium\n- **Category:** Architecture\n- **Evidence:** `/Users/ben/code/flow/.worktrees/add-flowflow-triage-issues-skill/agents/issue-triage.md` — the Output Format section (lines 111–145) ends with the `### Out-of-scope envelope` block. There is no `## END-OF-FINDINGS` literal anywhere in the agent file. The `tests/structural.rs` diff adds three tests for this agent but includes no `issue_triage_agent_declares_end_of_findings_marker` test. By contrast, `.claude/rules/cognitive-isolation.md` \"Checklist for New Consumers\" states: \"For high-investigation agents (full repo walks, large doc trees), declare the `## END-OF-FINDINGS` completion marker in Output Format AND add a per-agent sibling test in `tests/skill_contracts.rs` per 'Completion-marker contract' above.\" The skill's Step 3 substitutes `### Verdict` / `### Out of scope` as the truncation signal, which is a domain-specific alternative that was not sanctioned by the rule.\n- **Recommendation:** Add `## END-OF-FINDINGS` as the final literal in the agent's Output Format section, after the out-of-scope envelope block. Add a corresponding `test_issue_triage_agent_declares_end_of_findings_marker` test in `tests/skill_contracts.rs` that reads the agent file and asserts the marker is present. The skill's `### Verdict` check in Step 3 can remain as an additional domain-specific signal — both can coexist. This closes the rule violation without disrupting the existing truncation detection logic.\n\n---\n\n**Finding 2: CLAUDE.md \"Key Files\" count and list stale after adding seventh agent**\n\n- **Severity:** Low\n- **Category:** Documentation\n- **Evidence:** `/Users/ben/code/flow/CLAUDE.md` (main repo, not in diff) — the \"Sub-Agents\" section under \"Architecture\" reads: `agents/*.md — six custom plugin sub-agents (ci-fixer, reviewer, pre-mortem, adversarial, learn-analyst, documentation)`. This PR adds `agents/issue-triage.md` as a permanent on-main artifact, making the total seven. The Key Files section (under \"Key Files\") lists `agents/*.md` with the parenthetical \"(six custom plugin sub-agents)\" which is now incorrect. Per `.claude/rules/docs-with-behavior.md` \"What Counts\": \"New permanent on-main artifact → `CLAUDE.md` 'Key Files' section. Future-session readers rely on Key Files as their index to the repository surface area; a new permanent artifact that is absent from Key Files is effectively invisible until a later PR rediscovers it.\"\n- **Recommendation:** Update both the \"Key Files\" section and the \"Sub-Agents\" subsection of CLAUDE.md to say \"seven\" and add `issue-triage` to the named list, e.g.: `agents/*.md — seven custom plugin sub-agents (ci-fixer, reviewer, pre-mortem, adversarial, learn-analyst, documentation, issue-triage)`. Per `docs-with-behavior.md`, this update belongs in the same PR as the agent addition.\n\n---\n\n**Finding 3: `test_flow_triage_issues_skill_dispatches_issue_triage_agent` is vacuous against the regression it claims to guard**\n\n- **Severity:** Low\n- **Category:** Test Coverage\n- **Evidence:** `tests/skill_contracts.rs` (diff lines ~+4115 to +4130, truncated). The test comment states it \"guards against agent redirection\" — specifically \"a wrong dispatch target sends the model into an unbounded sub-agent.\" The test asserts `content.contains(\"issue-triage\")`. However, reading `skills/flow-triage-issues/SKILL.md`, the string `issue-triage` appears in multiple prose locations outside the Agent dispatch instruction: the preamble (\"Dispatches the `issue-triage` sub-agent\"), Hard Rules (\"Use the `issue-triage` sub-agent only\"), Step 4 (\"The verdict format ... and the 4-disposition closed set ... are locked by contract tests\"), and the description frontmatter. A future author who changed the Agent tool invocation to dispatch `general-purpose` but left the prose references intact would not be caught by this test. The test would pass vacuously while the dispatch target is wrong. Per `.claude/rules/tests-guard-real-regressions.md`: a test that still passes when the production line it claims to cover is changed is speculative.\n- **Recommendation:** Strengthen the assertion to target the specific dispatch instruction text in Step 2. The unique phrase that cannot survive a dispatch-target change is something like: `assert!(content.contains(\"Invoke the \\`issue-triage\\` sub-agent in the foreground via the Agent tool\"))` — this exact phrasing from SKILL.md line 72 would disappear if the dispatch were changed to any other agent. Alternatively, assert both that `issue-triage` appears AND that `general-purpose` does NOT appear in the skill content, which is also meaningful.\n\n---\n\n**Finding 4: No mechanical enforcement preventing the agent from mutating GitHub state during non-flow invocations**\n\n- **Severity:** Low\n- **Category:** Security\n- **Evidence:** `agents/issue-triage.md` frontmatter: `disallowedTools: Edit, Write` — this blocks only filesystem mutations via Claude Code's Edit and Write tools. `tools: Bash` is allowed. The agent prose (lines 35–38) states: \"The agent **never** mutates GitHub state. No `gh issue close`, no `gh issue edit`, no `gh issue comment`, no labels, no PR creation. Read-only investigation only. The `disallowedTools: Edit, Write` frontmatter enforces this for filesystem mutations; the absence of mutating `gh` calls in your investigation enforces it for shared state.\" The second clause (\"the absence of mutating `gh` calls in your investigation\") is advisory, not mechanical. `validate-pretool` Layer 8 whitelist enforcement applies only \"when a flow is active\" per `.claude/rules/hook-vs-instruction.md`. The triage skill is a utility skill documented as \"Available at any point in the workflow\" including outside active flows. In a non-flow invocation context, Layer 8 does not apply, and the agent could call `gh issue close <N>` via Bash without mechanical rejection.\n- **Recommendation:** This is a known architectural trade-off for utility skills running outside flows — the same gap exists for other utility skills. Accept this with documentation: add a note in the agent's Scope section acknowledging that the \"never mutate\" constraint is advisory during non-flow invocations and relies on model compliance. Alternatively, add `gh issue close *`, `gh issue edit *`, and `gh issue comment *` to `FLOW_DENY` so they are blocked at the settings level regardless of flow state. The FLOW_DENY approach would require a `compute_config_hash` bump but provides mechanical enforcement. The documentation approach is lower cost and consistent with how the adversarial and other Bash-enabled agents handle this.\n\n## END-OF-FINDINGS",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/add-flowflow-triage-issues-skill",
  "compact_count": 3,
  "findings": [
    {
      "finding": "D1-D8 documentation findings",
      "reason": "Bureaucracy-trap and agent-confusion findings. D1/D4 propose duplicating prose between SKILL.md and docs page that is already discoverable. D2 conflates two separate concepts (10-Question Lens = the questions, Verdict Card = the output structure). D3 misread the agent's actual verdict-card fields. D5 claims a missing cross-reference that already exists three times in agents/issue-triage.md. D6/D7 are agent self-reports that it couldn't see one-line HTML/README diffs that are fine. D8 proposes Why/Enforcement sections for assess-issues.md that mirror the existing tone of that short rule. Per code-review-scope.md value test, none of these findings change behavior or unblock a future reader.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:30:38-07:00"
    },
    {
      "finding": "R1/PM4/PM6/A7/A11/A14: Missing END-OF-FINDINGS marker on agents/issue-triage.md + gameable Verdict marker check + missing sibling contract test",
      "reason": "Added '## END-OF-FINDINGS' as the literal final structural element in agents/issue-triage.md per .claude/rules/cognitive-isolation.md 'Completion-marker contract'. Added a new sibling test issue_triage_agent_declares_end_of_findings_marker in tests/skill_contracts.rs. Updated SKILL.md Step 3 to require BOTH the END-OF-FINDINGS marker AND a complete verdict card (all 5 fields) or out-of-scope envelope before rendering — defeats the echoed-template spoofing surfaced by adversarial F7/F11/F14.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:50:34-07:00"
    },
    {
      "finding": "R2: CLAUDE.md Key Files + Sub-Agents stale (six -> seven agents)",
      "reason": "Updated CLAUDE.md Key Files line to 'seven custom plugin sub-agents' with issue-triage appended to the named list, and Sub-Agents architecture section to 'Seven custom plugin sub-agents' with issue-triage in the sonnet tier alongside reviewer/pre-mortem. Per .claude/rules/docs-with-behavior.md 'What Counts'.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:50:43-07:00"
    },
    {
      "finding": "R3: test_flow_triage_issues_skill_dispatches_issue_triage_agent was vacuous (substring match on issue-triage)",
      "reason": "Strengthened the test to require a dispatch instruction LINE that contains both 'issue-triage' and 'sub-agent', so prose mentions of issue-triage elsewhere in the file cannot satisfy the assertion. The mutation-style test (renaming the dispatch target) now correctly fails.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:50:51-07:00"
    },
    {
      "finding": "PM2/PM3: Issue-number argument validation was model-interpreted (gh argument injection, regex-metacharacter injection into git log --grep)",
      "reason": "Tightened SKILL.md Step 1 to require the regex ^[1-9][0-9]*$ exactly — pure decimal positive integer, no leading zero, no sign, no decimal point, no scientific notation, no whitespace, no quotes, no flags. Rejects '42 --repo other/repo', '1[23]', '1.5', '0', and other shapes that would have flowed into gh and git as flags or regex metacharacters. PM3 is subsumed by PM2's fix because pure decimal numbers contain no BRE metacharacters.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:51:01-07:00"
    },
    {
      "finding": "R4/PM1: Bash-mediated GitHub state mutation was prose-only (disallowedTools doesn't cover gh subcommands)",
      "reason": "Documented the enforcement boundary explicitly in agents/issue-triage.md Hard Rules. The agent now names the constraint as a discipline this prompt enforces, lists the specific gh subcommands that must never run (close, edit, comment, label add), and notes that validate-pretool's allow-list enforcement is the additional mechanical backstop during active flows but does not fire during non-flow invocations. Per .claude/rules/code-review-scope.md, mechanical FLOW_DENY widening would be over-scope for this PR.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:51:11-07:00"
    },
    {
      "finding": "PM5: Step 5 HARD-GATE printed slash commands that autonomous mode could execute",
      "reason": "Reworked SKILL.md Step 5 HARD-GATE to (a) describe each manual next-step in prose without slash-command literals (e.g. 'Read the evidence to confirm, then close the issue manually via the GitHub UI or your CLI of choice' instead of 'Next: gh issue close <num>'), and (b) explicitly forbid Skill tool invocation, gh-state-mutating subcommands, and git writes after rendering the verdict. The HARD-GATE prohibitions are now mechanical instructions to the model, not just literal command echoes.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:51:21-07:00"
    },
    {
      "finding": "A1/A8/A15: Disposition allowlist drift — denylist/presence check accepts 5th+ disposition",
      "reason": "Strengthened test_flow_triage_issues_skill_disposition_set_is_canonical to (a) parse the HARD-GATE block bullet list and require every '**<token>**' bullet to be in the closed allowlist {close, decompose, keep-open, fix-now, out of scope}, and (b) defense-in-depth: regex-forbid common alternative tokens (wontfix, won't fix, stale, invalid, reopened, pending, wip, needs-info) anywhere in the file body. Adversarial test for adding 'pending' or 'reopened' as a 5th disposition now correctly fails.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:51:31-07:00"
    },
    {
      "finding": "A2/A6/A9/A12/A13/A16: HARD-GATE prohibitions could live outside the gate (loose substring matching)",
      "reason": "Added extract_hard_gate_block helper that returns the inner content of the first <HARD-GATE>...</HARD-GATE> block, asserting both opening and closing tags exist. The test_flow_triage_issues_skill_has_no_side_effects_hard_gate test now binds all prohibition checks (auto-close, auto-label, auto-comment, never close, never auto-invoke) to the gate block, so prose elsewhere in the file cannot satisfy the assertion. Adversarial tests proving prohibitions could live in 'Bad practices' sections or in passive prose now correctly fail.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:51:41-07:00"
    },
    {
      "finding": "A3/A10: 10-question ordering used find() first-occurrence; markers in code blocks satisfied check",
      "reason": "Strengthened test_issue_triage_agent_enumerates_ten_questions to require each marker as a line whose trimmed prefix begins with '### N. <heading>'. Line-prefix anchoring defeats the prose-mention bypass — 'answer question 1. Real?' running text never starts a line with '### 1. Real'. The questions live in the agent's Output Format fenced template (canonical structure); the new test matches them there because line-prefix matching is structurally correct regardless of whether the line is inside a fence.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:51:52-07:00"
    },
    {
      "finding": "A4/A5: tools and disallowedTools substring matching accepted malformed names (Read_Editor, Edit_Self)",
      "reason": "Added split_tools helper that splits the YAML scalar value on ',' and trims each token, then asserts exact set equality against the canonical {Read, Glob, Grep, Bash} for tools and {Edit, Write} for disallowedTools. Substring matching that accepted 'Read_Editor' as if it were 'Read' (giving false confidence on a security-relevant boundary) now correctly fails.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-08T14:52:01-07:00"
    },
    {
      "finding": "Tenant 3 candidate: 'Mid-flow gate failures — drive through, do not survey' user-correction",
      "reason": "Per learn-analyst's forward-facing filter, the principle is too specific to a particular infrastructure-bug class to codify as a durable rule. Single-flow evidence is insufficient — the existing autonomous-flow-self-recovery.md already covers mechanical-failure recovery as the related pattern. No new rule.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-08T14:56:42-07:00"
    },
    {
      "finding": "Tenant 2: Rule tension between autonomous-phase-discipline and explicit user pause directives",
      "reason": "The rule's block forbids model-initiated pauses but had no carve-out documenting how the model should handle explicit user pause directives ('pause until I get back'). The Stop hook mechanically refuses voluntary turn-ends in autonomous mode regardless of cause, leaving an undocumented friction point. Added new section 'Explicit User Pause Directives' with three sanctioned responses (capture via flow-note + acknowledge in prose, continue to user-named boundary, never use abort for a pause), plus a Resumption Discipline subsection. Forward-facing per .claude/rules/forward-facing-authoring.md — describes the principle and mechanical interaction without referencing the incident that surfaced it.",
      "outcome": "rule_clarified",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-08T14:58:34-07:00",
      "path": ".claude/rules/autonomous-phase-discipline.md"
    },
    {
      "finding": "Tenant 1: extract_implementation_plan does not track fenced code blocks; surfaces as Plan-phase truncation gate refusal on issue bodies with fenced ## headings",
      "reason": "Real process gap NOT remediated in this PR — the workaround was to edit the issue body. The root cause is a code bug in src/plan_extract.rs that should be fixed in a separate flow. Filed as benkruger/flow#1381 with reproduction steps and acceptance criteria.",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-08T15:05:09-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1381"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "issues_filed": [
    {
      "label": "Flow",
      "title": "extract_implementation_plan does not respect fenced code blocks when scanning for next ## heading",
      "url": "https://github.com/benkruger/flow/issues/1381",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-08T15:05:00-07:00"
    }
  ],
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-08T15:06:04-07:00",
    "session_id": "0296df33-04e1-4d3e-859f-4e719930ca20",
    "model": "claude-opus-4-7",
    "five_hour_pct": 16,
    "seven_day_pct": 39,
    "session_input_tokens": 727,
    "session_output_tokens": 408891,
    "session_cache_creation_tokens": 3223003,
    "session_cache_read_tokens": 268445366,
    "by_model": {
      "claude-opus-4-7": {
        "input": 727,
        "output": 408891,
        "cache_create": 3223003,
        "cache_read": 268445366
      }
    },
    "turn_count": 434,
    "tool_call_count": 263,
    "context_at_last_turn_tokens": 906819,
    "context_window_pct": 453.4095
  },
  "_auto_continue": "/flow:flow-complete"
}
````

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Flow | extract_implementation_plan does not respect fenced code blocks when scanning for next ## heading | Learn | #1381 |

<!-- end:Issues Filed -->