### PR TITLE
Add Structural Coderead Field To

### DIFF
--- a/agents/pre-mortem.md
+++ b/agents/pre-mortem.md
@@ -94,10 +94,13 @@ For each finding, produce a structured block:
 - **Blast radius:** What systems or users would be affected
 - **What tests missed:** Which test gaps allowed this to ship
 - **Severity:** Critical / High / Medium / Low
-- **code_read:** `<file>:<line_range>` — the source location you
-  read with Read or Grep to verify the Trace step. Cite the file
-  and line range you actually inspected, not the diff hunk.
-  Required for every finding.
+- **code_read:** `<file>:<line_range>[, <file>:<line_range>...]` —
+  one or more source locations you read with Read or Grep to
+  verify the Trace step, comma-separated when the Trace spans
+  multiple files. Cite the file and line range you actually
+  inspected, not the diff hunk. For multi-file Traces, list every
+  load-bearing read so triage can audit each one. Required for
+  every finding.
 - **Evidence:** Specific file paths and line references from the diff
 
 If no credible failure modes are found, report:
@@ -155,6 +158,7 @@ For each finding:
 3. Blast radius
 4. What tests missed
 5. Severity
-6. Evidence
+6. code_read
+7. Evidence
 
 Or: "No findings" if no credible failure modes exist.

--- a/agents/pre-mortem.md
+++ b/agents/pre-mortem.md
@@ -94,6 +94,10 @@ For each finding, produce a structured block:
 - **Blast radius:** What systems or users would be affected
 - **What tests missed:** Which test gaps allowed this to ship
 - **Severity:** Critical / High / Medium / Low
+- **code_read:** `<file>:<line_range>` — the source location you
+  read with Read or Grep to verify the Trace step. Cite the file
+  and line range you actually inspected, not the diff hunk.
+  Required for every finding.
 - **Evidence:** Specific file paths and line references from the diff
 
 If no credible failure modes are found, report:
@@ -114,8 +118,12 @@ file path and line range from the diff that triggers the concern.
 
 **Trace.** Walk the execution path step by step. Name each function,
 branch, or condition you traverse. Use Read or Grep to verify each
-step — do not assume behavior from names alone. If a step in the
-trace contradicts your premise, stop and discard the finding.
+step — do not assume behavior from names alone. Record the file and
+line range you read in the finding's `code_read` field. A finding
+without a `code_read` is not compliant — the schema requires it
+because diff-only reasoning produces findings structurally
+indistinguishable from real Trace executions. If a step in the trace
+contradicts your premise, stop and discard the finding.
 
 **Conclude.** State whether the failure mode is confirmed or
 refuted by the trace. A confirmed finding becomes a structured

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -372,6 +372,29 @@ fn learn_analyst_agent_has_design_note() {
     );
 }
 
+// --- Agent Output Format subsection extractor ---
+//
+// Both the END-OF-FINDINGS marker contract and the code_read field
+// contract assert content inside an agent's `## Output Format`
+// section. Each contract uses a bounded slice so a refactor that
+// guts the section is detected even when an unrelated sibling
+// section still mentions the asserted token (see
+// `.claude/rules/testing-gotchas.md` "Subsection-Local Assertions
+// in Contract Tests"). Extracting the bounded-slice walk into a
+// shared helper keeps the section boundary one source of truth.
+
+fn read_agent_output_format_section(agent_basename: &str) -> String {
+    let c = common::read_agent(agent_basename);
+    let tail_at_heading = c
+        .split_once("## Output Format")
+        .map(|(_, tail)| tail.to_string())
+        .unwrap_or_else(|| panic!("{agent_basename} must have ## Output Format section"));
+    tail_at_heading
+        .split_once("\n## ")
+        .map(|(section, _)| section.to_string())
+        .unwrap_or(tail_at_heading)
+}
+
 // --- END-OF-FINDINGS marker contract ---
 //
 // Three context-rich/high-investigation agents — reviewer,
@@ -386,15 +409,7 @@ fn learn_analyst_agent_has_design_note() {
 // names the drifted agent immediately.
 
 fn assert_agent_output_format_declares_end_of_findings(agent_basename: &str) {
-    let c = common::read_agent(agent_basename);
-    let tail_at_heading = c
-        .split_once("## Output Format")
-        .map(|(_, tail)| tail)
-        .unwrap_or_else(|| panic!("{agent_basename} must have ## Output Format section"));
-    let subsection = tail_at_heading
-        .split_once("\n## ")
-        .map(|(section, _)| section)
-        .unwrap_or(tail_at_heading);
+    let subsection = read_agent_output_format_section(agent_basename);
     assert!(
         subsection.contains("END-OF-FINDINGS"),
         "{agent_basename} Output Format must declare the literal `END-OF-FINDINGS` completion marker so the flow-code-review skill can detect maxTurns truncation by marker absence (see .claude/rules/cognitive-isolation.md \"Context Budget + Truncation Recovery\")"
@@ -427,20 +442,21 @@ fn documentation_agent_declares_end_of_findings_marker() {
 // Trace steps leave a structural gap rather than a plausible-looking
 // prose finding. The contract test guards against an accidental edit
 // or refactor that drops the field.
+//
+// Scope: pre-mortem only. The other agents that follow the same
+// reasoning discipline (reviewer, ci-fixer deep-diagnosis mode,
+// adversarial — see .claude/rules/semi-formal-reasoning.md) do not
+// yet declare the field; they are tracked separately rather than
+// scope-expanded here. The assertion is structural rather than a
+// loose substring match: it requires the bullet-shaped declaration
+// `- **code_read:**` so a future edit that demotes the field to a
+// prose mention or a code-block example would not satisfy the test.
 
 fn assert_agent_output_format_declares_code_read(agent_basename: &str) {
-    let c = common::read_agent(agent_basename);
-    let tail_at_heading = c
-        .split_once("## Output Format")
-        .map(|(_, tail)| tail)
-        .unwrap_or_else(|| panic!("{agent_basename} must have ## Output Format section"));
-    let subsection = tail_at_heading
-        .split_once("\n## ")
-        .map(|(section, _)| section)
-        .unwrap_or(tail_at_heading);
+    let subsection = read_agent_output_format_section(agent_basename);
     assert!(
-        subsection.contains("code_read"),
-        "{agent_basename} Output Format must declare a `code_read` field naming the file:line_range the agent verified via Read or Grep, so triage can detect findings produced from the diff alone without an actual codebase trace (see .claude/rules/semi-formal-reasoning.md)"
+        subsection.contains("- **code_read:**"),
+        "{agent_basename} Output Format must declare a `code_read` field as a bullet (`- **code_read:**`) naming the file:line_range the agent verified via Read or Grep, so triage can detect findings produced from the diff alone without an actual codebase trace (see .claude/rules/semi-formal-reasoning.md). The bullet-shaped assertion guards against future edits that demote the field to a prose mention or code-block example."
     );
 }
 

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -416,6 +416,39 @@ fn documentation_agent_declares_end_of_findings_marker() {
     assert_agent_output_format_declares_end_of_findings("documentation.md");
 }
 
+// --- code_read field contract ---
+//
+// The pre-mortem agent's safety value depends on the agent actually
+// executing the Premise → Trace → Conclude reasoning discipline. A
+// structural `code_read` field in the Output Format finding block
+// converts "the agent verified the code" from an implicit claim into
+// a required output: triage that sees a non-conforming or missing
+// `code_read` value can dismiss the finding immediately, and skipped
+// Trace steps leave a structural gap rather than a plausible-looking
+// prose finding. The contract test guards against an accidental edit
+// or refactor that drops the field.
+
+fn assert_agent_output_format_declares_code_read(agent_basename: &str) {
+    let c = common::read_agent(agent_basename);
+    let tail_at_heading = c
+        .split_once("## Output Format")
+        .map(|(_, tail)| tail)
+        .unwrap_or_else(|| panic!("{agent_basename} must have ## Output Format section"));
+    let subsection = tail_at_heading
+        .split_once("\n## ")
+        .map(|(section, _)| section)
+        .unwrap_or(tail_at_heading);
+    assert!(
+        subsection.contains("code_read"),
+        "{agent_basename} Output Format must declare a `code_read` field naming the file:line_range the agent verified via Read or Grep, so triage can detect findings produced from the diff alone without an actual codebase trace (see .claude/rules/semi-formal-reasoning.md)"
+    );
+}
+
+#[test]
+fn pre_mortem_agent_declares_code_read_field() {
+    assert_agent_output_format_declares_code_read("pre-mortem.md");
+}
+
 // --- Halt instructions wrapped in fix-first HARD-GATE ---
 //
 // When a phase skill instructs the model to halt the workflow on an


### PR DESCRIPTION
## What

#1399.

Closes #1399

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/add-structural-coderead-field-to/log` |
| State | `.flow-states/add-structural-coderead-field-to/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 7m |
| Code Review | 21m |
| Learn | 4m |
| Complete | <1m |
| **Total** | **33m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/add-structural-coderead-field-to.json</summary>

```json
{
  "schema_version": 1,
  "branch": "add-structural-coderead-field-to",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1403,
  "pr_url": "https://github.com/benkruger/flow/pull/1403",
  "started_at": "2026-05-09T13:29:03-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/add-structural-coderead-field-to/log",
    "state": ".flow-states/add-structural-coderead-field-to/state.json"
  },
  "session_tty": "/dev/ttys002",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "#1399",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-09T13:29:03-07:00",
      "completed_at": "2026-05-09T13:29:36-07:00",
      "session_started_at": null,
      "cumulative_seconds": 33,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-09T13:29:36-07:00",
        "five_hour_pct": 17,
        "seven_day_pct": 28
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-09T13:29:49-07:00",
      "completed_at": "2026-05-09T13:36:49-07:00",
      "session_started_at": null,
      "cumulative_seconds": 420,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T13:29:49-07:00",
        "five_hour_pct": 17,
        "seven_day_pct": 28
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-09T13:32:05-07:00",
          "five_hour_pct": 18,
          "seven_day_pct": 28
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-09T13:35:22-07:00",
          "five_hour_pct": 20,
          "seven_day_pct": 30
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T13:36:49-07:00",
        "five_hour_pct": 20,
        "seven_day_pct": 30
      }
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-05-09T13:37:02-07:00",
      "completed_at": "2026-05-09T13:58:15-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1273,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T13:37:02-07:00",
        "five_hour_pct": 21,
        "seven_day_pct": 30
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_review_step",
          "captured_at": "2026-05-09T13:38:54-07:00",
          "five_hour_pct": 21,
          "seven_day_pct": 30
        },
        {
          "step": 3,
          "field": "code_review_step",
          "captured_at": "2026-05-09T13:52:43-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 32
        },
        {
          "step": 4,
          "field": "code_review_step",
          "captured_at": "2026-05-09T13:58:05-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 32
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T13:58:15-07:00",
        "five_hour_pct": 30,
        "seven_day_pct": 32
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-09T13:58:24-07:00",
      "completed_at": "2026-05-09T14:03:07-07:00",
      "session_started_at": null,
      "cumulative_seconds": 283,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T13:58:24-07:00",
        "five_hour_pct": 30,
        "seven_day_pct": 32
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-09T14:01:54-07:00",
          "five_hour_pct": 32,
          "seven_day_pct": 33
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-09T14:01:58-07:00",
          "five_hour_pct": 32,
          "seven_day_pct": 33
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-09T14:02:03-07:00",
          "five_hour_pct": 32,
          "seven_day_pct": 33
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-09T14:02:12-07:00",
          "five_hour_pct": 32,
          "seven_day_pct": 33
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-09T14:02:40-07:00",
          "five_hour_pct": 32,
          "seven_day_pct": 33
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-09T14:02:51-07:00",
          "five_hour_pct": 32,
          "seven_day_pct": 33
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T14:03:07-07:00",
        "five_hour_pct": 32,
        "seven_day_pct": 33
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-09T14:03:23-07:00",
      "completed_at": "2026-05-09T14:03:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 20,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-09T14:03:43-07:00",
        "five_hour_pct": 32,
        "seven_day_pct": 33
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-09T13:29:49-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-05-09T13:37:02-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-09T13:58:24-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-09T14:03:23-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-09T13:29:03-07:00",
    "five_hour_pct": 17,
    "seven_day_pct": 28
  },
  "code_task_name": "Add code_read field to pre-mortem Output Format and update Reasoning Discipline",
  "code_task": 2,
  "diff_stats": {
    "files_changed": 2,
    "insertions": 43,
    "deletions": 2,
    "captured_at": "2026-05-09T13:36:49-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "compact_summary": "<analysis>\nLooking at this conversation, the user has provided a detailed system context and rules framework for the FLOW plugin project, along with a previous summary that describes an ongoing Learn-phase analysis task. Let me analyze the key aspects:\n\n1. **Previous Work State**: The summary indicates that I was in the middle of a Learn-phase analysis of PR #1403 (branch: `add-structural-coderead-field-to`), examining changes to add a `code_read` field to the pre-mortem agent's output schema.\n\n2. **File Reads Completed**: Before the summary request, I had successfully read:\n   - `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/.claude/rules/subprocess-test-hygiene.md`\n   - `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/.claude/rules/no-waivers.md`\n   - `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/.claude/rules/reachable-is-testable.md`\n   - `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/.claude/rules/tests-guard-real-regressions.md`\n   - `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/tests/skill_contracts.rs` (partial read, lines 1-100)\n\n3. **The Task**: The user's explicit intent was to perform a two-gate Learn-phase analysis of PR #1403:\n   - Gate 1: Forward-facing (principle applicable to future sessions)\n   - Gate 2: Value (gap was remediated or truly open)\n   - Report only findings that pass BOTH gates\n   - Use explicit \"No findings\" markers for categories with zero findings\n   - Avoid inventing findings to fill sections\n\n4. **Context About the PR**: The PR involves:\n   - Adding a `code_read` field to the pre-mortem agent's output schema\n   - Modifying `agents/pre-mortem.md` to include the new field\n   - Adding a contract test in `tests/skill_contracts.rs` to verify the field exists\n   - Purpose: Making agent verification of code mandatory and auditable\n\n5. **Current State**: The user has requested a text-only summary (no tools) and has provided extensive rules documentation from the `.claude/rules/` directory covering various aspects like:\n   - subprocess-test-hygiene\n   - no-waivers\n   - reachable-is-testable\n   - tests-guard-real-regressions\n   - semi-formal-reasoning\n   - And many other rules files\n\n6. **User's Current Request**: After providing all the context and rules files, the user is now asking for a comprehensive text-only summary of the conversation, with explicit instruction NOT to use any tools.\n\nThe previous summary in the system reminder indicates that:\n- The work had just begun with initial file reads\n- The analysis was about to proceed to examine test file changes\n- The two-gate filter needed to be applied systematically\n- This was the initial phase of the Learn-phase analysis\n\nKey details from the previous summary:\n- Plan.md describes a two-task implementation to add a `code_read` field\n- The field is to be added between `Severity` and `Evidence` in the finding schema\n- Tests are being added via TDD approach\n- Out-of-scope observations were noted (no END-OF-FINDINGS marker, no triage-side validator)\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user has requested a Learn-phase analysis of PR #1403 (branch: `add-structural-coderead-field-to`) using a rigorous two-gate filter. The explicit intent is to identify findings that: (1) are forward-facing (a future session can understand and apply the principle without knowing the incident), and (2) represent a gap that was NOT caught and remediated in this PR itself. The user emphasizes that \"No findings\" is the most common correct answer and explicitly instructs against inventing findings. All findings must pass BOTH gates or be dropped. If all categories produce zero findings, the response must state this explicitly with \"No findings\" markers.\n\n2. Key Technical Concepts:\n   - FLOW plugin architecture: Five-phase development lifecycle (Start, Code, Code Review, Learn, Complete)\n   - Pre-mortem agent: A custom plugin sub-agent that identifies code failure modes using Premise → Trace → Conclude reasoning discipline\n   - Cognitive isolation: Sub-agents receive only persisted artifacts, not conversation history\n   - Two-gate test for Learn-phase findings: Forward-facing (principle applicable to future sessions) + Value (gap was remediated or truly open)\n   - Code Review scope discipline: Real findings caught and fixed in the same PR; filing is not an option\n   - Semi-formal reasoning: Agents that produce prose findings must include Reasoning Discipline sections with explicit verification steps\n   - Contract testing: Assertions about specific SKILL.md content in agents (e.g., output field declarations)\n   - 100% code coverage requirement with no waivers, enforced mechanically by `bin/flow ci`\n   - Subprocess test hygiene: Environment neutralization to prevent external service calls and coverage artifact leaks\n   - Reachable-is-testable triage: Three questions to determine if code is dead, testable with fixtures, or over-engineered\n   - Tests guard real regressions: Every test must name a specific regression path with a named consumer\n   - Permission model with allow/deny lists and mechanical enforcement hooks\n   - State file mutations via `bin/flow` subcommands, never computed timestamps\n   - Worktree isolation and branch-scoped state management\n\n3. Files and Code Sections:\n   - `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/agents/pre-mortem.md`\n      - Core file being modified to add `code_read` field\n      - Sections: Output Format (lines 87-104), Reasoning Discipline (lines 111-138), Return Format (lines 152-164)\n      - Change: Adding a new `code_read` field to the finding schema between `Severity` and `Evidence`\n      - Purpose: Making agent verification of code mandatory and auditable\n      - Key addition: \"A finding without a `code_read` is not compliant — the schema requires it because diff-only reasoning produces findings structurally indistinguishable from real Trace executions\"\n   \n   - `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/tests/skill_contracts.rs`\n      - Test file being modified\n      - New helper: `assert_agent_output_format_declares_code_read(agent_basename: &str)` function\n      - New test: `pre_mortem_agent_declares_code_read_field()` that calls the helper\n      - Purpose: Contract test ensuring the `code_read` field is present in the pre-mortem agent's Output Format section\n      - Pattern: Subsection-local assertion using split_once to bound the Output Format section\n   \n   - `plan.md` at `/Users/ben/code/flow/.flow-states/add-structural-coderead-field-to/plan.md`\n      - Describes the implementation plan with Context, Exploration, Risks, Approach, Dependency Graph, and Tasks sections\n      - Two tasks: (1) Add contract test for code_read field (TDD), (2) Add code_read field to pre-mortem agent output format and update Reasoning Discipline\n      - Out-of-scope observations: pre-mortem lacks END-OF-FINDINGS marker (deferred); no triage-side validator for code_read cites (deferred)\n      - Risk mitigation: Explicit format specification prevents placeholder text; \"No findings\" reports don't need code_read field\n\n4. Errors and fixes:\n   - No errors have been encountered yet. The task has just begun with the user providing comprehensive context and framework instructions. Initial file reads (subprocess-test-hygiene.md, no-waivers.md, reachable-is-testable.md, tests-guard-real-regressions.md, and partial skill_contracts.rs) completed successfully before this summary request interrupted the analysis work.\n\n5. Problem Solving:\n   - No problems have been encountered yet. The framing instructions establish clear criteria for what constitutes a reportable finding vs. what should be dropped, which should prevent the common error of over-reporting or creating artificial findings to fill sections.\n\n6. All user messages:\n   - Initial comprehensive message: Framing section explaining the two-gate test, followed by DIFF showing changes to pre-mortem.md and skill_contracts.rs, followed by STATE FILE DATA, PLAN reference, PROJECT_ROOT and BRANCH context, followed by inline instructions to read plan.md and CLAUDE.md, followed by comprehensive rules files from .claude/rules/ directory. The user explicitly states: \"No findings is the most common correct answer and explicitly instructs against inventing findings. All findings must pass BOTH gates or be dropped.\"\n   \n   - Second message (current): Critical instruction requesting text-only summary with explicit prohibition on tool use. User states: \"Respond with TEXT ONLY. Do NOT call any tools. Do NOT use Read, Bash, Grep, Glob, Edit, Write, or ANY other tool. You already have all the context you need in the conversation above. Tool calls will be REJECTED and will waste your only turn — you will fail the task.\"\n\n7. Pending Tasks:\n   - Complete the Learn-phase analysis of PR #1403 by examining all files and applying the two-gate filter to identify findings that are: (a) forward-facing (applicable to future sessions), and (b) represent gaps that were NOT remediated in this PR\n   - Report findings using proper formatting with category markers\n   - Return \"No findings\" for any category where no findings pass both gates\n   - Provide explicit rationale for any findings reported, citing which gate each passes\n\n8. Current Work:\n   The Learn-phase analysis of PR #1403 was just beginning when the summary request interrupted the process. I had started by:\n   - Reading `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/.claude/rules/subprocess-test-hygiene.md` - to understand environment neutralization requirements\n   - Reading `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/.claude/rules/no-waivers.md` - to understand the 100% coverage requirement and its enforcement\n   - Reading `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/.claude/rules/reachable-is-testable.md` - to understand triage questions for determining testability\n   - Reading `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/.claude/rules/tests-guard-real-regressions.md` - to understand the requirement that tests must guard named regressions\n   - Beginning to read `/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to/tests/skill_contracts.rs` to examine the contract test implementation\n   \n   The analysis had NOT yet:\n   - Examined the test file changes in detail\n   - Applied the two-gate filter systematically\n   - Identified any findings across the various rule domains\n\n9. Optional Next Step:\n   Upon resuming, the next step should be to complete the comprehensive Learn-phase analysis by:\n   1. Systematically examining the test changes in `tests/skill_contracts.rs` to understand the contract test implementation\n   2. Applying the two-gate filter to each potential finding across all tenants (architecture, simplicity, maintainability, correctness, test coverage, documentation)\n   3. For each tenant, determining whether any gaps exist that are: (a) forward-facing (applicable to future sessions), AND (b) not remediated in this PR\n   4. Reporting only findings that pass both gates, with explicit category markers and rationale\n   5. Using \"No findings\" markers for categories with zero qualifying findings, per the explicit instruction: \"If all categories produce zero, say so explicitly with 'No findings' markers — do NOT invent findings to fill sections.\"\n   \n   This directly aligns with the user's most recent explicit request in the initial message: \"your task is to create a detailed summary of the conversation so far\" followed by \"Upon resuming, the next step should be to complete the comprehensive Learn-phase analysis\" which is the work that was interrupted by the summary request.\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/add-structural-coderead-field-to",
  "compact_count": 6,
  "findings": [
    {
      "finding": "Section marker '// --- code_read field contract ---' violates rust-patterns.md primary_name single-identifier convention",
      "reason": "False positive: every existing marker in tests/skill_contracts.rs uses a multi-word descriptive phrase. rust-patterns.md says match existing style; the new marker follows the file's established convention.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T13:52:29-07:00"
    },
    {
      "finding": "agents/pre-mortem.md ## Return Format section omits code_read entry",
      "reason": "Output Format declares code_read between Severity and Evidence; Return Format enumerates 6 fields without it. Four agents independently flagged the inconsistency. Fixed by adding code_read as item 6 in Return Format, renumbering Evidence to 7.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T13:56:22-07:00"
    },
    {
      "finding": "Helper assert_agent_output_format_declares_code_read duplicates Output Format section extraction logic from sibling helper",
      "reason": "Both helpers used the same split_once chain to bound the subsection. Extracted shared read_agent_output_format_section helper under a new section marker; both assertion functions now call it.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T13:56:29-07:00"
    },
    {
      "finding": "code_read field with single file:line_range citation could force suppression or degradation of multi-file findings",
      "reason": "Pre-mortem Trace can span multiple files (race conditions, security findings). Fixed by clarifying the field accepts comma-separated entries: <file>:<line_range>[, <file>:<line_range>...] with explicit guidance that multi-file Traces list every load-bearing read.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T13:56:35-07:00"
    },
    {
      "finding": "Contract test substring assertion subsection.contains(code_read) bypassable by prose mention or code-block example",
      "reason": "Adversarial probes demonstrated the bypass: a future edit could remove the bullet declaration but keep a sentence containing the substring. Tightened the assertion to subsection.contains with the bullet shape so prose mentions and code-block examples no longer satisfy the test. Updated the failure message to name the structural requirement.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T13:56:43-07:00"
    },
    {
      "finding": "Contract test scopes code_read requirement to pre-mortem only without documenting why sibling reasoning agents are excluded",
      "reason": "Per .claude/rules/semi-formal-reasoning.md the discipline applies to four agents (pre-mortem, reviewer, ci-fixer deep-diagnosis mode, adversarial). Plan deliberately scoped to pre-mortem first. Added a Scope paragraph to the section comment naming the other three agents and recording that they are tracked separately rather than scope-expanded here.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T13:56:51-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-09T14:03:43-07:00",
    "five_hour_pct": 32,
    "seven_day_pct": 33
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>