### PR TITLE
Improve Mono Repo Cwd Recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,8 @@ Worktree creation mirrors every `.venv` discovered under the project root into t
 
 `cwd_scope::enforce` runs as the first action in every subcommand that runs tools or mutates state: `ci`, `build`, `lint`, `format`, `test`, `phase-enter`, `phase-finalize`, `phase-transition`, `set-timestamp`, `add-finding`. Read-only subcommands (`format-status`, `status`, `tombstone-audit`, `base-branch`) do not enforce.
 
+When a mono-repo session resumes (context compaction, orchestration, multi-skill chain), the agent's Bash tool cwd may reset to the main repo root and every subsequent `bin/flow` call hard-errors under `cwd_scope::enforce`. Two recovery paths exist: every `phase-enter` response carries a `worktree_cwd` field that joins `worktree_path` with `relative_cwd`, and the phase-enter skills (`flow-code`, `flow-code-review`, `flow-learn`) run `cd "<worktree_cwd>"` immediately after the HARD-GATE so the re-anchor is automatic at every phase entry. When `cwd_scope::enforce` still fires (e.g. mid-phase tool calls in a session that lost cwd between Bash invocations), the error message names the expected directory and ends with a copy-pasteable `cd "<expected>"` line the user can run verbatim.
+
 ### State File
 
 The state file (`.flow-states/<branch>/state.json`) is the backbone. Schema reference: `docs/reference/flow-state-schema.md`. Test fixtures: `tests/common/mod.rs` helpers.

--- a/skills/flow-code-review/SKILL.md
+++ b/skills/flow-code-review/SKILL.md
@@ -32,8 +32,9 @@ ${CLAUDE_PLUGIN_ROOT}/bin/flow phase-enter --phase flow-code-review --steps-tota
 Parse the JSON output. If `"status": "error"`, STOP and show the error.
 
 If `"status": "ok"`, capture the returned fields:
-`project_root`, `branch`, `worktree_path`, `pr_number`, `pr_url`,
-`feature`, `slack_thread_ts`, `plan_file`, and `mode` (commit + continue).
+`project_root`, `branch`, `worktree_path`, `worktree_cwd`,
+`relative_cwd`, `pr_number`, `pr_url`, `feature`, `slack_thread_ts`,
+`plan_file`, and `mode` (commit + continue).
 
 </HARD-GATE>
 
@@ -41,6 +42,22 @@ Use the returned fields for all downstream references. Do not re-read
 the state file or re-run git commands to gather the same information.
 Do not `cd` to the project root — `bin/flow` commands find paths
 internally.
+
+## Re-anchor cwd
+
+Mono-repo flows started inside a subdirectory (e.g. `api/`) capture
+that path as `relative_cwd` and rely on cwd staying at
+`<worktree>/<relative_cwd>` so subsequent `bin/flow` calls pass the
+cwd-drift guard. Context loss between skill invocations can reset cwd
+to the main repo root; running `cd "<worktree_cwd>"` here re-anchors
+regardless of how the session got here. Substituting the
+`worktree_cwd` value from the phase-enter response is a no-op `cd`
+for root-level flows (where it equals `worktree_path`) and a
+real re-anchor for mono-repo flows.
+
+```bash
+cd "<worktree_cwd>"
+```
 
 ## Six Tenants
 

--- a/skills/flow-code-review/SKILL.md
+++ b/skills/flow-code-review/SKILL.md
@@ -49,11 +49,10 @@ Mono-repo flows started inside a subdirectory (e.g. `api/`) capture
 that path as `relative_cwd` and rely on cwd staying at
 `<worktree>/<relative_cwd>` so subsequent `bin/flow` calls pass the
 cwd-drift guard. Context loss between skill invocations can reset cwd
-to the main repo root; running `cd "<worktree_cwd>"` here re-anchors
-regardless of how the session got here. Substituting the
-`worktree_cwd` value from the phase-enter response is a no-op `cd`
-for root-level flows (where it equals `worktree_path`) and a
-real re-anchor for mono-repo flows.
+to the main repo root; the bash block below re-anchors regardless of
+how the session got here. Substitute the `worktree_cwd` value from the
+phase-enter response — a no-op for root-level flows (where it equals
+`worktree_path`) and a real re-anchor for mono-repo flows.
 
 ```bash
 cd "<worktree_cwd>"

--- a/skills/flow-code/SKILL.md
+++ b/skills/flow-code/SKILL.md
@@ -32,8 +32,9 @@ ${CLAUDE_PLUGIN_ROOT}/bin/flow phase-enter --phase flow-code
 Parse the JSON output. If `"status": "error"`, STOP and show the error.
 
 If `"status": "ok"`, capture the returned fields:
-`project_root`, `branch`, `worktree_path`, `pr_number`, `pr_url`,
-`feature`, `slack_thread_ts`, `plan_file`, and `mode` (commit + continue).
+`project_root`, `branch`, `worktree_path`, `worktree_cwd`,
+`relative_cwd`, `pr_number`, `pr_url`, `feature`, `slack_thread_ts`,
+`plan_file`, and `mode` (commit + continue).
 
 </HARD-GATE>
 
@@ -41,6 +42,22 @@ Use the returned fields for all downstream references. Do not re-read
 the state file or re-run git commands to gather the same information.
 Do not `cd` to the project root — `bin/flow` commands find paths
 internally.
+
+## Re-anchor cwd
+
+Mono-repo flows started inside a subdirectory (e.g. `api/`) capture
+that path as `relative_cwd` and rely on cwd staying at
+`<worktree>/<relative_cwd>` so subsequent `bin/flow` calls pass the
+cwd-drift guard. Context loss between skill invocations can reset cwd
+to the main repo root; running `cd "<worktree_cwd>"` here re-anchors
+regardless of how the session got here. Substituting the
+`worktree_cwd` value from the phase-enter response is a no-op `cd`
+for root-level flows (where it equals `worktree_path`) and a
+real re-anchor for mono-repo flows.
+
+```bash
+cd "<worktree_cwd>"
+```
 
 ## Concurrency
 

--- a/skills/flow-code/SKILL.md
+++ b/skills/flow-code/SKILL.md
@@ -49,11 +49,10 @@ Mono-repo flows started inside a subdirectory (e.g. `api/`) capture
 that path as `relative_cwd` and rely on cwd staying at
 `<worktree>/<relative_cwd>` so subsequent `bin/flow` calls pass the
 cwd-drift guard. Context loss between skill invocations can reset cwd
-to the main repo root; running `cd "<worktree_cwd>"` here re-anchors
-regardless of how the session got here. Substituting the
-`worktree_cwd` value from the phase-enter response is a no-op `cd`
-for root-level flows (where it equals `worktree_path`) and a
-real re-anchor for mono-repo flows.
+to the main repo root; the bash block below re-anchors regardless of
+how the session got here. Substitute the `worktree_cwd` value from the
+phase-enter response — a no-op for root-level flows (where it equals
+`worktree_path`) and a real re-anchor for mono-repo flows.
 
 ```bash
 cd "<worktree_cwd>"

--- a/skills/flow-learn/SKILL.md
+++ b/skills/flow-learn/SKILL.md
@@ -32,8 +32,9 @@ ${CLAUDE_PLUGIN_ROOT}/bin/flow phase-enter --phase flow-learn --steps-total 7
 Parse the JSON output. If `"status": "error"`, STOP and show the error.
 
 If `"status": "ok"`, capture the returned fields:
-`project_root`, `branch`, `worktree_path`, `pr_number`, `pr_url`,
-`feature`, `slack_thread_ts`, `plan_file`, and `mode` (commit + continue).
+`project_root`, `branch`, `worktree_path`, `worktree_cwd`,
+`relative_cwd`, `pr_number`, `pr_url`, `feature`, `slack_thread_ts`,
+`plan_file`, and `mode` (commit + continue).
 
 </HARD-GATE>
 
@@ -44,6 +45,22 @@ internally.
 
 Use `<worktree_path>` for CLAUDE.md and `.claude/rules/` edits.
 Use `<project_root>` for `.flow-states/` paths only.
+
+## Re-anchor cwd
+
+Mono-repo flows started inside a subdirectory (e.g. `api/`) capture
+that path as `relative_cwd` and rely on cwd staying at
+`<worktree>/<relative_cwd>` so subsequent `bin/flow` calls pass the
+cwd-drift guard. Context loss between skill invocations can reset cwd
+to the main repo root; running `cd "<worktree_cwd>"` here re-anchors
+regardless of how the session got here. Substituting the
+`worktree_cwd` value from the phase-enter response is a no-op `cd`
+for root-level flows (where it equals `worktree_path`) and a
+real re-anchor for mono-repo flows.
+
+```bash
+cd "<worktree_cwd>"
+```
 
 ## Three Tenants
 

--- a/skills/flow-learn/SKILL.md
+++ b/skills/flow-learn/SKILL.md
@@ -52,11 +52,10 @@ Mono-repo flows started inside a subdirectory (e.g. `api/`) capture
 that path as `relative_cwd` and rely on cwd staying at
 `<worktree>/<relative_cwd>` so subsequent `bin/flow` calls pass the
 cwd-drift guard. Context loss between skill invocations can reset cwd
-to the main repo root; running `cd "<worktree_cwd>"` here re-anchors
-regardless of how the session got here. Substituting the
-`worktree_cwd` value from the phase-enter response is a no-op `cd`
-for root-level flows (where it equals `worktree_path`) and a
-real re-anchor for mono-repo flows.
+to the main repo root; the bash block below re-anchors regardless of
+how the session got here. Substitute the `worktree_cwd` value from the
+phase-enter response — a no-op for root-level flows (where it equals
+`worktree_path`) and a real re-anchor for mono-repo flows.
 
 ```bash
 cd "<worktree_cwd>"

--- a/src/cwd_scope.rs
+++ b/src/cwd_scope.rs
@@ -131,10 +131,18 @@ pub fn enforce(cwd: &Path, project_root: &Path) -> Result<(), String> {
     let expected_canon = expected.canonicalize().unwrap_or_else(|_| expected.clone());
 
     if !cwd_canon.starts_with(&expected_canon) {
+        // Reaching this branch implies relative_cwd is non-empty:
+        // when relative_cwd is empty, expected equals worktree_root,
+        // and current_branch_in succeeding above guarantees cwd is a
+        // descendant of worktree_root — so starts_with always holds.
+        // The mono-repo hint and the copy-pasteable `cd "<expected>"`
+        // line therefore always apply on the err path.
         return Err(format!(
-            "cwd drift: expected {} (or a subdirectory), current {}. cd to the expected directory before running bin/flow commands.",
+            "This is a mono-repo flow (subdir: {}). Session cwd likely lost between skill invocations. cwd drift: expected {} (or a subdirectory), current {}. Run:\ncd \"{}\"",
+            relative_cwd,
             expected_canon.display(),
-            cwd_canon.display()
+            cwd_canon.display(),
+            expected_canon.display()
         ));
     }
 

--- a/src/cwd_scope.rs
+++ b/src/cwd_scope.rs
@@ -101,6 +101,21 @@ pub fn enforce(cwd: &Path, project_root: &Path) -> Result<(), String> {
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
+    // Per `.claude/rules/external-input-path-construction.md`: state-
+    // derived strings flowing into `Path::join` and shell-bearing
+    // interpolation must pass a positive validator. An attacker (or
+    // a corrupt state file) supplying `..`, `/etc`, or a `"`-bearing
+    // value would otherwise relax the prefix check or break the
+    // `cd "<expected>"` recovery line. Fail closed: a state file
+    // with an unsafe `relative_cwd` is corrupt; the user must fix
+    // it before any state-mutating subcommand runs.
+    if !FlowPaths::is_safe_relative_cwd(relative_cwd) {
+        return Err(format!(
+            "Invalid relative_cwd in state file: {:?}. Must be empty or a relative path with no `..` segments, no leading `/`, no NUL bytes, and no `\"` characters. State file may be corrupt; fix `relative_cwd` in `.flow-states/<branch>/state.json` or restart the flow.",
+            relative_cwd
+        ));
+    }
+
     // current_branch_in(cwd) succeeded above, so cwd is a live
     // git-managed directory: `git rev-parse --show-toplevel` must
     // succeed too. Any failure here is a race (cwd removed mid-call)

--- a/src/flow_paths.rs
+++ b/src/flow_paths.rs
@@ -96,6 +96,45 @@ impl FlowPaths {
             && !branch.contains('\0')
     }
 
+    /// Positive validator for `relative_cwd` values read from the
+    /// state file. Per
+    /// `.claude/rules/external-input-path-construction.md`, every
+    /// state-derived string that flows into `Path::join` or a shell-
+    /// bearing literal must pass a positive validator before
+    /// construction. Accepts:
+    ///
+    /// - the empty string (the root-flow sentinel)
+    /// - non-empty paths whose every `/`-separated component is
+    ///   non-empty and is not `.` or `..`
+    ///
+    /// Rejects:
+    ///
+    /// - leading `/` or `\` (absolute paths — `Path::join` would
+    ///   replace `worktree_path` entirely)
+    /// - any `..` or `.` component (path traversal)
+    /// - empty components from leading or duplicate slashes
+    /// - `\0` (NUL bytes truncate paths in implementation-defined
+    ///   ways)
+    /// - `"` (double quotes break shell-bearing interpolation in
+    ///   `cd "<worktree_cwd>"` and the cwd_scope error message)
+    pub fn is_safe_relative_cwd(s: &str) -> bool {
+        if s.is_empty() {
+            return true;
+        }
+        if s.starts_with('/') || s.starts_with('\\') {
+            return false;
+        }
+        if s.contains('\0') || s.contains('"') {
+            return false;
+        }
+        for component in s.split('/') {
+            if component.is_empty() || component == "." || component == ".." {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Sole constructor — returns `Some(FlowPaths)` when `branch`
     /// passes `is_valid_branch`, `None` otherwise. Callers that hold
     /// a branch already validated upstream (state-file keyspace,

--- a/src/phase_enter.rs
+++ b/src/phase_enter.rs
@@ -288,6 +288,23 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     // Compute worktree path
     let worktree_path = root.join(".worktrees").join(&branch);
 
+    // `relative_cwd` carries the mono-repo subdirectory the flow was
+    // started in (empty for root-level flows). `worktree_cwd` joins it
+    // onto `worktree_path` so the response carries a copy-pasteable
+    // recovery path for sessions that lost cwd through context loss
+    // or skill chaining. Consumers: every phase skill that runs
+    // `cd "<worktree_cwd>"` after invoking phase-enter.
+    let relative_cwd = state
+        .get("relative_cwd")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let worktree_cwd = if relative_cwd.is_empty() {
+        worktree_path.clone()
+    } else {
+        worktree_path.join(&relative_cwd)
+    };
+
     // Build response with all state data the skill needs
     let mut response = json!({
         "status": "ok",
@@ -295,6 +312,8 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         "project_root": root.to_string_lossy(),
         "branch": branch,
         "worktree_path": worktree_path.to_string_lossy(),
+        "relative_cwd": relative_cwd,
+        "worktree_cwd": worktree_cwd.to_string_lossy(),
         "mode": {
             "commit": commit_mode,
             "continue": continue_mode,

--- a/src/phase_enter.rs
+++ b/src/phase_enter.rs
@@ -294,11 +294,28 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     // recovery path for sessions that lost cwd through context loss
     // or skill chaining. Consumers: every phase skill that runs
     // `cd "<worktree_cwd>"` after invoking phase-enter.
+    //
+    // Per `.claude/rules/external-input-path-construction.md`: validate
+    // the state-file value before joining. An unsafe `relative_cwd`
+    // (containing `..`, an absolute prefix, NUL, or `"`) would let
+    // `Path::join` escape the worktree (`..` parents) or replace the
+    // base entirely (absolute), and break the `cd "<worktree_cwd>"`
+    // shell-bearing instruction. Fail closed: emit a structured
+    // error so the user fixes the state file before any cd action.
     let relative_cwd = state
         .get("relative_cwd")
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+    if !FlowPaths::is_safe_relative_cwd(&relative_cwd) {
+        return Ok(json!({
+            "status": "error",
+            "message": format!(
+                "Invalid relative_cwd in state file: {:?}. Must be empty or a relative path with no `..` segments, no leading `/`, no NUL bytes, and no `\"` characters.",
+                relative_cwd
+            ),
+        }));
+    }
     let worktree_cwd = if relative_cwd.is_empty() {
         worktree_path.clone()
     } else {

--- a/tests/cwd_scope.rs
+++ b/tests/cwd_scope.rs
@@ -183,6 +183,57 @@ fn cwd_scope_does_not_panic_on_slash_branch() {
     );
 }
 
+/// Regression: when enforce returns an error, the message must
+/// contain a `cd "<absolute_path>"` line so the user can copy-paste
+/// the recovery command. Triggered via the standard mismatch path
+/// (relative_cwd="api", cwd at worktree root). Without the cd line,
+/// the user has to mentally reconstruct the path from the prose.
+/// Consumer: every Bash-tool error surface that reports cwd_scope
+/// failures.
+#[test]
+fn cwd_drift_error_includes_cd_command_for_root_flow() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    init_git_repo(&root, "feature-x");
+    write_state(&root, "feature-x", "api");
+    let result = enforce(&root, &root);
+    let msg = result.unwrap_err();
+    let expected_cd = format!(r#"cd "{}/api""#, root.display());
+    assert!(
+        msg.contains(&expected_cd),
+        "error must contain copy-pasteable `{}`; got: {}",
+        expected_cd,
+        msg
+    );
+}
+
+/// Regression: when enforce errors with a non-empty relative_cwd,
+/// the message must include a hint that this is a mono-repo flow
+/// and that cwd was likely lost between skill invocations. Without
+/// the hint, mono-repo users see a generic cwd-drift error and miss
+/// the recovery context. Consumer: same as the root-flow test —
+/// every Bash-tool error surface reporting cwd_scope failures in a
+/// mono-repo setup.
+#[test]
+fn cwd_drift_error_includes_monorepo_hint_for_subdir_flow() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    init_git_repo(&root, "feature-x");
+    write_state(&root, "feature-x", "api");
+    let result = enforce(&root, &root);
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("mono-repo"),
+        "error must mention 'mono-repo' for non-empty relative_cwd; got: {}",
+        msg
+    );
+    assert!(
+        msg.contains("api"),
+        "error must name the subdir from relative_cwd; got: {}",
+        msg
+    );
+}
+
 #[test]
 fn enforce_canonicalize_fallback_nonexistent_relative_cwd() {
     // When `relative_cwd` names a subdirectory that does not yet exist

--- a/tests/cwd_scope.rs
+++ b/tests/cwd_scope.rs
@@ -191,7 +191,7 @@ fn cwd_scope_does_not_panic_on_slash_branch() {
 /// Consumer: every Bash-tool error surface that reports cwd_scope
 /// failures.
 #[test]
-fn cwd_drift_error_includes_cd_command_for_root_flow() {
+fn cwd_drift_error_includes_copy_pasteable_cd_command() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path().canonicalize().unwrap();
     init_git_repo(&root, "feature-x");
@@ -230,6 +230,67 @@ fn cwd_drift_error_includes_monorepo_hint_for_subdir_flow() {
     assert!(
         msg.contains("api"),
         "error must name the subdir from relative_cwd; got: {}",
+        msg
+    );
+}
+
+/// Regression: state file with `relative_cwd=".."` would silently
+/// disable the cwd guard if validation were missing — `expected`
+/// becomes the parent of the worktree and `cwd.starts_with(expected)`
+/// holds for every cwd inside `.worktrees/`. Per
+/// `.claude/rules/external-input-path-construction.md`, an unsafe
+/// state-file value must fail closed with a structured error. Consumer:
+/// every state-mutating bin/flow subcommand that calls cwd_scope.
+#[test]
+fn enforce_rejects_traversal_relative_cwd() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    init_git_repo(&root, "feature-x");
+    write_state(&root, "feature-x", "..");
+    let result = enforce(&root, &root);
+    assert!(result.is_err(), "traversal `..` must fail closed");
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("Invalid relative_cwd"),
+        "error must name the validation failure; got: {}",
+        msg
+    );
+}
+
+/// Regression: state file with absolute `relative_cwd="/etc"` would
+/// otherwise let `Path::join` replace the worktree root entirely. Same
+/// fail-closed posture and consumer as the traversal case.
+#[test]
+fn enforce_rejects_absolute_relative_cwd() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    init_git_repo(&root, "feature-x");
+    write_state(&root, "feature-x", "/etc");
+    let result = enforce(&root, &root);
+    assert!(result.is_err(), "absolute path must fail closed");
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("Invalid relative_cwd"),
+        "error must name the validation failure; got: {}",
+        msg
+    );
+}
+
+/// Regression: state file with `relative_cwd` containing `"` would
+/// otherwise corrupt the `cd "<expected>"` recovery line in the err
+/// message. Same fail-closed posture and consumer.
+#[test]
+fn enforce_rejects_double_quote_relative_cwd() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    init_git_repo(&root, "feature-x");
+    write_state(&root, "feature-x", "api\"injected");
+    let result = enforce(&root, &root);
+    assert!(result.is_err(), "double-quote must fail closed");
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("Invalid relative_cwd"),
+        "error must name the validation failure; got: {}",
         msg
     );
 }

--- a/tests/flow_paths.rs
+++ b/tests/flow_paths.rs
@@ -300,6 +300,82 @@ fn try_new_returns_none_for_nul_branch() {
     assert!(FlowPaths::try_new("/p", "branch\0name").is_none());
 }
 
+// --- is_safe_relative_cwd ---
+//
+// Per `.claude/rules/external-input-path-construction.md`, a state-
+// derived `relative_cwd` value flowing into `Path::join` and into the
+// `cd "<worktree_cwd>"` shell-bearing instruction must pass a positive
+// validator. These tests pin the validator's accept/reject surface for
+// every rejection class the rule names: empty (allowed — root sentinel),
+// single and nested non-empty paths (allowed), absolute paths (rejected),
+// `..` and `.` segments (rejected), NUL bytes (rejected), `"`
+// (rejected). Consumers: `cwd_scope::enforce`, `phase_enter::run_impl`.
+
+#[test]
+fn is_safe_relative_cwd_accepts_empty() {
+    assert!(FlowPaths::is_safe_relative_cwd(""));
+}
+
+#[test]
+fn is_safe_relative_cwd_accepts_single_component() {
+    assert!(FlowPaths::is_safe_relative_cwd("api"));
+}
+
+#[test]
+fn is_safe_relative_cwd_accepts_nested_components() {
+    assert!(FlowPaths::is_safe_relative_cwd("packages/api"));
+}
+
+#[test]
+fn is_safe_relative_cwd_rejects_absolute_path() {
+    assert!(!FlowPaths::is_safe_relative_cwd("/etc"));
+}
+
+#[test]
+fn is_safe_relative_cwd_rejects_backslash_absolute() {
+    assert!(!FlowPaths::is_safe_relative_cwd("\\windows"));
+}
+
+#[test]
+fn is_safe_relative_cwd_rejects_parent_traversal() {
+    assert!(!FlowPaths::is_safe_relative_cwd(".."));
+}
+
+#[test]
+fn is_safe_relative_cwd_rejects_parent_in_middle() {
+    assert!(!FlowPaths::is_safe_relative_cwd("api/../etc"));
+}
+
+#[test]
+fn is_safe_relative_cwd_rejects_dot_segment() {
+    assert!(!FlowPaths::is_safe_relative_cwd("."));
+}
+
+#[test]
+fn is_safe_relative_cwd_rejects_dot_in_middle() {
+    assert!(!FlowPaths::is_safe_relative_cwd("api/./b"));
+}
+
+#[test]
+fn is_safe_relative_cwd_rejects_nul_byte() {
+    assert!(!FlowPaths::is_safe_relative_cwd("api\0b"));
+}
+
+#[test]
+fn is_safe_relative_cwd_rejects_double_quote() {
+    assert!(!FlowPaths::is_safe_relative_cwd("api\"b"));
+}
+
+#[test]
+fn is_safe_relative_cwd_rejects_trailing_slash() {
+    assert!(!FlowPaths::is_safe_relative_cwd("api/"));
+}
+
+#[test]
+fn is_safe_relative_cwd_rejects_double_slash() {
+    assert!(!FlowPaths::is_safe_relative_cwd("api//b"));
+}
+
 // --- FlowStatesDir ---
 
 #[test]

--- a/tests/phase_enter.rs
+++ b/tests/phase_enter.rs
@@ -922,6 +922,113 @@ fn phase_enter_args_clap_derives_covered() {
     assert!(args.steps_total.is_none());
 }
 
+/// Verify phase-enter response includes `relative_cwd: ""` and
+/// `worktree_cwd` equal to `worktree_path` for a root-level flow.
+/// Regression: a session resuming after context loss reads
+/// `worktree_cwd` from the phase-enter response to re-anchor cwd; the
+/// field must always be present, including for root-level flows where
+/// it equals `worktree_path`. Consumer: every phase skill that runs
+/// `cd "<worktree_cwd>"` after invoking `phase-enter`.
+#[test]
+fn phase_enter_response_includes_relative_cwd_for_root_flow() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "root-flow-cwd";
+    let repo = create_git_repo(dir.path(), branch);
+    create_state(&repo, branch, "flow-start", "complete", None);
+
+    let output = run_phase_enter(&repo, &["--phase", "flow-code", "--branch", branch]);
+    assert_eq!(output.status.code(), Some(0));
+    let data = parse_output(&output);
+    assert_eq!(data["status"], "ok");
+    assert_eq!(
+        data["relative_cwd"], "",
+        "root-level flow must report relative_cwd=\"\""
+    );
+    let wt_cwd = data["worktree_cwd"]
+        .as_str()
+        .expect("worktree_cwd must be present in response");
+    let wt_path = data["worktree_path"]
+        .as_str()
+        .expect("worktree_path must be present in response");
+    assert_eq!(
+        wt_cwd, wt_path,
+        "root-level flow: worktree_cwd must equal worktree_path"
+    );
+}
+
+/// Verify phase-enter response carries `relative_cwd: "api"` and
+/// `worktree_cwd` equal to `<worktree_path>/api` for a mono-repo
+/// flow started inside `api/`. Regression: a session resuming after
+/// context loss in a mono-repo flow needs `worktree_cwd` to include
+/// the subdir suffix so `cd "<worktree_cwd>"` re-anchors at the
+/// correct subtree. Consumer: same skills as the root-flow case.
+#[test]
+fn phase_enter_response_includes_worktree_cwd_for_subdir_flow() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "subdir-flow-cwd";
+    let repo = create_git_repo(dir.path(), branch);
+
+    Command::new("git")
+        .args(["checkout", branch])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+
+    let api_dir = repo.join("api");
+    fs::create_dir_all(&api_dir).unwrap();
+
+    let state_dir = flow_states_dir(&repo);
+    let branch_dir = state_dir.join(branch);
+    fs::create_dir_all(&branch_dir).unwrap();
+    fs::write(
+        branch_dir.join("state.json"),
+        serde_json::to_string(&json!({
+            "branch": branch,
+            "relative_cwd": "api",
+            "current_phase": "flow-start",
+            "phases": {
+                "flow-start": {"status": "complete"}
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["phase-enter", "--phase", "flow-code", "--branch", branch])
+        .current_dir(&api_dir)
+        .env_remove("FLOW_SIMULATE_BRANCH")
+        .env_remove("FLOW_CI_RUNNING")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let last = stdout.trim().lines().last().unwrap_or("");
+    let data: Value = serde_json::from_str(last).unwrap_or(json!({}));
+    assert_eq!(data["status"], "ok");
+    assert_eq!(
+        data["relative_cwd"], "api",
+        "mono-repo flow must echo state's relative_cwd"
+    );
+    let wt_cwd = data["worktree_cwd"]
+        .as_str()
+        .expect("worktree_cwd must be present in response");
+    let wt_path = data["worktree_path"]
+        .as_str()
+        .expect("worktree_path must be present in response");
+    assert_eq!(
+        wt_cwd,
+        format!("{}/api", wt_path),
+        "mono-repo flow: worktree_cwd must be worktree_path joined with relative_cwd"
+    );
+}
+
 /// Covers the implicit `None` arm of all five `if let Some(x) = field`
 /// blocks that build the response (pr_number, pr_url, feature,
 /// slack_thread_ts, plan_file). State has none of the optional fields

--- a/tests/phase_enter.rs
+++ b/tests/phase_enter.rs
@@ -922,6 +922,47 @@ fn phase_enter_args_clap_derives_covered() {
     assert!(args.steps_total.is_none());
 }
 
+/// Regression: state file with an unsafe `relative_cwd` (traversal,
+/// absolute path, NUL, or double-quote) must fail closed in
+/// phase-enter rather than letting the unsafe value flow into
+/// `Path::join` for `worktree_cwd` or into the skill's
+/// `cd "<worktree_cwd>"` instruction. Per
+/// `.claude/rules/external-input-path-construction.md`. Consumer:
+/// every phase skill that re-anchors cwd via the response.
+#[test]
+fn phase_enter_rejects_unsafe_relative_cwd() {
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "unsafe-rel-cwd";
+    let repo = create_git_repo(dir.path(), branch);
+    let state_dir = flow_states_dir(&repo);
+    let branch_dir = state_dir.join(branch);
+    fs::create_dir_all(&branch_dir).unwrap();
+    fs::write(
+        branch_dir.join("state.json"),
+        serde_json::to_string(&json!({
+            "branch": branch,
+            "relative_cwd": "/etc",
+            "current_phase": "flow-start",
+            "phases": {
+                "flow-start": {"status": "complete"}
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let output = run_phase_enter(&repo, &["--phase", "flow-code", "--branch", branch]);
+    assert_eq!(output.status.code(), Some(0));
+    let data = parse_output(&output);
+    assert_eq!(data["status"], "error");
+    let msg = data["message"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("Invalid relative_cwd"),
+        "unsafe relative_cwd must produce a structured error; got: {}",
+        msg
+    );
+}
+
 /// Verify phase-enter response includes `relative_cwd: ""` and
 /// `worktree_cwd` equal to `worktree_path` for a root-level flow.
 /// Regression: a session resuming after context loss reads

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -1715,6 +1715,68 @@ fn phase_enter_skills_no_action_enter() {
     }
 }
 
+/// Returns the slice of `content` between the first `phase-enter`
+/// invocation and the `## Resume Check` heading. Used by per-skill
+/// re-anchor tests to bound the assertion scope per
+/// `.claude/rules/testing-gotchas.md` "Subsection-Local Assertions
+/// in Contract Tests".
+fn slice_between_phase_enter_and_resume_check(content: &str) -> &str {
+    let after_enter = content
+        .split_once("phase-enter --phase")
+        .map(|(_, t)| t)
+        .expect("phase-enter --phase invocation must exist");
+    after_enter
+        .split_once("\n## Resume Check")
+        .map(|(s, _)| s)
+        .unwrap_or(after_enter)
+}
+
+/// Regression: flow-code/SKILL.md must instruct `cd "<worktree_cwd>"`
+/// between the phase-enter HARD-GATE and the Resume Check. Without
+/// this, a session resuming Code phase after context loss has no
+/// way to re-anchor cwd, and every subsequent bin/flow call fails
+/// with cwd_scope::enforce blocking. Consumer: every Code-phase
+/// session running on a mono-repo flow.
+#[test]
+fn flow_code_re_anchors_cwd_after_phase_enter() {
+    let c = common::read_skill("flow-code");
+    let bounded = slice_between_phase_enter_and_resume_check(&c);
+    assert!(
+        bounded.contains(r#"cd "<worktree_cwd>""#),
+        "flow-code/SKILL.md must instruct `cd \"<worktree_cwd>\"` between phase-enter and Resume Check"
+    );
+}
+
+/// Regression: flow-code-review/SKILL.md must instruct
+/// `cd "<worktree_cwd>"` between the phase-enter HARD-GATE and the
+/// Resume Check. Without this, a session resuming Code Review after
+/// context loss cannot re-anchor cwd. Consumer: every Code-Review-
+/// phase session running on a mono-repo flow.
+#[test]
+fn flow_code_review_re_anchors_cwd_after_phase_enter() {
+    let c = common::read_skill("flow-code-review");
+    let bounded = slice_between_phase_enter_and_resume_check(&c);
+    assert!(
+        bounded.contains(r#"cd "<worktree_cwd>""#),
+        "flow-code-review/SKILL.md must instruct `cd \"<worktree_cwd>\"` between phase-enter and Resume Check"
+    );
+}
+
+/// Regression: flow-learn/SKILL.md must instruct `cd "<worktree_cwd>"`
+/// between the phase-enter HARD-GATE and the Resume Check. Without
+/// this, a session resuming Learn after context loss cannot re-anchor
+/// cwd. Consumer: every Learn-phase session running on a mono-repo
+/// flow.
+#[test]
+fn flow_learn_re_anchors_cwd_after_phase_enter() {
+    let c = common::read_skill("flow-learn");
+    let bounded = slice_between_phase_enter_and_resume_check(&c);
+    assert!(
+        bounded.contains(r#"cd "<worktree_cwd>""#),
+        "flow-learn/SKILL.md must instruct `cd \"<worktree_cwd>\"` between phase-enter and Resume Check"
+    );
+}
+
 #[test]
 fn release_complete_banner_confirms_marketplace_update() {
     let c = fs::read_to_string(

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -1780,49 +1780,72 @@ fn slice_between_phase_enter_and_resume_check(content: &str) -> &str {
         .unwrap_or(after_enter)
 }
 
+/// Returns true when `bounded` contains `target` inside a fenced
+/// ```bash``` block. The model only executes `bash` fences; if the
+/// instruction lives in prose or a different fence type the cwd
+/// never re-anchors at runtime. The search walks every `bash` fence
+/// in the slice and checks the body up to the next closing fence
+/// for `target`.
+fn bash_fence_contains(bounded: &str, target: &str) -> bool {
+    let mut rest = bounded;
+    while let Some((_, after_open)) = rest.split_once("```bash") {
+        let body_end = after_open.find("\n```").unwrap_or(after_open.len());
+        let body = &after_open[..body_end];
+        if body.contains(target) {
+            return true;
+        }
+        rest = &after_open[body_end..];
+    }
+    false
+}
+
 /// Regression: flow-code/SKILL.md must instruct `cd "<worktree_cwd>"`
-/// between the phase-enter HARD-GATE and the Resume Check. Without
-/// this, a session resuming Code phase after context loss has no
-/// way to re-anchor cwd, and every subsequent bin/flow call fails
-/// with cwd_scope::enforce blocking. Consumer: every Code-phase
+/// inside a bash fence between the phase-enter HARD-GATE and the
+/// Resume Check. Without this, a session resuming Code phase after
+/// context loss has no way to re-anchor cwd, and every subsequent
+/// bin/flow call fails with cwd_scope::enforce blocking. The bash
+/// fence is load-bearing: the model only executes ` ```bash ` blocks,
+/// so a future regression that moves the instruction into prose
+/// would silently disable runtime cd. Consumer: every Code-phase
 /// session running on a mono-repo flow.
 #[test]
 fn flow_code_re_anchors_cwd_after_phase_enter() {
     let c = common::read_skill("flow-code");
     let bounded = slice_between_phase_enter_and_resume_check(&c);
     assert!(
-        bounded.contains(r#"cd "<worktree_cwd>""#),
-        "flow-code/SKILL.md must instruct `cd \"<worktree_cwd>\"` between phase-enter and Resume Check"
+        bash_fence_contains(bounded, r#"cd "<worktree_cwd>""#),
+        "flow-code/SKILL.md must instruct `cd \"<worktree_cwd>\"` inside a bash fence between phase-enter and Resume Check"
     );
 }
 
 /// Regression: flow-code-review/SKILL.md must instruct
-/// `cd "<worktree_cwd>"` between the phase-enter HARD-GATE and the
-/// Resume Check. Without this, a session resuming Code Review after
-/// context loss cannot re-anchor cwd. Consumer: every Code-Review-
-/// phase session running on a mono-repo flow.
+/// `cd "<worktree_cwd>"` inside a bash fence between the phase-enter
+/// HARD-GATE and the Resume Check. Without this, a session resuming
+/// Code Review after context loss cannot re-anchor cwd at runtime
+/// (the model only executes bash fences). Consumer: every Code-
+/// Review-phase session running on a mono-repo flow.
 #[test]
 fn flow_code_review_re_anchors_cwd_after_phase_enter() {
     let c = common::read_skill("flow-code-review");
     let bounded = slice_between_phase_enter_and_resume_check(&c);
     assert!(
-        bounded.contains(r#"cd "<worktree_cwd>""#),
-        "flow-code-review/SKILL.md must instruct `cd \"<worktree_cwd>\"` between phase-enter and Resume Check"
+        bash_fence_contains(bounded, r#"cd "<worktree_cwd>""#),
+        "flow-code-review/SKILL.md must instruct `cd \"<worktree_cwd>\"` inside a bash fence between phase-enter and Resume Check"
     );
 }
 
 /// Regression: flow-learn/SKILL.md must instruct `cd "<worktree_cwd>"`
-/// between the phase-enter HARD-GATE and the Resume Check. Without
-/// this, a session resuming Learn after context loss cannot re-anchor
-/// cwd. Consumer: every Learn-phase session running on a mono-repo
-/// flow.
+/// inside a bash fence between the phase-enter HARD-GATE and the
+/// Resume Check. Without this, a session resuming Learn after context
+/// loss cannot re-anchor cwd at runtime. Consumer: every Learn-phase
+/// session running on a mono-repo flow.
 #[test]
 fn flow_learn_re_anchors_cwd_after_phase_enter() {
     let c = common::read_skill("flow-learn");
     let bounded = slice_between_phase_enter_and_resume_check(&c);
     assert!(
-        bounded.contains(r#"cd "<worktree_cwd>""#),
-        "flow-learn/SKILL.md must instruct `cd \"<worktree_cwd>\"` between phase-enter and Resume Check"
+        bash_fence_contains(bounded, r#"cd "<worktree_cwd>""#),
+        "flow-learn/SKILL.md must instruct `cd \"<worktree_cwd>\"` inside a bash fence between phase-enter and Resume Check"
     );
 }
 


### PR DESCRIPTION
## What

#1398.

Closes #1398

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/improve-mono-repo-cwd-recovery/log` |
| State | `.flow-states/improve-mono-repo-cwd-recovery/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 33m |
| Code Review | 33m |
| Learn | 3m |
| Complete | <1m |
| **Total** | **1h 12m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/improve-mono-repo-cwd-recovery.json</summary>

```json
{
  "schema_version": 1,
  "branch": "improve-mono-repo-cwd-recovery",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1404,
  "pr_url": "https://github.com/benkruger/flow/pull/1404",
  "started_at": "2026-05-09T13:29:41-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/improve-mono-repo-cwd-recovery/log",
    "state": ".flow-states/improve-mono-repo-cwd-recovery/state.json"
  },
  "session_tty": "/dev/ttys003",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "#1398",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-09T13:29:41-07:00",
      "completed_at": "2026-05-09T13:30:30-07:00",
      "session_started_at": null,
      "cumulative_seconds": 49,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-09T13:30:30-07:00",
        "five_hour_pct": 17,
        "seven_day_pct": 28
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-09T13:30:38-07:00",
      "completed_at": "2026-05-09T14:04:36-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2038,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T13:30:38-07:00",
        "five_hour_pct": 18,
        "seven_day_pct": 28
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-09T13:37:56-07:00",
          "five_hour_pct": 21,
          "seven_day_pct": 30
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-09T13:37:56-07:00",
          "five_hour_pct": 21,
          "seven_day_pct": 30
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-09T13:47:10-07:00",
          "five_hour_pct": 26,
          "seven_day_pct": 31
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-09T13:47:10-07:00",
          "five_hour_pct": 26,
          "seven_day_pct": 31
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-09T13:55:39-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 32
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-09T13:55:39-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 32
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-09T14:03:20-07:00",
          "five_hour_pct": 32,
          "seven_day_pct": 33
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T14:04:36-07:00",
        "five_hour_pct": 32,
        "seven_day_pct": 33
      }
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-05-09T14:04:49-07:00",
      "completed_at": "2026-05-09T14:38:17-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2008,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T14:04:49-07:00",
        "five_hour_pct": 32,
        "seven_day_pct": 33
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_review_step",
          "captured_at": "2026-05-09T14:11:30-07:00",
          "five_hour_pct": 33,
          "seven_day_pct": 33
        },
        {
          "step": 3,
          "field": "code_review_step",
          "captured_at": "2026-05-09T14:22:29-07:00",
          "five_hour_pct": 38,
          "seven_day_pct": 35
        },
        {
          "step": 4,
          "field": "code_review_step",
          "captured_at": "2026-05-09T14:38:07-07:00",
          "five_hour_pct": 40,
          "seven_day_pct": 35
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T14:38:17-07:00",
        "five_hour_pct": 40,
        "seven_day_pct": 35
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-09T14:38:28-07:00",
      "completed_at": "2026-05-09T14:42:08-07:00",
      "session_started_at": null,
      "cumulative_seconds": 220,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T14:38:28-07:00",
        "five_hour_pct": 40,
        "seven_day_pct": 35
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-09T14:40:50-07:00",
          "five_hour_pct": 40,
          "seven_day_pct": 35
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-09T14:41:18-07:00",
          "five_hour_pct": 41,
          "seven_day_pct": 35
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-09T14:41:28-07:00",
          "five_hour_pct": 41,
          "seven_day_pct": 35
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-09T14:41:39-07:00",
          "five_hour_pct": 41,
          "seven_day_pct": 35
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-09T14:41:47-07:00",
          "five_hour_pct": 41,
          "seven_day_pct": 35
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T14:42:08-07:00",
        "five_hour_pct": 41,
        "seven_day_pct": 35
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-09T14:42:25-07:00",
      "completed_at": "2026-05-09T14:42:44-07:00",
      "session_started_at": null,
      "cumulative_seconds": 19,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-09T14:42:44-07:00",
        "five_hour_pct": 41,
        "seven_day_pct": 35
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-09T13:30:38-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-code-review",
      "timestamp": "2026-05-09T14:04:49-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-09T14:38:28-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-09T14:42:25-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-code-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-09T13:29:41-07:00",
    "five_hour_pct": 17,
    "seven_day_pct": 28
  },
  "code_task_name": "Update CLAUDE.md Subdirectory Context section with cwd-recovery paragraph",
  "code_task": 7,
  "diff_stats": {
    "files_changed": 9,
    "insertions": 308,
    "deletions": 8,
    "captured_at": "2026-05-09T14:04:36-07:00"
  },
  "code_review_steps_total": 4,
  "code_review_step": 4,
  "compact_summary": "<analysis>\nThe user is asking me to summarize the conversation according to a specific structure. Let me analyze what has happened:\n\n1. **Initial Context**: The user provided a DIFF summary of PR #1404 (improve-mono-repo-cwd-recovery), which involves adding cwd recovery mechanisms for mono-repo flows.\n\n2. **The FRAMING Section**: The user explicitly stated they want me to apply the \"two-gate test\" to filter findings:\n   - Gate 1: Forward-facing — would a future session understand and apply the principle?\n   - Gate 2: Value — was the gap caught and remediated in this PR?\n   - If both gates pass, report the finding. Otherwise, drop it.\n   - \"No findings\" is the correct answer for most categories.\n\n3. **What I Should Have Done**: I should have analyzed the PR against three Learn tenants:\n   - Tenant 1: Did the FLOW process work? (Process gaps in the plugin's workflow)\n   - Tenant 2: Did Claude follow the rules? (Compliance with CLAUDE.md and .claude/rules/)\n   - Tenant 3: What rules should exist but don't? (Forward-looking patterns)\n\n4. **What Actually Happened**: I spent the entire conversation reading files from the worktree:\n   - Read phase_enter.rs (359 lines)\n   - Read cwd_scope.rs (166 lines)\n   - Read flow_paths.rs (started reading, got cut off by system reminders)\n   - Never actually performed the analysis requested\n\n5. **The Critical Error**: The user's framing explicitly states \"Most Learn phases produce zero findings. Your job is to filter, not to find things to say\" and \"No findings in any category is the most common correct answer.\" I should have:\n   - Analyzed the diff and state file data\n   - Applied the two-gate test to candidate findings\n   - Reported findings only if they pass both gates\n   - Said \"No findings\" for categories where nothing passed the gates\n\n6. **Current State**: The conversation ends with my reading of flow_paths.rs being interrupted by system reminders loading rule files, and the user has now asked for a summary WITHOUT using any tools.\n\nThe user's intent is clear: they wanted a Learn phase analysis of PR #1404 using the two-gate filter. I should have provided findings (or \"No findings\" statements) organized by the three tenants, but instead I spent time gathering context files without doing the actual analysis work.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user requested a Learn phase analysis (Phase 4 findings audit) for PR #1404 (\"improve-mono-repo-cwd-recovery\") using a strict two-gate filter:\n   - Gate 1 (Forward-facing): Would a future session understand and apply the principle independently?\n   - Gate 2 (Value): Was the gap caught and remediated in this PR?\n   \n   Only findings passing BOTH gates should be reported. The user explicitly stated \"No findings\" is the most common correct answer and should be reported explicitly for each category.\n   \n   The analysis was to be organized around three Learn tenants:\n   - Tenant 1: Did the FLOW process work? (Process gaps in plugin workflow)\n   - Tenant 2: Did Claude follow the rules? (Compliance with CLAUDE.md and .claude/rules/)\n   - Tenant 3: What rules should exist but don't? (Forward-looking patterns)\n\n2. Key Technical Concepts:\n   - Mono-repo CWD recovery mechanism for FLOW phases\n   - Phase-enter response contract including worktree_cwd and relative_cwd fields\n   - Three phase-enter skills: flow-code, flow-code-review, flow-learn\n   - CWD scope enforcement via cwd_scope::enforce()\n   - Path safety validation via FlowPaths::is_safe_relative_cwd()\n   - Fail-closed semantics for invalid relative_cwd\n   - Copy-pasteable cd commands in error messages\n   - Two-gate filter discipline for Learn phase findings\n\n3. Files and Code Sections:\n   The user provided a DIFF summary showing changes to multiple files:\n   - CLAUDE.md: Added paragraph in Subdirectory Context section documenting cwd-recovery contract\n   - skills/flow-code/SKILL.md, flow-code-review/SKILL.md, flow-learn/SKILL.md: Added \"Re-anchor cwd\" section after phase-enter HARD-GATE with captured-fields and cd command block\n   - src/phase_enter.rs: Extended with relative_cwd and worktree_cwd reading, validation, and emission in JSON response\n   - src/cwd_scope.rs: Added relative_cwd validation before joining, structured error on invalid input, reworded cwd-drift error with mono-repo hint and copy-pasteable cd line\n   - src/flow_paths.rs: Added FlowPaths::is_safe_relative_cwd validator\n   - tests/flow_paths.rs: 13 unit tests for validator\n   - tests/cwd_scope.rs: 3 fail-closed regression tests + 2 wording tests; 1 test renamed\n   - tests/phase_enter.rs: 3 tests covering relative_cwd, worktree_cwd response, unsafe relative_cwd rejection\n   - tests/skill_contracts.rs: 3 per-skill re-anchor contract tests + bash_fence_contains helper\n   \n   I read the following files but did not complete analysis:\n   - src/phase_enter.rs (359 lines) - Shows phase-enter implementation with relative_cwd/worktree_cwd handling, validation via FlowPaths::is_safe_relative_cwd, and JSON response construction\n   - src/cwd_scope.rs (166 lines) - Shows cwd enforcement with relative_cwd validation and error messaging with copy-pasteable cd line\n   - src/flow_paths.rs (partial read) - Shows FlowPaths structure with validator functions\n\n4. Errors and fixes:\n   No actual errors were encountered because I did not proceed far enough to execute the two-gate analysis. The critical issue is that I misunderstood the task by reading files instead of applying analytical reasoning to the provided diff and state file data.\n\n5. Problem Solving:\n   No problems were actively solved. The conversation was interrupted before the actual analysis work began. The user provided complete information in the FRAMING section, DIFF section, and STATE FILE DATA section, which was sufficient to perform the analysis without additional file reads.\n\n6. All user messages:\n   - Initial message: Provided FRAMING with two-gate filter instructions, DIFF summary of PR #1404 changes, STATE FILE DATA showing PR completion status (all 7 code tasks done, all 4 code review steps done, learn phase in_progress), PLAN showing all 7 tasks executed, PROJECT CLAUDE.MD reference, and RULES FILES reference. Requested audit against three Learn tenants. Ended with explicit instruction: \"Return only findings that pass both gates. If all categories produce zero, say so explicitly with 'No findings' markers — do NOT invent findings to fill sections.\"\n   - Final message (this one): Critical instruction requesting TEXT ONLY summary with NO TOOL CALLS, emphasizing that tool calls will be rejected and waste the only turn.\n\n7. Pending Tasks:\n   - Provide Learn phase analysis of PR #1404 applying the two-gate filter\n   - Organize findings by three tenants (Tenant 1, 2, 3)\n   - Report \"No findings\" explicitly for any category where nothing passes both gates\n   - Do NOT invent findings to fill sections\n\n8. Current Work:\n   The conversation was focused on gathering context for a Learn phase findings analysis of PR #1404. The user provided comprehensive information:\n   - FRAMING explaining the two-gate filter methodology\n   - DIFF describing 12 modified files implementing mono-repo CWD recovery\n   - STATE FILE DATA showing the PR is complete (flow-code and flow-code-review phases finished, flow-learn in progress)\n   - Detailed PLAN showing 7 tasks across 4 atomic commit groups, with notes on plan deviations\n   \n   I began reading source files (phase_enter.rs, cwd_scope.rs, flow_paths.rs) to understand the implementation details but had not yet:\n   - Analyzed whether the cwd recovery mechanism introduces any Tenant 1 process gaps\n   - Audited Claude's compliance with CLAUDE.md and .claude/rules/ for Tenant 2\n   - Identified any forward-looking patterns needing new rules for Tenant 3\n   - Applied the two-gate filter to any candidate findings\n\n9. Optional Next Step:\n   The next step is to provide the Learn phase analysis using the two-gate filter. The user's explicit request was: \"Audit against the three Learn tenants: Tenant 1: Did the FLOW process work? Tenant 2: Did Claude follow the rules? Tenant 3: What rules should exist but don't?\" with the critical constraint that \"If all categories produce zero, say so explicitly with 'No findings' markers — do NOT invent findings to fill sections.\"\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/improve-mono-repo-cwd-recovery",
  "compact_count": 6,
  "findings": [
    {
      "finding": "Pre-mortem F4: asymmetric canonicalization causes spurious drift errors with empty relative_cwd",
      "reason": "False positive: when relative_cwd is empty, expected equals worktree_root which is the live git-managed directory we just resolved branch from; expected.canonicalize() succeeds at the same symlink-resolved form as cwd_canon, so starts_with holds. The unreachability claim in the new comment is correct for this path.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T14:22:04-07:00"
    },
    {
      "finding": "Reviewer F1 + Pre-mortem F1/F2/F3 + Adversarial F1/F2: state-derived relative_cwd flows into Path::join and shell-bearing interpolation without a positive validator",
      "reason": "Added FlowPaths::is_safe_relative_cwd validator (rejects empty=allowed, leading /, leading backslash, .. segments, . segments, NUL, double-quote, leading/trailing/duplicate slashes); applied at the boundary in cwd_scope::enforce (fail-closed Err) and phase_enter::run_impl (fail-closed status:error). Added validator unit tests in tests/flow_paths.rs and integration tests in tests/cwd_scope.rs covering traversal, absolute, and double-quote rejection paths.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T14:32:53-07:00"
    },
    {
      "finding": "Adversarial F3: contract tests check the literal cd string but do not enforce that it appears inside a bash fence",
      "reason": "Replaced bare contains() check in tests/skill_contracts.rs with bash_fence_contains helper that walks every bash fence in the bounded slice. Reworded the prose preamble in three SKILL.md files so the literal cd command appears only inside the bash fence (no prose duplication).",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T14:33:01-07:00"
    },
    {
      "finding": "Reviewer F3: test name cwd_drift_error_includes_cd_command_for_root_flow contradicts its fixture (relative_cwd=api)",
      "reason": "Renamed to cwd_drift_error_includes_copy_pasteable_cd_command, removing the misleading _for_root_flow suffix. The test name now describes what the assertion proves (cd line is present and copy-pasteable) without claiming the fixture is a root flow.",
      "outcome": "fixed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T14:33:09-07:00"
    },
    {
      "finding": "Reviewer F2: docs/skills/flow-{code,code-review,learn}.md and docs/reference/flow-state-schema.md not updated for the new Re-anchor cwd step and phase-enter response fields",
      "reason": "Partial dismissal as bureaucracy-trap per .claude/rules/code-review-scope.md Tenant 6 triage. (1) docs/reference/flow-state-schema.md already documents relative_cwd at lines 108; worktree_cwd is a phase-enter subcommand response field, not a state-file field — doesn't belong in the state schema. (2) docs/skills/<name>.md files are high-level skill summaries; the cwd re-anchor step is an internal SKILL.md detail already documented in CLAUDE.md Subdirectory Context (Task 7) and the SKILL.md Re-anchor cwd subsection. Adding a third copy at the docs/skills level duplicates information already discoverable via grep, fails Discoverability and Forward-applicability triage.",
      "outcome": "dismissed",
      "phase": "flow-code-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T14:33:19-07:00"
    },
    {
      "finding": "Tenant 1: Skill re-anchor instructions lack error recovery guidance",
      "reason": "Agent's own value-test marked Gate 2 as YES (caught and remediated by cwd_scope::enforce + the new copy-pasteable cd error message). Per Learn skill's two-gate filter, this is the system working — not a process gap.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-09T14:40:57-07:00"
    },
    {
      "finding": "Tenant 1: Phase-enter response contract underspecified in docs/reference/flow-state-schema.md",
      "reason": "Same partial-dismissal as Code Review Reviewer F2. flow-state-schema.md scope is state.json shape, not subcommand response shapes. The phase-enter response contract is documented in CLAUDE.md Subdirectory Context paragraph. Adding it to the state schema doc would misalign that doc's scope. Caught and remediated by the CLAUDE.md update in Task 7.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-09T14:41:04-07:00"
    },
    {
      "finding": "Tenant 3: Missing rule about copy-pasteable error-message recovery commands",
      "reason": "Speculative — only example is this PR, no evidence of recurrence across flows. Per .claude/rules/forward-facing-authoring.md prohibited patterns: 'rule clarifications whose only example is the current PR' do not survive the filter. The discipline of copy-pasteable cd lines in error messages is sound but a one-PR observation is not enough signal to codify; a future flow that surfaces the same pattern from a different angle would be the trigger.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-09T14:41:11-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-09T14:42:44-07:00",
    "five_hour_pct": 41,
    "seven_day_pct": 35
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>