### PR TITLE
Tui Improvements Bundle Ctrl C X

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -7,7 +7,7 @@
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::execute;
@@ -30,6 +30,26 @@ use crate::utils::format_tokens;
 
 /// Auto-refresh interval.
 const REFRESH_MS: u64 = 2000;
+
+/// Format an elapsed `Duration` as a short "updated Ns/Nm/Nh ago"
+/// string. Pure helper — accepts a `Duration` so tests can construct
+/// arbitrary values without mocking `Instant::now()`.
+///
+/// Buckets:
+///
+/// - `< 60s`   → `"updated Ns ago"`
+/// - `< 60m`   → `"updated Nm ago"`
+/// - otherwise → `"updated Nh ago"`
+pub fn format_age(elapsed: Duration) -> String {
+    let secs = elapsed.as_secs();
+    if secs < 60 {
+        format!("updated {}s ago", secs)
+    } else if secs < 3600 {
+        format!("updated {}m ago", secs / 60)
+    } else {
+        format!("updated {}h ago", secs / 3600)
+    }
+}
 
 /// Apply a key event to the filter state machine (`filter_query` +
 /// `filter_input_active`). Pure helper — operates entirely on the
@@ -260,6 +280,9 @@ pub struct TuiApp {
     /// True while the user is typing into the filter — chars append,
     /// Backspace pops, Enter commits, Esc cancels.
     pub filter_input_active: bool,
+    /// Wall clock of the most recent successful data fetch. Drives
+    /// the "updated Ns ago" indicator in the metrics row.
+    pub last_refresh: Instant,
 }
 
 impl TuiApp {
@@ -300,6 +323,7 @@ impl TuiApp {
             platform,
             filter_query: None,
             filter_input_active: false,
+            last_refresh: Instant::now(),
         }
     }
 
@@ -329,6 +353,7 @@ impl TuiApp {
         }
         self.metrics =
             tui_data::load_account_metrics(&self.root, Some(self.platform.home.as_path()));
+        self.last_refresh = Instant::now();
     }
 
     /// Run the TUI event loop against a caller-supplied draw closure
@@ -692,9 +717,10 @@ impl TuiApp {
             return vec![];
         }
         let cost_text = format!("${}/mo", self.metrics.cost_monthly);
+        let age_text = format_age(self.last_refresh.elapsed());
         if self.metrics.stale {
             let rl_text = "5h:--  7d:--".to_string();
-            let total_width = cost_text.len() + 2 + rl_text.len() + 2;
+            let total_width = cost_text.len() + 2 + rl_text.len() + 2 + age_text.len() + 2;
             if total_width > max_x.saturating_sub(30) {
                 return vec![];
             }
@@ -702,11 +728,20 @@ impl TuiApp {
                 Span::styled(cost_text, Style::default().add_modifier(Modifier::DIM)),
                 Span::raw("  "),
                 Span::styled(rl_text, Style::default().add_modifier(Modifier::DIM)),
+                Span::raw("  "),
+                Span::raw(age_text),
             ]
         } else {
             let rl_5h_text = format!("5h:{}%", self.metrics.rl_5h.unwrap_or(0));
             let rl_7d_text = format!("7d:{}%", self.metrics.rl_7d.unwrap_or(0));
-            let total_width = cost_text.len() + 2 + rl_5h_text.len() + 2 + rl_7d_text.len() + 2;
+            let total_width = cost_text.len()
+                + 2
+                + rl_5h_text.len()
+                + 2
+                + rl_7d_text.len()
+                + 2
+                + age_text.len()
+                + 2;
             if total_width > max_x.saturating_sub(30) {
                 return vec![];
             }
@@ -716,6 +751,8 @@ impl TuiApp {
                 Span::styled(rl_5h_text, rl_color(self.metrics.rl_5h.unwrap_or(0))),
                 Span::raw("  "),
                 Span::styled(rl_7d_text, rl_color(self.metrics.rl_7d.unwrap_or(0))),
+                Span::raw("  "),
+                Span::raw(age_text),
             ]
         }
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -349,6 +349,9 @@ impl TuiApp {
                 self.issue_selected = 0;
             }
             KeyCode::Enter => self.open_worktree(),
+            KeyCode::Char('o') => {
+                self.open_worktree_shell();
+            }
             KeyCode::Char('p') => self.open_pr(),
             KeyCode::Char('l') => self.view = View::Log,
             KeyCode::Char('i') => self.view = View::Issues,
@@ -468,6 +471,36 @@ impl TuiApp {
         let _ = execute!(io::stdout(), EnterAlternateScreen);
 
         self.refresh_data();
+    }
+
+    /// Open a fresh iTerm2 tab (or window when none is open) and run
+    /// `cd <worktree>` so the user lands in the active flow's worktree
+    /// without leaving the TUI. Returns true when osascript reports
+    /// `"opened"`.
+    pub fn open_worktree_shell(&self) -> bool {
+        if self.flows.is_empty() {
+            return false;
+        }
+        let flow = &self.flows[self.selected];
+        let path = if std::path::Path::new(&flow.worktree).is_absolute() {
+            flow.worktree.clone()
+        } else {
+            self.root.join(&flow.worktree).to_string_lossy().to_string()
+        };
+        let script = build_iterm_open_worktree_script(&path);
+        match Command::new(&self.platform.osascript_binary)
+            .arg("-e")
+            .arg(&script)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+        {
+            Ok(output) => {
+                output.status.success()
+                    && String::from_utf8_lossy(&output.stdout).trim() == "opened"
+            }
+            Err(_) => false,
+        }
     }
 
     /// Activate an iTerm2 tab by matching its session tty. Reads the
@@ -1529,6 +1562,36 @@ fn build_iterm_activation_script(session_tty: &str) -> String {
     return "not found"
 end tell"#,
         tty = escaped
+    )
+}
+
+/// Build the AppleScript text that asks iTerm2 to open a fresh shell
+/// in a new tab (or new window if no window exists) and `cd` into the
+/// supplied worktree path.
+///
+/// `path` is escaped via [`escape_applescript_string`] before being
+/// interpolated into the AppleScript double-quoted literal — the same
+/// injection-safety contract as [`build_iterm_activation_script`].
+///
+/// Pure helper — `pub` so unit tests can verify the rendered script
+/// content directly. The osascript invocation lives in
+/// `TuiApp::open_worktree_shell`.
+pub fn build_iterm_open_worktree_script(path: &str) -> String {
+    let escaped = escape_applescript_string(path);
+    format!(
+        r#"tell application "iTerm2"
+    if (count of windows) = 0 then
+        create window with default profile
+    else
+        tell current window to create tab with default profile
+    end if
+    tell current session of current window
+        write text "cd \"{p}\" && clear"
+    end tell
+    activate
+    return "opened"
+end tell"#,
+        p = escaped
     )
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -31,6 +31,74 @@ use crate::utils::format_tokens;
 /// Auto-refresh interval.
 const REFRESH_MS: u64 = 2000;
 
+/// Apply a key event to the filter state machine (`filter_query` +
+/// `filter_input_active`). Pure helper — operates entirely on the
+/// passed mutable refs so tests can drive transitions without a full
+/// `TuiApp`.
+///
+/// State transitions:
+///
+/// - Inactive → `/`  → active, query becomes `Some("")` if it was
+///   `None`; an existing committed query persists (so `/` re-enters
+///   the same query for editing).
+/// - Active → `<char>` → query gets the char appended.
+/// - Active → Backspace → query pops one char (no-op when empty).
+/// - Active → Enter → inactive, query persists when non-empty,
+///   becomes `None` when empty.
+/// - Active → Esc → inactive AND query cleared to `None`.
+/// - Other keys are ignored in both modes.
+pub fn apply_filter_key(query: &mut Option<String>, input_active: &mut bool, key: KeyCode) {
+    if !*input_active {
+        if matches!(key, KeyCode::Char('/')) {
+            *input_active = true;
+            if query.is_none() {
+                *query = Some(String::new());
+            }
+        }
+        return;
+    }
+
+    match key {
+        KeyCode::Char(c) => {
+            if let Some(q) = query.as_mut() {
+                q.push(c);
+            }
+        }
+        KeyCode::Backspace => {
+            if let Some(q) = query.as_mut() {
+                q.pop();
+            }
+        }
+        KeyCode::Enter => {
+            *input_active = false;
+            if let Some(q) = query.as_ref() {
+                if q.is_empty() {
+                    *query = None;
+                }
+            }
+        }
+        KeyCode::Esc => {
+            *input_active = false;
+            *query = None;
+        }
+        _ => {}
+    }
+}
+
+/// Decide whether a flow row should be visible under the current
+/// filter state. `input_active` mode shows everything (so the row
+/// list doesn't churn while the user types); a committed non-empty
+/// query gates rows by case-insensitive branch substring match.
+pub fn flow_matches_filter(branch: &str, query: Option<&str>, input_active: bool) -> bool {
+    if input_active {
+        return true;
+    }
+    match query {
+        Some(q) if !q.is_empty() => branch.to_lowercase().contains(&q.to_lowercase()),
+        _ => true,
+    }
+}
+
 /// Build the prominent detail-pane phase header above the timeline.
 ///
 /// Result shape: `"Phase {phase_number} ({phase_label}) — step {current} of {total}: {name}"`.
@@ -185,6 +253,13 @@ pub struct TuiApp {
     pub issue_selected: usize,
     pub metrics: AccountMetrics,
     pub platform: TuiAppPlatform,
+    /// Filter query for the list pane. `None` = no filter, `Some(s)`
+    /// where s is non-empty = branch substring filter, `Some("")` =
+    /// editing an empty query (treated as no filter for visibility).
+    pub filter_query: Option<String>,
+    /// True while the user is typing into the filter — chars append,
+    /// Backspace pops, Enter commits, Esc cancels.
+    pub filter_input_active: bool,
 }
 
 impl TuiApp {
@@ -223,6 +298,8 @@ impl TuiApp {
                 stale: true,
             },
             platform,
+            filter_query: None,
+            filter_input_active: false,
         }
     }
 
@@ -318,6 +395,17 @@ impl TuiApp {
             return;
         }
 
+        // Filter input mode preempts the normal dispatch so chars
+        // append to the query instead of triggering shortcuts.
+        if self.filter_input_active {
+            apply_filter_key(
+                &mut self.filter_query,
+                &mut self.filter_input_active,
+                key.code,
+            );
+            return;
+        }
+
         match key.code {
             KeyCode::Char('q') => self.running = false,
             KeyCode::Right => self.active_tab = 1.min(self.active_tab + 1),
@@ -349,6 +437,13 @@ impl TuiApp {
                 self.issue_selected = 0;
             }
             KeyCode::Enter => self.open_worktree(),
+            KeyCode::Char('/') => {
+                apply_filter_key(
+                    &mut self.filter_query,
+                    &mut self.filter_input_active,
+                    KeyCode::Char('/'),
+                );
+            }
             KeyCode::Char('o') => {
                 self.open_worktree_shell();
             }
@@ -685,10 +780,23 @@ impl TuiApp {
         // Cross-tab indicator
         let orch_issue = self.get_orch_issue_in_progress();
 
-        let list_end = self.flows.len().min(max_y.saturating_sub(18));
+        // Apply the filter before truncating so list_end counts only
+        // visible rows, keeping the viewport calculations correct.
+        let filtered_flows: Vec<&FlowSummary> = self
+            .flows
+            .iter()
+            .filter(|flow| {
+                flow_matches_filter(
+                    &flow.branch,
+                    self.filter_query.as_deref(),
+                    self.filter_input_active,
+                )
+            })
+            .collect();
+        let list_end = filtered_flows.len().min(max_y.saturating_sub(18));
 
         // Pre-compute column data
-        let col_data: Vec<(String, String, String, String, String)> = self.flows[..list_end]
+        let col_data: Vec<(String, String, String, String, String)> = filtered_flows[..list_end]
             .iter()
             .map(|flow| {
                 let counter = phase_step_counter(&flow.state);
@@ -772,11 +880,11 @@ impl TuiApp {
         )));
         frame.render_widget(hdr_line, Rect::new(area.x, area.y + 3, area.width, 1));
 
-        // Flow rows. `list_end = self.flows.len().min(max_y - 18)`
+        // Flow rows. `list_end = filtered_flows.len().min(max_y - 18)`
         // already bounds `i` so `row = 4 + i <= max_y - 15`, which is
         // always less than the panel's footer row at `max_y - 1`. No
         // additional clamp is needed inside the loop.
-        for (i, flow) in self.flows.iter().enumerate().take(list_end) {
+        for (i, flow) in filtered_flows.iter().enumerate().take(list_end) {
             let row = 4 + i;
 
             let marker = if i == self.selected {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -24,7 +24,8 @@ use serde_json::Value;
 
 use crate::flow_paths::FlowPaths;
 use crate::tui_data::{
-    self, phase_step_counter, AccountMetrics, FlowSummary, OrchestrationSummary, PhaseStepCounter,
+    self, phase_step_counter, read_start_lock_holder, AccountMetrics, FlowSummary,
+    OrchestrationSummary, PhaseStepCounter,
 };
 use crate::utils::format_tokens;
 
@@ -283,6 +284,11 @@ pub struct TuiApp {
     /// Wall clock of the most recent successful data fetch. Drives
     /// the "updated Ns ago" indicator in the metrics row.
     pub last_refresh: Instant,
+    /// Branch name of the flow currently holding the start lock, or
+    /// `None` when no flow is queued. Drives the
+    /// `🔒 start lock: <holder>` banner so concurrent engineers can
+    /// see start-gate contention at a glance.
+    pub start_lock_holder: Option<String>,
 }
 
 impl TuiApp {
@@ -324,6 +330,7 @@ impl TuiApp {
             filter_query: None,
             filter_input_active: false,
             last_refresh: Instant::now(),
+            start_lock_holder: None,
         }
     }
 
@@ -353,6 +360,7 @@ impl TuiApp {
         }
         self.metrics =
             tui_data::load_account_metrics(&self.root, Some(self.platform.home.as_path()));
+        self.start_lock_holder = read_start_lock_holder(&self.root);
         self.last_refresh = Instant::now();
     }
 
@@ -698,6 +706,17 @@ impl TuiApp {
             let metrics_p = Paragraph::new(metrics_line);
             let metrics_area = Rect::new(area.x + col, area.y, metrics_width as u16 + 2, 1);
             frame.render_widget(metrics_p, metrics_area);
+        }
+
+        // Row 1: start-lock holder banner — surfaces start-gate
+        // contention so engineers running concurrent flows can see who
+        // holds the lock without tailing log files.
+        if let Some(ref holder) = self.start_lock_holder {
+            let banner = Paragraph::new(Line::from(Span::styled(
+                format!("  \u{1F512} start lock: {}", holder),
+                Style::default().fg(Color::Yellow),
+            )));
+            frame.render_widget(banner, Rect::new(area.x, area.y + 1, area.width, 1));
         }
 
         // Row 2: tab bar

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -31,6 +31,28 @@ use crate::utils::format_tokens;
 /// Auto-refresh interval.
 const REFRESH_MS: u64 = 2000;
 
+/// Build the prominent detail-pane phase header above the timeline.
+///
+/// Result shape: `"Phase {phase_number} ({phase_label}) — step {current} of {total}: {name}"`.
+/// The `: {name}` suffix is dropped when `counter.name` is `None`.
+/// Returns `None` when `counter` is `None` (no header to show) or when
+/// `total <= 0` (no meaningful X-of-Y).
+pub fn detail_pane_phase_header(counter: Option<&PhaseStepCounter>) -> Option<String> {
+    let c = counter?;
+    if c.total <= 0 {
+        return None;
+    }
+    let name_suffix = c
+        .name
+        .as_ref()
+        .map(|n| format!(": {}", n))
+        .unwrap_or_default();
+    Some(format!(
+        "Phase {} ({}) \u{2014} step {} of {}{}",
+        c.phase_number, c.phase_label, c.current, c.total, name_suffix
+    ))
+}
+
 /// Build the phase-column label for a list-pane row.
 ///
 /// Result shape: `"{phase_number}: {phase_name}"` always, with a
@@ -831,6 +853,21 @@ impl TuiApp {
             Rect::new(area.x, area.y + row as u16, area.width, 1),
         );
         row += 2;
+
+        // Prominent X-of-Y header above the timeline (skipped when the
+        // active phase carries no counter — e.g., a flow that has just
+        // entered Start and has not yet stamped start_step).
+        if let Some(header) = detail_pane_phase_header(phase_step_counter(&flow.state).as_ref()) {
+            let header_line = Paragraph::new(Line::from(Span::styled(
+                format!("  {}", header),
+                Style::default().add_modifier(Modifier::BOLD),
+            )));
+            frame.render_widget(
+                header_line,
+                Rect::new(area.x, area.y + row as u16, area.width, 1),
+            );
+            row += 2;
+        }
 
         // Phase timeline
         for entry in &flow.timeline {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -187,6 +187,7 @@ pub enum View {
     Log,
     Issues,
     Tasks,
+    Help,
 }
 
 /// Platform-bound external dependencies injected into `TuiApp`.
@@ -289,6 +290,9 @@ pub struct TuiApp {
     /// `🔒 start lock: <holder>` banner so concurrent engineers can
     /// see start-gate contention at a glance.
     pub start_lock_holder: Option<String>,
+    /// View the user was on before opening the help overlay (`?`),
+    /// so any subsequent key can restore them to where they were.
+    pub previous_view: Option<View>,
 }
 
 impl TuiApp {
@@ -331,6 +335,7 @@ impl TuiApp {
             filter_input_active: false,
             last_refresh: Instant::now(),
             start_lock_holder: None,
+            previous_view: None,
         }
     }
 
@@ -412,6 +417,7 @@ impl TuiApp {
                 View::Log => self.render_log_view(frame, area),
                 View::Issues => self.render_issues_view(frame, area),
                 View::Tasks => self.render_tasks_view(frame, area),
+                View::Help => self.render_help_view(frame, area),
             }
         }
     }
@@ -425,6 +431,23 @@ impl TuiApp {
 
         if self.confirming_abort {
             self.handle_abort_confirm(key);
+            return;
+        }
+
+        // Help overlay: `?` toggles in from any view, any subsequent
+        // key restores the prior view. Q and Ctrl-C still quit
+        // because they are handled above this branch.
+        if self.view == View::Help {
+            if let Some(prev) = self.previous_view.take() {
+                self.view = prev;
+            } else {
+                self.view = View::List;
+            }
+            return;
+        }
+        if matches!(key.code, KeyCode::Char('?')) {
+            self.previous_view = Some(self.view);
+            self.view = View::Help;
             return;
         }
 
@@ -1186,7 +1209,7 @@ impl TuiApp {
     }
 
     fn render_list_footer(&self, frame: &mut Frame, area: Rect) {
-        let footer_text = " [\u{2190}\u{2192}] Tab  [\u{2191}\u{2193}] Navigate  [Enter] Worktree  [p] PR  [i] Issues  [I] Issue  [t] Tasks  [l] Log  [a] Abort  [r] Refresh  [q] Quit  Ctrl-C/q quit";
+        let footer_text = " ?=help  Ctrl-C/q=quit";
         let footer = Paragraph::new(Line::from(Span::styled(
             footer_text,
             Style::default().add_modifier(Modifier::DIM),
@@ -1204,7 +1227,7 @@ impl TuiApp {
         if self.orch_data.is_none() {
             let msg = Paragraph::new(Line::from("  No orchestration running."));
             frame.render_widget(msg, Rect::new(area.x, area.y + 5, area.width, 1));
-            let footer_text = " [\u{2190}\u{2192}] Tab  [r] Refresh  [q] Quit  Ctrl-C/q quit";
+            let footer_text = " ?=help  Ctrl-C/q=quit";
             let footer = Paragraph::new(Line::from(Span::styled(
                 footer_text,
                 Style::default().add_modifier(Modifier::DIM),
@@ -1312,8 +1335,7 @@ impl TuiApp {
         }
 
         // Footer
-        let footer_text =
-            " [\u{2190}\u{2192}] Tab  [\u{2191}\u{2193}] Navigate  [i] Issue  [r] Refresh  [q] Quit  Ctrl-C/q quit";
+        let footer_text = " ?=help  Ctrl-C/q=quit";
         let footer = Paragraph::new(Line::from(Span::styled(
             footer_text,
             Style::default().add_modifier(Modifier::DIM),
@@ -1380,7 +1402,7 @@ impl TuiApp {
         }
 
         // Footer
-        let footer_text = " [Esc] Back  [q] Quit  Ctrl-C/q quit";
+        let footer_text = " ?=help  Ctrl-C/q=quit";
         let footer = Paragraph::new(Line::from(Span::styled(
             footer_text,
             Style::default().add_modifier(Modifier::DIM),
@@ -1457,8 +1479,87 @@ impl TuiApp {
         }
 
         // Footer
-        let footer_text =
-            " [Esc] Back  [Enter] Open  [\u{2191}\u{2193}] Navigate  [q] Quit  Ctrl-C/q quit";
+        let footer_text = " ?=help  Ctrl-C/q=quit";
+        let footer = Paragraph::new(Line::from(Span::styled(
+            footer_text,
+            Style::default().add_modifier(Modifier::DIM),
+        )));
+        let y = area.y + area.height.saturating_sub(1);
+        frame.render_widget(footer, Rect::new(area.x, y, area.width, 1));
+    }
+
+    fn render_help_view(&self, frame: &mut Frame, area: Rect) {
+        let max_x = area.width as usize;
+        let border: String = "\u{2500}".repeat(max_x);
+        let border_line = Paragraph::new(Line::from(Span::styled(
+            &border,
+            Style::default().add_modifier(Modifier::DIM),
+        )));
+        frame.render_widget(border_line, Rect::new(area.x, area.y, area.width, 1));
+        let header = Paragraph::new(Line::from(Span::styled(
+            " FLOW \u{2014} Help ",
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        frame.render_widget(
+            header,
+            Rect::new(area.x + 2, area.y, area.width.saturating_sub(2), 1),
+        );
+
+        // Help body — every keybinding the TUI accepts. Grouped by
+        // view so a user pressing `?` from a view can find what
+        // applies. The list-pane / orchestration / detail view
+        // bindings live in `handle_list_input`, `handle_orch_input`,
+        // and the top-level `handle_key` match arms.
+        let lines: &[(&str, &str)] = &[
+            ("List view", ""),
+            ("  \u{2191}/\u{2193}", "navigate flows"),
+            ("  Enter", "open existing iTerm session"),
+            ("  o", "open new iTerm tab in worktree"),
+            ("  p", "open PR in browser"),
+            ("  i", "issues view"),
+            ("  I", "open flow issue in browser"),
+            ("  t", "tasks view"),
+            ("  l", "log view"),
+            ("  a", "abort flow"),
+            ("  r", "refresh data"),
+            ("  /", "filter by branch substring"),
+            ("", ""),
+            ("Filter input", ""),
+            ("  <chars>", "append to query"),
+            ("  Backspace", "pop char"),
+            ("  Enter", "commit query"),
+            ("  Esc", "cancel and clear"),
+            ("", ""),
+            ("Tab navigation", ""),
+            ("  \u{2190}/\u{2192}", "switch tab"),
+            ("", ""),
+            ("Other views (Log/Issues/Tasks)", ""),
+            ("  Esc", "back to list"),
+            ("  Enter", "open issue (Issues view)"),
+            ("", ""),
+            ("Global", ""),
+            ("  ?", "toggle this help (any key restores)"),
+            ("  Ctrl-C/q", "quit"),
+        ];
+
+        let max_y = area.height as usize;
+        for (i, (key, desc)) in lines.iter().enumerate() {
+            let row = 2 + i;
+            if row >= max_y.saturating_sub(1) {
+                break;
+            }
+            let line = if desc.is_empty() {
+                Paragraph::new(Line::from(Span::styled(
+                    format!("  {}", key),
+                    Style::default().add_modifier(Modifier::BOLD),
+                )))
+            } else {
+                Paragraph::new(Line::from(format!("  {:<16}  {}", key, desc)))
+            };
+            frame.render_widget(line, Rect::new(area.x, area.y + row as u16, area.width, 1));
+        }
+
+        let footer_text = " ?=help  Ctrl-C/q=quit";
         let footer = Paragraph::new(Line::from(Span::styled(
             footer_text,
             Style::default().add_modifier(Modifier::DIM),
@@ -1515,7 +1616,7 @@ impl TuiApp {
         }
 
         // Footer
-        let footer_text = " [Esc] Back  [q] Quit  Ctrl-C/q quit";
+        let footer_text = " ?=help  Ctrl-C/q=quit";
         let footer = Paragraph::new(Line::from(Span::styled(
             footer_text,
             Style::default().add_modifier(Modifier::DIM),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
-use crossterm::event::{Event, KeyCode, KeyEvent};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
@@ -259,6 +259,11 @@ impl TuiApp {
 
     /// Handle a key event and update state.
     pub fn handle_key(&mut self, key: KeyEvent) {
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            self.running = false;
+            return;
+        }
+
         if self.confirming_abort {
             self.handle_abort_confirm(key);
             return;
@@ -917,7 +922,7 @@ impl TuiApp {
     }
 
     fn render_list_footer(&self, frame: &mut Frame, area: Rect) {
-        let footer_text = " [\u{2190}\u{2192}] Tab  [\u{2191}\u{2193}] Navigate  [Enter] Worktree  [p] PR  [i] Issues  [I] Issue  [t] Tasks  [l] Log  [a] Abort  [r] Refresh  [q] Quit";
+        let footer_text = " [\u{2190}\u{2192}] Tab  [\u{2191}\u{2193}] Navigate  [Enter] Worktree  [p] PR  [i] Issues  [I] Issue  [t] Tasks  [l] Log  [a] Abort  [r] Refresh  [q] Quit  Ctrl-C/q quit";
         let footer = Paragraph::new(Line::from(Span::styled(
             footer_text,
             Style::default().add_modifier(Modifier::DIM),
@@ -935,7 +940,7 @@ impl TuiApp {
         if self.orch_data.is_none() {
             let msg = Paragraph::new(Line::from("  No orchestration running."));
             frame.render_widget(msg, Rect::new(area.x, area.y + 5, area.width, 1));
-            let footer_text = " [\u{2190}\u{2192}] Tab  [r] Refresh  [q] Quit";
+            let footer_text = " [\u{2190}\u{2192}] Tab  [r] Refresh  [q] Quit  Ctrl-C/q quit";
             let footer = Paragraph::new(Line::from(Span::styled(
                 footer_text,
                 Style::default().add_modifier(Modifier::DIM),
@@ -1044,7 +1049,7 @@ impl TuiApp {
 
         // Footer
         let footer_text =
-            " [\u{2190}\u{2192}] Tab  [\u{2191}\u{2193}] Navigate  [i] Issue  [r] Refresh  [q] Quit";
+            " [\u{2190}\u{2192}] Tab  [\u{2191}\u{2193}] Navigate  [i] Issue  [r] Refresh  [q] Quit  Ctrl-C/q quit";
         let footer = Paragraph::new(Line::from(Span::styled(
             footer_text,
             Style::default().add_modifier(Modifier::DIM),
@@ -1111,7 +1116,7 @@ impl TuiApp {
         }
 
         // Footer
-        let footer_text = " [Esc] Back  [q] Quit";
+        let footer_text = " [Esc] Back  [q] Quit  Ctrl-C/q quit";
         let footer = Paragraph::new(Line::from(Span::styled(
             footer_text,
             Style::default().add_modifier(Modifier::DIM),
@@ -1188,7 +1193,8 @@ impl TuiApp {
         }
 
         // Footer
-        let footer_text = " [Esc] Back  [Enter] Open  [\u{2191}\u{2193}] Navigate  [q] Quit";
+        let footer_text =
+            " [Esc] Back  [Enter] Open  [\u{2191}\u{2193}] Navigate  [q] Quit  Ctrl-C/q quit";
         let footer = Paragraph::new(Line::from(Span::styled(
             footer_text,
             Style::default().add_modifier(Modifier::DIM),
@@ -1245,7 +1251,7 @@ impl TuiApp {
         }
 
         // Footer
-        let footer_text = " [Esc] Back  [q] Quit";
+        let footer_text = " [Esc] Back  [q] Quit  Ctrl-C/q quit";
         let footer = Paragraph::new(Line::from(Span::styled(
             footer_text,
             Style::default().add_modifier(Modifier::DIM),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -339,6 +339,32 @@ impl TuiApp {
         }
     }
 
+    /// View of `self.flows` after the active filter is applied. The
+    /// list pane renders this slice, and `self.selected` is treated
+    /// as an index into THIS list — not the raw `self.flows`. Every
+    /// action and detail-pane render must look up the active flow
+    /// through `selected_visible_flow` so the highlighted row and
+    /// the actioned row stay in sync.
+    pub fn visible_flows(&self) -> Vec<&FlowSummary> {
+        self.flows
+            .iter()
+            .filter(|flow| {
+                flow_matches_filter(
+                    &flow.branch,
+                    self.filter_query.as_deref(),
+                    self.filter_input_active,
+                )
+            })
+            .collect()
+    }
+
+    /// The flow the user has currently highlighted, respecting the
+    /// active filter. Returns `None` when the filter excludes every
+    /// row or `self.selected` outruns the visible list.
+    pub fn selected_visible_flow(&self) -> Option<&FlowSummary> {
+        self.visible_flows().get(self.selected).copied()
+    }
+
     /// Open a URL in the default browser using the platform-supplied
     /// binary. Production: `open <url>` on macOS. Tests: `/bin/true
     /// <url>` — ignores the URL, exits 0, no side effect.
@@ -435,9 +461,15 @@ impl TuiApp {
         }
 
         // Help overlay: `?` toggles in from any view, any subsequent
-        // key restores the prior view. Q and Ctrl-C still quit
-        // because they are handled above this branch.
+        // key restores the prior view. `q` and `Ctrl-C` still quit
+        // — `Ctrl-C` is handled above this branch, and `q` short-
+        // circuits here so the user is not silently bounced back to
+        // the prior view when they meant to exit.
         if self.view == View::Help {
+            if matches!(key.code, KeyCode::Char('q')) {
+                self.running = false;
+                return;
+            }
             if let Some(prev) = self.previous_view.take() {
                 self.view = prev;
             } else {
@@ -489,7 +521,8 @@ impl TuiApp {
                 self.issue_selected = 0;
             }
             KeyCode::Down => {
-                self.selected = (self.selected + 1).min(self.flows.len().saturating_sub(1));
+                let visible_len = self.visible_flows().len();
+                self.selected = (self.selected + 1).min(visible_len.saturating_sub(1));
                 self.issue_selected = 0;
             }
             KeyCode::Enter => self.open_worktree(),
@@ -501,7 +534,10 @@ impl TuiApp {
                 );
             }
             KeyCode::Char('o') => {
-                self.open_worktree_shell();
+                // The success bool is intentionally discarded — the
+                // TUI has no banner surface to report failure on, and
+                // the user will notice if the shell didn't open.
+                let _ = self.open_worktree_shell();
             }
             KeyCode::Char('p') => self.open_pr(),
             KeyCode::Char('l') => self.view = View::Log,
@@ -515,10 +551,9 @@ impl TuiApp {
     }
 
     fn handle_issues_input(&mut self, key: KeyEvent) {
-        if self.flows.is_empty() {
+        let Some(flow) = self.selected_visible_flow() else {
             return;
-        }
-        let flow = &self.flows[self.selected];
+        };
         let issue_count = flow.issues.len();
         if issue_count == 0 {
             return;
@@ -569,14 +604,18 @@ impl TuiApp {
     // --- Actions ---
 
     fn open_worktree(&self) {
-        let flow = &self.flows[self.selected];
+        let Some(flow) = self.selected_visible_flow() else {
+            return;
+        };
         if let Some(tty) = worktree_session_tty(flow) {
             self.activate_iterm_tab(tty);
         }
     }
 
     fn open_pr(&self) {
-        let flow = &self.flows[self.selected];
+        let Some(flow) = self.selected_visible_flow() else {
+            return;
+        };
         if let Some(ref url) = flow.pr_url {
             let files_url = pr_files_url(url);
             self.open_url(&files_url);
@@ -584,7 +623,9 @@ impl TuiApp {
     }
 
     fn open_flow_issue(&self) {
-        let flow = &self.flows[self.selected];
+        let Some(flow) = self.selected_visible_flow() else {
+            return;
+        };
         if let Some(url) = flow_issue_url(&flow.state, self.repo.as_deref(), &flow.issue_numbers) {
             self.open_url(&url);
         }
@@ -601,10 +642,9 @@ impl TuiApp {
     }
 
     fn abort_flow(&mut self) {
-        if self.flows.is_empty() {
+        let Some(flow) = self.selected_visible_flow() else {
             return;
-        }
-        let flow = &self.flows[self.selected];
+        };
         let args =
             build_cleanup_command_args(&self.root, &flow.branch, &flow.worktree, flow.pr_number);
         let bin_flow = self.platform.bin_flow_path.clone();
@@ -629,10 +669,9 @@ impl TuiApp {
     /// without leaving the TUI. Returns true when osascript reports
     /// `"opened"`.
     pub fn open_worktree_shell(&self) -> bool {
-        if self.flows.is_empty() {
+        let Some(flow) = self.selected_visible_flow() else {
             return false;
-        }
-        let flow = &self.flows[self.selected];
+        };
         let path = if std::path::Path::new(&flow.worktree).is_absolute() {
             flow.worktree.clone()
         } else {
@@ -1044,7 +1083,13 @@ impl TuiApp {
     }
 
     fn render_detail_panel(&self, frame: &mut Frame, area: Rect, start_row: usize) {
-        let flow = &self.flows[self.selected];
+        // Walk through the visible-flows view so the detail pane
+        // and the highlighted list row always describe the same flow
+        // when a filter is active. The render_list_view caller is
+        // already gated on visible_flows being non-empty.
+        let Some(flow) = self.selected_visible_flow() else {
+            return;
+        };
         let max_y = area.height as usize;
         let mut row = start_row;
 
@@ -1348,10 +1393,9 @@ impl TuiApp {
         let max_y = area.height as usize;
         let max_x = area.width as usize;
 
-        if self.flows.is_empty() {
+        let Some(flow) = self.selected_visible_flow() else {
             return;
-        }
-        let flow = &self.flows[self.selected];
+        };
 
         // Header
         let header_text = format!(" {} \u{2014} Log ", flow.feature);
@@ -1415,10 +1459,9 @@ impl TuiApp {
         let max_y = area.height as usize;
         let max_x = area.width as usize;
 
-        if self.flows.is_empty() {
+        let Some(flow) = self.selected_visible_flow() else {
             return;
-        }
-        let flow = &self.flows[self.selected];
+        };
         let issues = &flow.issues;
 
         // Header
@@ -1488,6 +1531,11 @@ impl TuiApp {
         frame.render_widget(footer, Rect::new(area.x, y, area.width, 1));
     }
 
+    /// Render the help overlay activated by `?`. Lists every binding
+    /// the TUI accepts, grouped by view (List, Filter input, Tabs,
+    /// Other views, Global) so a user pressing `?` from any view can
+    /// find the bindings that apply. Returns to the previous view on
+    /// any subsequent keystroke (or quits on `q`/`Ctrl-C`).
     fn render_help_view(&self, frame: &mut Frame, area: Rect) {
         let max_x = area.width as usize;
         let border: String = "\u{2500}".repeat(max_x);
@@ -1572,10 +1620,9 @@ impl TuiApp {
         let max_y = area.height as usize;
         let max_x = area.width as usize;
 
-        if self.flows.is_empty() {
+        let Some(flow) = self.selected_visible_flow() else {
             return;
-        }
-        let flow = &self.flows[self.selected];
+        };
 
         // Header
         let header_text = format!(" {} \u{2014} Tasks ", flow.feature);
@@ -1830,19 +1877,51 @@ end tell"#,
     )
 }
 
+/// Wrap `s` in single quotes and escape any embedded single quotes
+/// using the standard POSIX shell idiom `'\''` (close, literal `'`,
+/// reopen). Inside single quotes, every other byte is literal — no
+/// `$(...)`, backtick, or variable expansion. Pure helper.
+fn escape_shell_single_quoted(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
 /// Build the AppleScript text that asks iTerm2 to open a fresh shell
 /// in a new tab (or new window if no window exists) and `cd` into the
 /// supplied worktree path.
 ///
-/// `path` is escaped via [`escape_applescript_string`] before being
-/// interpolated into the AppleScript double-quoted literal — the same
-/// injection-safety contract as [`build_iterm_activation_script`].
+/// The path passes through TWO escape layers because iTerm's
+/// `write text` types its argument as keystrokes into the shell:
+///
+/// 1. [`escape_shell_single_quoted`] wraps the path in `'...'` and
+///    escapes embedded `'` so the shell treats `$(...)`, backticks,
+///    `;`, `|`, `&`, and history expansion as literal bytes.
+/// 2. [`escape_applescript_string`] escapes any remaining `\` or `"`
+///    so the AppleScript double-quoted literal stays intact.
+///
+/// Without the shell-single-quote layer, a path containing `$(...)`
+/// or backticks would be expanded by the shell when the typed
+/// keystrokes arrive — a remote-code-execution vector through any
+/// state-derived worktree path. AppleScript escape alone is
+/// insufficient because `escape_applescript_string` only escapes
+/// AppleScript structural chars and lets shell metacharacters
+/// through.
 ///
 /// Pure helper — `pub` so unit tests can verify the rendered script
 /// content directly. The osascript invocation lives in
 /// `TuiApp::open_worktree_shell`.
 pub fn build_iterm_open_worktree_script(path: &str) -> String {
-    let escaped = escape_applescript_string(path);
+    let shell_quoted = escape_shell_single_quoted(path);
+    let escaped = escape_applescript_string(&shell_quoted);
     format!(
         r#"tell application "iTerm2"
     if (count of windows) = 0 then
@@ -1851,7 +1930,7 @@ pub fn build_iterm_open_worktree_script(path: &str) -> String {
         tell current window to create tab with default profile
     end if
     tell current session of current window
-        write text "cd \"{p}\" && clear"
+        write text "cd {p} && clear"
     end tell
     activate
     return "opened"

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -23,11 +23,38 @@ use ratatui::Frame;
 use serde_json::Value;
 
 use crate::flow_paths::FlowPaths;
-use crate::tui_data::{self, AccountMetrics, FlowSummary, OrchestrationSummary};
+use crate::tui_data::{
+    self, phase_step_counter, AccountMetrics, FlowSummary, OrchestrationSummary, PhaseStepCounter,
+};
 use crate::utils::format_tokens;
 
 /// Auto-refresh interval.
 const REFRESH_MS: u64 = 2000;
+
+/// Build the phase-column label for a list-pane row.
+///
+/// Result shape: `"{phase_number}: {phase_name}"` always, with a
+/// `" {current}/{total}"` suffix when `counter` is `Some` and `total > 0`,
+/// followed by ` ({annotation})` when annotation is non-empty. The
+/// counter suffix gives users a quick X-of-Y read without expanding
+/// the row.
+pub fn list_row_phase_label(
+    phase_number: usize,
+    phase_name: &str,
+    counter: Option<&PhaseStepCounter>,
+    annotation: &str,
+) -> String {
+    let mut out = format!("{}: {}", phase_number, phase_name);
+    if let Some(c) = counter {
+        if c.total > 0 {
+            out.push_str(&format!(" {}/{}", c.current, c.total));
+        }
+    }
+    if !annotation.is_empty() {
+        out.push_str(&format!(" ({})", annotation));
+    }
+    out
+}
 
 /// Boxed draw closure passed into [`TuiApp::run_event_loop`]. The
 /// inner `&mut dyn FnMut(&mut Frame)` is the render callback the
@@ -609,10 +636,13 @@ impl TuiApp {
         let col_data: Vec<(String, String, String, String, String)> = self.flows[..list_end]
             .iter()
             .map(|flow| {
-                let mut phase_info = format!("{}: {}", flow.phase_number, flow.phase_name);
-                if !flow.annotation.is_empty() {
-                    phase_info.push_str(&format!(" ({})", flow.annotation));
-                }
+                let counter = phase_step_counter(&flow.state);
+                let phase_info = list_row_phase_label(
+                    flow.phase_number,
+                    &flow.phase_name,
+                    counter.as_ref(),
+                    &flow.annotation,
+                );
                 let pr_info = flow
                     .pr_number
                     .map(|n| format!("PR #{}", n))

--- a/src/tui_data.rs
+++ b/src/tui_data.rs
@@ -113,7 +113,17 @@ pub fn phase_step_counter(state: &Value) -> Option<PhaseStepCounter> {
         state.get(key).and_then(tolerant_i64_opt)
     }
 
-    let phase_key = state.get("current_phase").and_then(|v| v.as_str())?;
+    let raw_phase_key = state.get("current_phase").and_then(|v| v.as_str())?;
+    // Normalize the legacy `flow-code-review` value to the canonical
+    // `flow-review` key (renamed in PR #1402) so step-name lookups
+    // and total counts resolve against the single canonical entry in
+    // `step_names()`. Mirrors the serde alias on `FlowState::phase`
+    // in `src/state.rs`.
+    let phase_key = if raw_phase_key == "flow-code-review" {
+        "flow-review"
+    } else {
+        raw_phase_key
+    };
     let names_map = step_names();
     let lookup_name = |cur: i64| -> Option<String> {
         names_map
@@ -144,8 +154,16 @@ pub fn phase_step_counter(state: &Value) -> Option<PhaseStepCounter> {
                 .map(|s| s.to_string());
             ("Code", 2, cur, tot, nm)
         }
-        "flow-code-review" => {
-            let cur = read(state, "code_review_step")?;
+        "flow-review" => {
+            // Read the canonical `review_step` key first; fall back
+            // to the legacy `code_review_step` so state files
+            // written by older plugin versions still surface step
+            // progress. Mirrors the serde alias on
+            // `FlowState::review_step` in `src/state.rs`.
+            let cur = state
+                .get("review_step")
+                .or_else(|| state.get("code_review_step"))
+                .and_then(tolerant_i64_opt)?;
             let tot = names_map
                 .get(phase_key)
                 .map(|m| m.len() as i64)

--- a/src/tui_data.rs
+++ b/src/tui_data.rs
@@ -10,6 +10,7 @@ use chrono::{DateTime, FixedOffset};
 use serde::Serialize;
 use serde_json::Value;
 
+use crate::commands::start_lock;
 use crate::flow_paths::FlowStatesDir;
 use crate::phase_config::{self, PHASE_ORDER};
 use crate::utils::{
@@ -73,6 +74,19 @@ pub fn status_icon(status: &str) -> &'static str {
 
 /// Staleness threshold for rate limit data (10 minutes).
 pub const STALE_THRESHOLD_SECONDS: u64 = 600;
+
+/// Read the start-lock holder name from the queue directory, if any.
+///
+/// Returns the basename of the first (lowest-mtime, then alphabetical)
+/// queue entry — the flow that currently holds the start lock — or
+/// `None` when the queue is empty or unreadable. Drives the
+/// `🔒 start lock: <holder>` banner in the TUI metrics row so engineers
+/// can see start-gate contention without tailing log files.
+pub fn read_start_lock_holder(root: &Path) -> Option<String> {
+    let queue_dir = start_lock::queue_path(root);
+    let (entries, _stale) = start_lock::list_queue(&queue_dir, false);
+    entries.into_iter().next().map(|(_mtime, name)| name)
+}
 
 /// Aggregated per-phase step counter for X-of-Y displays.
 ///

--- a/src/tui_data.rs
+++ b/src/tui_data.rs
@@ -74,6 +74,92 @@ pub fn status_icon(status: &str) -> &'static str {
 /// Staleness threshold for rate limit data (10 minutes).
 pub const STALE_THRESHOLD_SECONDS: u64 = 600;
 
+/// Aggregated per-phase step counter for X-of-Y displays.
+///
+/// `current` and `total` are returned as stored in the state file (no
+/// +1 display offset) so consumers can choose their own formatting.
+/// `name` is the step name from `step_names()` for ordered-step phases,
+/// or `code_task_name` for the Code phase. Returns `None` when
+/// `current_phase` is missing/unknown OR when the per-phase counter
+/// field is absent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PhaseStepCounter {
+    pub phase_label: &'static str,
+    pub phase_number: u8,
+    pub current: i64,
+    pub total: i64,
+    pub name: Option<String>,
+}
+
+/// Compute the X-of-Y counter for the active phase.
+///
+/// See [`PhaseStepCounter`] for the return semantics.
+pub fn phase_step_counter(state: &Value) -> Option<PhaseStepCounter> {
+    fn read(state: &Value, key: &str) -> Option<i64> {
+        state.get(key).and_then(tolerant_i64_opt)
+    }
+
+    let phase_key = state.get("current_phase").and_then(|v| v.as_str())?;
+    let names_map = step_names();
+    let lookup_name = |cur: i64| -> Option<String> {
+        names_map
+            .get(phase_key)
+            .and_then(|m| m.get(&cur))
+            .map(|s| s.to_string())
+    };
+
+    let (phase_label, phase_number, current, total, name): (
+        &'static str,
+        u8,
+        i64,
+        i64,
+        Option<String>,
+    ) = match phase_key {
+        "flow-start" => {
+            let cur = read(state, "start_step")?;
+            let tot = read(state, "start_steps_total").unwrap_or(0);
+            ("Start", 1, cur, tot, lookup_name(cur))
+        }
+        "flow-code" => {
+            let cur = read(state, "code_task")?;
+            let tot = read(state, "code_tasks_total").unwrap_or(0);
+            let nm = state
+                .get("code_task_name")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+            ("Code", 2, cur, tot, nm)
+        }
+        "flow-code-review" => {
+            let cur = read(state, "code_review_step")?;
+            let tot = names_map
+                .get(phase_key)
+                .map(|m| m.len() as i64)
+                .unwrap_or(0);
+            ("Code Review", 3, cur, tot, lookup_name(cur))
+        }
+        "flow-learn" => {
+            let cur = read(state, "learn_step")?;
+            let tot = read(state, "learn_steps_total").unwrap_or(0);
+            ("Learn", 4, cur, tot, lookup_name(cur))
+        }
+        "flow-complete" => {
+            let cur = read(state, "complete_step")?;
+            let tot = read(state, "complete_steps_total").unwrap_or(0);
+            ("Complete", 5, cur, tot, lookup_name(cur))
+        }
+        _ => return None,
+    };
+
+    Some(PhaseStepCounter {
+        phase_label,
+        phase_number,
+        current,
+        total,
+        name,
+    })
+}
+
 /// Return 'name - step N of M' or 'step N of M' or '' depending on what's populated.
 pub fn step_annotation(step: i64, total: i64, name: &str) -> String {
     if step <= 0 {

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -14,7 +14,8 @@ use ratatui::{Frame, Terminal};
 
 use flow_rs::tui::{
     apply_filter_key, build_iterm_open_worktree_script, detail_pane_phase_header,
-    flow_matches_filter, list_row_phase_label, DrawFn, EventSourceFn, TuiApp, TuiAppPlatform, View,
+    flow_matches_filter, format_age, list_row_phase_label, DrawFn, EventSourceFn, TuiApp,
+    TuiAppPlatform, View,
 };
 use flow_rs::tui_data::{
     AccountMetrics, FlowSummary, IssueSummary, OrchestrationItem, OrchestrationSummary,
@@ -582,6 +583,56 @@ fn test_render_tasks_view_no_plan() {
     app.view = View::Tasks;
     let output = render_to_string(&app, 80, 40);
     assert!(output.contains("No plan file."));
+}
+
+// --- format_age ---
+
+#[test]
+fn test_format_age_zero() {
+    assert_eq!(
+        format_age(std::time::Duration::from_secs(0)),
+        "updated 0s ago"
+    );
+}
+
+#[test]
+fn test_format_age_seconds_below_minute() {
+    assert_eq!(
+        format_age(std::time::Duration::from_secs(45)),
+        "updated 45s ago"
+    );
+}
+
+#[test]
+fn test_format_age_one_minute_boundary() {
+    assert_eq!(
+        format_age(std::time::Duration::from_secs(60)),
+        "updated 1m ago"
+    );
+}
+
+#[test]
+fn test_format_age_minutes_below_hour() {
+    assert_eq!(
+        format_age(std::time::Duration::from_secs(45 * 60)),
+        "updated 45m ago"
+    );
+}
+
+#[test]
+fn test_format_age_one_hour_boundary() {
+    assert_eq!(
+        format_age(std::time::Duration::from_secs(3700)),
+        "updated 1h ago"
+    );
+}
+
+#[test]
+fn test_format_age_many_hours() {
+    assert_eq!(
+        format_age(std::time::Duration::from_secs(5 * 3600)),
+        "updated 5h ago"
+    );
 }
 
 // --- apply_filter_key + flow_matches_filter ---

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -13,8 +13,8 @@ use ratatui::backend::TestBackend;
 use ratatui::{Frame, Terminal};
 
 use flow_rs::tui::{
-    detail_pane_phase_header, list_row_phase_label, DrawFn, EventSourceFn, TuiApp, TuiAppPlatform,
-    View,
+    build_iterm_open_worktree_script, detail_pane_phase_header, list_row_phase_label, DrawFn,
+    EventSourceFn, TuiApp, TuiAppPlatform, View,
 };
 use flow_rs::tui_data::{
     AccountMetrics, FlowSummary, IssueSummary, OrchestrationItem, OrchestrationSummary,
@@ -582,6 +582,127 @@ fn test_render_tasks_view_no_plan() {
     app.view = View::Tasks;
     let output = render_to_string(&app, 80, 40);
     assert!(output.contains("No plan file."));
+}
+
+// --- build_iterm_open_worktree_script ---
+
+#[test]
+fn test_build_iterm_open_worktree_script_vanilla_path() {
+    let script = build_iterm_open_worktree_script("/Users/me/code/foo");
+    assert!(
+        script.contains(r#"cd \"/Users/me/code/foo\""#),
+        "expected escaped cd in script:\n{}",
+        script
+    );
+    assert!(script.contains("create tab with default profile"));
+    assert!(script.contains("create window with default profile"));
+}
+
+#[test]
+fn test_build_iterm_open_worktree_script_path_with_quotes() {
+    let script = build_iterm_open_worktree_script("/Users/foo \"bar\"/code");
+    // Each `"` in the input becomes `\"` in the rendered AppleScript
+    // source per `escape_applescript_string`. The whole `cd "..."`
+    // wrapping itself contributes the outer `\"` pair.
+    assert!(
+        script.contains(r#"cd \"/Users/foo \"bar\"/code\""#),
+        "expected escaped quotes:\n{}",
+        script
+    );
+}
+
+#[test]
+fn test_build_iterm_open_worktree_script_path_with_backslash() {
+    let script = build_iterm_open_worktree_script("/foo\\bar/code");
+    assert!(
+        script.contains(r#"cd \"/foo\\bar/code\""#),
+        "expected escaped backslash:\n{}",
+        script
+    );
+}
+
+#[test]
+fn test_build_iterm_open_worktree_script_path_with_spaces() {
+    // Spaces don't need escaping but must pass through unchanged.
+    let script = build_iterm_open_worktree_script("/Users/me/code with space");
+    assert!(
+        script.contains(r#"cd \"/Users/me/code with space\""#),
+        "expected spaces preserved:\n{}",
+        script
+    );
+}
+
+#[test]
+fn test_open_worktree_shell_empty_flows_returns_false() {
+    let app = make_app();
+    assert!(!app.open_worktree_shell());
+}
+
+#[test]
+fn test_open_worktree_shell_relative_path_joins_with_root() {
+    // No flows would short-circuit; populate one with a relative
+    // worktree path so the absolute-path branch is taken.
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_fixture_script(dir.path(), "osascript", "#!/bin/sh\necho opened\n");
+    let mut app = make_app_with_osascript(&script.to_string_lossy());
+    let mut flow = make_flow("Rel", "Code", 3);
+    flow.worktree = ".worktrees/rel".to_string();
+    app.flows = vec![flow];
+    assert!(app.open_worktree_shell());
+}
+
+#[test]
+fn test_open_worktree_shell_absolute_path_used_directly() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_fixture_script(dir.path(), "osascript", "#!/bin/sh\necho opened\n");
+    let mut app = make_app_with_osascript(&script.to_string_lossy());
+    let mut flow = make_flow("Abs", "Code", 3);
+    flow.worktree = "/abs/path/to/wt".to_string();
+    app.flows = vec![flow];
+    assert!(app.open_worktree_shell());
+}
+
+#[test]
+fn test_open_worktree_shell_osascript_failure_returns_false() {
+    let mut app = make_app_with_osascript("/bin/false");
+    let mut flow = make_flow("F", "Code", 3);
+    flow.worktree = "/abs/wt".to_string();
+    app.flows = vec![flow];
+    assert!(!app.open_worktree_shell());
+}
+
+#[test]
+fn test_open_worktree_shell_spawn_error_returns_false() {
+    let mut app = make_app_with_osascript("/nonexistent/osascript");
+    let mut flow = make_flow("S", "Code", 3);
+    flow.worktree = "/abs/wt".to_string();
+    app.flows = vec![flow];
+    assert!(!app.open_worktree_shell());
+}
+
+#[test]
+fn test_open_worktree_shell_not_opened_returns_false() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_fixture_script(dir.path(), "osascript", "#!/bin/sh\necho something_else\n");
+    let mut app = make_app_with_osascript(&script.to_string_lossy());
+    let mut flow = make_flow("N", "Code", 3);
+    flow.worktree = "/abs/wt".to_string();
+    app.flows = vec![flow];
+    assert!(!app.open_worktree_shell());
+}
+
+#[test]
+fn test_input_o_invokes_open_worktree_shell() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_fixture_script(dir.path(), "osascript", "#!/bin/sh\necho opened\n");
+    let mut app = make_app_with_osascript(&script.to_string_lossy());
+    let mut flow = make_flow("O", "Code", 3);
+    flow.worktree = "/abs/wt".to_string();
+    app.flows = vec![flow];
+    // 'o' keybinding wired in handle_list_input — drives through
+    // open_worktree_shell, returning unit (no assertion on bool here;
+    // covered above), exercises the match arm.
+    app.handle_key(key(KeyCode::Char('o')));
 }
 
 // --- detail_pane_phase_header ---

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -12,10 +12,10 @@ use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, Ke
 use ratatui::backend::TestBackend;
 use ratatui::{Frame, Terminal};
 
-use flow_rs::tui::{DrawFn, EventSourceFn, TuiApp, TuiAppPlatform, View};
+use flow_rs::tui::{list_row_phase_label, DrawFn, EventSourceFn, TuiApp, TuiAppPlatform, View};
 use flow_rs::tui_data::{
     AccountMetrics, FlowSummary, IssueSummary, OrchestrationItem, OrchestrationSummary,
-    TimelineEntry,
+    PhaseStepCounter, TimelineEntry,
 };
 
 // --- Helpers ---
@@ -545,6 +545,103 @@ fn test_render_tasks_view_no_plan() {
     app.view = View::Tasks;
     let output = render_to_string(&app, 80, 40);
     assert!(output.contains("No plan file."));
+}
+
+// --- list_row_phase_label ---
+
+fn pc(label: &'static str, num: u8, current: i64, total: i64) -> PhaseStepCounter {
+    PhaseStepCounter {
+        phase_label: label,
+        phase_number: num,
+        current,
+        total,
+        name: None,
+    }
+}
+
+#[test]
+fn test_list_row_label_start_present() {
+    let c = pc("Start", 1, 2, 5);
+    assert_eq!(
+        list_row_phase_label(1, "Start", Some(&c), ""),
+        "1: Start 2/5"
+    );
+}
+
+#[test]
+fn test_list_row_label_start_missing() {
+    assert_eq!(list_row_phase_label(1, "Start", None, ""), "1: Start");
+}
+
+#[test]
+fn test_list_row_label_code_present() {
+    let c = pc("Code", 2, 3, 7);
+    assert_eq!(list_row_phase_label(2, "Code", Some(&c), ""), "2: Code 3/7");
+}
+
+#[test]
+fn test_list_row_label_code_missing() {
+    assert_eq!(list_row_phase_label(2, "Code", None, ""), "2: Code");
+}
+
+#[test]
+fn test_list_row_label_code_review_present() {
+    let c = pc("Code Review", 3, 2, 4);
+    assert_eq!(
+        list_row_phase_label(3, "Code Review", Some(&c), ""),
+        "3: Code Review 2/4"
+    );
+}
+
+#[test]
+fn test_list_row_label_code_review_missing() {
+    assert_eq!(
+        list_row_phase_label(3, "Code Review", None, ""),
+        "3: Code Review"
+    );
+}
+
+#[test]
+fn test_list_row_label_learn_present() {
+    let c = pc("Learn", 4, 5, 7);
+    assert_eq!(
+        list_row_phase_label(4, "Learn", Some(&c), ""),
+        "4: Learn 5/7"
+    );
+}
+
+#[test]
+fn test_list_row_label_learn_missing() {
+    assert_eq!(list_row_phase_label(4, "Learn", None, ""), "4: Learn");
+}
+
+#[test]
+fn test_list_row_label_complete_present() {
+    let c = pc("Complete", 5, 4, 6);
+    assert_eq!(
+        list_row_phase_label(5, "Complete", Some(&c), ""),
+        "5: Complete 4/6"
+    );
+}
+
+#[test]
+fn test_list_row_label_complete_missing() {
+    assert_eq!(list_row_phase_label(5, "Complete", None, ""), "5: Complete");
+}
+
+#[test]
+fn test_list_row_label_appends_annotation() {
+    let c = pc("Code", 2, 3, 7);
+    assert_eq!(
+        list_row_phase_label(2, "Code", Some(&c), "task 3 of 7"),
+        "2: Code 3/7 (task 3 of 7)"
+    );
+}
+
+#[test]
+fn test_list_row_label_zero_total_skips_counter() {
+    let c = pc("Code", 2, 1, 0);
+    assert_eq!(list_row_phase_label(2, "Code", Some(&c), ""), "2: Code");
 }
 
 // --- Input handling ---

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -557,6 +557,27 @@ fn test_input_quit() {
 }
 
 #[test]
+fn test_input_ctrl_c_quits() {
+    let mut app = make_app();
+    let ctrl_c = KeyEvent {
+        code: KeyCode::Char('c'),
+        modifiers: KeyModifiers::CONTROL,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    };
+    app.handle_key(ctrl_c);
+    assert!(!app.running);
+}
+
+#[test]
+fn test_input_plain_c_does_not_quit() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("A", "Code", 3)];
+    app.handle_key(key(KeyCode::Char('c')));
+    assert!(app.running);
+}
+
+#[test]
 fn test_input_navigate_up_down() {
     let mut app = make_app();
     app.flows = vec![

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -439,13 +439,20 @@ fn test_render_detail_panel_with_issues() {
 }
 
 #[test]
-fn test_render_footer_keybindings() {
+fn test_render_footer_collapsed_to_help_pointer() {
     let mut app = make_app();
     app.flows = vec![make_flow("Test", "Code", 3)];
-    // Footer is very wide — use 160 cols to fit all keybindings
     let output = render_to_string(&app, 160, 40);
-    assert!(output.contains("[q] Quit"));
-    assert!(output.contains("[p] PR"));
+    assert!(
+        output.contains("?=help"),
+        "footer should point at the help overlay; got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("Ctrl-C/q=quit"),
+        "footer should still mention how to quit; got:\n{}",
+        output
+    );
 }
 
 #[test]
@@ -545,7 +552,7 @@ fn test_render_log_view_empty() {
     app.view = View::Log;
     let output = render_to_string(&app, 80, 40);
     assert!(output.contains("No log entries."));
-    assert!(output.contains("[Esc] Back"));
+    assert!(output.contains("?=help"));
 }
 
 #[test]
@@ -583,6 +590,80 @@ fn test_render_tasks_view_no_plan() {
     app.view = View::Tasks;
     let output = render_to_string(&app, 80, 40);
     assert!(output.contains("No plan file."));
+}
+
+// --- help overlay (?) ---
+
+#[test]
+fn test_input_question_mark_enters_help_from_list() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("A", "Code", 3)];
+    assert_eq!(app.view, View::List);
+    app.handle_key(key(KeyCode::Char('?')));
+    assert_eq!(app.view, View::Help);
+    assert_eq!(app.previous_view, Some(View::List));
+}
+
+#[test]
+fn test_input_question_mark_enters_help_from_log() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("A", "Code", 3)];
+    app.view = View::Log;
+    app.handle_key(key(KeyCode::Char('?')));
+    assert_eq!(app.view, View::Help);
+    assert_eq!(app.previous_view, Some(View::Log));
+}
+
+#[test]
+fn test_input_any_key_in_help_restores_previous_view() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("A", "Code", 3)];
+    app.view = View::Issues;
+    app.handle_key(key(KeyCode::Char('?')));
+    assert_eq!(app.view, View::Help);
+    app.handle_key(key(KeyCode::Char('x')));
+    assert_eq!(app.view, View::Issues);
+    assert_eq!(app.previous_view, None);
+}
+
+#[test]
+fn test_input_help_with_no_previous_view_falls_back_to_list() {
+    // Defensive: if `view == Help` but `previous_view` is None
+    // (manual fixture state), restoring should default to List.
+    let mut app = make_app();
+    app.flows = vec![make_flow("A", "Code", 3)];
+    app.view = View::Help;
+    app.previous_view = None;
+    app.handle_key(key(KeyCode::Char('x')));
+    assert_eq!(app.view, View::List);
+}
+
+#[test]
+fn test_render_help_view_breaks_when_viewport_overflows() {
+    // Small height — help has ~25 rows of content; with height 8 the
+    // break path inside the row loop must fire after the first few
+    // lines so the loop doesn't draw past the footer row.
+    let mut app = make_app();
+    app.view = View::Help;
+    let _ = render_to_string(&app, 80, 8);
+}
+
+#[test]
+fn test_render_help_view_lists_every_documented_binding() {
+    let mut app = make_app();
+    app.view = View::Help;
+    let output = render_to_string(&app, 100, 40);
+    // Sample of bindings the help view must mention.
+    for binding in &[
+        "Enter", "PR", "issues", "tasks", "log", "abort", "refresh", "filter", "?", "Ctrl-C/q",
+    ] {
+        assert!(
+            output.contains(binding),
+            "help view missing `{}` binding:\n{}",
+            binding,
+            output
+        );
+    }
 }
 
 // --- start_lock_holder banner ---

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -13,8 +13,8 @@ use ratatui::backend::TestBackend;
 use ratatui::{Frame, Terminal};
 
 use flow_rs::tui::{
-    build_iterm_open_worktree_script, detail_pane_phase_header, list_row_phase_label, DrawFn,
-    EventSourceFn, TuiApp, TuiAppPlatform, View,
+    apply_filter_key, build_iterm_open_worktree_script, detail_pane_phase_header,
+    flow_matches_filter, list_row_phase_label, DrawFn, EventSourceFn, TuiApp, TuiAppPlatform, View,
 };
 use flow_rs::tui_data::{
     AccountMetrics, FlowSummary, IssueSummary, OrchestrationItem, OrchestrationSummary,
@@ -582,6 +582,196 @@ fn test_render_tasks_view_no_plan() {
     app.view = View::Tasks;
     let output = render_to_string(&app, 80, 40);
     assert!(output.contains("No plan file."));
+}
+
+// --- apply_filter_key + flow_matches_filter ---
+
+#[test]
+fn test_filter_slash_inactive_enters_input() {
+    let mut q: Option<String> = None;
+    let mut active = false;
+    apply_filter_key(&mut q, &mut active, KeyCode::Char('/'));
+    assert!(active);
+    assert_eq!(q, Some(String::new()));
+}
+
+#[test]
+fn test_filter_other_key_inactive_no_op() {
+    let mut q: Option<String> = None;
+    let mut active = false;
+    apply_filter_key(&mut q, &mut active, KeyCode::Char('a'));
+    assert!(!active);
+    assert_eq!(q, None);
+}
+
+#[test]
+fn test_filter_char_active_appends() {
+    let mut q: Option<String> = Some(String::new());
+    let mut active = true;
+    apply_filter_key(&mut q, &mut active, KeyCode::Char('a'));
+    apply_filter_key(&mut q, &mut active, KeyCode::Char('b'));
+    assert_eq!(q, Some("ab".to_string()));
+    assert!(active);
+}
+
+#[test]
+fn test_filter_backspace_active_pops() {
+    let mut q: Option<String> = Some("ab".to_string());
+    let mut active = true;
+    apply_filter_key(&mut q, &mut active, KeyCode::Backspace);
+    assert_eq!(q, Some("a".to_string()));
+}
+
+#[test]
+fn test_filter_backspace_empty_query_no_underflow() {
+    let mut q: Option<String> = Some(String::new());
+    let mut active = true;
+    apply_filter_key(&mut q, &mut active, KeyCode::Backspace);
+    assert_eq!(q, Some(String::new()));
+}
+
+#[test]
+fn test_filter_enter_with_query_persists() {
+    let mut q: Option<String> = Some("foo".to_string());
+    let mut active = true;
+    apply_filter_key(&mut q, &mut active, KeyCode::Enter);
+    assert!(!active);
+    assert_eq!(q, Some("foo".to_string()));
+}
+
+#[test]
+fn test_filter_enter_with_empty_query_clears() {
+    let mut q: Option<String> = Some(String::new());
+    let mut active = true;
+    apply_filter_key(&mut q, &mut active, KeyCode::Enter);
+    assert!(!active);
+    assert_eq!(q, None);
+}
+
+#[test]
+fn test_filter_char_with_none_query_is_no_op() {
+    // Defensive arm: input_active=true with query=None — Char input
+    // is a no-op rather than auto-creating Some("").
+    let mut q: Option<String> = None;
+    let mut active = true;
+    apply_filter_key(&mut q, &mut active, KeyCode::Char('a'));
+    assert_eq!(q, None);
+    assert!(active);
+}
+
+#[test]
+fn test_filter_backspace_with_none_query_is_no_op() {
+    // Defensive arm: input_active=true with query=None — Backspace
+    // is a no-op rather than panicking.
+    let mut q: Option<String> = None;
+    let mut active = true;
+    apply_filter_key(&mut q, &mut active, KeyCode::Backspace);
+    assert_eq!(q, None);
+    assert!(active);
+}
+
+#[test]
+fn test_filter_enter_with_none_query_is_no_op() {
+    // Defensive arm: input_active=true with query=None shouldn't
+    // arise from the state machine's own transitions, but if a caller
+    // hand-constructs this state, Enter must still finalize cleanly.
+    let mut q: Option<String> = None;
+    let mut active = true;
+    apply_filter_key(&mut q, &mut active, KeyCode::Enter);
+    assert!(!active);
+    assert_eq!(q, None);
+}
+
+#[test]
+fn test_filter_esc_clears_query() {
+    let mut q: Option<String> = Some("foo".to_string());
+    let mut active = true;
+    apply_filter_key(&mut q, &mut active, KeyCode::Esc);
+    assert!(!active);
+    assert_eq!(q, None);
+}
+
+#[test]
+fn test_filter_slash_with_committed_query_re_enters_input() {
+    let mut q: Option<String> = Some("foo".to_string());
+    let mut active = false;
+    apply_filter_key(&mut q, &mut active, KeyCode::Char('/'));
+    assert!(active);
+    assert_eq!(q, Some("foo".to_string()));
+}
+
+#[test]
+fn test_filter_other_key_active_no_op() {
+    let mut q: Option<String> = Some("a".to_string());
+    let mut active = true;
+    apply_filter_key(&mut q, &mut active, KeyCode::Up);
+    assert_eq!(q, Some("a".to_string()));
+    assert!(active);
+}
+
+#[test]
+fn test_filter_backspace_inactive_no_query_returns_false() {
+    let mut q: Option<String> = None;
+    let mut active = false;
+    apply_filter_key(&mut q, &mut active, KeyCode::Backspace);
+    assert_eq!(q, None);
+    assert!(!active);
+}
+
+#[test]
+fn test_visibility_input_active_shows_all() {
+    assert!(flow_matches_filter("anything", Some("xyz"), true));
+    assert!(flow_matches_filter("anything", None, true));
+}
+
+#[test]
+fn test_visibility_query_none_shows_all() {
+    assert!(flow_matches_filter("anything", None, false));
+}
+
+#[test]
+fn test_visibility_query_empty_shows_all() {
+    assert!(flow_matches_filter("anything", Some(""), false));
+}
+
+#[test]
+fn test_visibility_query_substring_match_case_insensitive() {
+    assert!(flow_matches_filter("MyFeature", Some("feat"), false));
+    assert!(flow_matches_filter("myfeature", Some("FEAT"), false));
+}
+
+#[test]
+fn test_visibility_query_no_match() {
+    assert!(!flow_matches_filter("alpha-branch", Some("zeta"), false));
+}
+
+#[test]
+fn test_input_slash_enters_filter_mode() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("A", "Code", 3)];
+    app.handle_key(key(KeyCode::Char('/')));
+    assert!(app.filter_input_active);
+    assert_eq!(app.filter_query, Some(String::new()));
+}
+
+#[test]
+fn test_input_filter_typing_appends_to_query() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("A", "Code", 3)];
+    app.handle_key(key(KeyCode::Char('/')));
+    app.handle_key(key(KeyCode::Char('a')));
+    app.handle_key(key(KeyCode::Char('b')));
+    assert_eq!(app.filter_query, Some("ab".to_string()));
+}
+
+#[test]
+fn test_input_filter_q_does_not_quit_in_input_mode() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("A", "Code", 3)];
+    app.handle_key(key(KeyCode::Char('/')));
+    app.handle_key(key(KeyCode::Char('q')));
+    assert!(app.running, "q should not quit during filter input");
+    assert_eq!(app.filter_query, Some("q".to_string()));
 }
 
 // --- build_iterm_open_worktree_script ---

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -12,7 +12,10 @@ use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, Ke
 use ratatui::backend::TestBackend;
 use ratatui::{Frame, Terminal};
 
-use flow_rs::tui::{list_row_phase_label, DrawFn, EventSourceFn, TuiApp, TuiAppPlatform, View};
+use flow_rs::tui::{
+    detail_pane_phase_header, list_row_phase_label, DrawFn, EventSourceFn, TuiApp, TuiAppPlatform,
+    View,
+};
 use flow_rs::tui_data::{
     AccountMetrics, FlowSummary, IssueSummary, OrchestrationItem, OrchestrationSummary,
     PhaseStepCounter, TimelineEntry,
@@ -208,6 +211,40 @@ fn test_render_detail_panel_phases() {
     assert!(output.contains("[x]"));
     assert!(output.contains("[>]"));
     assert!(output.contains("[ ]"));
+}
+
+#[test]
+fn test_render_detail_panel_renders_phase_step_header_when_counter_present() {
+    let mut app = make_app();
+    let mut flow = make_flow("Counter Feature", "Code", 2);
+    flow.state = serde_json::json!({
+        "branch": "counter-feature",
+        "repo": "test/repo",
+        "current_phase": "flow-code",
+        "code_task": 3,
+        "code_tasks_total": 7,
+        "code_task_name": "implement_helper",
+    });
+    app.flows = vec![flow];
+    let output = render_to_string(&app, 120, 40);
+    assert!(
+        output.contains("Phase 2 (Code) \u{2014} step 3 of 7: implement_helper"),
+        "expected detail-pane header in output, got:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_render_detail_panel_omits_phase_step_header_when_counter_missing() {
+    let mut app = make_app();
+    let flow = make_flow("No Counter", "Code", 2);
+    app.flows = vec![flow];
+    let output = render_to_string(&app, 120, 40);
+    assert!(
+        !output.contains("Phase 2 (Code) \u{2014} step"),
+        "header should not render without a counter; got:\n{}",
+        output
+    );
 }
 
 /// Build a valid-FlowState Value with one phase carrying non-zero
@@ -545,6 +582,70 @@ fn test_render_tasks_view_no_plan() {
     app.view = View::Tasks;
     let output = render_to_string(&app, 80, 40);
     assert!(output.contains("No plan file."));
+}
+
+// --- detail_pane_phase_header ---
+
+#[test]
+fn test_detail_header_code_with_name() {
+    let c = PhaseStepCounter {
+        phase_label: "Code",
+        phase_number: 2,
+        current: 3,
+        total: 7,
+        name: Some("implement_helper".to_string()),
+    };
+    assert_eq!(
+        detail_pane_phase_header(Some(&c)),
+        Some("Phase 2 (Code) \u{2014} step 3 of 7: implement_helper".to_string())
+    );
+}
+
+#[test]
+fn test_detail_header_code_no_name() {
+    let c = PhaseStepCounter {
+        phase_label: "Code",
+        phase_number: 2,
+        current: 1,
+        total: 4,
+        name: None,
+    };
+    assert_eq!(
+        detail_pane_phase_header(Some(&c)),
+        Some("Phase 2 (Code) \u{2014} step 1 of 4".to_string())
+    );
+}
+
+#[test]
+fn test_detail_header_none_counter() {
+    assert_eq!(detail_pane_phase_header(None), None);
+}
+
+#[test]
+fn test_detail_header_zero_total() {
+    let c = PhaseStepCounter {
+        phase_label: "Code",
+        phase_number: 2,
+        current: 1,
+        total: 0,
+        name: None,
+    };
+    assert_eq!(detail_pane_phase_header(Some(&c)), None);
+}
+
+#[test]
+fn test_detail_header_start_with_name() {
+    let c = PhaseStepCounter {
+        phase_label: "Start",
+        phase_number: 1,
+        current: 2,
+        total: 5,
+        name: Some("CI gate".to_string()),
+    };
+    assert_eq!(
+        detail_pane_phase_header(Some(&c)),
+        Some("Phase 1 (Start) \u{2014} step 2 of 5: CI gate".to_string())
+    );
 }
 
 // --- list_row_phase_label ---

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -585,6 +585,34 @@ fn test_render_tasks_view_no_plan() {
     assert!(output.contains("No plan file."));
 }
 
+// --- start_lock_holder banner ---
+
+#[test]
+fn test_render_header_renders_lock_banner_when_holder_set() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("A", "Code", 3)];
+    app.start_lock_holder = Some("alpha-feature".to_string());
+    let output = render_to_string(&app, 80, 40);
+    assert!(
+        output.contains("start lock: alpha-feature"),
+        "expected lock banner in output:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_render_header_omits_lock_banner_when_no_holder() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("A", "Code", 3)];
+    app.start_lock_holder = None;
+    let output = render_to_string(&app, 80, 40);
+    assert!(
+        !output.contains("start lock:"),
+        "lock banner should not render with no holder; got:\n{}",
+        output
+    );
+}
+
 // --- format_age ---
 
 #[test]

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -592,7 +592,119 @@ fn test_render_tasks_view_no_plan() {
     assert!(output.contains("No plan file."));
 }
 
+// --- filter + selection alignment ---
+
+#[test]
+fn test_filter_selection_detail_pane_aligns_with_visible_row() {
+    // Three flows with filter matching only Banana, selected=0.
+    // The detail pane must render banana-feature, not apple.
+    let mut app = make_app();
+    app.flows = vec![
+        make_flow("Apple Feature", "Code", 3),
+        make_flow("Banana Feature", "Code", 3),
+        make_flow("Cherry Feature", "Code", 3),
+    ];
+    app.flows[0].branch = "apple-feature".to_string();
+    app.flows[1].branch = "banana-feature".to_string();
+    app.flows[2].branch = "cherry-feature".to_string();
+    app.flows[0].worktree = ".worktrees/apple-feature".to_string();
+    app.flows[1].worktree = ".worktrees/banana-feature".to_string();
+    app.flows[2].worktree = ".worktrees/cherry-feature".to_string();
+    app.filter_query = Some("banana".to_string());
+    app.filter_input_active = false;
+    app.selected = 0;
+    let output = render_to_string(&app, 140, 60);
+    assert!(
+        output.contains("Branch: banana-feature"),
+        "detail pane must reflect the highlighted (filtered) row:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("Branch: apple-feature"),
+        "detail pane must not reflect a hidden flow:\n{}",
+        output
+    );
+}
+
+#[test]
+fn test_visible_flows_filters_and_selected_visible_flow_lookup() {
+    let mut app = make_app();
+    app.flows = vec![
+        make_flow("Apple", "Code", 3),
+        make_flow("Banana", "Code", 3),
+    ];
+    app.flows[0].branch = "apple".to_string();
+    app.flows[1].branch = "banana".to_string();
+    app.filter_query = Some("banana".to_string());
+    app.filter_input_active = false;
+    app.selected = 0;
+    let visible = app.visible_flows();
+    assert_eq!(visible.len(), 1);
+    assert_eq!(visible[0].branch, "banana");
+    assert_eq!(
+        app.selected_visible_flow().map(|f| f.branch.as_str()),
+        Some("banana")
+    );
+}
+
+#[test]
+fn test_selected_visible_flow_returns_none_when_filter_excludes_everything() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("Apple", "Code", 3)];
+    app.flows[0].branch = "apple".to_string();
+    app.filter_query = Some("zeta".to_string());
+    app.filter_input_active = false;
+    assert!(app.selected_visible_flow().is_none());
+}
+
+#[test]
+fn test_input_down_clamps_against_visible_flows_under_filter() {
+    let mut app = make_app();
+    app.flows = vec![
+        make_flow("Apple", "Code", 3),
+        make_flow("Banana", "Code", 3),
+        make_flow("Cherry", "Code", 3),
+    ];
+    app.flows[0].branch = "apple".to_string();
+    app.flows[1].branch = "banana".to_string();
+    app.flows[2].branch = "cherry".to_string();
+    app.filter_query = Some("banana".to_string());
+    app.filter_input_active = false;
+    app.selected = 0;
+    // Only Banana is visible; Down must clamp to 0, not advance.
+    app.handle_key(key(KeyCode::Down));
+    assert_eq!(app.selected, 0);
+}
+
+#[test]
+fn test_open_actions_no_op_when_filter_excludes_everything() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("Apple", "Code", 3)];
+    app.flows[0].branch = "apple".to_string();
+    app.filter_query = Some("zeta".to_string());
+    app.filter_input_active = false;
+    // Enter, p, I, a all dispatch through selected_visible_flow which
+    // returns None — every action arm must early-return without panic.
+    app.handle_key(key(KeyCode::Enter));
+    app.handle_key(key(KeyCode::Char('p')));
+    app.handle_key(key(KeyCode::Char('I')));
+    app.handle_key(key(KeyCode::Char('o')));
+    // Render with the all-excluded filter still active — render_detail_panel
+    // must early-return rather than panic.
+    let _ = render_to_string(&app, 80, 40);
+}
+
 // --- help overlay (?) ---
+
+#[test]
+fn test_input_q_in_help_quits() {
+    let mut app = make_app();
+    app.flows = vec![make_flow("A", "Code", 3)];
+    app.handle_key(key(KeyCode::Char('?')));
+    assert_eq!(app.view, View::Help);
+    app.handle_key(key(KeyCode::Char('q')));
+    assert!(!app.running, "q in Help view must quit, not restore");
+}
 
 #[test]
 fn test_input_question_mark_enters_help_from_list() {
@@ -940,8 +1052,8 @@ fn test_input_filter_q_does_not_quit_in_input_mode() {
 fn test_build_iterm_open_worktree_script_vanilla_path() {
     let script = build_iterm_open_worktree_script("/Users/me/code/foo");
     assert!(
-        script.contains(r#"cd \"/Users/me/code/foo\""#),
-        "expected escaped cd in script:\n{}",
+        script.contains("cd '/Users/me/code/foo'"),
+        "expected single-quoted shell cd in script:\n{}",
         script
     );
     assert!(script.contains("create tab with default profile"));
@@ -951,12 +1063,13 @@ fn test_build_iterm_open_worktree_script_vanilla_path() {
 #[test]
 fn test_build_iterm_open_worktree_script_path_with_quotes() {
     let script = build_iterm_open_worktree_script("/Users/foo \"bar\"/code");
-    // Each `"` in the input becomes `\"` in the rendered AppleScript
-    // source per `escape_applescript_string`. The whole `cd "..."`
-    // wrapping itself contributes the outer `\"` pair.
+    // Double quotes in the path are inside shell single-quotes so the
+    // shell sees them literally. The AppleScript layer still escapes
+    // each `"` as `\"` because the shell-quoted form is interpolated
+    // into an AppleScript double-quoted literal.
     assert!(
-        script.contains(r#"cd \"/Users/foo \"bar\"/code\""#),
-        "expected escaped quotes:\n{}",
+        script.contains(r#"cd '/Users/foo \"bar\"/code'"#),
+        "expected AppleScript-escaped quotes inside shell single-quotes:\n{}",
         script
     );
 }
@@ -965,8 +1078,8 @@ fn test_build_iterm_open_worktree_script_path_with_quotes() {
 fn test_build_iterm_open_worktree_script_path_with_backslash() {
     let script = build_iterm_open_worktree_script("/foo\\bar/code");
     assert!(
-        script.contains(r#"cd \"/foo\\bar/code\""#),
-        "expected escaped backslash:\n{}",
+        script.contains(r#"cd '/foo\\bar/code'"#),
+        "expected AppleScript-escaped backslash inside shell single-quotes:\n{}",
         script
     );
 }
@@ -976,8 +1089,48 @@ fn test_build_iterm_open_worktree_script_path_with_spaces() {
     // Spaces don't need escaping but must pass through unchanged.
     let script = build_iterm_open_worktree_script("/Users/me/code with space");
     assert!(
-        script.contains(r#"cd \"/Users/me/code with space\""#),
-        "expected spaces preserved:\n{}",
+        script.contains("cd '/Users/me/code with space'"),
+        "expected spaces preserved inside shell single-quotes:\n{}",
+        script
+    );
+}
+
+#[test]
+fn test_build_iterm_open_worktree_script_neutralizes_dollar_paren() {
+    // Shell-single-quoted: $(...) inside `'...'` is literal in shell.
+    let script = build_iterm_open_worktree_script("/feat/$(echo INJECTED)");
+    assert!(
+        script.contains("cd '/feat/$(echo INJECTED)'"),
+        "expected $(...) wrapped in shell single quotes:\n{}",
+        script
+    );
+}
+
+#[test]
+fn test_build_iterm_open_worktree_script_neutralizes_backticks() {
+    let script = build_iterm_open_worktree_script("/feat/`echo INJECTED`");
+    assert!(
+        script.contains("cd '/feat/`echo INJECTED`'"),
+        "expected backticks wrapped in shell single quotes:\n{}",
+        script
+    );
+}
+
+#[test]
+fn test_build_iterm_open_worktree_script_path_with_single_quote() {
+    // Single quote in the path requires the close-escape-reopen idiom
+    // `'\''` at shell level so the shell sees the literal char. The
+    // backslash in `'\''` is then doubled by escape_applescript_string
+    // to `\\` because `\` is structural inside an AppleScript double-
+    // quoted literal — so the rendered AppleScript source contains
+    // `'\\''`. AppleScript parses `\\` back to `\`, so iTerm types
+    // `'\''` into the shell, which the shell parses as the single
+    // quote literal.
+    let script = build_iterm_open_worktree_script("/feat/o'malley");
+    assert!(
+        script.contains(r#"cd '/feat/o'\\''malley'"#),
+        "expected single-quote escaped via close-escape-reopen, with\
+         the inner backslash AppleScript-escaped to \\\\:\n{}",
         script
     );
 }

--- a/tests/tui_data.rs
+++ b/tests/tui_data.rs
@@ -4,8 +4,8 @@ use chrono::{DateTime, FixedOffset};
 use flow_rs::phase_config::{self, PHASE_ORDER};
 use flow_rs::tui_data::{
     flow_summary, load_account_metrics, load_all_flows, load_orchestration, orchestration_summary,
-    parse_log_entries, phase_timeline, phase_token_table, run_impl_main, status_icon,
-    step_annotation, step_names,
+    parse_log_entries, phase_step_counter, phase_timeline, phase_token_table, run_impl_main,
+    status_icon, step_annotation, step_names, PhaseStepCounter,
 };
 use serde_json::{json, Value};
 
@@ -53,6 +53,153 @@ fn make_state(current_phase: &str, phase_statuses: &[(&str, &str)]) -> Value {
         "phases": phases,
         "prompt": "",
     })
+}
+
+// --- step_annotation ---
+
+// --- phase_step_counter ---
+
+#[test]
+fn test_phase_step_counter_missing_current_phase() {
+    let state = json!({});
+    assert_eq!(phase_step_counter(&state), None);
+}
+
+#[test]
+fn test_phase_step_counter_unknown_phase() {
+    let state = json!({"current_phase": "flow-mystery"});
+    assert_eq!(phase_step_counter(&state), None);
+}
+
+#[test]
+fn test_phase_step_counter_start_present() {
+    let mut state = make_state("flow-start", &[("flow-start", "in_progress")]);
+    state["start_step"] = json!(2);
+    state["start_steps_total"] = json!(5);
+    let got = phase_step_counter(&state).expect("counter present");
+    assert_eq!(
+        got,
+        PhaseStepCounter {
+            phase_label: "Start",
+            phase_number: 1,
+            current: 2,
+            total: 5,
+            name: Some("CI gate".to_string()),
+        }
+    );
+}
+
+#[test]
+fn test_phase_step_counter_start_missing() {
+    let state = make_state("flow-start", &[("flow-start", "in_progress")]);
+    assert_eq!(phase_step_counter(&state), None);
+}
+
+#[test]
+fn test_phase_step_counter_code_present() {
+    let mut state = make_state("flow-code", &[("flow-code", "in_progress")]);
+    state["code_task"] = json!(3);
+    state["code_tasks_total"] = json!(7);
+    state["code_task_name"] = json!("implement_helper");
+    let got = phase_step_counter(&state).expect("counter present");
+    assert_eq!(
+        got,
+        PhaseStepCounter {
+            phase_label: "Code",
+            phase_number: 2,
+            current: 3,
+            total: 7,
+            name: Some("implement_helper".to_string()),
+        }
+    );
+}
+
+#[test]
+fn test_phase_step_counter_code_missing() {
+    let state = make_state("flow-code", &[("flow-code", "in_progress")]);
+    assert_eq!(phase_step_counter(&state), None);
+}
+
+#[test]
+fn test_phase_step_counter_code_review_present() {
+    let mut state = make_state("flow-code-review", &[("flow-code-review", "in_progress")]);
+    state["code_review_step"] = json!(2);
+    let got = phase_step_counter(&state).expect("counter present");
+    assert_eq!(
+        got,
+        PhaseStepCounter {
+            phase_label: "Code Review",
+            phase_number: 3,
+            current: 2,
+            total: 4,
+            name: Some("reviewing".to_string()),
+        }
+    );
+}
+
+#[test]
+fn test_phase_step_counter_code_review_missing() {
+    let state = make_state("flow-code-review", &[("flow-code-review", "in_progress")]);
+    assert_eq!(phase_step_counter(&state), None);
+}
+
+#[test]
+fn test_phase_step_counter_learn_present() {
+    let mut state = make_state("flow-learn", &[("flow-learn", "in_progress")]);
+    state["learn_step"] = json!(3);
+    state["learn_steps_total"] = json!(7);
+    let got = phase_step_counter(&state).expect("counter present");
+    assert_eq!(
+        got,
+        PhaseStepCounter {
+            phase_label: "Learn",
+            phase_number: 4,
+            current: 3,
+            total: 7,
+            name: Some("applying learnings".to_string()),
+        }
+    );
+}
+
+#[test]
+fn test_phase_step_counter_learn_missing() {
+    let state = make_state("flow-learn", &[("flow-learn", "in_progress")]);
+    assert_eq!(phase_step_counter(&state), None);
+}
+
+#[test]
+fn test_phase_step_counter_complete_present() {
+    let mut state = make_state("flow-complete", &[("flow-complete", "in_progress")]);
+    state["complete_step"] = json!(4);
+    state["complete_steps_total"] = json!(6);
+    let got = phase_step_counter(&state).expect("counter present");
+    assert_eq!(
+        got,
+        PhaseStepCounter {
+            phase_label: "Complete",
+            phase_number: 5,
+            current: 4,
+            total: 6,
+            name: Some("confirming".to_string()),
+        }
+    );
+}
+
+#[test]
+fn test_phase_step_counter_complete_missing() {
+    let state = make_state("flow-complete", &[("flow-complete", "in_progress")]);
+    assert_eq!(phase_step_counter(&state), None);
+}
+
+#[test]
+fn test_phase_step_counter_code_present_no_name() {
+    let mut state = make_state("flow-code", &[("flow-code", "in_progress")]);
+    state["code_task"] = json!(2);
+    state["code_tasks_total"] = json!(5);
+    let got = phase_step_counter(&state).expect("counter present");
+    assert_eq!(got.name, None);
+    assert_eq!(got.current, 2);
+    assert_eq!(got.total, 5);
 }
 
 // --- step_annotation ---

--- a/tests/tui_data.rs
+++ b/tests/tui_data.rs
@@ -4,8 +4,9 @@ use chrono::{DateTime, FixedOffset};
 use flow_rs::phase_config::{self, PHASE_ORDER};
 use flow_rs::tui_data::{
     flow_summary, load_account_metrics, load_all_flows, load_orchestration, orchestration_summary,
-    parse_log_entries, phase_step_counter, phase_timeline, phase_token_table, run_impl_main,
-    status_icon, step_annotation, step_names, PhaseStepCounter,
+    parse_log_entries, phase_step_counter, phase_timeline, phase_token_table,
+    read_start_lock_holder, run_impl_main, status_icon, step_annotation, step_names,
+    PhaseStepCounter,
 };
 use serde_json::{json, Value};
 
@@ -56,6 +57,64 @@ fn make_state(current_phase: &str, phase_statuses: &[(&str, &str)]) -> Value {
 }
 
 // --- step_annotation ---
+
+// --- read_start_lock_holder ---
+
+#[test]
+fn test_read_start_lock_holder_empty_queue() {
+    let dir = tempfile::TempDir::new().unwrap();
+    assert_eq!(read_start_lock_holder(dir.path()), None);
+}
+
+#[test]
+fn test_read_start_lock_holder_single_entry_returns_holder() {
+    use std::fs;
+    let dir = tempfile::TempDir::new().unwrap();
+    let queue = dir
+        .path()
+        .canonicalize()
+        .unwrap()
+        .join(".flow-states")
+        .join("start-queue");
+    fs::create_dir_all(&queue).unwrap();
+    fs::write(queue.join("alpha-feature"), "").unwrap();
+    assert_eq!(
+        read_start_lock_holder(dir.path()),
+        Some("alpha-feature".to_string())
+    );
+}
+
+#[test]
+fn test_read_start_lock_holder_multiple_entries_returns_oldest_by_mtime() {
+    use filetime::{set_file_mtime, FileTime};
+    use std::fs;
+    let dir = tempfile::TempDir::new().unwrap();
+    let queue = dir
+        .path()
+        .canonicalize()
+        .unwrap()
+        .join(".flow-states")
+        .join("start-queue");
+    fs::create_dir_all(&queue).unwrap();
+    let earlier = queue.join("alpha-feature");
+    let later = queue.join("beta-feature");
+    fs::write(&earlier, "").unwrap();
+    fs::write(&later, "").unwrap();
+    // Use recent timestamps so neither entry exceeds start_lock's
+    // STALE_TIMEOUT_SECONDS — both within the last minute, with
+    // `earlier` 60s back and `later` 30s back.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    set_file_mtime(&earlier, FileTime::from_unix_time(now - 60, 0)).unwrap();
+    set_file_mtime(&later, FileTime::from_unix_time(now - 30, 0)).unwrap();
+    assert_eq!(
+        read_start_lock_holder(dir.path()),
+        Some("alpha-feature".to_string())
+    );
+}
 
 // --- phase_step_counter ---
 


### PR DESCRIPTION
## What

#1406.

Closes #1406

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/tui-improvements-bundle-ctrl-c-x/log` |
| State | `.flow-states/tui-improvements-bundle-ctrl-c-x/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 2h 21m |
| Code Review | 46m |
| Learn | 4m |
| Complete | 12m |
| **Total** | **3h 25m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/tui-improvements-bundle-ctrl-c-x.json</summary>

```json
{
  "schema_version": 1,
  "branch": "tui-improvements-bundle-ctrl-c-x",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1407,
  "pr_url": "https://github.com/benkruger/flow/pull/1407",
  "started_at": "2026-05-09T15:17:36-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/tui-improvements-bundle-ctrl-c-x/log",
    "state": ".flow-states/tui-improvements-bundle-ctrl-c-x/state.json"
  },
  "session_tty": "/dev/ttys002",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "#1406",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-09T15:17:36-07:00",
      "completed_at": "2026-05-09T15:18:13-07:00",
      "session_started_at": null,
      "cumulative_seconds": 37,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-09T15:18:13-07:00",
        "five_hour_pct": 46,
        "seven_day_pct": 37
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-09T15:18:22-07:00",
      "completed_at": "2026-05-09T17:39:47-07:00",
      "session_started_at": null,
      "cumulative_seconds": 8485,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T15:18:22-07:00",
        "five_hour_pct": 46,
        "seven_day_pct": 37
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-09T15:22:00-07:00",
          "five_hour_pct": 47,
          "seven_day_pct": 37
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-09T15:26:04-07:00",
          "five_hour_pct": 49,
          "seven_day_pct": 37
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-09T15:42:50-07:00",
          "five_hour_pct": 52,
          "seven_day_pct": 38
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-09T15:42:50-07:00",
          "five_hour_pct": 52,
          "seven_day_pct": 38
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-09T16:03:34-07:00",
          "five_hour_pct": 61,
          "seven_day_pct": 41
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-09T16:03:34-07:00",
          "five_hour_pct": 61,
          "seven_day_pct": 41
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-09T16:18:17-07:00",
          "five_hour_pct": 65,
          "seven_day_pct": 42
        },
        {
          "step": 8,
          "field": "code_task",
          "captured_at": "2026-05-09T16:18:17-07:00",
          "five_hour_pct": 65,
          "seven_day_pct": 42
        },
        {
          "step": 9,
          "field": "code_task",
          "captured_at": "2026-05-09T16:25:38-07:00",
          "five_hour_pct": 67,
          "seven_day_pct": 42
        },
        {
          "step": 10,
          "field": "code_task",
          "captured_at": "2026-05-09T16:25:38-07:00",
          "five_hour_pct": 67,
          "seven_day_pct": 42
        },
        {
          "step": 11,
          "field": "code_task",
          "captured_at": "2026-05-09T16:45:41-07:00",
          "five_hour_pct": 1,
          "seven_day_pct": 43
        },
        {
          "step": 12,
          "field": "code_task",
          "captured_at": "2026-05-09T16:45:41-07:00",
          "five_hour_pct": 1,
          "seven_day_pct": 43
        },
        {
          "step": 13,
          "field": "code_task",
          "captured_at": "2026-05-09T16:52:24-07:00",
          "five_hour_pct": 1,
          "seven_day_pct": 43
        },
        {
          "step": 14,
          "field": "code_task",
          "captured_at": "2026-05-09T16:52:24-07:00",
          "five_hour_pct": 1,
          "seven_day_pct": 43
        },
        {
          "step": 15,
          "field": "code_task",
          "captured_at": "2026-05-09T17:11:23-07:00",
          "five_hour_pct": 3,
          "seven_day_pct": 44
        },
        {
          "step": 16,
          "field": "code_task",
          "captured_at": "2026-05-09T17:11:23-07:00",
          "five_hour_pct": 3,
          "seven_day_pct": 44
        },
        {
          "step": 17,
          "field": "code_task",
          "captured_at": "2026-05-09T17:11:23-07:00",
          "five_hour_pct": 3,
          "seven_day_pct": 44
        },
        {
          "step": 18,
          "field": "code_task",
          "captured_at": "2026-05-09T17:38:17-07:00",
          "five_hour_pct": 6,
          "seven_day_pct": 44
        },
        {
          "step": 19,
          "field": "code_task",
          "captured_at": "2026-05-09T17:38:17-07:00",
          "five_hour_pct": 6,
          "seven_day_pct": 44
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T17:39:47-07:00",
        "five_hour_pct": 7,
        "seven_day_pct": 45
      }
    },
    "flow-code-review": {
      "name": "Code Review",
      "status": "pending",
      "started_at": null,
      "completed_at": null,
      "session_started_at": null,
      "cumulative_seconds": 0,
      "visit_count": 0
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-09T18:29:15-07:00",
      "completed_at": "2026-05-09T18:33:45-07:00",
      "session_started_at": null,
      "cumulative_seconds": 270,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T18:29:15-07:00",
        "five_hour_pct": 28,
        "seven_day_pct": 50
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-09T18:32:43-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 51
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-09T18:32:49-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 51
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-09T18:32:59-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 51
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-09T18:33:00-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 51
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-09T18:33:16-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 51
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-09T18:33:33-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 51
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T18:33:45-07:00",
        "five_hour_pct": 30,
        "seven_day_pct": 51
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-09T18:34:03-07:00",
      "completed_at": "2026-05-09T18:46:50-07:00",
      "session_started_at": null,
      "cumulative_seconds": 767,
      "visit_count": 1,
      "step_snapshots": [
        {
          "step": 2,
          "field": "complete_step",
          "captured_at": "2026-05-09T18:34:22-07:00",
          "five_hour_pct": 30,
          "seven_day_pct": 51
        },
        {
          "step": 2,
          "field": "complete_step",
          "captured_at": "2026-05-09T18:45:05-07:00",
          "five_hour_pct": 31,
          "seven_day_pct": 51
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T18:46:50-07:00",
        "five_hour_pct": 32,
        "seven_day_pct": 51
      }
    },
    "flow-review": {
      "status": "complete",
      "started_at": "2026-05-09T17:40:35-07:00",
      "session_started_at": null,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T17:40:35-07:00",
        "five_hour_pct": 7,
        "seven_day_pct": 45
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_review_step",
          "captured_at": "2026-05-09T17:43:31-07:00",
          "five_hour_pct": 7,
          "seven_day_pct": 45
        },
        {
          "step": 2,
          "field": "code_review_step",
          "captured_at": "2026-05-09T18:03:00-07:00",
          "five_hour_pct": 19,
          "seven_day_pct": 48
        },
        {
          "step": 3,
          "field": "code_review_step",
          "captured_at": "2026-05-09T18:03:39-07:00",
          "five_hour_pct": 19,
          "seven_day_pct": 48
        },
        {
          "step": 4,
          "field": "code_review_step",
          "captured_at": "2026-05-09T18:26:54-07:00",
          "five_hour_pct": 27,
          "seven_day_pct": 50
        }
      ],
      "cumulative_seconds": 2794,
      "completed_at": "2026-05-09T18:27:09-07:00",
      "window_at_complete": {
        "captured_at": "2026-05-09T18:27:09-07:00",
        "five_hour_pct": 27,
        "seven_day_pct": 50
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-09T15:18:22-07:00"
    },
    {
      "from": "flow-code-review",
      "to": "flow-review",
      "timestamp": "2026-05-09T17:40:35-07:00"
    },
    {
      "from": "flow-code",
      "to": "flow-learn",
      "timestamp": "2026-05-09T18:29:15-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-09T18:34:03-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    }
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-09T15:17:36-07:00",
    "five_hour_pct": 44,
    "seven_day_pct": 36
  },
  "code_task_name": "Help overlay (?) + footer collapse",
  "code_task": 19,
  "diff_stats": {
    "files_changed": 4,
    "insertions": 1426,
    "deletions": 29,
    "captured_at": "2026-05-09T17:39:47-07:00"
  },
  "review_steps_total": 4,
  "review_step": 0,
  "code_review_step": 4,
  "compact_summary": "<analysis>\nLet me carefully analyze the entire conversation to capture all critical details.\n\nThe user initiated the conversation with a very specific framing instruction for Learn phase findings in a FLOW development context. They provided:\n\n1. A FRAMING section explaining the two-gate test for findings:\n   - Forward-facing: would future sessions understand and apply the principle?\n   - Value: was the gap caught and remediated in this PR?\n\n2. A DIFF section describing:\n   - Branch: `tui-improvements-bundle-ctrl-c-x`\n   - Worktree location: `/Users/ben/code/flow/.worktrees/tui-improvements-bundle-ctrl-c-x`\n   - Instruction: run `git diff origin/main...HEAD` to retrieve full diff\n   - Diff stats: 4 files changed, 1426 insertions, 29 deletions\n   - Files touched: src/tui.rs (heavy), src/tui_data.rs, tests/tui.rs (heavy), tests/tui_data.rs\n\n3. Branch commits (newest first):\n   - a4efe1b6 Fix Code Review findings — shell injection in iTerm shortcut, filter selection mismatch, q-from-Help, return-discard, doc comment\n   - 8a66ac57 Add `?` help overlay\n   - 59fcf76c Add start-lock holder banner\n   - 446d4841 Add \"updated Ns ago\" indicator\n   - 92141672 Add `/` filter\n   - 168061d2 Add `o` keybinding (iTerm shell)\n   - 1bcd2dac Add detail-pane phase header\n   - 679661b3 Add list-pane row counter\n   - 52ee8d3f Add phase_step_counter helper\n   - 05ac31c4 Add Ctrl-C universal quit\n   - 64aa2224 Start tui-improvements-bundle-ctrl-c-x branch\n\n4. STATE FILE DATA detailing:\n   - Phase visit counts and timings\n   - Code phase: 1 visit, 8485s (~141 min), 19 step snapshots\n   - Code Review: 1 visit, 2794s (~47 min), completed in 4 steps\n   - Notes: empty\n   - Mode: auto/auto throughout\n   - 8 Code Review findings: 3 dismissed, 5 fixed\n\n5. DISMISSED Code Review findings:\n   - Unbounded reads + HOME validation (pre-existing, outside diff scope)\n   - Module doc comment expansion (vague speculation, doc-bureaucracy)\n   - Help overlay text organization (UX nitpick, already grouped)\n\n6. FIXED Code Review findings:\n   - Shell injection via build_iterm_open_worktree_script (added escape_shell_single_quoted helper, two-layer escape)\n   - Filter selection index mismatch (added visible_flows / selected_visible_flow helpers, routed through filtered list)\n   - q does not quit from Help view (short-circuited q in Help branch)\n   - open_worktree_shell return value silently discarded (bound to let _ with comment)\n   - Missing doc comment on render_help_view (added doc comment)\n\n7. Session log notable deviations:\n   - 15:42:42 — Atomic-group split: tasks {4,6,8} split into 3 commits despite being marked atomic (each step independently shippable)\n   - 15:55:47 — Rule drift on base: filing-issues.md, security-gates.md, external-input-path-construction.md, docs-with-behavior.md, CLAUDE.md edited mid-flow on main (decision: defer to Code Review)\n   - 16:57:32 — Plan deviation Tasks 15-17: minimal lock-holder banner only; per-flow lock_state field + row bg coloring deferred\n\n8. PLAN SUMMARY:\n   - 8 TUI features bundled into 19 tasks (TDD pairs + atomic groups)\n   - Features: Ctrl-C universal quit + footer hint, phase_step_counter helper + list/detail consumers (atomic {4,6,8}), iTerm new-tab `o` keybinding, `/` filter, format_age \"updated Ns ago\" indicator, start-lock holder banner (atomic {17}), help overlay + footer collapse\n   - Files touched: src/tui.rs and src/tui_data.rs\n\n9. The user then provided comprehensive system-reminder context including:\n   - CLAUDE.md (project architecture and design philosophy)\n   - Multiple rule files (.claude/rules/*.md) covering:\n     - docs-with-behavior.md (documentation updates required with code changes)\n     - repo-level-only.md (all rules and instructions target project repo)\n     - worktree-commands.md (use `git -C` instead of `cd && git`, etc.)\n     - external-input-path-construction.md (path validation for state-derived strings)\n     - And 60+ additional rules covering various aspects of FLOW development\n\n10. The user's actual explicit request:\n    - \"PRODUCE STRUCTURED FINDINGS in your standard format with the three tenant categories.\"\n    - \"Apply the two-gate test to every candidate finding before reporting it\"\n    - \"Return only findings that pass both gates.\"\n    - \"If all categories produce zero, say so explicitly with 'No findings' markers — do NOT invent findings to fill sections.\"\n    - \"End with the END-OF-FINDINGS marker\"\n\n11. My response approach:\n    - I attempted to read the plan file at `/Users/ben/code/flow/.flow-states/tui-improvements-bundle-ctrl-c-x/plan.md`\n    - I successfully read the complete plan file (216 lines) detailing all 19 tasks across 8 features\n    - I attempted bash commands to change directory and run git diff, but encountered an issue with bash execution\n    - I then attempted to read project files to conduct the Learn phase analysis\n\nThe key issue is that I was attempting to execute the user's request to produce Learn phase findings, which requires:\n1. Understanding the complete scope of work completed\n2. Applying the two-gate test: forward-facing principle + value already captured\n3. Producing structured findings in tenant categories (or \"No findings\" if appropriate)\n\nHowever, I did not complete this task because I ran out of turns or the conversation was redirected by the user's final critical instruction.\n\nThe final user message is critical: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.\"\n\nThis tells me the user wants me to provide a summary of the entire conversation so far using only text, without making any further tool calls.\n</analysis>\n\n<summary>\n\n1. Primary Request and Intent:\n   The user asked me to conduct a Learn phase analysis for a completed FLOW development session. The primary task was to \"PRODUCE STRUCTURED FINDINGS in your standard format with the three tenant categories\" by applying a two-gate test to every candidate finding before reporting. The two gates are: (1) Forward-facing — would a future session understand and apply the principle? (2) Value — was the gap caught and remediated in this PR? The user explicitly stated to return only findings passing both gates, use \"No findings\" markers if all categories produce zero, and NOT invent findings to fill sections. The session involved a TUI improvements bundle branch (`tui-improvements-bundle-ctrl-c-x`) with 8 features bundled into 19 tasks across the Code phase (141 minutes, 19 snapshots) and Code Review phase (47 minutes, 4 steps).\n\n2. Key Technical Concepts:\n   - FLOW lifecycle: 5-phase development workflow (Start, Code, Code Review, Learn, Complete)\n   - TUI improvements: 8 separate features bundled into a single PR\n   - Two-gate test for findings: forward-facing + value-based assessment\n   - Code Review findings triage: Real vs. False positive vs. Dismissed\n   - Plan-commit atomicity: atomic groups marking related tasks that must land together\n   - State files and phase tracking: code_task counter, phase status, visit counts\n   - Rule files: 60+ rules covering development discipline (.claude/rules/*.md)\n   - Test-driven development (TDD) with test/implementation pairs\n   - Security-sensitive features: shell injection escaping, input validation, path safety\n   - Auto/auto mode: autonomous flow execution\n\n3. Files and Code Sections:\n   - `.flow-states/tui-improvements-bundle-ctrl-c-x/plan.md`: Complete implementation plan with 8 TUI features across 19 tasks, including Context, Exploration, Risks, Approach, Dependency Graph, and Tasks section. This file was successfully read and showed the full scope of work.\n   - `src/tui.rs`: Heavy modifications for TUI improvements (primary implementation file)\n   - `src/tui_data.rs`: Data layer modifications for TUI state management\n   - `tests/tui.rs`: Heavy test additions for TUI features\n   - `tests/tui_data.rs`: Test additions for data layer\n   - `.flow-states/tui-improvements-bundle-ctrl-c-x/log`: Session log with phase timings and notable deviations\n   - Project rule files at `.claude/rules/`: including code-review-scope.md, plan-commit-atomicity.md, docs-with-behavior.md, security-gates.md, subprocess-argument-escaping.md, and 50+ others\n\n4. Errors and fixes:\n   - Initial bash command attempts failed due to tool constraints; this was expected given the user's focus on reading state data\n   - The user provided comprehensive system-reminder context (CLAUDE.md and all rule files) to ensure I had necessary reference material for the Learn phase analysis\n   - No errors in file reading; the plan.md file was successfully read and contained complete task specifications\n\n5. Problem Solving:\n   - The primary task was to analyze whether findings from the PR (which had already been through Code Review and fixed) warrant Learn phase documentation or rule updates\n   - The session data showed: 8 Code Review findings identified → 3 dismissed with rationale, 5 fixed in the same PR\n   - Notable deviations were explicitly logged in the session log: atomic-group split decision (16:42:42), rule drift deferral (15:55:47), plan deviation for lock-state implementation (16:57:32)\n   - No ongoing troubleshooting; the PR completion and Code Review were already finalized\n\n6. All user messages:\n   - Initial request with FRAMING instructions for Learn phase findings analysis\n   - Detailed specification of the diff (4 files changed, 1426 insertions, 29 deletions)\n   - Complete state file data showing phase timings and Code Review findings breakdown\n   - Commit history with 11 commits showing progression of the bundle\n   - Explicit instruction to read plan file at `/Users/ben/code/flow/.flow-states/tui-improvements-bundle-ctrl-c-x/plan.md`\n   - Instruction to read CLAUDE.md at `/Users/ben/code/flow/.worktrees/tui-improvements-bundle-ctrl-c-x/CLAUDE.md`\n   - Instruction to read all rule files via Glob at `.claude/rules/*.md`\n   - Final CRITICAL instruction: \"Respond with TEXT ONLY. Do NOT call any tools. Tool calls will be REJECTED and will waste your only turn.\"\n\n7. Pending Tasks:\n   - No explicit pending tasks remain; the user's final critical instruction redirected the session to produce this summary instead of continuing with tool-based analysis\n   - The original Learn phase findings analysis remains conceptually incomplete (was not executed due to the final user instruction)\n\n8. Current Work:\n   The conversation had progressed to the point of attempting to conduct a Learn phase analysis for a completed FLOW development session. The user provided the full context including:\n   - Plan file specification (19 tasks across 8 features)\n   - Code Review findings summary (5 fixed, 3 dismissed)\n   - Session log with explicit decision logging\n   - All necessary rule files as system-reminders\n   \n   The work involved reading the plan file to understand the full scope, understanding the Code Review findings that were already fixed, and then determining whether additional findings should be recorded for Learn phase (following the two-gate test: forward-facing principle + captured in this PR already).\n\n9. Optional Next Step:\n   When the user is ready to continue, the next step should be to apply the two-gate test to determine if any findings from this session warrant Learn phase recording. The user's final instruction \"PRODUCE STRUCTURED FINDINGS in your standard format with the three tenant categories\" indicates that once tool restrictions are lifted (if they are), the analysis should proceed to identify whether:\n   - Any gaps in process discipline emerged (Tenant 1: Architecture & Process)\n   - Any simplifications could have reduced complexity (Tenant 2: Simplicity)  \n   - Any rule clarifications are needed (Tenant 6: Documentation)\n   \n   Based on the session data showing explicit logging of all deviations (atomic-group split, rule drift, plan deviation) and the Code Review process fixing all 5 real findings, the likely conclusion is either \"No findings\" or findings limited to rule clarifications about specific deviations that were already documented in the session log.\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/tui-improvements-bundle-ctrl-c-x",
  "compact_count": 7,
  "findings": [
    {
      "finding": "Unbounded reads + HOME validation in load_account_metrics",
      "reason": "Pre-existing code outside this PR's diff; out of Code Review scope",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:03:22-07:00"
    },
    {
      "finding": "Module doc comment may need expansion",
      "reason": "Vague speculation with no specific drift identified; doc-bureaucracy per code-review-scope.md value test",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:03:28-07:00"
    },
    {
      "finding": "Help overlay text organization",
      "reason": "UX nitpick; help text is already grouped by context (List/Filter/Tabs/Other/Global)",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:03:34-07:00"
    },
    {
      "finding": "Shell injection via build_iterm_open_worktree_script (dollar-paren and backticks)",
      "reason": "Fixed by adding escape_shell_single_quoted helper that wraps the path in shell single-quotes before AppleScript escape so shell metacharacters become literal",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:24:59-07:00"
    },
    {
      "finding": "Filter selection index mismatch — actions targeted hidden flow under active filter",
      "reason": "Fixed by adding visible_flows and selected_visible_flow helpers; every action handler and the detail-pane renderer now route through the filtered list, and Down clamps against visible length",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:25:06-07:00"
    },
    {
      "finding": "q does not quit from Help view",
      "reason": "Fixed by short-circuiting q in the Help branch of handle_key before the previous-view restore",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:25:13-07:00"
    },
    {
      "finding": "open_worktree_shell return value silently discarded",
      "reason": "Fixed at the o keybinding call site by binding to let _ with a comment explaining the deliberate discard",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:25:19-07:00"
    },
    {
      "finding": "Missing doc comment on render_help_view",
      "reason": "Fixed by adding a doc comment summarising the help overlay's purpose, grouping, and exit semantics",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:25:27-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "_continue_pending": "commit",
  "window_at_complete": {
    "captured_at": "2026-05-09T18:46:50-07:00",
    "five_hour_pct": 32,
    "seven_day_pct": 51
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>