### PR TITLE
Capture Cost Data Per Flow

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,6 +6,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/flow hook capture-session",
+            "async": false
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
             "async": false
           }

--- a/skills/flow-complete/SKILL.md
+++ b/skills/flow-complete/SKILL.md
@@ -647,10 +647,29 @@ Complete:, Total:), Code Review Findings and Learn Findings sections
 section (per-phase token totals + cost in USD, plus a Total row; an
 optional By Model breakdown when 2+ models contributed; an optional
 "↻" marker and footer note when a rate-limit window reset was
-observed mid-flow — the section is omitted entirely when no phase
-carries window snapshot data), and artifact counts (issues filed
-count, notes captured count). Do not add a separate PR line — it
-is part of the summary.
+observed mid-flow — the section renders one row per non-pending
+phase and is omitted entirely only when every phase is still
+"pending"), and artifact counts (issues filed count, notes
+captured count). Do not add a separate PR line — it is part of
+the summary.
+
+The Token Cost section uses these conditional output markers when
+snapshot data is incomplete:
+
+- **`—` (em-dash)** in the cost column means the per-phase or
+  Total cost is unknown for the row. A phase shows `—` when its
+  start or end snapshot lacks `session_cost_usd`; the Total row
+  shows `—` when no phase contributed a complete cost pair.
+- **`*` (asterisk suffix)** on a cost value (e.g. `$0.450*`) marks
+  the row as partial: the phase ran but the snapshot data was not
+  fully recoverable, so the displayed value is the best-effort
+  computation from available endpoints. The Total cost is
+  suffixed with `*` when any phase contributed `None` cost into
+  the aggregate.
+- **`* cost partial — some phases had no cost data`** appears as
+  a footnote line below the Total when the Total carries the `*`
+  marker, naming the cause so the reader does not have to
+  reconstruct it from per-phase rows.
 
 If the `complete-finalize` JSON output has a non-empty
 `issues_links` field, render it as regular text (not inside a code

--- a/src/commands/init_state.rs
+++ b/src/commands/init_state.rs
@@ -7,7 +7,9 @@ use serde_json::{json, Value};
 use crate::commands::log::append_log;
 use crate::flow_paths::FlowPaths;
 use crate::git::{current_branch_in, project_root};
+use crate::hooks::capture_session::read_captured_session;
 use crate::label_issues::LABEL;
+use crate::lock::mutate_state;
 use crate::output::{json_error, json_ok};
 use crate::phase_config::{auto_skills, build_initial_phases, freeze_phases, read_flow_json};
 use crate::state::SkillConfig;
@@ -15,6 +17,48 @@ use crate::utils::{
     branch_name, check_duplicate_issue, detect_tty, extract_issue_numbers, fetch_issue_info, now,
     plugin_root, read_prompt_file,
 };
+use crate::window_snapshot::home_dir_or_empty;
+
+/// Read the SessionStart capture file under `$HOME/.claude/` and seed
+/// the freshly-created state file's `session_id` and `transcript_path`
+/// fields. Fail-open: a missing/malformed capture file leaves the
+/// state's session_id Null, matching the pre-fix degradation path.
+///
+/// Two upstream invariants justify the `.expect()` calls inside:
+///
+/// 1. `branch` was just successfully validated by `create_state`'s own
+///    `FlowPaths::try_new` call. Re-validating here would duplicate
+///    the check; per `.claude/rules/external-input-validation.md`
+///    "Callers that hold a branch already validated upstream chain
+///    `.expect`", the second call is documentation, not a panic
+///    vector.
+/// 2. The state file at `state_path` was just written by `create_state`
+///    as a `serde_json::Map` wrapped in `Value::Object`. The closure's
+///    `.as_object_mut().expect(...)` documents the same postcondition
+///    per `.claude/rules/testability-means-simplicity.md` "When the
+///    test resists the real production path", and prevents the
+///    `Value::IndexMut` panic the `.claude/rules/rust-patterns.md`
+///    "State Mutation Object Guards" rule targets — `Map::insert` on
+///    the unwrapped object cannot trigger that panic.
+fn seed_session_id_from_capture(project_root: &Path, branch: &str) {
+    let home = home_dir_or_empty();
+    let (session_id, transcript_path) = match read_captured_session(&home) {
+        Some(c) => c,
+        None => return,
+    };
+    let state_path = FlowPaths::try_new(project_root, branch)
+        .expect("branch validated upstream by create_state's FlowPaths::try_new")
+        .state_file();
+    let _ = mutate_state(&state_path, &mut |state| {
+        let obj = state
+            .as_object_mut()
+            .expect("create_state just wrote a JSON object to state_path");
+        obj.insert("session_id".into(), json!(session_id));
+        if let Some(tp) = transcript_path.as_ref() {
+            obj.insert("transcript_path".into(), json!(tp));
+        }
+    });
+}
 
 /// Create the initial FLOW state file with null PR fields.
 ///
@@ -276,6 +320,15 @@ pub fn run(
         json_error(&e, &[("step", json!("create_state"))]);
         std::process::exit(1);
     }
+
+    // Seed session_id and transcript_path from the SessionStart hook's
+    // capture file before downstream window snapshots run. Per
+    // `.claude/rules/external-input-path-construction.md`, both fields
+    // are validated by `read_captured_session` against the same
+    // is_safe_* predicates the existing `capture_for_active_state`
+    // path uses, so a malformed capture file leaves session_id Null
+    // (graceful degradation matching the pre-fix behavior).
+    seed_session_id_from_capture(&root, &branch);
 
     let _ = append_log(
         &root,

--- a/src/format_complete_summary.rs
+++ b/src/format_complete_summary.rs
@@ -61,60 +61,107 @@ fn outcome_label(outcome: &str) -> &'static str {
 }
 
 /// Render the Token Cost section from `state.phases.<phase>.window_at_*`
-/// snapshots via `window_deltas::phase_delta`. Returns an empty Vec
-/// when no phase has populated snapshots — the renderer skips the
-/// section entirely rather than rendering a header with no rows.
+/// snapshots via `window_deltas::phase_delta`.
+///
+/// Per-phase rendering rules (issue #1410):
+///
+/// - Each phase whose `status` is not `"pending"` produces a row,
+///   even when its delta is unknown — silent skip on parse error or
+///   missing `window_at_enter` was the chief cause of the
+///   never-rendered Token Cost section. Unknown cost is shown as
+///   `—`; the row is marked `*` when the phase contributed without
+///   a complete cost-pair.
+/// - The section header is omitted only when every phase is
+///   `"pending"`. Any non-pending phase forces the header so users
+///   see whatever data is available.
+/// - The total line uses the same Some/None formatting as per-phase
+///   rows; an `*` suffix marks the total as approximate when any
+///   phase contributed `None` cost.
 fn token_cost_section(state: &Value) -> Vec<String> {
     let names = phase_config::phase_names();
 
-    let mut phase_rows: Vec<(String, i64, f64, bool)> = Vec::new();
+    let phases_obj = state
+        .get("phases")
+        .and_then(|p| p.as_object())
+        .cloned()
+        .unwrap_or_default();
+    if phases_obj.is_empty() {
+        return Vec::new();
+    }
+
+    // Per-phase row tuple: (display_name, tokens, cost, reset, partial).
+    let mut phase_rows: Vec<(String, i64, Option<f64>, bool, bool)> = Vec::new();
     let mut total_tokens: i64 = 0;
-    let mut total_cost: f64 = 0.0;
+    let mut total_cost: Option<f64> = None;
+    let mut total_partial = false;
     let mut combined_by_model: IndexMap<String, ModelTokens> = IndexMap::new();
     let mut reset_observed_anywhere = false;
 
     for &key in PHASE_ORDER {
-        let Some(phase_v) = state.get("phases").and_then(|p| p.get(key)) else {
+        let Some(phase_v) = phases_obj.get(key) else {
             continue;
         };
-        let Ok(phase_state) = serde_json::from_value::<PhaseState>(phase_v.clone()) else {
-            continue;
-        };
-        let Some(report) = phase_delta(&phase_state) else {
-            continue;
-        };
-        let tokens = report
-            .input_tokens_delta
-            .saturating_add(report.output_tokens_delta)
-            .saturating_add(report.cache_creation_tokens_delta)
-            .saturating_add(report.cache_read_tokens_delta);
-        // Skip phases that contributed nothing — the section is for
-        // surface-able token activity, not a per-phase placeholder.
-        if tokens == 0 && report.cost_delta_usd.abs() < f64::EPSILON {
+        let status = phase_v
+            .get("status")
+            .and_then(|s| s.as_str())
+            .unwrap_or("pending");
+        if status == "pending" {
+            // Phase never started — render no row to keep noise bounded.
             continue;
         }
+        // `phase_config::phase_names()` is keyed by PHASE_ORDER, so
+        // every PHASE_ORDER key is present. The `.expect` documents
+        // the upstream invariant per
+        // `.claude/rules/testability-means-simplicity.md`.
         let name = names
             .get(key)
             .cloned()
             .expect("phase_config::phase_names is keyed by PHASE_ORDER");
-        phase_rows.push((
-            name,
-            tokens,
-            report.cost_delta_usd,
-            report.window_reset_observed,
-        ));
+
+        // PhaseState parse error and "phase has no enter snapshot"
+        // both produce a placeholder row instead of a silent skip.
+        // The placeholder records the phase ran but cost/tokens were
+        // not recoverable from snapshots.
+        let report = serde_json::from_value::<PhaseState>(phase_v.clone())
+            .ok()
+            .and_then(|ps| phase_delta(&ps));
+
+        let (tokens, cost, reset, row_partial) = match report {
+            Some(r) => {
+                let tokens = r
+                    .input_tokens_delta
+                    .saturating_add(r.output_tokens_delta)
+                    .saturating_add(r.cache_creation_tokens_delta)
+                    .saturating_add(r.cache_read_tokens_delta);
+                if r.window_reset_observed {
+                    reset_observed_anywhere = true;
+                }
+                for (model, mt) in &r.by_model_delta {
+                    let entry = combined_by_model.entry(model.clone()).or_default();
+                    entry.input = entry.input.saturating_add(mt.input);
+                    entry.output = entry.output.saturating_add(mt.output);
+                    entry.cache_create = entry.cache_create.saturating_add(mt.cache_create);
+                    entry.cache_read = entry.cache_read.saturating_add(mt.cache_read);
+                }
+                (
+                    tokens,
+                    r.cost_delta_usd,
+                    r.window_reset_observed,
+                    r.total_partial,
+                )
+            }
+            None => (0, None, false, true),
+        };
+
         total_tokens = total_tokens.saturating_add(tokens);
-        total_cost += report.cost_delta_usd;
-        if report.window_reset_observed {
-            reset_observed_anywhere = true;
+        match cost {
+            Some(c) => total_cost = Some(total_cost.unwrap_or(0.0) + c),
+            None => total_partial = true,
         }
-        for (model, mt) in &report.by_model_delta {
-            let entry = combined_by_model.entry(model.clone()).or_default();
-            entry.input = entry.input.saturating_add(mt.input);
-            entry.output = entry.output.saturating_add(mt.output);
-            entry.cache_create = entry.cache_create.saturating_add(mt.cache_create);
-            entry.cache_read = entry.cache_read.saturating_add(mt.cache_read);
+        if row_partial {
+            total_partial = true;
         }
+        phase_rows.push((name, tokens, cost, reset, row_partial));
     }
 
     if phase_rows.is_empty() {
@@ -124,22 +171,32 @@ fn token_cost_section(state: &Value) -> Vec<String> {
     let mut lines = Vec::new();
     lines.push("  Token Cost".to_string());
     lines.push(format!("  {}", "─".repeat(28)));
-    for (name, tokens, cost, reset) in &phase_rows {
-        let marker = if *reset { " ↻" } else { "" };
+    for (name, tokens, cost, reset, partial) in &phase_rows {
+        let reset_marker = if *reset { " ↻" } else { "" };
+        let partial_marker = if *partial { "*" } else { "" };
+        let cost_str = match cost {
+            Some(c) => format!("${:.3}{}", c, partial_marker),
+            None => "—".to_string(),
+        };
         lines.push(format!(
-            "  {:<16} {:>8}  ${:.3}{}",
+            "  {:<16} {:>8}  {}{}",
             format!("{}:", name),
             format_tokens(*tokens),
-            cost,
-            marker
+            cost_str,
+            reset_marker
         ));
     }
     lines.push(format!("  {}", "─".repeat(28)));
+    let total_partial_marker = if total_partial { "*" } else { "" };
+    let total_cost_str = match total_cost {
+        Some(c) => format!("${:.3}{}", c, total_partial_marker),
+        None => "—".to_string(),
+    };
     lines.push(format!(
-        "  {:<16} {:>8}  ${:.3}",
+        "  {:<16} {:>8}  {}",
         "Total:",
         format_tokens(total_tokens),
-        total_cost
+        total_cost_str
     ));
     if combined_by_model.len() >= 2 {
         lines.push(String::new());
@@ -160,6 +217,10 @@ fn token_cost_section(state: &Value) -> Vec<String> {
     if reset_observed_anywhere {
         lines.push(String::new());
         lines.push("  ↻ rate-limit window reset observed mid-flow".to_string());
+    }
+    if total_partial {
+        lines.push(String::new());
+        lines.push("  * cost partial — some phases had no cost data".to_string());
     }
     lines.push(String::new());
     lines

--- a/src/format_status.rs
+++ b/src/format_status.rs
@@ -29,7 +29,12 @@ fn tokens_line(state: &Value) -> Option<String> {
         .saturating_add(report.output_tokens_delta)
         .saturating_add(report.cache_creation_tokens_delta)
         .saturating_add(report.cache_read_tokens_delta);
-    if total == 0 && report.cost_delta_usd.abs() < f64::EPSILON && !report.window_reset_observed {
+    // Cost is now `Option<f64>` (issue #1410). Treat `None` (no
+    // cost data) and `Some(0.0)` as the same "no surfacable cost"
+    // for the omission gate; the rendering branch below
+    // distinguishes them.
+    let cost_is_negligible = report.cost_delta_usd.is_none_or(|c| c.abs() < f64::EPSILON);
+    if total == 0 && cost_is_negligible && !report.window_reset_observed {
         return None;
     }
     let marker = if report.window_reset_observed {
@@ -37,10 +42,14 @@ fn tokens_line(state: &Value) -> Option<String> {
     } else {
         ""
     };
+    let cost_str = match report.cost_delta_usd {
+        Some(c) => format!("${:.3}", c),
+        None => "—".to_string(),
+    };
     Some(format!(
-        "  Tokens  : {}  (${:.3}){}",
+        "  Tokens  : {}  ({}){}",
         format_tokens(total),
-        report.cost_delta_usd,
+        cost_str,
         marker
     ))
 }

--- a/src/hooks/capture_session.rs
+++ b/src/hooks/capture_session.rs
@@ -23,6 +23,24 @@ use serde_json::{json, Value};
 
 use crate::window_snapshot::{home_dir_or_empty, is_safe_session_id, is_safe_transcript_path};
 
+/// Capture-file payload byte cap per
+/// `.claude/rules/external-input-path-construction.md` "Enforce a
+/// documented size cap on every external read". The capture file
+/// holds two short JSON string fields (`session_id` ≤ 256 bytes
+/// per `is_safe_session_id`, `transcript_path` typically a few
+/// hundred bytes); 64 KB bounds a corrupted, hand-edited, or
+/// adversarially-grown file to a value the SessionStart hook can
+/// process without unbounded heap allocation, matching the byte-cap
+/// pattern in `src/window_snapshot.rs::TRANSCRIPT_BYTE_CAP`.
+const CAPTURE_FILE_BYTE_CAP: u64 = 64 * 1024;
+
+/// Stdin payload byte cap for the SessionStart hook. Claude Code
+/// passes a small JSON object on stdin; 64 KB is generous and
+/// bounds a runaway producer or hostile injection at the input
+/// boundary so a multi-megabyte stdin cannot reach the validator
+/// or be re-serialized into the capture file.
+const STDIN_BYTE_CAP: u64 = 64 * 1024;
+
 /// Canonical capture-file path under `<home>/.claude/`. Co-located with
 /// `rate-limits.json` and `projects/` so all FLOW HOME-dependent state
 /// shares the same directory tree.
@@ -35,7 +53,8 @@ pub(crate) fn capture_file_path(home: &Path) -> PathBuf {
 /// Returns `Some((session_id, transcript_path))` when:
 /// 1. `home` is absolute (rejects empty / relative env-var values per
 ///    `.claude/rules/external-input-path-construction.md`).
-/// 2. The capture file exists and parses as JSON.
+/// 2. The capture file exists, fits within [`CAPTURE_FILE_BYTE_CAP`],
+///    and parses as JSON.
 /// 3. `session_id` matches [`is_safe_session_id`].
 /// 4. `transcript_path` is either absent OR matches
 ///    [`is_safe_transcript_path`] against `home`.
@@ -48,7 +67,11 @@ pub(crate) fn read_captured_session(home: &Path) -> Option<(String, Option<Strin
         return None;
     }
     let path = capture_file_path(home);
-    let content = fs::read_to_string(&path).ok()?;
+    let file = fs::File::open(&path).ok()?;
+    let mut content = String::new();
+    file.take(CAPTURE_FILE_BYTE_CAP)
+        .read_to_string(&mut content)
+        .ok()?;
     let parsed: Value = serde_json::from_str(&content).ok()?;
     let session_id = parsed
         .get("session_id")
@@ -68,7 +91,9 @@ pub(crate) fn read_captured_session(home: &Path) -> Option<(String, Option<Strin
 /// the hook must never block the SessionStart event.
 pub fn run() {
     let mut buf = String::new();
-    let _ = std::io::stdin().read_to_string(&mut buf);
+    let _ = std::io::stdin()
+        .take(STDIN_BYTE_CAP)
+        .read_to_string(&mut buf);
     let input: Value = serde_json::from_str(&buf).unwrap_or(Value::Null);
     let session_id = match input.get("session_id").and_then(|v| v.as_str()) {
         Some(s) if is_safe_session_id(s) => s.to_string(),
@@ -98,5 +123,18 @@ pub fn run() {
         .parent()
         .expect("capture_file_path always returns <home>/.claude/<basename>");
     let _ = fs::create_dir_all(parent);
+    // Symlink-safe write per `.claude/rules/rust-patterns.md`
+    // "Symlink-Safe Existence Checks Before Writes". A pre-existing
+    // symlink at `path` would cause `fs::write` to follow the link
+    // and overwrite its target — an arbitrary-write primitive
+    // exploitable on shared `~/.claude/` directories. Detecting any
+    // existing entry via `fs::symlink_metadata` (which does NOT
+    // follow symlinks) and removing it first ensures `fs::write`
+    // always creates a fresh regular file.
+    if let Ok(meta) = fs::symlink_metadata(&path) {
+        if meta.file_type().is_symlink() {
+            let _ = fs::remove_file(&path);
+        }
+    }
     let _ = fs::write(&path, payload.to_string());
 }

--- a/src/hooks/capture_session.rs
+++ b/src/hooks/capture_session.rs
@@ -1,0 +1,102 @@
+//! SessionStart hook: persist `session_id` and `transcript_path` so
+//! flow-start can seed them into the new flow's state file.
+//!
+//! Claude Code delivers `session_id` and `transcript_path` to hooks via
+//! stdin JSON, but does not expose either as an environment variable
+//! visible to Bash-tool subprocesses. Without this capture, the
+//! `session_id` field of a freshly-created state file stays Null and
+//! the per-session cost-file lookup at `<project_root>/.claude/cost/
+//! <YYYY-MM>/<session_id>.txt` cannot resolve, leaving the Token Cost
+//! section's start anchor empty (issue #1410).
+//!
+//! The hook fires on every Claude Code SessionStart and overwrites the
+//! capture file unconditionally. Multi-session machines accept
+//! last-writer-wins: a wrong session_id at flow-start would cause the
+//! cost lookup to fail gracefully (no cost file matches), which is no
+//! worse than the pre-fix state where session_id was always Null.
+
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use crate::window_snapshot::{home_dir_or_empty, is_safe_session_id, is_safe_transcript_path};
+
+/// Canonical capture-file path under `<home>/.claude/`. Co-located with
+/// `rate-limits.json` and `projects/` so all FLOW HOME-dependent state
+/// shares the same directory tree.
+pub(crate) fn capture_file_path(home: &Path) -> PathBuf {
+    home.join(".claude").join("flow-current-session.json")
+}
+
+/// Read and validate the capture file written by [`run`].
+///
+/// Returns `Some((session_id, transcript_path))` when:
+/// 1. `home` is absolute (rejects empty / relative env-var values per
+///    `.claude/rules/external-input-path-construction.md`).
+/// 2. The capture file exists and parses as JSON.
+/// 3. `session_id` matches [`is_safe_session_id`].
+/// 4. `transcript_path` is either absent OR matches
+///    [`is_safe_transcript_path`] against `home`.
+///
+/// Returns `None` on any failure path — fail-open semantics so a
+/// malformed or missing capture file leaves the caller's state
+/// untouched.
+pub(crate) fn read_captured_session(home: &Path) -> Option<(String, Option<String>)> {
+    if home.as_os_str().is_empty() || !home.is_absolute() {
+        return None;
+    }
+    let path = capture_file_path(home);
+    let content = fs::read_to_string(&path).ok()?;
+    let parsed: Value = serde_json::from_str(&content).ok()?;
+    let session_id = parsed
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| is_safe_session_id(s))
+        .map(|s| s.to_string())?;
+    let transcript_path = parsed
+        .get("transcript_path")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .filter(|tp| is_safe_transcript_path(Path::new(tp), home));
+    Some((session_id, transcript_path))
+}
+
+/// SessionStart hook entry point. Reads stdin JSON, validates the
+/// payload, writes the capture file. Errors are silently swallowed —
+/// the hook must never block the SessionStart event.
+pub fn run() {
+    let mut buf = String::new();
+    let _ = std::io::stdin().read_to_string(&mut buf);
+    let input: Value = serde_json::from_str(&buf).unwrap_or(Value::Null);
+    let session_id = match input.get("session_id").and_then(|v| v.as_str()) {
+        Some(s) if is_safe_session_id(s) => s.to_string(),
+        _ => return,
+    };
+    let home = home_dir_or_empty();
+    if home.as_os_str().is_empty() || !home.is_absolute() {
+        return;
+    }
+    let transcript_path = input
+        .get("transcript_path")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)
+        .filter(|p| is_safe_transcript_path(p, &home))
+        .map(|p| p.to_string_lossy().to_string());
+    let payload = json!({
+        "session_id": session_id,
+        "transcript_path": transcript_path,
+    });
+    let path = capture_file_path(&home);
+    // `capture_file_path` always returns `<home>/.claude/<basename>`,
+    // so `parent()` is always `Some(<home>/.claude)`. The `.expect`
+    // documents the upstream invariant per
+    // `.claude/rules/testability-means-simplicity.md` "When the test
+    // resists the real production path".
+    let parent = path
+        .parent()
+        .expect("capture_file_path always returns <home>/.claude/<basename>");
+    let _ = fs::create_dir_all(parent);
+    let _ = fs::write(&path, payload.to_string());
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -169,6 +169,7 @@ pub fn read_hook_input() -> Option<Value> {
     serde_json::from_str(&input).ok()
 }
 
+pub mod capture_session;
 pub mod post_compact;
 pub mod stop_continue;
 pub mod stop_failure;

--- a/src/main.rs
+++ b/src/main.rs
@@ -452,6 +452,10 @@ enum HookCommands {
     /// PostCompact hook: capture compaction summary into state file.
     #[command(name = "post-compact")]
     PostCompact,
+    /// SessionStart hook: persist session_id + transcript_path so
+    /// flow-start can seed them into the new flow's state file.
+    #[command(name = "capture-session")]
+    CaptureSession,
 }
 
 fn main() {
@@ -856,6 +860,7 @@ fn main() {
             HookCommands::StopContinue => hooks::stop_continue::run(),
             HookCommands::StopFailure => hooks::stop_failure::run(),
             HookCommands::PostCompact => hooks::post_compact::run(),
+            HookCommands::CaptureSession => hooks::capture_session::run(),
         },
         Some(Commands::External(_)) => {
             process::exit(127);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -855,7 +855,9 @@ impl TuiApp {
             let active_rows: Vec<&tui_data::PhaseTokenRow> = token_rows
                 .iter()
                 .filter(|r| {
-                    r.tokens > 0 || r.cost_usd.abs() > f64::EPSILON || r.window_reset_observed
+                    r.tokens > 0
+                        || r.cost_usd.is_some_and(|c| c.abs() > f64::EPSILON)
+                        || r.window_reset_observed
                 })
                 .collect();
             if !active_rows.is_empty() {
@@ -877,11 +879,15 @@ impl TuiApp {
                     } else {
                         ""
                     };
+                    let cost_str = match r.cost_usd {
+                        Some(c) => format!("${:.3}", c),
+                        None => "—".to_string(),
+                    };
                     let line_text = format!(
-                        "    {}: {}  ${:.3}{}",
+                        "    {}: {}  {}{}",
                         r.phase_name,
                         format_tokens(r.tokens),
-                        r.cost_usd,
+                        cost_str,
                         marker
                     );
                     let line = Paragraph::new(Line::from(line_text));

--- a/src/tui_data.rs
+++ b/src/tui_data.rs
@@ -314,7 +314,11 @@ pub struct PhaseTokenRow {
     pub phase_number: usize,
     pub status: String,
     pub tokens: i64,
-    pub cost_usd: f64,
+    /// `None` when the phase has no `(Some, Some)` cost pair (issue
+    /// #1410). The TUI renders `None` as the em-dash placeholder and
+    /// excludes None-cost rows from the cost-based "active" filter
+    /// below.
+    pub cost_usd: Option<f64>,
     pub window_reset_observed: bool,
     pub in_progress: bool,
 }
@@ -370,7 +374,7 @@ pub fn phase_token_table(state: &Value) -> Vec<PhaseTokenRow> {
                     .saturating_add(report.cache_read_tokens_delta);
                 (total, report.cost_delta_usd, report.window_reset_observed)
             })
-            .unwrap_or((0, 0.0, false));
+            .unwrap_or((0, None, false));
 
         rows.push(PhaseTokenRow {
             phase_key: key.to_string(),

--- a/src/window_deltas.rs
+++ b/src/window_deltas.rs
@@ -37,15 +37,13 @@ use crate::state::{FlowState, ModelTokens, PhaseState, WindowSnapshot};
 /// displaying the latest absolute pct instead.
 ///
 /// `cost_delta_usd: Option<f64>` — `None` means cost is unknown
-/// for this report (no Some-Some pair contributed). Aggregation
-/// in [`DeltaReport::add`] sums Some contributions and sets
+/// for this report (no Some-Some pair contributed). A delta is
+/// produced only when both endpoints carry a populated cost;
+/// any missing endpoint leaves cost as `None` so renderers can
+/// display `—` instead of inventing a number. Aggregation in
+/// [`DeltaReport::add`] sums Some contributions and sets
 /// `total_partial = true` when any folded contribution was
-/// `None`. Renderers display `Some(c)` as `${c:.3}` and `None`
-/// as `—` (issue #1410). The asymmetric pre-fix arms (Some,
-/// None → end_value; None, Some → end_value) silently
-/// fabricated deltas from cumulative session totals; the new
-/// (Some, Some) → Some(diff), else → None semantics make the
-/// missing-data condition explicit.
+/// `None`, signalling renderers to mark the total as approximate.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeltaReport {
     pub input_tokens_delta: i64,
@@ -200,10 +198,14 @@ pub fn by_model_rollup(state: &FlowState) -> IndexMap<String, ModelTokens> {
 /// report — a single snapshot has no anchor pair to subtract.
 ///
 /// Each snapshot whose `session_id` is `None` is given a synthetic
-/// per-index key (`__none_<i>`), so two consecutive None snapshots
-/// are treated as distinct sessions rather than collapsed into one
-/// empty-string session that would fabricate a cross-snapshot
-/// delta from cumulative session totals (issue #1410).
+/// per-index key prefixed with NUL (`\0__none_<i>`), so two
+/// consecutive None snapshots are treated as distinct sessions
+/// rather than collapsed into one empty-string session that would
+/// fabricate a cross-snapshot delta from cumulative session totals
+/// (issue #1410). The NUL prefix makes the synthetic-key namespace
+/// disjoint from any real `session_id` — `is_safe_session_id`
+/// rejects NUL so a captured id can never collide with a synthetic
+/// key of the same shape.
 fn deltas_from_snapshots(snapshots: &[&WindowSnapshot]) -> DeltaReport {
     let mut total = DeltaReport::zero();
     if snapshots.len() < 2 {
@@ -212,7 +214,7 @@ fn deltas_from_snapshots(snapshots: &[&WindowSnapshot]) -> DeltaReport {
     let key_for = |i: usize, snap: &WindowSnapshot| -> String {
         snap.session_id
             .clone()
-            .unwrap_or_else(|| format!("__none_{}", i))
+            .unwrap_or_else(|| format!("\0__none_{}", i))
     };
     // Walk consecutive snapshots looking for session boundaries.
     // Within each session: subtract the first session-snapshot from
@@ -258,12 +260,9 @@ fn pair_delta(start: &WindowSnapshot, end: &WindowSnapshot) -> DeltaReport {
         start.session_cache_read_tokens,
     );
     // Cost is reported only when BOTH endpoints carry a populated
-    // value. Previous arms fabricated deltas: (Some, None) returned
-    // the end's cumulative value as if it were a delta; (None, Some)
-    // dropped the start. Both shapes silently miscounted (issue
-    // #1410). Now: only `(Some, Some)` produces `Some(end - start)`;
-    // every other shape produces `None` so renderers can mark the
-    // missing data with `—` instead of inventing a number.
+    // value. Any missing endpoint produces `None` so renderers can
+    // mark the partial-data span with `—` instead of inventing a
+    // number from a cumulative session total.
     let cost_delta_usd = match (start.session_cost_usd, end.session_cost_usd) {
         (Some(s), Some(e)) => Some(e - s),
         _ => None,

--- a/src/window_deltas.rs
+++ b/src/window_deltas.rs
@@ -29,22 +29,34 @@ use crate::state::{FlowState, ModelTokens, PhaseState, WindowSnapshot};
 /// Per-phase delta computed from a phase's enter / step / complete
 /// snapshots.
 ///
-/// Token, cost, turn, and tool counters are simple non-negative
-/// deltas (cross-session sum). Rate-limit pct deltas are
-/// `Option<i64>` because a window reset (curr < prev) makes the
-/// pct delta meaningless for that span — `window_reset_observed`
-/// records whether any span observed a reset so a reader can
-/// switch to displaying the latest absolute pct instead.
+/// Token, turn, and tool counters are simple non-negative deltas
+/// (cross-session sum). Rate-limit pct deltas are `Option<i64>`
+/// because a window reset (curr < prev) makes the pct delta
+/// meaningless for that span — `window_reset_observed` records
+/// whether any span observed a reset so a reader can switch to
+/// displaying the latest absolute pct instead.
+///
+/// `cost_delta_usd: Option<f64>` — `None` means cost is unknown
+/// for this report (no Some-Some pair contributed). Aggregation
+/// in [`DeltaReport::add`] sums Some contributions and sets
+/// `total_partial = true` when any folded contribution was
+/// `None`. Renderers display `Some(c)` as `${c:.3}` and `None`
+/// as `—` (issue #1410). The asymmetric pre-fix arms (Some,
+/// None → end_value; None, Some → end_value) silently
+/// fabricated deltas from cumulative session totals; the new
+/// (Some, Some) → Some(diff), else → None semantics make the
+/// missing-data condition explicit.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeltaReport {
     pub input_tokens_delta: i64,
     pub output_tokens_delta: i64,
     pub cache_creation_tokens_delta: i64,
     pub cache_read_tokens_delta: i64,
-    pub cost_delta_usd: f64,
+    pub cost_delta_usd: Option<f64>,
     pub five_hour_pct_delta: Option<i64>,
     pub seven_day_pct_delta: Option<i64>,
     pub window_reset_observed: bool,
+    pub total_partial: bool,
     pub turn_count_delta: i64,
     pub tool_call_count_delta: i64,
     pub by_model_delta: IndexMap<String, ModelTokens>,
@@ -52,26 +64,34 @@ pub struct DeltaReport {
 
 impl DeltaReport {
     /// All-zero / `None` report — a defined "no contribution" value
-    /// that callers can fold into running totals.
+    /// that callers can fold into running totals. `cost_delta_usd`
+    /// starts as `None` so [`DeltaReport::add`] can distinguish
+    /// "no Some seen yet" from "Some(0.0) seen".
     fn zero() -> Self {
         Self {
             input_tokens_delta: 0,
             output_tokens_delta: 0,
             cache_creation_tokens_delta: 0,
             cache_read_tokens_delta: 0,
-            cost_delta_usd: 0.0,
+            cost_delta_usd: None,
             five_hour_pct_delta: Some(0),
             seven_day_pct_delta: Some(0),
             window_reset_observed: false,
+            total_partial: false,
             turn_count_delta: 0,
             tool_call_count_delta: 0,
             by_model_delta: IndexMap::new(),
         }
     }
 
-    /// Fold `other` into `self` element-wise. Token / cost / turn
-    /// counters add. Pct deltas Option-add — `None` is sticky so a
-    /// reset in any folded report propagates to the total.
+    /// Fold `other` into `self` element-wise. Token / turn / tool
+    /// counters add. Cost folds with Option semantics: a `Some`
+    /// contribution adds into the running total (initializing it
+    /// from `None` to `Some(x)` on the first `Some`); a `None`
+    /// contribution leaves the total unchanged but flips
+    /// `total_partial = true` so renderers can mark the total as
+    /// approximate. Pct deltas Option-add — `None` is sticky so a
+    /// reset in any folded report propagates.
     fn add(&mut self, other: &Self) {
         self.input_tokens_delta = self
             .input_tokens_delta
@@ -85,7 +105,18 @@ impl DeltaReport {
         self.cache_read_tokens_delta = self
             .cache_read_tokens_delta
             .saturating_add(other.cache_read_tokens_delta);
-        self.cost_delta_usd += other.cost_delta_usd;
+        match other.cost_delta_usd {
+            Some(x) => {
+                self.cost_delta_usd = Some(self.cost_delta_usd.unwrap_or(0.0) + x);
+            }
+            None => {
+                self.total_partial = true;
+            }
+        }
+        // No `other.total_partial` propagation: production callers
+        // only fold pair_delta outputs (which always set
+        // `total_partial: false`); folding an aggregated report into
+        // another would be a future change with its own tests.
         self.five_hour_pct_delta = match (self.five_hour_pct_delta, other.five_hour_pct_delta) {
             (Some(a), Some(b)) => Some(a.saturating_add(b)),
             _ => None,
@@ -215,10 +246,16 @@ fn pair_delta(start: &WindowSnapshot, end: &WindowSnapshot) -> DeltaReport {
         end.session_cache_read_tokens,
         start.session_cache_read_tokens,
     );
-    let cost_delta_usd = match (end.session_cost_usd, start.session_cost_usd) {
-        (Some(a), Some(b)) => a - b,
-        (Some(a), None) => a,
-        _ => 0.0,
+    // Cost is reported only when BOTH endpoints carry a populated
+    // value. Previous arms fabricated deltas: (Some, None) returned
+    // the end's cumulative value as if it were a delta; (None, Some)
+    // dropped the start. Both shapes silently miscounted (issue
+    // #1410). Now: only `(Some, Some)` produces `Some(end - start)`;
+    // every other shape produces `None` so renderers can mark the
+    // missing data with `—` instead of inventing a number.
+    let cost_delta_usd = match (start.session_cost_usd, end.session_cost_usd) {
+        (Some(s), Some(e)) => Some(e - s),
+        _ => None,
     };
     let (five_hour_pct_delta, five_reset) =
         pct_delta_with_reset(start.five_hour_pct, end.five_hour_pct);
@@ -257,6 +294,9 @@ fn pair_delta(start: &WindowSnapshot, end: &WindowSnapshot) -> DeltaReport {
         five_hour_pct_delta,
         seven_day_pct_delta,
         window_reset_observed,
+        // pair_delta produces a single-pair report; partial
+        // tracking is an aggregator concern computed by `add`.
+        total_partial: false,
         turn_count_delta,
         tool_call_count_delta,
         by_model_delta,

--- a/src/window_deltas.rs
+++ b/src/window_deltas.rs
@@ -198,22 +198,33 @@ pub fn by_model_rollup(state: &FlowState) -> IndexMap<String, ModelTokens> {
 /// `session_id`, and compute per-session deltas summed into one
 /// report. Empty input or single-snapshot input returns the zero
 /// report — a single snapshot has no anchor pair to subtract.
+///
+/// Each snapshot whose `session_id` is `None` is given a synthetic
+/// per-index key (`__none_<i>`), so two consecutive None snapshots
+/// are treated as distinct sessions rather than collapsed into one
+/// empty-string session that would fabricate a cross-snapshot
+/// delta from cumulative session totals (issue #1410).
 fn deltas_from_snapshots(snapshots: &[&WindowSnapshot]) -> DeltaReport {
     let mut total = DeltaReport::zero();
     if snapshots.len() < 2 {
         return total;
     }
+    let key_for = |i: usize, snap: &WindowSnapshot| -> String {
+        snap.session_id
+            .clone()
+            .unwrap_or_else(|| format!("__none_{}", i))
+    };
     // Walk consecutive snapshots looking for session boundaries.
     // Within each session: subtract the first session-snapshot from
     // the last session-snapshot to get that session's contribution.
     let mut session_start: usize = 0;
-    let mut current_session = snapshots[0].session_id.as_deref().unwrap_or("");
+    let mut current_session = key_for(0, snapshots[0]);
     for i in 1..=snapshots.len() {
         let next_session = if i < snapshots.len() {
-            snapshots[i].session_id.as_deref().unwrap_or("")
+            key_for(i, snapshots[i])
         } else {
             // Sentinel value to flush the final session.
-            "\0__END__"
+            "\0__END__".to_string()
         };
         if next_session != current_session {
             // Flush the [session_start, i-1] span.

--- a/src/window_snapshot.rs
+++ b/src/window_snapshot.rs
@@ -128,10 +128,18 @@ pub fn capture_for_active_state(home: &Path, state: &Value, project_root: &Path)
     )
 }
 
+/// Maximum accepted length for a `session_id`. Real Claude Code
+/// session ids are UUIDs (36 chars); the cap is generously sized
+/// at 256 bytes to leave room for future identifier formats while
+/// bounding the payload an attacker can land in the capture file
+/// or state file via a hostile SessionStart producer.
+pub(crate) const SESSION_ID_MAX_LEN: usize = 256;
+
 /// Validate a state-derived `session_id` against the shape Claude
 /// Code populates: alphanumeric plus `-` and `_`, no path separators
-/// or traversal segments. Rejects `..`, `.`, `/`, `\`, NUL, and any
-/// other character that could escape the per-session cost-file path.
+/// or traversal segments, length ≤ [`SESSION_ID_MAX_LEN`]. Rejects
+/// `..`, `.`, `/`, `\`, NUL, oversized strings, and any other
+/// character that could escape the per-session cost-file path.
 ///
 /// Cross-module consumers: `src/hooks/capture_session.rs` validates
 /// stdin-supplied session_id at SessionStart and validates the
@@ -140,7 +148,7 @@ pub fn capture_for_active_state(home: &Path, state: &Value, project_root: &Path)
 /// the same validator runs at every state-derived path-construction
 /// site.
 pub(crate) fn is_safe_session_id(s: &str) -> bool {
-    if s.is_empty() || s == "." || s == ".." {
+    if s.is_empty() || s == "." || s == ".." || s.len() > SESSION_ID_MAX_LEN {
         return false;
     }
     s.chars()

--- a/src/window_snapshot.rs
+++ b/src/window_snapshot.rs
@@ -132,7 +132,14 @@ pub fn capture_for_active_state(home: &Path, state: &Value, project_root: &Path)
 /// Code populates: alphanumeric plus `-` and `_`, no path separators
 /// or traversal segments. Rejects `..`, `.`, `/`, `\`, NUL, and any
 /// other character that could escape the per-session cost-file path.
-fn is_safe_session_id(s: &str) -> bool {
+///
+/// Cross-module consumers: `src/hooks/capture_session.rs` validates
+/// stdin-supplied session_id at SessionStart and validates the
+/// capture-file payload that `src/commands/init_state.rs::run` reads
+/// at flow-start. Per `.claude/rules/external-input-path-construction.md`,
+/// the same validator runs at every state-derived path-construction
+/// site.
+pub(crate) fn is_safe_session_id(s: &str) -> bool {
     if s.is_empty() || s == "." || s == ".." {
         return false;
     }

--- a/tests/commands/init_state.rs
+++ b/tests/commands/init_state.rs
@@ -44,6 +44,13 @@ fn run_init_state(dir: &std::path::Path, args: &[&str]) -> std::process::Output 
         .arg("init-state")
         .args(args)
         .current_dir(dir)
+        // Isolate HOME so init_state's SessionStart capture-file read
+        // (issue #1410) cannot pick up a real
+        // `~/.claude/flow-current-session.json` written by the
+        // developer's active Claude Code session. Without this, tests
+        // that assert `state.session_id.is_null()` would intermittently
+        // fail when run inside Claude Code.
+        .env("HOME", dir)
         .output()
         .unwrap()
 }

--- a/tests/format_complete_summary.rs
+++ b/tests/format_complete_summary.rs
@@ -79,35 +79,13 @@ fn token_cost_section_with_full_data_renders_per_phase_and_total() {
     // for Start phase. Across 3 phases the combined Total should be > 0.
 }
 
-/// Empty state (no snapshots anywhere) → section is omitted entirely.
-#[test]
-fn token_cost_section_with_no_snapshots_returns_empty() {
-    let state = all_complete_state();
-    let result = format_complete_summary(&state, None);
-    assert!(
-        !result.summary.contains("Token Cost"),
-        "Token Cost header must not appear when no phases have snapshots"
-    );
-}
-
-/// Partial data: only some phases have snapshots → other phases are
-/// silently skipped from the per-phase rows.
-#[test]
-fn token_cost_section_with_partial_data_skips_unpopulated_phases() {
-    let mut state = all_complete_state();
-    // Only flow-code has snapshots.
-    add_phase_snapshots(&mut state, "flow-code", 10, 50);
-    let result = format_complete_summary(&state, None);
-    assert!(result.summary.contains("Token Cost"));
-    // Plan and Start phases must NOT appear in the Token Cost rows.
-    let token_section_start = result.summary.find("Token Cost").expect("section");
-    let after_token = &result.summary[token_section_start..];
-    let next_section = after_token.find("\n\n").unwrap_or(after_token.len());
-    let token_block = &after_token[..next_section];
-    assert!(token_block.contains("Code:"));
-    assert!(!token_block.contains("Start:"));
-    assert!(!token_block.contains("Plan:"));
-}
+// Pre-fix tests `token_cost_section_with_no_snapshots_returns_empty`
+// and `token_cost_section_with_partial_data_skips_unpopulated_phases`
+// were removed per `.claude/rules/supersession.md` — both asserted
+// the buggy "skip silently when no snapshots" behavior the plan
+// (issue #1410) explicitly replaces. The new contract is exercised
+// by the plan-named `token_cost_section_*` tests in the
+// "Renderer placeholder behavior" block below.
 
 /// Window reset observed: pct delta drops between enter and complete
 /// for a phase → reset marker (↻) appears next to that phase row and
@@ -176,19 +154,11 @@ fn token_cost_section_with_null_phases_value_returns_empty() {
     assert!(!result.summary.contains("Token Cost"));
 }
 
-/// Phase has snapshots but every counter field is zero → the
-/// delta is all-zero and the row is skipped from the section.
-#[test]
-fn token_cost_section_with_zero_delta_phase_is_skipped() {
-    let mut state = all_complete_state();
-    // enter=0 and complete=0 → all numeric snapshot fields zero,
-    // so the delta is zero across the board.
-    add_phase_snapshots(&mut state, "flow-code", 0, 0);
-    let result = format_complete_summary(&state, None);
-    // Section should NOT render — the only phase with snapshots
-    // contributed nothing.
-    assert!(!result.summary.contains("Token Cost"));
-}
+// Pre-fix test `token_cost_section_with_zero_delta_phase_is_skipped`
+// was removed per `.claude/rules/supersession.md` — the new contract
+// renders a row whenever a phase's status is not "pending", even when
+// the delta is zero. See the plan-named tests below for the new
+// "section omitted only when every phase is pending" semantics.
 
 /// Phase has snapshots with cost but no token delta → the row is
 /// kept (the cost arm of the AND-skip branch fires false).
@@ -220,21 +190,13 @@ fn token_cost_section_with_missing_phases_object_returns_empty() {
     assert!(!result.summary.contains("Token Cost"));
 }
 
-/// Phase value with a malformed `window_at_enter` shape (wrong type)
-/// → from_value::<PhaseState> returns Err and the phase is skipped.
-#[test]
-fn token_cost_section_with_unparseable_phase_skips_silently() {
-    let mut state = all_complete_state();
-    // Replace one phase entry with a non-object value so PhaseState
-    // deserialization fails.
-    state["phases"]["flow-code"] = json!("not an object");
-    // Plus add a real snapshot pair on a different phase so the
-    // section renders for that phase but skips flow-code.
-    add_phase_snapshots(&mut state, "flow-learn", 5, 10);
-    let result = format_complete_summary(&state, None);
-    assert!(result.summary.contains("Token Cost"));
-    assert!(result.summary.contains("Learn:"));
-}
+// Pre-fix test `token_cost_section_with_unparseable_phase_skips_silently`
+// was removed per `.claude/rules/supersession.md` — the new contract
+// renders a placeholder row (cost = "—") for phases whose PhaseState
+// fails to deserialize, instead of silently dropping them. The plan-
+// named tests below (`token_cost_section_renders_em_dash_for_unknown_cost`,
+// `token_cost_section_renders_phase_with_missing_window_at_enter`)
+// cover the placeholder shape.
 
 /// `format_tokens` boundary cases: < 1000 (raw integer), >= 1M
 /// (megaformat). Drives both branches via crafted snapshots that
@@ -253,6 +215,188 @@ fn token_cost_section_format_tokens_covers_small_and_million_ranges() {
     assert!(result.summary.contains("150"));
     // M suffix for the million-range phase.
     assert!(result.summary.contains("M"));
+}
+
+// --- Renderer placeholder behavior (issue #1410) ---
+//
+// The pre-fix renderer silently dropped the entire Token Cost
+// section when no phase had a complete snapshot pair. The fix:
+// any phase whose status is not "pending" produces a row, with
+// `—` placeholders for unknown values. The five tests below
+// cover the new contract per Task 8 of the plan.
+
+/// All phases pending → no row contributes → section omitted
+/// (only path that still hides the header).
+#[test]
+fn token_cost_section_omitted_only_when_no_phases_have_run() {
+    let mut state = all_complete_state();
+    // Reset every phase to pending so no phase has run.
+    for key in [
+        "flow-start",
+        "flow-code",
+        "flow-review",
+        "flow-learn",
+        "flow-complete",
+    ] {
+        state["phases"][key]["status"] = json!("pending");
+    }
+    let result = format_complete_summary(&state, None);
+    assert!(
+        !result.summary.contains("Token Cost"),
+        "section header must not appear when every phase is pending"
+    );
+}
+
+/// Any phase with status != "pending" forces the section header,
+/// even when no phase has snapshots and every per-phase delta
+/// would be unknown.
+#[test]
+fn token_cost_section_renders_header_when_any_phase_has_run() {
+    let state = all_complete_state();
+    // No snapshots added — every phase has run (status="complete")
+    // but no phase contributes a delta.
+    let result = format_complete_summary(&state, None);
+    assert!(
+        result.summary.contains("Token Cost"),
+        "section header must render when at least one phase has run"
+    );
+    assert!(
+        result.summary.contains("Total:"),
+        "total row must render alongside the header"
+    );
+}
+
+/// A phase whose snapshots have `session_cost_usd: None` produces
+/// an em-dash row instead of `$0.000`. The pre-fix code rendered
+/// `$0.000` for both "no cost" and "computed zero cost", erasing
+/// the distinction.
+#[test]
+fn token_cost_section_renders_em_dash_for_unknown_cost() {
+    let mut state = all_complete_state();
+    let mut enter = snapshot_value("S1", 1, "claude-opus-4-7");
+    let mut complete = snapshot_value("S1", 5, "claude-opus-4-7");
+    enter["session_cost_usd"] = json!(null);
+    complete["session_cost_usd"] = json!(null);
+    state["phases"]["flow-code"]["window_at_enter"] = enter;
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+    let result = format_complete_summary(&state, None);
+    assert!(result.summary.contains("Token Cost"));
+    assert!(
+        result.summary.contains("—"),
+        "em-dash placeholder must appear when cost data is unknown"
+    );
+}
+
+/// A phase with only `window_at_complete` (no `window_at_enter`)
+/// renders a placeholder row marked partial. The pre-fix code
+/// silently skipped the phase via the `phase_delta` returns-None
+/// branch.
+#[test]
+fn token_cost_section_renders_phase_with_missing_window_at_enter() {
+    let mut state = all_complete_state();
+    // Only window_at_complete is set; window_at_enter is left
+    // unpopulated (state has no enter snapshot).
+    state["phases"]["flow-code"]["window_at_complete"] = snapshot_value("S1", 5, "claude-opus-4-7");
+    let result = format_complete_summary(&state, None);
+    assert!(result.summary.contains("Token Cost"));
+    // Code phase row still renders even without an enter anchor.
+    let token_section_start = result.summary.find("Token Cost").expect("section");
+    let after_token = &result.summary[token_section_start..];
+    assert!(
+        after_token.contains("Code:"),
+        "Code row must render even when window_at_enter is missing"
+    );
+    assert!(
+        after_token.contains("—"),
+        "missing-enter row must use em-dash for unknown cost"
+    );
+}
+
+/// State with only a subset of PHASE_ORDER keys present in
+/// `phases` exercises the `let Some(phase_v) = phases_obj.get(key)
+/// else { continue }` branch — older state files or hand-edited
+/// state may omit phase entries entirely.
+#[test]
+fn token_cost_section_skips_phase_keys_missing_from_state() {
+    let mut state = all_complete_state();
+    let phases_obj = state["phases"].as_object().unwrap().clone();
+    let flow_code_entry = phases_obj.get("flow-code").cloned().unwrap();
+    let mut new_phases = serde_json::Map::new();
+    new_phases.insert("flow-code".to_string(), flow_code_entry);
+    state["phases"] = json!(new_phases);
+    add_phase_snapshots(&mut state, "flow-code", 0, 5);
+    let result = format_complete_summary(&state, None);
+    // The four PHASE_ORDER entries missing from the phases map hit
+    // the `continue` arm; only flow-code contributes a row inside
+    // the Token Cost section. Bound the assertion to that section
+    // (other sections — phase timing, by-model — may still mention
+    // "Start" via PHASE_NAMES_LIST).
+    let token_section_start = result
+        .summary
+        .find("Token Cost")
+        .expect("Token Cost section must render");
+    let after_token = &result.summary[token_section_start..];
+    let token_block_end = after_token.find("\n\n").unwrap_or(after_token.len());
+    let token_block = &after_token[..token_block_end];
+    assert!(
+        token_block.contains("Code:"),
+        "token block:\n{}",
+        token_block
+    );
+    assert!(
+        !token_block.contains("Start:"),
+        "missing PHASE_ORDER keys must not produce rows:\n{}",
+        token_block
+    );
+}
+
+/// Total `total_partial=false` branch: every running phase
+/// contributed `Some` cost, so the total has no `*` partial marker.
+#[test]
+fn token_cost_section_total_not_partial_when_every_phase_has_cost() {
+    // Set every phase except flow-code to status=pending so they
+    // skip; flow-code is the only running phase and has populated
+    // snapshots → cost is Some → total_partial stays false.
+    let mut state = all_complete_state();
+    for key in ["flow-start", "flow-review", "flow-learn", "flow-complete"] {
+        state["phases"][key]["status"] = json!("pending");
+    }
+    add_phase_snapshots(&mut state, "flow-code", 0, 5);
+    let result = format_complete_summary(&state, None);
+    assert!(result.summary.contains("Token Cost"));
+    assert!(
+        !result.summary.contains("cost partial"),
+        "footnote must NOT appear when every running phase has populated cost"
+    );
+}
+
+/// When at least one phase contributes `None` cost, the total row
+/// is marked partial via a `*` suffix so the user sees the total
+/// is approximate.
+#[test]
+fn token_cost_section_total_marks_partial_when_any_unknown() {
+    let mut state = all_complete_state();
+    // flow-start has both cost endpoints populated → contributes
+    // a known value to the total.
+    add_phase_snapshots(&mut state, "flow-start", 0, 5);
+    // flow-code has only window_at_complete → contributes None.
+    state["phases"]["flow-code"]["window_at_complete"] = snapshot_value("S1", 5, "claude-opus-4-7");
+    let result = format_complete_summary(&state, None);
+    assert!(result.summary.contains("Token Cost"));
+    // The total line carries the partial marker; the footnote
+    // explains it.
+    assert!(
+        result.summary.contains("Total:"),
+        "Total: header must render"
+    );
+    assert!(
+        result.summary.contains("*"),
+        "partial marker must appear when any phase contributed None cost"
+    );
+    assert!(
+        result.summary.contains("cost partial"),
+        "footnote must explain the partial marker"
+    );
 }
 
 // --- basic summary ---

--- a/tests/format_status.rs
+++ b/tests/format_status.rs
@@ -994,6 +994,32 @@ fn tokens_block_renders_for_in_progress_phase_with_step_snapshots() {
     assert!(panel.contains("Tokens  :"), "Panel:\n{}", panel);
 }
 
+/// Tokens line renders the em-dash placeholder for cost when every
+/// snapshot pair lacks `session_cost_usd` but tokens grew (issue
+/// #1410). The pre-fix code rendered `$0.000` here, masking the
+/// "no cost data" condition behind a literal-zero value.
+#[test]
+fn tokens_block_renders_em_dash_when_cost_unknown_but_tokens_grew() {
+    let mut state = make_state("flow-code", &[("flow-code", "in_progress")]);
+    let mut enter = snapshot_value("S1", 0, "claude-opus-4-7");
+    let mut complete = snapshot_value("S1", 5, "claude-opus-4-7");
+    // Force tokens to grow so the line is not omitted; clear cost on
+    // both endpoints so the cost arm produces None.
+    enter["session_input_tokens"] = json!(100);
+    complete["session_input_tokens"] = json!(500);
+    enter["session_cost_usd"] = json!(null);
+    complete["session_cost_usd"] = json!(null);
+    state["phases"]["flow-code"]["window_at_enter"] = enter;
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+    let panel = format_panel(&state, VERSION, None, false, None);
+    assert!(panel.contains("Tokens  :"), "Panel:\n{}", panel);
+    assert!(
+        panel.contains("(—)"),
+        "em-dash placeholder must appear in cost field when cost data is unknown:\n{}",
+        panel
+    );
+}
+
 /// Window reset observed mid-flow (pct decreases between snapshots) →
 /// the Tokens line carries the ↻ reset marker so the user knows the
 /// rate-limit window rolled over.

--- a/tests/hooks/capture_session.rs
+++ b/tests/hooks/capture_session.rs
@@ -167,3 +167,137 @@ fn capture_session_handles_unparseable_stdin() {
         "no file when stdin is unparseable"
     );
 }
+
+#[test]
+fn capture_session_rejects_oversized_session_id() {
+    // `is_safe_session_id` caps session id length at SESSION_ID_MAX_LEN
+    // (256). A 257-char string should fail validation and the hook
+    // should write no capture file. Defends against hostile producers
+    // who could otherwise pass arbitrary-length payloads through the
+    // alphanumeric character class.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().canonicalize().unwrap();
+    let huge_sid: String = "a".repeat(257);
+    let stdin = format!(r#"{{"session_id":"{}"}}"#, huge_sid);
+    let code = run_capture_session(Some(&home), stdin.as_bytes());
+    assert_eq!(code, Some(0));
+    assert!(
+        !capture_file(&home).exists(),
+        "session_id over 256 bytes must be rejected; capture file must not be written"
+    );
+}
+
+#[test]
+fn capture_session_caps_stdin_payload_size() {
+    // STDIN_BYTE_CAP truncates the read at 64 KiB. A multi-megabyte
+    // stdin payload that would otherwise produce a multi-megabyte
+    // capture file is truncated mid-string, fails JSON parse, and
+    // the hook returns without writing. The parent's write_all may
+    // raise BrokenPipe once the child closes its read end (cap hit
+    // before parent finishes writing) — that is the cap working as
+    // designed; tolerate the error and assert on the file outcome.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().canonicalize().unwrap();
+    let huge_sid: String = "a".repeat(5 * 1024 * 1024);
+    let stdin = format!(r#"{{"session_id":"{}"}}"#, huge_sid);
+
+    let mut cmd = flow_rs_no_recursion();
+    cmd.args(["hook", "capture-session"])
+        .env("HOME", &home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn capture-session");
+    // Best-effort write — BrokenPipe is the expected outcome when
+    // the cap fires before the parent finishes the multi-MB write.
+    let _ = child
+        .stdin
+        .as_mut()
+        .expect("piped stdin")
+        .write_all(stdin.as_bytes());
+    let output = child.wait_with_output().expect("wait capture-session");
+    assert_eq!(output.status.code(), Some(0));
+
+    let path = capture_file(&home);
+    if path.exists() {
+        let written = fs::metadata(&path).unwrap().len();
+        assert!(
+            written < 1024 * 1024,
+            "stdin cap must bound the written capture file; got {} bytes",
+            written
+        );
+    }
+}
+
+#[test]
+fn capture_session_overwrites_existing_regular_file() {
+    // Symlink-safe gate's `else` arm: when fs::symlink_metadata
+    // returns Ok AND the entry is a regular file (not a symlink),
+    // remove_file is skipped and fs::write overwrites in place.
+    // Exercised on every second-and-later hook invocation against
+    // the same HOME.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().canonicalize().unwrap();
+    let path = capture_file(&home);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, br#"{"session_id":"stale","transcript_path":null}"#).unwrap();
+
+    let stdin = r#"{"session_id":"fresh-sid"}"#;
+    let code = run_capture_session(Some(&home), stdin.as_bytes());
+    assert_eq!(code, Some(0));
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(parsed["session_id"], "fresh-sid");
+    let meta = fs::symlink_metadata(&path).unwrap();
+    assert!(
+        meta.file_type().is_file(),
+        "regular file remains a regular file after overwrite"
+    );
+}
+
+#[test]
+fn capture_session_replaces_existing_symlink_at_capture_path() {
+    // Symlink-safe write: a pre-existing symlink at the capture path
+    // must NOT be followed (otherwise an attacker who can plant a
+    // symlink under ~/.claude/ gains an arbitrary-write primitive).
+    // The hook detects the symlink via fs::symlink_metadata and
+    // removes it before writing, so the result is a regular file
+    // and the symlink's target is untouched.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().canonicalize().unwrap();
+    fs::create_dir_all(home.join(".claude")).unwrap();
+
+    // Plant a sentinel at a third-party path. The symlink will
+    // point at this. After the hook runs, the sentinel must be
+    // unchanged — the hook MUST NOT have followed the symlink.
+    let sentinel_target = dir.path().join("sentinel.txt");
+    fs::write(&sentinel_target, b"untouched").unwrap();
+    let sentinel_canon = sentinel_target.canonicalize().unwrap();
+
+    let path = capture_file(&home);
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&sentinel_canon, &path).unwrap();
+
+    let stdin = r#"{"session_id":"abc-123"}"#;
+    let code = run_capture_session(Some(&home), stdin.as_bytes());
+    assert_eq!(code, Some(0));
+
+    // Sentinel must be unchanged — hook MUST NOT have written through the symlink.
+    let sentinel_after = fs::read_to_string(&sentinel_canon).unwrap();
+    assert_eq!(
+        sentinel_after, "untouched",
+        "fs::write must not have followed the symlink to overwrite the target"
+    );
+
+    // Capture path must now be a regular file (the symlink was removed).
+    let meta = fs::symlink_metadata(&path).unwrap();
+    assert!(
+        meta.file_type().is_file(),
+        "capture path must be a regular file after symlink-safe write; got {:?}",
+        meta.file_type()
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(parsed["session_id"], "abc-123");
+}

--- a/tests/hooks/capture_session.rs
+++ b/tests/hooks/capture_session.rs
@@ -1,0 +1,169 @@
+//! Tests for `src/hooks/capture_session.rs`.
+//!
+//! Drive the SessionStart hook through the compiled binary so the
+//! production stdin parse + path resolution + write path is exercised
+//! end-to-end. Each test sets `HOME=<tempdir>` to scope the capture
+//! file location (per `.claude/rules/external-input-path-construction.md`
+//! "Validate env-var-derived paths as absolute") and uses
+//! `env_remove("FLOW_CI_RUNNING")` so the child inherits a fresh
+//! recursion guard.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+fn flow_rs_no_recursion() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_flow-rs"));
+    cmd.env_remove("FLOW_CI_RUNNING");
+    cmd
+}
+
+fn capture_file(home: &Path) -> PathBuf {
+    home.join(".claude").join("flow-current-session.json")
+}
+
+/// Spawn `flow-rs hook capture-session`, pipe `stdin_bytes`, wait for
+/// exit. Returns the child's exit code. Wraps the verbose stdin/stdout
+/// boilerplate so individual tests stay focused on assertions.
+fn run_capture_session(home_env: Option<&Path>, stdin_bytes: &[u8]) -> Option<i32> {
+    let mut cmd = flow_rs_no_recursion();
+    cmd.args(["hook", "capture-session"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    match home_env {
+        Some(h) => {
+            cmd.env("HOME", h);
+        }
+        None => {
+            cmd.env_remove("HOME");
+        }
+    }
+    let mut child = cmd.spawn().expect("spawn capture-session");
+    child
+        .stdin
+        .as_mut()
+        .expect("piped stdin")
+        .write_all(stdin_bytes)
+        .expect("write stdin");
+    let output = child.wait_with_output().expect("wait capture-session");
+    output.status.code()
+}
+
+#[test]
+fn capture_session_writes_file_when_session_id_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().canonicalize().unwrap();
+    let projects = home.join(".claude").join("projects").join("proj");
+    fs::create_dir_all(&projects).unwrap();
+    let transcript = projects.join("session.jsonl");
+    fs::write(&transcript, "").unwrap();
+
+    let stdin = format!(
+        r#"{{"session_id":"abc-123","transcript_path":"{}"}}"#,
+        transcript.display()
+    );
+    let code = run_capture_session(Some(&home), stdin.as_bytes());
+    assert_eq!(code, Some(0));
+
+    let path = capture_file(&home);
+    assert!(path.exists(), "capture file must be written");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(parsed["session_id"], "abc-123");
+    assert_eq!(parsed["transcript_path"], transcript.display().to_string());
+}
+
+#[test]
+fn capture_session_skips_when_session_id_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().canonicalize().unwrap();
+    let stdin = r#"{}"#;
+    let code = run_capture_session(Some(&home), stdin.as_bytes());
+    assert_eq!(code, Some(0));
+    assert!(
+        !capture_file(&home).exists(),
+        "no file when session_id absent"
+    );
+}
+
+#[test]
+fn capture_session_rejects_invalid_session_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().canonicalize().unwrap();
+    // Slash → fails is_safe_session_id.
+    let stdin = r#"{"session_id":"../etc/passwd"}"#;
+    let code = run_capture_session(Some(&home), stdin.as_bytes());
+    assert_eq!(code, Some(0));
+    assert!(
+        !capture_file(&home).exists(),
+        "no file when session_id is path-traversal-shaped"
+    );
+}
+
+#[test]
+fn capture_session_omits_invalid_transcript_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().canonicalize().unwrap();
+    // session_id valid; transcript_path outside ~/.claude/projects/.
+    let stdin = r#"{"session_id":"valid-sid","transcript_path":"/etc/passwd"}"#;
+    let code = run_capture_session(Some(&home), stdin.as_bytes());
+    assert_eq!(code, Some(0));
+    let path = capture_file(&home);
+    assert!(path.exists());
+    let parsed: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(parsed["session_id"], "valid-sid");
+    assert!(
+        parsed["transcript_path"].is_null(),
+        "invalid transcript_path must be stored as null; got: {}",
+        parsed["transcript_path"]
+    );
+}
+
+#[test]
+fn capture_session_skips_when_home_empty() {
+    let stdin = r#"{"session_id":"valid-sid"}"#;
+    // No HOME set → hook fails open, returns 0, writes nothing.
+    let code = run_capture_session(None, stdin.as_bytes());
+    assert_eq!(code, Some(0));
+}
+
+#[test]
+fn capture_session_skips_when_home_is_relative() {
+    // HOME=relative-path triggers the `!is_absolute()` arm of the
+    // empty-or-relative gate. The capture file is never written
+    // because joining a relative HOME with `.claude/...` would
+    // resolve against the worktree's cwd — exactly the
+    // hostile-config trap `.claude/rules/external-input-path-construction.md`
+    // "Validate env-var-derived paths as absolute" defends against.
+    let mut cmd = flow_rs_no_recursion();
+    cmd.args(["hook", "capture-session"])
+        .env("HOME", "relative-home")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn capture-session");
+    child
+        .stdin
+        .as_mut()
+        .expect("piped stdin")
+        .write_all(br#"{"session_id":"valid-sid"}"#)
+        .expect("write stdin");
+    let output = child.wait_with_output().expect("wait capture-session");
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[test]
+fn capture_session_handles_unparseable_stdin() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().canonicalize().unwrap();
+    let stdin = b"not valid JSON";
+    let code = run_capture_session(Some(&home), stdin);
+    assert_eq!(code, Some(0));
+    assert!(
+        !capture_file(&home).exists(),
+        "no file when stdin is unparseable"
+    );
+}

--- a/tests/hooks/main.rs
+++ b/tests/hooks/main.rs
@@ -14,6 +14,7 @@
 #[path = "../common/mod.rs"]
 mod common;
 
+mod capture_session;
 mod dispatcher;
 mod shared;
 mod stop_continue;

--- a/tests/start_init.rs
+++ b/tests/start_init.rs
@@ -1226,6 +1226,44 @@ fn start_init_session_id_remains_null_when_home_unset() {
 }
 
 #[test]
+fn start_init_session_id_remains_null_when_capture_file_has_invalid_utf8() {
+    // Covers `read_captured_session`'s read_to_string-failure
+    // branch: the capture file opens cleanly but its bytes are
+    // not valid UTF-8 (interrupted write left a partial multibyte
+    // sequence; or a binary file landed at the path). `take(CAP)`
+    // then `read_to_string` returns Err(InvalidData), the `?`
+    // short-circuits to `None`, and seed leaves session_id Null.
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    write_flow_json(&repo, &current_plugin_version(), None);
+    let stub_dir = create_default_gh_stub(&repo);
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let home = home.canonicalize().unwrap();
+    let capture_path = capture_file_path(&home);
+    fs::create_dir_all(capture_path.parent().unwrap()).unwrap();
+    // 0xFF is never valid as the leading byte of a UTF-8 sequence;
+    // read_to_string returns InvalidData.
+    fs::write(&capture_path, [0xFFu8, 0xFE, 0xFD]).unwrap();
+
+    let output = run_start_init_with_home(&repo, "invalid-utf8-capture", &home, &stub_dir);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    let branch = data["branch"].as_str().unwrap();
+    let state = read_state_for_branch(&repo, branch);
+    assert!(
+        state["session_id"].is_null(),
+        "invalid-utf8 capture file must leave session_id null; got: {}",
+        state["session_id"]
+    );
+}
+
+#[test]
 fn start_init_session_id_remains_null_when_capture_file_unparseable() {
     // Covers `read_captured_session`'s parse-failure branch — capture
     // file exists but contains non-JSON bytes (interrupted hook write,

--- a/tests/start_init.rs
+++ b/tests/start_init.rs
@@ -948,3 +948,313 @@ fn test_prime_check_infrastructure_err_returns_error() {
         "Lock must be released on prime-check infrastructure error"
     );
 }
+
+// --- Session ID capture at start-init (issue #1410) ---
+//
+// SessionStart hook writes ~/.claude/flow-current-session.json with
+// session_id + transcript_path; start-init reads that file when
+// creating the initial state so window_at_start can pick up the
+// per-session cost file. Without these tests the asymmetric
+// pair_delta bug (start has no session_id → cost lookup silently
+// fails → token-cost section silently skips) ships uncaught.
+
+/// Compute the canonical capture file path under `<home>`.
+fn capture_file_path(home: &Path) -> PathBuf {
+    home.join(".claude").join("flow-current-session.json")
+}
+
+/// Write a capture file with the given session_id and optional
+/// transcript_path. Mirrors the payload shape produced by
+/// `src/hooks/capture_session.rs`.
+fn write_capture_file(home: &Path, session_id: &str, transcript_path: Option<&str>) {
+    let path = capture_file_path(home);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let payload = serde_json::json!({
+        "session_id": session_id,
+        "transcript_path": transcript_path,
+    });
+    fs::write(&path, payload.to_string()).unwrap();
+}
+
+/// Read the state file produced by start-init for the named branch.
+fn read_state_for_branch(repo: &Path, branch: &str) -> serde_json::Value {
+    let path = flow_states_dir(repo).join(branch).join("state.json");
+    let content = fs::read_to_string(&path).expect("state file must exist");
+    serde_json::from_str(&content).expect("state file must be valid JSON")
+}
+
+/// Run start-init with HOME pinned to a tempdir so capture-file reads
+/// hit fixture paths instead of the developer's real `~/.claude/`.
+/// Sibling helpers `run_start_init` (no HOME injection) live above.
+fn run_start_init_with_home(
+    repo: &Path,
+    feature_name: &str,
+    home: &Path,
+    stub_dir: &Path,
+) -> Output {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path_env = format!(
+        "{}:{}",
+        stub_dir.to_string_lossy(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["start-init", feature_name])
+        .current_dir(repo)
+        .env("PATH", &path_env)
+        .env("CLAUDE_PLUGIN_ROOT", &manifest_dir)
+        .env("HOME", home)
+        .env_remove("FLOW_SIMULATE_BRANCH")
+        .env_remove("FLOW_CI_RUNNING")
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn start_init_populates_session_id_from_session_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    write_flow_json(&repo, &current_plugin_version(), None);
+    let stub_dir = create_default_gh_stub(&repo);
+    let home = dir.path().join("home").canonicalize().unwrap_or_else(|_| {
+        let h = dir.path().join("home");
+        fs::create_dir_all(&h).unwrap();
+        h.canonicalize().unwrap()
+    });
+    fs::create_dir_all(&home).unwrap();
+
+    let projects = home.join(".claude").join("projects").join("proj");
+    fs::create_dir_all(&projects).unwrap();
+    let transcript = projects.join("session.jsonl");
+    fs::write(&transcript, "").unwrap();
+    let transcript_str = transcript.display().to_string();
+    write_capture_file(&home, "abc-123", Some(&transcript_str));
+
+    let output = run_start_init_with_home(&repo, "session-id-test", &home, &stub_dir);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    let branch = data["branch"].as_str().expect("branch field present");
+    let state = read_state_for_branch(&repo, branch);
+    assert_eq!(
+        state["session_id"], "abc-123",
+        "session_id must be seeded from capture file"
+    );
+    assert_eq!(
+        state["transcript_path"], transcript_str,
+        "transcript_path must be seeded from capture file"
+    );
+}
+
+#[test]
+fn start_init_session_id_remains_null_when_neither_source_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    write_flow_json(&repo, &current_plugin_version(), None);
+    let stub_dir = create_default_gh_stub(&repo);
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let home = home.canonicalize().unwrap();
+    // No capture file present.
+
+    let output = run_start_init_with_home(&repo, "no-capture", &home, &stub_dir);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    let branch = data["branch"].as_str().unwrap();
+    let state = read_state_for_branch(&repo, branch);
+    assert!(
+        state["session_id"].is_null(),
+        "session_id must remain null when no capture file exists; got: {}",
+        state["session_id"]
+    );
+    assert!(
+        state["transcript_path"].is_null(),
+        "transcript_path must remain null when no capture file exists; got: {}",
+        state["transcript_path"]
+    );
+}
+
+#[test]
+fn start_init_rejects_invalid_session_id_per_is_safe_session_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    write_flow_json(&repo, &current_plugin_version(), None);
+    let stub_dir = create_default_gh_stub(&repo);
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let home = home.canonicalize().unwrap();
+    // Slash-bearing session_id → fails is_safe_session_id.
+    write_capture_file(&home, "../etc/passwd", None);
+
+    let output = run_start_init_with_home(&repo, "invalid-sid", &home, &stub_dir);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    let branch = data["branch"].as_str().unwrap();
+    let state = read_state_for_branch(&repo, branch);
+    assert!(
+        state["session_id"].is_null(),
+        "invalid session_id must be rejected; got: {}",
+        state["session_id"]
+    );
+}
+
+#[test]
+fn window_at_start_carries_session_id_when_populated() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    write_flow_json(&repo, &current_plugin_version(), None);
+    let stub_dir = create_default_gh_stub(&repo);
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let home = home.canonicalize().unwrap();
+    write_capture_file(&home, "sid-window", None);
+
+    let output = run_start_init_with_home(&repo, "window-sid", &home, &stub_dir);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    let branch = data["branch"].as_str().unwrap();
+    let state = read_state_for_branch(&repo, branch);
+    assert_eq!(
+        state["window_at_start"]["session_id"], "sid-window",
+        "window_at_start.session_id must mirror state.session_id; got window: {}",
+        state["window_at_start"]
+    );
+}
+
+#[test]
+fn window_at_start_reads_cost_when_session_id_and_cost_file_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    write_flow_json(&repo, &current_plugin_version(), None);
+    let stub_dir = create_default_gh_stub(&repo);
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let home = home.canonicalize().unwrap();
+    let session_id = "cost-test-sid";
+    write_capture_file(&home, session_id, None);
+
+    // Pre-create the cost file at <repo>/.claude/cost/<YYYY-MM>/<session_id>.txt.
+    // The year-month component matches `chrono::Local::now().format("%Y-%m")`
+    // which is what `cost_file_path` in src/window_snapshot.rs computes.
+    let year_month = chrono::Local::now().format("%Y-%m").to_string();
+    let cost_dir = repo.join(".claude").join("cost").join(&year_month);
+    fs::create_dir_all(&cost_dir).unwrap();
+    fs::write(cost_dir.join(format!("{}.txt", session_id)), "1.42\n").unwrap();
+
+    let output = run_start_init_with_home(&repo, "cost-test", &home, &stub_dir);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    let branch = data["branch"].as_str().unwrap();
+    let state = read_state_for_branch(&repo, branch);
+    let cost = state["window_at_start"]["session_cost_usd"].as_f64();
+    assert!(
+        cost.is_some(),
+        "window_at_start.session_cost_usd must be populated when cost file exists; window_at_start: {}",
+        state["window_at_start"]
+    );
+    assert!(
+        (cost.unwrap() - 1.42).abs() < 1e-9,
+        "cost mismatch: expected 1.42, got {}",
+        cost.unwrap()
+    );
+}
+
+#[test]
+fn start_init_session_id_remains_null_when_home_unset() {
+    // Covers `read_captured_session`'s empty-/non-absolute-home early
+    // return — reachable from the production seed path when HOME is
+    // unset (test runner shells, CI environments, sandboxed containers).
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    write_flow_json(&repo, &current_plugin_version(), None);
+    let stub_dir = create_default_gh_stub(&repo);
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path_env = format!(
+        "{}:{}",
+        stub_dir.to_string_lossy(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let output = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["start-init", "home-unset"])
+        .current_dir(&repo)
+        .env("PATH", &path_env)
+        .env("CLAUDE_PLUGIN_ROOT", &manifest_dir)
+        .env_remove("HOME")
+        .env_remove("FLOW_SIMULATE_BRANCH")
+        .env_remove("FLOW_CI_RUNNING")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    let branch = data["branch"].as_str().unwrap();
+    let state = read_state_for_branch(&repo, branch);
+    assert!(
+        state["session_id"].is_null(),
+        "HOME unset must trigger read_captured_session's empty-home guard; got: {}",
+        state["session_id"]
+    );
+}
+
+#[test]
+fn start_init_session_id_remains_null_when_capture_file_unparseable() {
+    // Covers `read_captured_session`'s parse-failure branch — capture
+    // file exists but contains non-JSON bytes (interrupted hook write,
+    // disk corruption, hand edit). Fail-open: state stays Null.
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    write_flow_json(&repo, &current_plugin_version(), None);
+    let stub_dir = create_default_gh_stub(&repo);
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let home = home.canonicalize().unwrap();
+    // Malformed JSON at the capture path triggers serde_json::from_str → Err.
+    let capture_path = capture_file_path(&home);
+    fs::create_dir_all(capture_path.parent().unwrap()).unwrap();
+    fs::write(&capture_path, "{ not valid json").unwrap();
+
+    let output = run_start_init_with_home(&repo, "malformed-capture", &home, &stub_dir);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    let branch = data["branch"].as_str().unwrap();
+    let state = read_state_for_branch(&repo, branch);
+    assert!(
+        state["session_id"].is_null(),
+        "malformed capture file must leave session_id null; got: {}",
+        state["session_id"]
+    );
+}

--- a/tests/start_init.rs
+++ b/tests/start_init.rs
@@ -1258,3 +1258,129 @@ fn start_init_session_id_remains_null_when_capture_file_unparseable() {
         state["session_id"]
     );
 }
+
+/// Cost-per-flow integration test (issue #1410, plan Task 10):
+/// proves the SessionStart capture path → init-state seeding →
+/// window_at_start cost capture → format_complete_summary
+/// rendering chain works end-to-end. Pre-fix the chain broke at
+/// the first step (session_id stayed Null), which masked every
+/// downstream lookup as "no cost data" and silently hid the
+/// Token Cost section. Had this test existed before the fix, the
+/// bug would have failed CI.
+#[test]
+fn cost_per_flow_token_cost_section_renders_phase_delta_end_to_end() {
+    use chrono::Local;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    write_flow_json(&repo, &current_plugin_version(), None);
+    let stub_dir = create_default_gh_stub(&repo);
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let home = home.canonicalize().unwrap();
+    let session_id = "cost-flow-sid";
+    write_capture_file(&home, session_id, None);
+
+    // Pre-create the cost file at <repo>/.claude/cost/<YYYY-MM>/<session_id>.txt
+    // with an initial value. capture_for_active_state reads this file
+    // when start-init writes window_at_start, so this seeds the start
+    // anchor with cost=1.00.
+    let year_month = Local::now().format("%Y-%m").to_string();
+    let cost_dir = repo.join(".claude").join("cost").join(&year_month);
+    fs::create_dir_all(&cost_dir).unwrap();
+    let cost_file = cost_dir.join(format!("{}.txt", session_id));
+    fs::write(&cost_file, "1.00\n").unwrap();
+
+    let output = run_start_init_with_home(&repo, "cost-flow-test", &home, &stub_dir);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    let branch = data["branch"].as_str().expect("branch field present");
+
+    // Confirm the start anchor carries the cost — without the
+    // session_id seed, this would be Null and every downstream
+    // delta would compute None.
+    let mut state = read_state_for_branch(&repo, branch);
+    assert_eq!(
+        state["window_at_start"]["session_cost_usd"]
+            .as_f64()
+            .expect("start cost populated"),
+        1.00,
+        "window_at_start cost must reflect the pre-flow cost file value"
+    );
+
+    // Simulate cost accruing during the Code phase: bump the
+    // cost file from 1.00 → 1.50 at phase-enter, then from 1.50
+    // → 2.50 at phase-finalize. Mutate the state file directly to
+    // add the phase snapshots that those subprocess calls would
+    // produce, with cost values mirroring the accrued totals.
+    fs::write(&cost_file, "2.50\n").unwrap();
+
+    // Build window_at_enter (cost=1.50, captured mid-flow) and
+    // window_at_complete (cost=2.50). The computed delta is
+    // 2.50 - 1.50 = 1.00 for the flow-code phase.
+    let snap_template = serde_json::json!({
+        "captured_at": "2026-01-01T00:00:00-08:00",
+        "session_id": session_id,
+        "model": "claude-opus-4-7",
+        "five_hour_pct": 50,
+        "seven_day_pct": 25,
+        "session_input_tokens": 100,
+        "session_output_tokens": 50,
+        "session_cache_creation_tokens": 0,
+        "session_cache_read_tokens": 0,
+        "by_model": {
+            "claude-opus-4-7": {"input": 100, "output": 50, "cache_create": 0, "cache_read": 0}
+        },
+        "turn_count": 1,
+        "tool_call_count": 2,
+        "context_at_last_turn_tokens": 100,
+        "context_window_pct": 0.05,
+    });
+    let mut enter_snap = snap_template.clone();
+    enter_snap["session_cost_usd"] = serde_json::json!(1.50);
+    enter_snap["session_input_tokens"] = serde_json::json!(100);
+    let mut complete_snap = snap_template.clone();
+    complete_snap["session_cost_usd"] = serde_json::json!(2.50);
+    complete_snap["session_input_tokens"] = serde_json::json!(500);
+    complete_snap["by_model"]["claude-opus-4-7"]["input"] = serde_json::json!(500);
+    state["phases"]["flow-code"]["status"] = serde_json::json!("complete");
+    state["phases"]["flow-code"]["window_at_enter"] = enter_snap;
+    state["phases"]["flow-code"]["window_at_complete"] = complete_snap;
+
+    let result = flow_rs::format_complete_summary::format_complete_summary(&state, None);
+    assert!(
+        result.summary.contains("Token Cost"),
+        "Token Cost section must render when session_id flows from capture file to phase deltas:\n{}",
+        result.summary
+    );
+    // Bound the assertion to the Token Cost section so other
+    // sections naming "Code" don't false-positive the check.
+    let token_section_start = result
+        .summary
+        .find("Token Cost")
+        .expect("Token Cost section present");
+    let token_block = &result.summary[token_section_start..];
+    let code_row_start = token_block
+        .find("Code:")
+        .expect("Code row must appear in Token Cost section");
+    let code_row_end = token_block[code_row_start..]
+        .find('\n')
+        .map(|n| code_row_start + n)
+        .unwrap_or(token_block.len());
+    let code_row = &token_block[code_row_start..code_row_end];
+    assert!(
+        code_row.contains("$1.000"),
+        "Code row must show the computed cost delta ($2.50 - $1.50 = $1.000); got: {:?}",
+        code_row
+    );
+    assert!(
+        !code_row.contains("—"),
+        "Code row must NOT show the em-dash placeholder when cost is fully populated; got: {:?}",
+        code_row
+    );
+}

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -353,6 +353,72 @@ fn test_render_detail_panel_token_table_breaks_when_viewport_overflows() {
     let _ = render_to_string(&app, 100, 18);
 }
 
+/// Token row keeps the cost-bearing entry when tokens did not grow
+/// but cost did. Drives the `is_some_and` arm of the active-rows
+/// filter — when `r.tokens == 0` the OR falls through to the cost
+/// check; the closure inside `is_some_and` runs only when cost is
+/// `Some(non-zero)`.
+#[test]
+fn test_render_detail_panel_token_row_kept_when_only_cost_changed() {
+    let mut app = make_app();
+    let mut flow = make_flow_with_token_snapshots();
+    // Force tokens to stay flat across the pair while cost grows.
+    flow.state["phases"]["flow-code"]["window_at_complete"]["session_input_tokens"] =
+        flow.state["phases"]["flow-code"]["window_at_enter"]["session_input_tokens"].clone();
+    flow.state["phases"]["flow-code"]["window_at_complete"]["session_output_tokens"] =
+        flow.state["phases"]["flow-code"]["window_at_enter"]["session_output_tokens"].clone();
+    flow.state["phases"]["flow-code"]["window_at_complete"]["by_model"]["claude-opus-4-7"]
+        ["input"] = flow.state["phases"]["flow-code"]["window_at_enter"]["by_model"]
+        ["claude-opus-4-7"]["input"]
+        .clone();
+    flow.state["phases"]["flow-code"]["window_at_complete"]["by_model"]["claude-opus-4-7"]
+        ["output"] = flow.state["phases"]["flow-code"]["window_at_enter"]["by_model"]
+        ["claude-opus-4-7"]["output"]
+        .clone();
+    // Cost stays Some(0.01)→Some(0.50) so cost delta is positive.
+    app.flows = vec![flow];
+    let output = render_to_string(&app, 100, 40);
+    assert!(
+        output.contains("Tokens"),
+        "Token table must render when cost grew without token growth:\n{}",
+        output
+    );
+    assert!(
+        output.contains("Code:"),
+        "Code phase row must render:\n{}",
+        output
+    );
+}
+
+/// Token row renders the em-dash placeholder for cost when a
+/// phase grew tokens but lacks `session_cost_usd` data on either
+/// snapshot endpoint (issue #1410). Pre-fix the row showed
+/// `$0.000`, masking the unknown-cost condition.
+#[test]
+fn test_render_detail_panel_token_row_renders_em_dash_for_unknown_cost() {
+    let mut app = make_app();
+    let mut flow = make_flow_with_token_snapshots();
+    // Strip cost from both endpoints so phase_delta produces None
+    // for cost while tokens still grow → row stays in active_rows
+    // and reaches the cost rendering branch.
+    flow.state["phases"]["flow-code"]["window_at_enter"]["session_cost_usd"] =
+        serde_json::json!(null);
+    flow.state["phases"]["flow-code"]["window_at_complete"]["session_cost_usd"] =
+        serde_json::json!(null);
+    app.flows = vec![flow];
+    let output = render_to_string(&app, 100, 40);
+    assert!(
+        output.contains("Tokens"),
+        "Token table must render when tokens grew:\n{}",
+        output
+    );
+    assert!(
+        output.contains("—"),
+        "em-dash placeholder must appear when cost data is unknown:\n{}",
+        output
+    );
+}
+
 /// Window-reset marker appears on rows where the rate-limit window
 /// rolled over mid-phase.
 #[test]

--- a/tests/tui_data.rs
+++ b/tests/tui_data.rs
@@ -1953,11 +1953,9 @@ fn phase_token_table_handles_missing_snapshots() {
     let rows = phase_token_table(&state);
     for row in &rows {
         assert_eq!(row.tokens, 0, "phase {} tokens", row.phase_key);
-        assert!(
-            row.cost_usd.abs() < f64::EPSILON,
-            "phase {} cost",
-            row.phase_key
-        );
+        // Missing snapshots → no cost pair → cost is `None` (issue
+        // #1410: the new sentinel for "no cost data").
+        assert!(row.cost_usd.is_none(), "phase {} cost", row.phase_key);
         assert!(!row.window_reset_observed, "phase {} reset", row.phase_key);
     }
 }
@@ -2001,7 +1999,10 @@ fn phase_token_table_with_snapshots_reports_tokens_and_cost() {
         .find(|r| r.phase_key == "flow-start")
         .expect("flow-start row");
     assert!(start_row.tokens > 0, "flow-start tokens > 0");
-    assert!(start_row.cost_usd > 0.0, "flow-start cost > 0");
+    assert!(
+        start_row.cost_usd.unwrap_or(0.0) > 0.0,
+        "flow-start cost > 0"
+    );
     let code_row = rows
         .iter()
         .find(|r| r.phase_key == "flow-code")
@@ -2089,7 +2090,10 @@ fn phase_token_table_with_unparseable_state_returns_zero_data_rows() {
     assert_eq!(rows.len(), PHASE_ORDER.len());
     for row in &rows {
         assert_eq!(row.tokens, 0);
-        assert!(row.cost_usd.abs() < f64::EPSILON);
+        // FlowState parse failure → no delta computable → cost is
+        // `None` (issue #1410). The pre-fix scaffold returned
+        // `0.0`; the new sentinel preserves the "no data" signal.
+        assert!(row.cost_usd.is_none());
         assert!(!row.window_reset_observed);
     }
 }

--- a/tests/window_deltas.rs
+++ b/tests/window_deltas.rs
@@ -608,3 +608,32 @@ fn deltas_from_snapshots_some_then_none_then_some_treated_as_three_sessions() {
     );
     assert_eq!(report.cost_delta_usd, None);
 }
+
+/// Regression: the synthetic per-index key for a None session_id is
+/// prefixed with NUL (`\0__none_<i>`). The NUL prefix makes the
+/// synthetic-key namespace disjoint from any real `session_id` —
+/// `is_safe_session_id` rejects NUL — so a captured session_id of
+/// shape `__none_0` (which DOES pass the alphanumeric+underscore
+/// validator) can never collide with the synthetic key for snapshot
+/// 0 of a different flow.
+#[test]
+fn deltas_from_snapshots_synthetic_key_disjoint_from_real_underscore_id() {
+    let mut s0 = snap("ignored", 5);
+    s0.session_id = None; // → synthetic key "\0__none_0"
+    s0.session_cost_usd = Some(0.50);
+
+    // Real session_id literally equal to "__none_0" — passes
+    // is_safe_session_id (alphanumeric + underscore) but is
+    // distinct from the synthetic "\0__none_0".
+    let mut s1 = snap("__none_0", 12);
+    s1.session_cost_usd = Some(2.00);
+
+    let phase = phase_with_snapshots(Some(s0), vec![], Some(s1));
+    let report = phase_delta(&phase).expect("populated");
+    assert_eq!(
+        report.cost_delta_usd, None,
+        "synthetic key for None session_id must not collide with a real \
+         session_id of shape `__none_0`; got cost={:?}",
+        report.cost_delta_usd
+    );
+}

--- a/tests/window_deltas.rs
+++ b/tests/window_deltas.rs
@@ -182,6 +182,23 @@ fn phase_delta_cross_session_groups_then_sums() {
     let report = phase_delta(&phase).expect("populated");
     assert_eq!(report.input_tokens_delta, 11);
     assert_eq!(report.turn_count_delta, 11);
+    // snap() seeds session_cost_usd as `Some(n * 0.01)` so both
+    // session segments have populated cost endpoints. The plan
+    // (issue #1410) calls out this assertion as the test gap that
+    // allowed the asymmetric pre-fix `pair_delta` to ship: without
+    // a cost check, the buggy (Some, None)/(None, Some) arms would
+    // have silently fabricated deltas across the session boundary.
+    // S1: 0.08 - 0.05 = 0.03; S2: 0.10 - 0.02 = 0.08; Total: 0.11.
+    let cost = report.cost_delta_usd.expect("cost is populated");
+    assert!(
+        (cost - 0.11).abs() < 1e-9,
+        "cross-session cost must sum each session independently; got {}",
+        cost
+    );
+    assert!(
+        !report.total_partial,
+        "all four cost endpoints are Some, so total_partial must be false"
+    );
 }
 
 /// Step snapshots between enter and complete contribute through
@@ -344,7 +361,11 @@ fn flow_total_empty_state_returns_zero_report() {
     let state = empty_state();
     let report = flow_total(&state);
     assert_eq!(report.input_tokens_delta, 0);
-    assert_eq!(report.cost_delta_usd, 0.0);
+    // Empty state has no cost contributions, so the zero report's
+    // `cost_delta_usd` is `None` — the new "no info" sentinel that
+    // distinguishes "we computed zero cost" from "we have no cost
+    // data at all" (issue #1410).
+    assert_eq!(report.cost_delta_usd, None);
     assert_eq!(report.five_hour_pct_delta, Some(0));
     assert!(!report.window_reset_observed);
     assert!(report.by_model_delta.is_empty());
@@ -369,29 +390,77 @@ fn flow_total_sticky_reset_flag_propagates() {
     assert!(report.window_reset_observed);
 }
 
-/// Cost delta with `start` as `None` and `end` populated treats
-/// the start as zero and reports the end's value as the delta.
+// --- pair_delta cost (Option<f64>) — issue #1410 ---
+//
+// pair_delta is private; tests drive it through phase_delta with
+// fixtures that produce a single (enter, complete) pair, isolating
+// the cost-arm logic. The four named tests below replace the
+// pre-fix tests `phase_delta_cost_with_none_start_uses_end_value`
+// and `phase_delta_cost_with_both_none_contributes_zero`, which
+// asserted the buggy fabricate-on-missing behavior. Per
+// `.claude/rules/supersession.md` the pre-fix tests are deleted
+// because their assertion contracts are obsolete.
+
+/// Both endpoints populated: cost delta is `Some(end - start)`.
 #[test]
-fn phase_delta_cost_with_none_start_uses_end_value() {
+fn pair_delta_cost_both_present_returns_some_difference() {
+    let mut enter = snap("S1", 0);
+    let mut complete = snap("S1", 0);
+    enter.session_cost_usd = Some(0.5);
+    complete.session_cost_usd = Some(2.0);
+    let phase = phase_with_snapshots(Some(enter), vec![], Some(complete));
+    let report = phase_delta(&phase).expect("populated");
+    assert_eq!(
+        report.cost_delta_usd,
+        Some(1.5),
+        "(Some, Some) must produce Some(end - start)"
+    );
+}
+
+/// End cost missing: pair_delta cannot infer a delta from a single
+/// endpoint, so the result is `None`. The pre-fix code returned
+/// `0.0`, silently dropping the start.
+#[test]
+fn pair_delta_cost_end_missing_returns_none() {
+    let mut enter = snap("S1", 0);
+    let mut complete = snap("S1", 0);
+    enter.session_cost_usd = Some(0.5);
+    complete.session_cost_usd = None;
+    let phase = phase_with_snapshots(Some(enter), vec![], Some(complete));
+    let report = phase_delta(&phase).expect("populated");
+    assert_eq!(
+        report.cost_delta_usd, None,
+        "(Some, None) must produce None — no fabricated delta"
+    );
+}
+
+/// Start cost missing: pair_delta cannot infer a delta. The pre-fix
+/// code returned the end's cumulative value, fabricating a delta
+/// from a session-total.
+#[test]
+fn pair_delta_cost_start_missing_returns_none() {
     let mut enter = snap("S1", 0);
     let mut complete = snap("S1", 0);
     enter.session_cost_usd = None;
-    complete.session_cost_usd = Some(0.42);
+    complete.session_cost_usd = Some(2.0);
     let phase = phase_with_snapshots(Some(enter), vec![], Some(complete));
     let report = phase_delta(&phase).expect("populated");
-    assert!((report.cost_delta_usd - 0.42).abs() < 1e-9);
+    assert_eq!(
+        report.cost_delta_usd, None,
+        "(None, Some) must produce None — no fabricated delta from cumulative end"
+    );
 }
 
-/// Cost delta where both endpoints are `None` contributes zero.
+/// Both endpoints missing: result is `None`.
 #[test]
-fn phase_delta_cost_with_both_none_contributes_zero() {
+fn pair_delta_cost_both_missing_returns_none() {
     let mut enter = snap("S1", 0);
     let mut complete = snap("S1", 0);
     enter.session_cost_usd = None;
     complete.session_cost_usd = None;
     let phase = phase_with_snapshots(Some(enter), vec![], Some(complete));
     let report = phase_delta(&phase).expect("populated");
-    assert_eq!(report.cost_delta_usd, 0.0);
+    assert_eq!(report.cost_delta_usd, None);
 }
 
 /// pct_delta_with_reset: when `start` is None and `end` is Some,

--- a/tests/window_deltas.rs
+++ b/tests/window_deltas.rs
@@ -538,17 +538,73 @@ fn phase_delta_with_single_snapshot_session_in_middle_skips_lone_snapshot() {
     assert_eq!(report.input_tokens_delta, 9);
 }
 
-/// Cross-session deltas when `session_id` is missing on a snapshot:
-/// missing session id is treated as the empty-string sentinel,
-/// grouping consecutive None snapshots together — they share a
-/// "no session" context.
+// Pre-fix test `phase_delta_with_missing_session_ids_groups_as_one_session`
+// was removed per `.claude/rules/supersession.md` — it asserted the
+// buggy behavior where consecutive None session_id snapshots were
+// collapsed into one synthetic empty-string session, producing a
+// spurious cross-snapshot delta. The plan-named
+// `deltas_from_snapshots_*` tests below cover the new contract:
+// each None session_id is a distinct session, so consecutive
+// None snapshots produce no pair delta.
+
+/// Two consecutive snapshots with `session_id: None` are treated as
+/// distinct sessions (each gets a unique synthetic key per snapshot
+/// index), so no pair_delta is computed across them. Pre-fix the
+/// `unwrap_or("")` collapsed both into one empty-string session and
+/// produced a spurious delta of 1.5 across them.
 #[test]
-fn phase_delta_with_missing_session_ids_groups_as_one_session() {
+fn deltas_from_snapshots_two_none_session_ids_treated_as_distinct_sessions() {
     let mut s_a = snap("ignored", 5);
     let mut s_b = snap("ignored", 12);
     s_a.session_id = None;
     s_b.session_id = None;
+    s_a.session_cost_usd = Some(0.5);
+    s_b.session_cost_usd = Some(2.0);
     let phase = phase_with_snapshots(Some(s_a), vec![], Some(s_b));
     let report = phase_delta(&phase).expect("populated");
+    assert_eq!(
+        report.input_tokens_delta, 0,
+        "two distinct None sessions must not produce a token delta"
+    );
+    assert_eq!(
+        report.cost_delta_usd, None,
+        "two distinct None sessions must not fabricate a cost delta from cumulative values"
+    );
+}
+
+/// `[None, Some("A"), Some("A")]`: the leading None snapshot is its
+/// own session (no pair); the two `Some("A")` snapshots form a pair.
+/// Only that pair's delta contributes.
+#[test]
+fn deltas_from_snapshots_none_then_some_session_id_split_at_boundary() {
+    let mut s_none = snap("ignored", 0);
+    s_none.session_id = None;
+    let s_a_enter = snap("A", 5);
+    let s_a_complete = snap("A", 12);
+    let phase = phase_with_snapshots(
+        Some(s_none),
+        vec![(1, "code_task", s_a_enter)],
+        Some(s_a_complete),
+    );
+    let report = phase_delta(&phase).expect("populated");
+    // Only the (Some("A"), Some("A")) pair contributes: 12 - 5 = 7.
     assert_eq!(report.input_tokens_delta, 7);
+}
+
+/// `[Some("A"), None, Some("B")]`: three distinct sessions, none of
+/// which has more than one snapshot, so no pair contributes a
+/// delta.
+#[test]
+fn deltas_from_snapshots_some_then_none_then_some_treated_as_three_sessions() {
+    let s_a = snap("A", 5);
+    let mut s_none = snap("ignored", 7);
+    s_none.session_id = None;
+    let s_b = snap("B", 10);
+    let phase = phase_with_snapshots(Some(s_a), vec![(1, "code_task", s_none)], Some(s_b));
+    let report = phase_delta(&phase).expect("populated");
+    assert_eq!(
+        report.input_tokens_delta, 0,
+        "three distinct single-snapshot sessions must not produce a delta"
+    );
+    assert_eq!(report.cost_delta_usd, None);
 }


### PR DESCRIPTION
## What

#1410.

Closes #1410

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/capture-cost-data-per-flow/log` |
| State | `.flow-states/capture-cost-data-per-flow/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 1h 40m |
| Code Review | 38m |
| Learn | 3m |
| Complete | <1m |
| **Total** | **2h 23m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/capture-cost-data-per-flow.json</summary>

```json
{
  "schema_version": 1,
  "branch": "capture-cost-data-per-flow",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1411,
  "pr_url": "https://github.com/benkruger/flow/pull/1411",
  "started_at": "2026-05-09T16:07:49-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/capture-cost-data-per-flow/log",
    "state": ".flow-states/capture-cost-data-per-flow/state.json"
  },
  "session_tty": "/dev/ttys004",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "#1410",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-09T16:07:49-07:00",
      "completed_at": "2026-05-09T16:08:20-07:00",
      "session_started_at": null,
      "cumulative_seconds": 31,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-09T16:08:20-07:00",
        "five_hour_pct": 63,
        "seven_day_pct": 41
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-09T16:08:34-07:00",
      "completed_at": "2026-05-09T17:49:19-07:00",
      "session_started_at": null,
      "cumulative_seconds": 6045,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T16:08:34-07:00",
        "five_hour_pct": 63,
        "seven_day_pct": 41
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-09T16:18:37-07:00",
          "five_hour_pct": 65,
          "seven_day_pct": 42
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-09T16:50:04-07:00",
          "five_hour_pct": 1,
          "seven_day_pct": 43
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-09T16:50:04-07:00",
          "five_hour_pct": 1,
          "seven_day_pct": 43
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-09T17:30:06-07:00",
          "five_hour_pct": 5,
          "seven_day_pct": 44
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-09T17:30:06-07:00",
          "five_hour_pct": 5,
          "seven_day_pct": 44
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-09T17:38:45-07:00",
          "five_hour_pct": 6,
          "seven_day_pct": 45
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-09T17:38:45-07:00",
          "five_hour_pct": 6,
          "seven_day_pct": 45
        },
        {
          "step": 8,
          "field": "code_task",
          "captured_at": "2026-05-09T17:42:45-07:00",
          "five_hour_pct": 7,
          "seven_day_pct": 45
        },
        {
          "step": 9,
          "field": "code_task",
          "captured_at": "2026-05-09T17:42:45-07:00",
          "five_hour_pct": 7,
          "seven_day_pct": 45
        },
        {
          "step": 10,
          "field": "code_task",
          "captured_at": "2026-05-09T17:47:51-07:00",
          "five_hour_pct": 9,
          "seven_day_pct": 45
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T17:49:19-07:00",
        "five_hour_pct": 9,
        "seven_day_pct": 45
      }
    },
    "flow-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-05-09T17:49:33-07:00",
      "completed_at": "2026-05-09T18:28:16-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2323,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T17:49:33-07:00",
        "five_hour_pct": 9,
        "seven_day_pct": 45
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-09T17:55:34-07:00",
          "five_hour_pct": 13,
          "seven_day_pct": 46
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-09T18:06:03-07:00",
          "five_hour_pct": 20,
          "seven_day_pct": 48
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-09T18:07:51-07:00",
          "five_hour_pct": 20,
          "seven_day_pct": 48
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-09T18:28:06-07:00",
          "five_hour_pct": 27,
          "seven_day_pct": 50
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T18:28:16-07:00",
        "five_hour_pct": 27,
        "seven_day_pct": 50
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-09T18:28:27-07:00",
      "completed_at": "2026-05-09T18:31:54-07:00",
      "session_started_at": null,
      "cumulative_seconds": 207,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T18:28:27-07:00",
        "five_hour_pct": 27,
        "seven_day_pct": 50
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-09T18:31:07-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 50
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-09T18:31:26-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 50
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-09T18:31:36-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 50
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-09T18:31:40-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 50
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-09T18:31:45-07:00",
          "five_hour_pct": 28,
          "seven_day_pct": 50
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T18:31:54-07:00",
        "five_hour_pct": 28,
        "seven_day_pct": 50
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-09T18:32:11-07:00",
      "completed_at": "2026-05-09T18:32:29-07:00",
      "session_started_at": null,
      "cumulative_seconds": 18,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-09T18:32:29-07:00",
        "five_hour_pct": 28,
        "seven_day_pct": 51
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-09T16:08:34-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-09T17:49:33-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-09T18:28:27-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-09T18:32:11-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    }
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-09T16:07:49-07:00",
    "five_hour_pct": 63,
    "seven_day_pct": 41
  },
  "code_task_name": "Task 10: Cost-per-flow integration test",
  "code_task": 10,
  "diff_stats": {
    "files_changed": 20,
    "insertions": 1431,
    "deletions": 149,
    "captured_at": "2026-05-09T17:49:19-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThe user's request is clear and specific: check documentation drift caused by PR #1410. The user provided:\n1. A worktree path: `/Users/ben/code/flow/.worktrees/capture-cost-data-per-flow`\n2. A detailed one-paragraph diff summary describing all code changes\n3. Four specific doc paths to check ONLY (no file walking, no git diff):\n   - `/Users/ben/code/flow/.worktrees/capture-cost-data-per-flow/CLAUDE.md`\n   - `/Users/ben/code/flow/.worktrees/capture-cost-data-per-flow/skills/flow-complete/SKILL.md`\n   - `/Users/ben/code/flow/.worktrees/capture-cost-data-per-flow/skills/flow-prime/SKILL.md`\n   - `/Users/ben/code/flow/.worktrees/capture-cost-data-per-flow/docs/reference/flow-state-schema.md`\n4. Four specific checks to perform:\n   - Check 1: CLAUDE.md \"Key Files\" section for entries about `src/hooks/capture_session.rs` or `hooks/hooks.json`\n   - Check 2: `skills/flow-complete/SKILL.md` output sections for \"—\" placeholder, \"*\" partial marker, footnote\n   - Check 3: `skills/flow-prime/SKILL.md` for SessionStart hooks documentation\n   - Check 4: `docs/reference/flow-state-schema.md` for cost_delta_usd or DeltaReport field type updates\n5. A value test from `.claude/rules/review-scope.md` to apply\n\nI read all four doc files completely. The diff summary describes PR #1410 changes:\n- NEW: `src/hooks/capture_session.rs` — SessionStart hook persisting session_id+transcript_path\n- NEW: `hooks/hooks.json` SessionStart entry registering \"bin/flow hook capture-session\"\n- MODIFIED: `src/commands/init_state.rs` — new `seed_session_id_from_capture` function\n- MODIFIED: `src/window_deltas.rs` — DeltaReport.cost_delta_usd changed to Option<f64>, new field total_partial\n- MODIFIED: `src/format_complete_summary.rs` — token_cost_section rewrite with \"—\" for unknown cost, \"*\" suffix for partial\n- MODIFIED: `src/format_status.rs` — tokens_line renders \"—\" for None cost\n- MODIFIED: `src/tui.rs` / `src/tui_data.rs` — PhaseTokenRow.cost_usd now Option<f64>, TUI renders \"—\"\n- MODIFIED: `src/window_snapshot.rs` — is_safe_session_id made pub(crate)\n- MODIFIED: `src/main.rs` / `src/hooks/mod.rs` — register new hook subcommand\n- NO changes to: skills/, .claude/rules/, agents/, flow-phases.json, docs/ files\n\nAfter reading all four docs:\n\n1. **CLAUDE.md**: The \"Key Files\" section (lines 53-67) lists permanent on-main artifacts. It has entries for `src/*.rs` collectively on line 62: \"src/*.rs — Rust source for all `bin/flow` subcommands. Per-module purpose lives in module doc comments.\" This is a collective listing pattern, not per-hook. The new `src/hooks/capture_session.rs` falls under this existing entry. The `hooks/hooks.json` entry is already listed on line 58. No new entries needed based on the existing collective pattern — this matches what the user noted about the pattern listing \"src/*.rs collectively, not per-hook.\"\n\n2. **skills/flow-complete/SKILL.md**: Lines 645-654 describe the summary output. It states \"token totals + cost in USD, plus a Total row; an optional By Model breakdown when 2+ models contributed; an optional \"↻\" marker and footer note when a rate-limit window reset was observed mid-flow — the section is omitted entirely when no phase carries window snapshot data\". The diff shows that `src/format_complete_summary.rs` has a rewrite that renders \"—\" for unknown cost and \"*\" suffix for partial rows with a footnote \"* cost partial — some phases had no cost data\". This documentation describes the output BEFORE the changes but does NOT mention the new \"—\" placeholder, \"*\" partial marker, or the footnote about partial cost. This is drift.\n\n3. **skills/flow-prime/SKILL.md**: I searched the entire document. There is NO mention of SessionStart hooks at all. The diff shows that `src/hooks/capture_session.rs` is a NEW SessionStart hook. The prime skill does not document SessionStart hooks, and therefore does not need to document the new \"capture-session\" hook. No drift here, but also no documentation of the new functionality.\n\n4. **docs/reference/flow-state-schema.md**: The document mentions in the Window Snapshot section that fields are \"optional (`<type> / null`)\" but `cost_delta_usd` does not appear anywhere in this file. The diff shows `src/window_deltas.rs` has DeltaReport.cost_delta_usd changed to Option<f64>, but this is an INTERNAL Rust struct per the user's note. The user explicitly states \"DeltaReport is internal Rust, not state-file persisted; only state-file fields belong in this doc.\" So there should be no entry for cost_delta_usd in the schema doc.\n\nKey findings:\n- DRIFT FOUND in skills/flow-complete/SKILL.md: The \"summary\" description at lines 645-654 does not document the new \"—\" for unknown cost, \"*\" suffix for partial rows, or the partial footnote that the rewritten token_cost_section now produces.\n- NO DRIFT in CLAUDE.md: The collective `src/*.rs` pattern already covers the new hook file.\n- NO DOCUMENTATION NEEDED in skills/flow-prime/SKILL.md: SessionStart hooks are not currently documented, and the new capture-session hook is not a user-facing skill (it's internal hook infrastructure).\n- NO DRIFT in docs/reference/flow-state-schema.md: DeltaReport is internal, not state-persisted.\n\nApplying the value test from review-scope.md: \"can a future reader derive the information from existing prose+code?\" For the flow-complete skill, a reader looking at the skill would NOT find any mention of the new output format changes (the \"—\" and \"*\" markers and the footnote). They would have to read the source code (`src/format_complete_summary.rs`) to discover this. This fails the value test — it's a real drift.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user requested documentation drift checking for PR #1410 against four specific doc files in a worktree. The task was explicitly scoped to:\n   - Check ONLY the four specified doc paths (no file walking, no git diff)\n   - Apply the value test from `.claude/rules/review-scope.md` (\"can a future reader derive the information from existing prose+code?\")\n   - Identify drift where future readers cannot understand new functionality from existing documentation\n   - Be brief in findings\n\n2. Key Technical Concepts:\n   - Documentation drift detection\n   - PR #1410 changes: SessionStart hook capturing session_id/transcript_path, cost_delta_usd type change to Option<f64>, token_cost_section rewrite\n   - Value-vs-Bureaucracy triage (from review-scope.md)\n   - Internal Rust structures vs. state-file persisted fields\n   - Module-level doc comment conventions\n\n3. Files and Code Sections:\n   - `/Users/ben/code/flow/.worktrees/capture-cost-data-per-flow/CLAUDE.md` (read completely)\n      - Key Files section (lines 53-67) lists permanent on-main artifacts\n      - Uses collective pattern for Rust source: `src/*.rs — Rust source for all bin/flow subcommands` (line 62)\n      - Already lists `hooks/hooks.json` on line 58\n      - New `src/hooks/capture_session.rs` falls under existing collective pattern\n   \n   - `/Users/ben/code/flow/.worktrees/capture-cost-data-per-flow/skills/flow-complete/SKILL.md` (read completely)\n      - Lines 645-654 describe summary output including token cost section\n      - Current prose: \"token totals + cost in USD, plus a Total row; an optional By Model breakdown when 2+ models contributed; an optional \"↻\" marker and footer note when a rate-limit window reset was observed mid-flow — the section is omitted entirely when no phase carries window snapshot data\"\n      - Does NOT document: \"—\" placeholder for unknown cost, \"*\" suffix for partial rows, footnote about partial cost data\n   \n   - `/Users/ben/code/flow/.worktrees/capture-cost-data-per-flow/skills/flow-prime/SKILL.md` (read completely)\n      - No SessionStart hook documentation present\n      - No need to document new capture-session hook (skill does not describe hook infrastructure)\n   \n   - `/Users/ben/code/flow/.worktrees/capture-cost-data-per-flow/docs/reference/flow-state-schema.md` (read completely)\n      - No mention of cost_delta_usd or DeltaReport\n      - Correct: DeltaReport is internal Rust struct, not state-file persisted\n\n4. Errors and fixes:\n   - No errors encountered. All four doc files were read successfully and analyzed against the diff summary.\n\n5. Problem Solving:\n   - Applied the value test correctly: identified that flow-complete skill documentation does not enable future readers to understand the new \"—\" and \"*\" output markers without reading source code\n   - Correctly classified internal Rust structures (DeltaReport) as out-of-scope for the state-schema doc\n   - Correctly identified that collective patterns in CLAUDE.md Key Files already cover new code files\n\n6. All user messages:\n   - User's initial message: \"You are checking documentation drift only. The diff is a one-paragraph summary below. Read ONLY the doc paths under DOC_PATHS and check each one against the summary for drift. Do not fetch any git diff. Do not walk any other files.\" followed by specific branch, worktree, diff summary, doc paths, and four specific checks with a value test from review-scope.md.\n\n7. Pending Tasks:\n   - None. User request was for drift analysis only, completed in the initial message.\n\n8. Current Work:\n   The work completed was reading and analyzing four documentation files against PR #1410's diff summary to identify drift. All four files were read in full and analyzed against the specific checks requested:\n   - Check 1: CLAUDE.md \"Key Files\" for new file entries (no drift found — uses collective pattern)\n   - Check 2: flow-complete SKILL.md output section for new markers (DRIFT FOUND — \"—\", \"*\", and footnote not documented)\n   - Check 3: flow-prime SKILL.md for SessionStart hooks (no documentation present, not applicable)\n   - Check 4: flow-state-schema.md for cost type updates (correctly excluded internal Rust struct)\n\n9. Optional Next Step:\n   No further action requested. The user asked for drift checking only, which is complete. The analysis found one documentation drift: skills/flow-complete/SKILL.md lines 645-654 do not document the new \"—\" placeholder, \"*\" partial marker, and the footnote about partial cost data that the rewritten token_cost_section now produces. This fails the value test because \"a future reader cannot derive the information from existing prose+code.\"\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/capture-cost-data-per-flow",
  "compact_count": 8,
  "findings": [
    {
      "finding": "Multi-session race on machine-global capture file singleton",
      "reason": "Pre-mortem's 'inflated cost' failure mode requires capture_for_active_state to also read the capture file, which it does not. Subsequent snapshots in Session A source session_id from ~/.claude/projects/<root>/<session>.jsonl, not the capture file. The race seeds a possibly-wrong id at init_state only; subsequent captures correctly identify A. The pair becomes (None, Some) which the new Option<f64> contract renders as '—' — graceful degradation matching the documented module-doc rationale.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:07:38-07:00"
    },
    {
      "finding": "read_captured_session lacks documented byte cap",
      "reason": "Added CAPTURE_FILE_BYTE_CAP=64KB constant + take(CAP) wrapper per .claude/rules/external-input-path-construction.md 'Enforce a documented size cap on every external read'",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:24:46-07:00"
    },
    {
      "finding": "Backward-facing comments in window_deltas.rs reference pre-fix behavior",
      "reason": "Rewrote DeltaReport doc and pair_delta inline comment to describe current contract only, removing 'pre-fix arms' / 'previous arms' / 'silently miscounted' phrasings per .claude/rules/comment-quality.md and .claude/rules/forward-facing-authoring.md",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:24:53-07:00"
    },
    {
      "finding": "fs::write to capture file follows pre-existing symlink (arbitrary-file-write primitive)",
      "reason": "Added symlink-safe write guard in capture_session::run: fs::symlink_metadata detects pre-existing entry; if symlink, fs::remove_file unlinks before fs::write creates a fresh regular file. Per .claude/rules/rust-patterns.md 'Symlink-Safe Existence Checks Before Writes'",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:25:01-07:00"
    },
    {
      "finding": "Synthetic __none_<i> session-key namespace collides with real session_id of same shape",
      "reason": "Prefixed synthetic key with NUL byte (\\0__none_<i>) so the namespace is disjoint from any value passing is_safe_session_id (which rejects NUL). Real underscore-shaped session_ids cannot collide with synthetic keys",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:25:08-07:00"
    },
    {
      "finding": "is_safe_session_id accepts unbounded-length strings (5MB session_id flooded capture file)",
      "reason": "Added SESSION_ID_MAX_LEN=256 constant; is_safe_session_id rejects strings > 256 bytes. Also added STDIN_BYTE_CAP=64KB on the hook's stdin read so a hostile producer cannot pass arbitrary-size payloads even before validation",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:25:15-07:00"
    },
    {
      "finding": "skills/flow-complete/SKILL.md missing documentation for new Token Cost markers (em-dash, asterisk, partial footnote)",
      "reason": "Extended the Token Cost section description to enumerate the three conditional output markers ('—' for unknown cost, '*' for partial rows/total, footnote line). Per .claude/rules/docs-with-behavior.md 'New field, line, or widget in a formatter's output → the user-facing SKILL.md'",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:25:24-07:00"
    },
    {
      "finding": "Plan-Phase Trigger in external-input-path-construction.md should require a structured table for byte-cap enumeration",
      "reason": "Rule item 4 already names the byte cap requirement. Author non-compliance with the existing rule produced the gap; Code Review caught and remediated in Step 4. One-off, not a cross-flow pattern. Value test fails: the system closed the gap. Dismiss.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-09T18:31:14-07:00"
    },
    {
      "finding": "Missing rule: synthetic identifiers must be disjoint from valid input namespace",
      "reason": "Code Review caught the synthetic-key namespace collision (real session_id of shape __none_0 vs synthetic __none_<i>) and the fix landed (NUL prefix). Principle captured in source comment and commit body. One-off Code-Review-catch — the cognitive-isolation system working. Value test fails per .claude/rules/review-scope.md and .claude/rules/forward-facing-authoring.md zero-artifact default. Dismiss.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-09T18:31:21-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-09T18:32:29-07:00",
    "five_hour_pct": 28,
    "seven_day_pct": 51
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>