### PR TITLE
Fix Three Hook Deadlock On

### DIFF
--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -268,3 +268,41 @@ only skill is the user-direction signal — `validate-skill` Layer
 1 ensures the model can only reach that Skill call after the user
 typed the slash command. See `.claude/rules/user-only-skills.md`
 Layer 2 for the full design.
+
+## Shared-Config Carve-Out
+
+The autonomous-phase block above protects against
+model-initiated prompts. The shared-config block from
+`validate_worktree_paths` (see `.claude/rules/permissions.md`
+"Shared Config Files — Express User Permission Required") is the
+opposite shape: another hook explicitly instructs the model to
+call `AskUserQuestion` to confirm a shared-config edit. Without a
+carve-out, the autonomous-phase block refuses the very prompt the
+prior hook demanded — the flow deadlocks while two hooks
+contradict each other.
+
+The trigger is system-initiated, not model-initiated: the
+shared-config BLOCKED message itself directs the next action.
+Letting the prompt fire completes the confirmation flow the
+system asked for.
+
+`validate-ask-user`'s `run_impl_main` calls
+`crate::hooks::transcript_walker::recent_edit_blocked_on_shared_config`
+between the user-only-skill carve-out and the block return. The
+helper walks the persisted transcript backward from the file
+tail, capped at `SHARED_CONFIG_BLOCK_BYTE_CAP` (4 MB), and
+returns `true` when it finds a `tool_result` block with
+`is_error: true` whose `content` contains the literal substring
+`"is a shared configuration file"` since the most recent real
+user turn. The substring is uniquely emitted by
+`crate::hooks::validate_worktree_paths::validate_shared_config`
+and locked in place by a presence-contract test in
+`tests/hooks/validate_worktree_paths.rs`.
+
+The user-only carve-out is checked first; both produce the same
+allow outcome, so the order is semantically irrelevant but the
+ordering is locked by an explicit regression test
+(`both_carve_outs_can_apply_user_only_wins_first`). Older user
+turns and tool_results predating the most recent real user turn
+are invisible to the helper — only the active confirmation
+window matters.

--- a/.claude/rules/hook-vs-instruction.md
+++ b/.claude/rules/hook-vs-instruction.md
@@ -74,13 +74,26 @@ insufficient:
 - **`AskUserQuestion` during an autonomous in-progress phase**
   — `validate-ask-user` rejects with exit 2 when
   `phases.<current_phase>.status == "in_progress"` AND
-  `skills.<current_phase>.continue == "auto"`. Carve-out: when
-  the most recent assistant Skill tool_use call (since the most
-  recent user turn) targets a skill in
-  `crate::hooks::transcript_walker::USER_ONLY_SKILLS`, the
-  block is suppressed so user-only skills' confirmation prompts
-  fire mid-autonomous. See `.claude/rules/user-only-skills.md`
-  Layer 2.
+  `skills.<current_phase>.continue == "auto"`. Two carve-outs
+  suppress the block:
+    - **User-only-skill carve-out**: when the most recent
+      assistant Skill tool_use call (since the most recent
+      user turn) targets a skill in
+      `crate::hooks::transcript_walker::USER_ONLY_SKILLS`, the
+      block is suppressed so user-only skills' confirmation
+      prompts fire mid-autonomous. See
+      `.claude/rules/user-only-skills.md` Layer 2.
+    - **Shared-config carve-out**: when the most recent
+      user-role turn carries a `validate_worktree_paths`
+      shared-config edit-block tool_result (a `tool_result`
+      with `is_error: true` whose content contains the
+      literal substring `"is a shared configuration file"`),
+      the block is suppressed so the system-initiated
+      AskUserQuestion the BLOCKED message demanded fires
+      instead of deadlocking. The user-only carve-out is
+      checked first. See
+      `.claude/rules/autonomous-phase-discipline.md`
+      "Shared-Config Carve-Out".
 - **Voluntary turn-end during autonomous in-progress phases** —
   `stop_continue::check_autonomous_in_progress` refuses the Stop
   event with `{"decision":"block"}` and an autonomous-mode reason

--- a/.claude/rules/permissions.md
+++ b/.claude/rules/permissions.md
@@ -341,3 +341,22 @@ is inside the worktree.
 The block message directs the model to confirm with the user via
 `AskUserQuestion` before proceeding, and points to this section
 for context.
+
+### Autonomous-phase carve-out for the confirmation prompt
+
+The block message instructs the model to call
+`AskUserQuestion` to confirm the shared-config edit. During an
+in-progress autonomous phase, the autonomous-phase block in
+`validate-ask-user` would refuse that prompt — two hooks
+contradicting each other and deadlocking the flow. To resolve
+the contradiction, `validate-ask-user::run_impl_main` carves out
+the AskUserQuestion when the persisted transcript carries a
+recent shared-config block: the carve-out lets the prompt fire
+so the system-initiated confirmation flow completes.
+
+The carve-out is system-initiated, not model-initiated, so it
+does not violate the autonomous-mode discipline against
+self-imposed pauses. See
+`.claude/rules/autonomous-phase-discipline.md` "Shared-Config
+Carve-Out" subsection for the helper, the detection signal, and
+the ordering relative to the user-only-skill carve-out.

--- a/.claude/rules/user-only-skills.md
+++ b/.claude/rules/user-only-skills.md
@@ -109,6 +109,14 @@ are invisible. Multi-tool assistant turns are scanned in full
 only Skill appearing second or later in the turn's content
 array still satisfies the carve-out.
 
+The user-only-skill carve-out is the first sanctioned exception
+to the autonomous-phase AskUserQuestion block. The shared-config
+carve-out (see `.claude/rules/autonomous-phase-discipline.md`
+"Shared-Config Carve-Out") is the second; both fire in
+`validate-ask-user::run_impl_main` between the autonomous-phase
+block and the block return, with the user-only check ordered
+first.
+
 ### Layer 3: `validate-claude-paths` transcript root lockdown
 
 `src/hooks/validate_claude_paths.rs::is_transcript_path` blocks

--- a/src/hooks/transcript_walker.rs
+++ b/src/hooks/transcript_walker.rs
@@ -114,6 +114,18 @@ pub const USER_ONLY_SKILLS: &[&str] = &[
 /// reachable regardless of total file size.
 pub const TRANSCRIPT_BYTE_CAP: u64 = 50 * 1024 * 1024;
 
+/// Smaller tail-bounded cap (4 MB) for shared-config block detection.
+/// `recent_edit_blocked_on_shared_config` only needs the last 1-2
+/// turns since the most recent real user turn — the most recent
+/// assistant tool call and its paired tool_result. 4 MB comfortably
+/// holds those turns even when they include large file contents in
+/// `tool_use.input` or `tool_result.content`. Using a smaller cap
+/// here than `TRANSCRIPT_BYTE_CAP` keeps the AskUserQuestion-blocked
+/// hot path fast — the helper runs synchronously inside the
+/// `validate-ask-user` hook and adds latency to every blocked
+/// AskUserQuestion call during in-progress autonomous phases.
+pub const SHARED_CONFIG_BLOCK_BYTE_CAP: u64 = 4 * 1024 * 1024;
+
 /// Normalize a gate-relevant string for comparison: strip NUL
 /// bytes, trim leading/trailing whitespace, and ASCII-lowercase.
 /// Per `.claude/rules/security-gates.md` "Normalize Before
@@ -150,7 +162,7 @@ pub fn last_user_message_invokes_skill(path: &Path, skill: &str, home: &Path) ->
     if skill_norm.is_empty() {
         return false;
     }
-    let lines = match read_capped(path) {
+    let lines = match read_capped(path, TRANSCRIPT_BYTE_CAP) {
         Some(s) => s,
         None => return false,
     };
@@ -209,7 +221,7 @@ pub fn most_recent_skill_in_user_only_set(path: &Path, home: &Path) -> bool {
     if !is_safe_transcript_path(path, home) {
         return false;
     }
-    let lines = match read_capped(path) {
+    let lines = match read_capped(path, TRANSCRIPT_BYTE_CAP) {
         Some(s) => s,
         None => return false,
     };
@@ -245,17 +257,26 @@ pub fn most_recent_skill_in_user_only_set(path: &Path, home: &Path) -> bool {
     false
 }
 
-/// Read the LAST `TRANSCRIPT_BYTE_CAP` bytes of `path` as a UTF-8
-/// String. Returns `None` on `File::open` error or non-UTF-8
-/// content.
+/// Read the LAST `cap` bytes of `path` as a UTF-8 String. Returns
+/// `None` on `File::open` error or non-UTF-8 content.
 ///
-/// The function seeks to `max(0, file_len - TRANSCRIPT_BYTE_CAP)`
-/// and reads forward to EOF. The buffer is the file's tail, which
-/// is what the backward walker needs — reading from the head
-/// silently omits recent turns on transcripts larger than the cap.
-/// A partial JSONL line at the buffer's start (mid-line truncation
-/// at the seek point) fails to parse and is silently skipped by
-/// the walker's `Err(_) => continue` branch.
+/// The function seeks to `max(0, file_len - cap)` and reads forward
+/// to EOF. The buffer is the file's tail, which is what the backward
+/// walker needs — reading from the head silently omits recent turns
+/// on transcripts larger than the cap. A partial JSONL line at the
+/// buffer's start (mid-line truncation at the seek point) fails to
+/// parse and is silently skipped by the walker's `Err(_) => continue`
+/// branch.
+///
+/// The `cap` parameter lets callers tune the backward-visibility
+/// window to the recency the walker needs.
+/// `last_user_message_invokes_skill` and
+/// `most_recent_skill_in_user_only_set` pass `TRANSCRIPT_BYTE_CAP`
+/// (50 MB) because user-only-skill detection may need to look past
+/// many recent assistant turns. `recent_edit_blocked_on_shared_config`
+/// passes the smaller `SHARED_CONFIG_BLOCK_BYTE_CAP` (4 MB) because
+/// it only needs the most recent assistant tool call and its paired
+/// tool_result.
 ///
 /// `metadata()` and `seek()` on a freshly-opened regular file are
 /// genuinely TOCTOU-only failure modes per the
@@ -265,19 +286,138 @@ pub fn most_recent_skill_in_user_only_set(path: &Path, home: &Path) -> bool {
 /// reachable failure surface for the open-file-then-stat-then-seek
 /// sequence. A test cannot reproduce metadata or seek failure on a
 /// freshly-opened regular file without root-level interference.
-fn read_capped(path: &Path) -> Option<String> {
+fn read_capped(path: &Path, cap: u64) -> Option<String> {
     let mut file = File::open(path).ok()?;
     let file_len = file
         .metadata()
         .expect("metadata succeeds on freshly-opened regular file (TOCTOU-only)")
         .len();
-    let start = file_len.saturating_sub(TRANSCRIPT_BYTE_CAP);
+    let start = file_len.saturating_sub(cap);
     file.seek(SeekFrom::Start(start))
         .expect("seek to non-negative absolute offset succeeds on regular file (TOCTOU-only)");
     let mut reader = BufReader::new(file);
     let mut buf = String::new();
     reader.read_to_string(&mut buf).ok()?;
     Some(buf)
+}
+
+/// Returns `true` when the persisted transcript shows, since the
+/// most recent real user turn, a tool_result block whose paired
+/// tool call was blocked by `validate_worktree_paths`' shared-config
+/// gate. Returns `false` on any I/O, parse, or validation failure
+/// (fail-open).
+///
+/// Detection signal: a `tool_result` block whose `is_error` is
+/// `true` AND whose `content` contains the literal substring
+/// `"is a shared configuration file"` — uniquely emitted by
+/// `crate::hooks::validate_worktree_paths::validate_shared_config`.
+/// The substring's presence is locked by a presence-contract test
+/// in `tests/hooks/validate_worktree_paths.rs`.
+///
+/// Companion to `validate_ask_user::validate`: when validate would
+/// have blocked the AskUserQuestion under autonomous-phase
+/// discipline, this helper's `true` return suppresses the block so
+/// the model can run the AskUserQuestion that
+/// `validate_worktree_paths`' BLOCKED message itself instructs the
+/// model to call. Without the carve-out, the model would deadlock
+/// — `validate-worktree-paths` says "use AskUserQuestion to
+/// confirm with the user" and `validate-ask-user` simultaneously
+/// blocks AskUserQuestion.
+///
+/// Walks lines backward from the file tail (read via `read_capped`
+/// with `SHARED_CONFIG_BLOCK_BYTE_CAP`). For each user-role turn:
+/// string content is the boundary (return `false`); array content
+/// is scanned for matching tool_result blocks. Older user turns
+/// are invisible — only the window since the most recent real user
+/// turn matters.
+///
+/// `transcript_path` is validated through
+/// `crate::window_snapshot::is_safe_transcript_path` per
+/// `.claude/rules/external-input-path-construction.md` (rejects
+/// empty, NUL-byte, relative, ParentDir-component, and
+/// prefix-escaping paths). `home` is passed in for the same
+/// testability reason as the sibling helpers.
+pub fn recent_edit_blocked_on_shared_config(transcript_path: &Path, home: &Path) -> bool {
+    if !is_safe_transcript_path(transcript_path, home) {
+        return false;
+    }
+    let lines = match read_capped(transcript_path, SHARED_CONFIG_BLOCK_BYTE_CAP) {
+        Some(s) => s,
+        None => return false,
+    };
+    for line in lines.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let turn: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let turn_type =
+            normalize_gate_input(turn.get("type").and_then(|v| v.as_str()).unwrap_or(""));
+        if turn_type != "user" {
+            continue;
+        }
+        // User turn reached. Real user turns (string content) are
+        // the boundary — older content is invisible. Tool-result-
+        // wrapped user turns (array content) are where the
+        // shared-config block lands.
+        let content = match turn.get("message").and_then(|m| m.get("content")) {
+            Some(c) => c,
+            None => return false,
+        };
+        if content.as_str().is_some() {
+            return false;
+        }
+        let blocks = match content.as_array() {
+            Some(arr) => arr,
+            None => return false,
+        };
+        for block in blocks {
+            if block.get("type").and_then(|v| v.as_str()) != Some("tool_result") {
+                continue;
+            }
+            if !block
+                .get("is_error")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let block_content = match block.get("content") {
+                Some(c) => c,
+                None => continue,
+            };
+            // tool_result.content is either a plain string or an
+            // array of content blocks (each typically a `text`
+            // block). Concatenate text fields for the array shape
+            // so a substring match catches both wire formats.
+            let text = if let Some(s) = block_content.as_str() {
+                s.to_string()
+            } else if let Some(items) = block_content.as_array() {
+                let mut joined = String::new();
+                for item in items {
+                    if let Some(t) = item.get("text").and_then(|v| v.as_str()) {
+                        if !joined.is_empty() {
+                            joined.push(' ');
+                        }
+                        joined.push_str(t);
+                    }
+                }
+                joined
+            } else {
+                continue;
+            };
+            if text.contains("is a shared configuration file") {
+                return true;
+            }
+        }
+        // The user turn was tool-result-wrapped but no block in it
+        // matched. Keep walking backward — earlier turns within the
+        // tail-bounded window may carry the matching block.
+    }
+    false
 }
 
 /// Walk an assistant turn's `message.content` array and return

--- a/src/hooks/transcript_walker.rs
+++ b/src/hooks/transcript_walker.rs
@@ -1,5 +1,5 @@
 //! Shared backward walker over the persisted Claude Code transcript
-//! JSONL. Two consumers share this module:
+//! JSONL. Three consumers share this module:
 //!
 //! 1. `src/hooks/validate_skill.rs` — Layer 1 of the user-only skill
 //!    enforcement chain. Calls
@@ -7,11 +7,20 @@
 //!    to decide whether the most recent user turn typed the matching
 //!    `<command-name>/<skill></command-name>` slash command. Without
 //!    a match, the model invocation of a user-only skill is blocked.
-//! 2. `src/hooks/validate_ask_user.rs` — Layer 2 carve-out. Calls
+//! 2. `src/hooks/validate_ask_user.rs` — Layer 2 user-only-skill
+//!    carve-out. Calls
 //!    `most_recent_skill_in_user_only_set(transcript_path, home)` to
 //!    allow `AskUserQuestion` confirmation prompts during in-progress
 //!    autonomous phases when the most recent assistant turn fires a
 //!    Skill tool_use targeting a user-only skill.
+//! 3. `src/hooks/validate_ask_user.rs` — shared-config carve-out.
+//!    Calls `recent_edit_blocked_on_shared_config(transcript_path, home)`
+//!    to allow `AskUserQuestion` confirmation prompts during
+//!    in-progress autonomous phases when the most recent user-role
+//!    turn carries a `validate_worktree_paths` shared-config edit
+//!    block. The shared-config block's BLOCKED message itself
+//!    instructs the model to call `AskUserQuestion` to confirm — the
+//!    carve-out lets the prompt fire instead of deadlocking.
 //!
 //! Both helpers are read-only over a JSONL transcript file. They
 //! never mutate state, never spawn subprocesses, and fail-open
@@ -31,13 +40,16 @@
 //!
 //! ## Tail-bounded read
 //!
-//! `read_capped` seeks to the LAST `TRANSCRIPT_BYTE_CAP` bytes of
-//! the file and reads forward to EOF. The walker iterates the
-//! resulting buffer in reverse line order, so the file's tail (the
-//! most recent turns) is always visible regardless of total file
-//! size. Reading from the head would silently omit the most recent
-//! turns on transcripts larger than the cap, defeating the entire
-//! enforcement chain on long autonomous flows.
+//! `read_capped` seeks to the LAST `cap` bytes of the file and reads
+//! forward to EOF, with the consumed read hard-bounded at `cap` via
+//! `file.take(cap)`. The walker iterates the resulting buffer in
+//! reverse line order, so the file's tail (the most recent turns) is
+//! always visible regardless of total file size. The two callers
+//! choose different caps tuned to their recency needs:
+//! `TRANSCRIPT_BYTE_CAP` (50 MB) for user-only-skill detection
+//! across long autonomous flows, and `SHARED_CONFIG_BLOCK_BYTE_CAP`
+//! (4 MB) for shared-config carve-out detection where only the most
+//! recent user-role turn matters.
 //!
 //! ## Gate normalization
 //!
@@ -295,24 +307,35 @@ fn read_capped(path: &Path, cap: u64) -> Option<String> {
     let start = file_len.saturating_sub(cap);
     file.seek(SeekFrom::Start(start))
         .expect("seek to non-negative absolute offset succeeds on regular file (TOCTOU-only)");
-    let mut reader = BufReader::new(file);
+    // Wrap the reader in `take(cap)` so the total bytes consumed
+    // by `read_to_string` are hard-bounded at `cap` even when the
+    // file grows after the `metadata()` call (concurrent writers).
+    // This matches the canonical byte-cap pattern documented in
+    // `.claude/rules/external-input-path-construction.md`.
+    let mut reader = BufReader::new(file.take(cap));
     let mut buf = String::new();
     reader.read_to_string(&mut buf).ok()?;
     Some(buf)
 }
 
-/// Returns `true` when the persisted transcript shows, since the
-/// most recent real user turn, a tool_result block whose paired
-/// tool call was blocked by `validate_worktree_paths`' shared-config
-/// gate. Returns `false` on any I/O, parse, or validation failure
-/// (fail-open).
+/// Returns `true` when the most recent user-role turn in the
+/// persisted transcript carries a `validate_worktree_paths` shared-
+/// config edit-block tool_result. Returns `false` on any I/O, parse,
+/// or validation failure (fail-open).
 ///
 /// Detection signal: a `tool_result` block whose `is_error` is
-/// `true` AND whose `content` contains the literal substring
-/// `"is a shared configuration file"` — uniquely emitted by
+/// truthy AND whose `content` contains the literal substring
+/// `"is a shared configuration file that affects every engineer"`
+/// — uniquely emitted by
 /// `crate::hooks::validate_worktree_paths::validate_shared_config`.
-/// The substring's presence is locked by a presence-contract test
-/// in `tests/hooks/validate_worktree_paths.rs`.
+/// The phrase is intentionally long: the shorter "is a shared
+/// configuration file" prefix could appear in unrelated error
+/// messages (a permission-denied error, a generic "this file is
+/// shared" warning), but the full phrase including "that affects
+/// every engineer" matches only the BLOCKED message produced by
+/// validate_worktree_paths. The substring's presence is locked by a
+/// presence-contract test in
+/// `tests/hooks/validate_worktree_paths.rs`.
 ///
 /// Companion to `validate_ask_user::validate`: when validate would
 /// have blocked the AskUserQuestion under autonomous-phase
@@ -325,17 +348,21 @@ fn read_capped(path: &Path, cap: u64) -> Option<String> {
 /// blocks AskUserQuestion.
 ///
 /// Walks lines backward from the file tail (read via `read_capped`
-/// with `SHARED_CONFIG_BLOCK_BYTE_CAP`). For each user-role turn:
-/// string content is the boundary (return `false`); array content
-/// is scanned for matching tool_result blocks. Older user turns
-/// are invisible — only the window since the most recent real user
-/// turn matters.
+/// with `SHARED_CONFIG_BLOCK_BYTE_CAP`) and stops at the most recent
+/// user-role turn — examining ONLY that turn's content. The carve-
+/// out fires iff the latest interaction the model received from the
+/// user-role channel was the shared-config block. If any other
+/// tool_result intervenes before the AskUserQuestion (a different
+/// tool's success or failure), the most recent user turn is no
+/// longer the shared-config block and the carve-out does not fire.
+/// This scoping keeps stale shared-config blocks from earlier in
+/// the session from authorizing unrelated AskUserQuestions later.
 ///
 /// `transcript_path` is validated through
 /// `crate::window_snapshot::is_safe_transcript_path` per
 /// `.claude/rules/external-input-path-construction.md` (rejects
-/// empty, NUL-byte, relative, ParentDir-component, and
-/// prefix-escaping paths). `home` is passed in for the same
+/// empty, NUL-byte, relative, ParentDir-component, prefix-escaping,
+/// and symlink-escape paths). `home` is passed in for the same
 /// testability reason as the sibling helpers.
 pub fn recent_edit_blocked_on_shared_config(transcript_path: &Path, home: &Path) -> bool {
     if !is_safe_transcript_path(transcript_path, home) {
@@ -359,65 +386,92 @@ pub fn recent_edit_blocked_on_shared_config(transcript_path: &Path, home: &Path)
         if turn_type != "user" {
             continue;
         }
-        // User turn reached. Real user turns (string content) are
-        // the boundary — older content is invisible. Tool-result-
-        // wrapped user turns (array content) are where the
-        // shared-config block lands.
-        let content = match turn.get("message").and_then(|m| m.get("content")) {
-            Some(c) => c,
-            None => return false,
-        };
-        if content.as_str().is_some() {
-            return false;
-        }
-        let blocks = match content.as_array() {
-            Some(arr) => arr,
-            None => return false,
-        };
-        for block in blocks {
-            if block.get("type").and_then(|v| v.as_str()) != Some("tool_result") {
-                continue;
-            }
-            if !block
-                .get("is_error")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false)
-            {
-                continue;
-            }
-            let block_content = match block.get("content") {
-                Some(c) => c,
-                None => continue,
-            };
-            // tool_result.content is either a plain string or an
-            // array of content blocks (each typically a `text`
-            // block). Concatenate text fields for the array shape
-            // so a substring match catches both wire formats.
-            let text = if let Some(s) = block_content.as_str() {
-                s.to_string()
-            } else if let Some(items) = block_content.as_array() {
-                let mut joined = String::new();
-                for item in items {
-                    if let Some(t) = item.get("text").and_then(|v| v.as_str()) {
-                        if !joined.is_empty() {
-                            joined.push(' ');
-                        }
-                        joined.push_str(t);
-                    }
-                }
-                joined
-            } else {
-                continue;
-            };
-            if text.contains("is a shared configuration file") {
-                return true;
-            }
-        }
-        // The user turn was tool-result-wrapped but no block in it
-        // matched. Keep walking backward — earlier turns within the
-        // tail-bounded window may carry the matching block.
+        // Most recent user-role turn reached. Examine its content
+        // and RETURN — do not continue walking backward to older
+        // turns. Scoping the carve-out to the immediately preceding
+        // user-role event keeps stale shared-config blocks from
+        // authorizing unrelated AskUserQuestions later in the
+        // session.
+        return user_turn_carries_shared_config_block(&turn);
     }
     false
+}
+
+/// Returns `true` when the user-role turn carries a tool_result
+/// block whose `is_error` is truthy AND whose `content` contains
+/// the shared-config substring. Returns `false` for string-content
+/// user turns (the user typed a message), missing or non-array
+/// content, and array content where no block matches.
+fn user_turn_carries_shared_config_block(turn: &Value) -> bool {
+    let content = match turn.get("message").and_then(|m| m.get("content")) {
+        Some(c) => c,
+        None => return false,
+    };
+    // String content is a real user-typed message — not a
+    // tool_result wrapper. The carve-out only fires when the
+    // most recent user-role event is a tool_result-wrapped turn
+    // carrying the shared-config block.
+    if content.as_str().is_some() {
+        return false;
+    }
+    let blocks = match content.as_array() {
+        Some(arr) => arr,
+        None => return false,
+    };
+    for block in blocks {
+        if block.get("type").and_then(|v| v.as_str()) != Some("tool_result") {
+            continue;
+        }
+        if !is_truthy(block.get("is_error")) {
+            continue;
+        }
+        let block_content = match block.get("content") {
+            Some(c) => c,
+            None => continue,
+        };
+        // tool_result.content is either a plain string or an
+        // array of content blocks (each typically a `text`
+        // block). Concatenate text fields for the array shape
+        // so a substring match catches both wire formats.
+        let text = if let Some(s) = block_content.as_str() {
+            s.to_string()
+        } else if let Some(items) = block_content.as_array() {
+            let mut joined = String::new();
+            for item in items {
+                if let Some(t) = item.get("text").and_then(|v| v.as_str()) {
+                    if !joined.is_empty() {
+                        joined.push(' ');
+                    }
+                    joined.push_str(t);
+                }
+            }
+            joined
+        } else {
+            continue;
+        };
+        if text.contains("is a shared configuration file that affects every engineer") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Defensive truthiness check for security-enforcement hook reads
+/// of boolean fields. Per `.claude/rules/rust-patterns.md` "Hook
+/// Input Boolean Field Tolerance": accept `true`, the strings
+/// `"true"` / `"1"` (case-insensitive), and any non-zero number.
+/// Everything else (including `null`, `false`, empty string,
+/// non-truthy strings, and `0`) is `false`.
+fn is_truthy(v: Option<&Value>) -> bool {
+    match v {
+        Some(Value::Bool(b)) => *b,
+        Some(Value::String(s)) => {
+            let norm = s.trim().to_ascii_lowercase();
+            norm == "true" || norm == "1"
+        }
+        Some(Value::Number(n)) => n.as_f64().is_some_and(|f| f != 0.0),
+        _ => false,
+    }
 }
 
 /// Walk an assistant turn's `message.content` array and return

--- a/src/hooks/validate_ask_user.rs
+++ b/src/hooks/validate_ask_user.rs
@@ -1,6 +1,6 @@
 //! PreToolUse hook for AskUserQuestion — enforces autonomous-phase discipline.
 //!
-//! Four outcomes, evaluated in order:
+//! Five outcomes, evaluated in order:
 //!
 //! 1. **Block** (exit 2, stderr message) — when the current phase is
 //!    mid-execution (`phases.<current_phase>.status == "in_progress"`)
@@ -19,11 +19,22 @@
 //!    `flow:flow-prime`). Allows the confirmation prompt to fire so
 //!    user-only skills' destructive-operation gates do not deadlock
 //!    when invoked from inside an in-progress autonomous phase.
-//! 3. **Auto-answer** (exit 0, JSON on stdout) — when `_auto_continue`
+//! 3. **Shared-config carve-out** — when `validate` would have
+//!    blocked the prompt but the persisted transcript shows a recent
+//!    `validate_worktree_paths` shared-config edit block (a
+//!    tool_result with `is_error: true` containing the literal
+//!    "is a shared configuration file" substring). The
+//!    `validate_worktree_paths` BLOCKED message itself instructs the
+//!    model to call AskUserQuestion to confirm — this carve-out lets
+//!    that prompt fire instead of deadlocking. Backed by
+//!    `crate::hooks::transcript_walker::recent_edit_blocked_on_shared_config`.
+//!    See `.claude/rules/autonomous-phase-discipline.md`
+//!    "Shared-Config Carve-Out" subsection.
+//! 4. **Auto-answer** (exit 0, JSON on stdout) — when `_auto_continue`
 //!    is set and the block did not fire. Answers the AskUserQuestion
 //!    with the successor skill command so phase transitions advance
 //!    even if the skill's HARD-GATE was ignored.
-//! 4. **Allow** (exit 0, no stdout) — otherwise. The tool call passes
+//! 5. **Allow** (exit 0, no stdout) — otherwise. The tool call passes
 //!    through to Claude Code's normal permission system.
 
 use std::path::{Path, PathBuf};
@@ -33,7 +44,9 @@ use serde_json::{json, Value};
 use super::read_hook_input;
 use crate::flow_paths::FlowPaths;
 use crate::git::{current_branch, project_root};
-use crate::hooks::transcript_walker::most_recent_skill_in_user_only_set;
+use crate::hooks::transcript_walker::{
+    most_recent_skill_in_user_only_set, recent_edit_blocked_on_shared_config,
+};
 use crate::lock::mutate_state;
 use crate::utils::now;
 use crate::window_snapshot::home_dir_or_empty;
@@ -232,6 +245,19 @@ fn run_impl_main(
         // the user just typed the slash command and the resulting
         // confirmation prompt is part of that user-initiated flow.
         if user_only_skill_carve_out_applies(transcript_path.as_deref(), home) {
+            return HookAction::AllowWithMark(state_path);
+        }
+        // Carve-out: shared-config edits that
+        // `validate_worktree_paths` blocked instruct the model to
+        // call AskUserQuestion to confirm. Letting the prompt
+        // fire — instead of deadlocking against the autonomous
+        // block — completes the system-initiated confirmation flow
+        // that the prior hook explicitly demanded.
+        let allow_shared_config = transcript_path
+            .as_deref()
+            .map(|p| recent_edit_blocked_on_shared_config(p, home))
+            .unwrap_or(false);
+        if allow_shared_config {
             return HookAction::AllowWithMark(state_path);
         }
         // `set_blocked` is intentionally not called — the hook

--- a/src/hooks/validate_ask_user.rs
+++ b/src/hooks/validate_ask_user.rs
@@ -20,10 +20,11 @@
 //!    user-only skills' destructive-operation gates do not deadlock
 //!    when invoked from inside an in-progress autonomous phase.
 //! 3. **Shared-config carve-out** — when `validate` would have
-//!    blocked the prompt but the persisted transcript shows a recent
-//!    `validate_worktree_paths` shared-config edit block (a
-//!    tool_result with `is_error: true` containing the literal
-//!    "is a shared configuration file" substring). The
+//!    blocked the prompt but the most recent user-role turn in the
+//!    persisted transcript carries a `validate_worktree_paths`
+//!    shared-config edit block (a tool_result with `is_error: true`
+//!    containing the literal substring "is a shared configuration
+//!    file that affects every engineer"). The
 //!    `validate_worktree_paths` BLOCKED message itself instructs the
 //!    model to call AskUserQuestion to confirm — this carve-out lets
 //!    that prompt fire instead of deadlocking. Backed by
@@ -253,6 +254,17 @@ fn run_impl_main(
         // fire — instead of deadlocking against the autonomous
         // block — completes the system-initiated confirmation flow
         // that the prior hook explicitly demanded.
+        //
+        // Ordering: the user-only-skill carve-out is checked first.
+        // If both conditions apply (the user typed a user-only
+        // slash command AND a shared-config block is in the
+        // transcript), the user-only branch fires first. The
+        // ordering is locked by the regression test
+        // `both_carve_outs_can_apply_user_only_wins_first` — both
+        // branches produce the same `AllowWithMark` outcome so the
+        // order is observationally equivalent today, but a future
+        // refactor that diverges the branches must preserve the
+        // ordering.
         let allow_shared_config = transcript_path
             .as_deref()
             .map(|p| recent_edit_blocked_on_shared_config(p, home))

--- a/src/window_snapshot.rs
+++ b/src/window_snapshot.rs
@@ -143,16 +143,19 @@ fn is_safe_session_id(s: &str) -> bool {
 /// Validate a state-derived `transcript_path` against the canonical
 /// location where Claude Code writes session transcripts:
 /// `<home>/.claude/projects/`. Rejects relative paths, paths
-/// outside that prefix, and paths containing a NUL byte. Production
-/// transcripts always live under that directory; values pointing
+/// outside that prefix, paths containing a NUL byte, paths with a
+/// `..` component, and paths whose canonical resolution escapes the
+/// prefix (catches symlink-based escapes where any component is a
+/// symlink pointing outside the prefix). Production transcripts
+/// always live under that directory as regular files; values pointing
 /// elsewhere are corrupted state and read attempts could leak
 /// arbitrary file contents into snapshot fields.
 ///
 /// Cross-module consumer: `src/hooks/transcript_walker.rs` validates
 /// the same `transcript_path` string before reading the JSONL
 /// session log to gate user-only skill invocations and the
-/// validate-ask-user carve-out. Per
-/// `.claude/rules/external-input-path-construction.md`, the same
+/// validate-ask-user carve-outs (user-only-skill and shared-config).
+/// Per `.claude/rules/external-input-path-construction.md`, the same
 /// validator runs at every state-derived path-construction site so
 /// the prefix-containment contract is enforced once.
 pub fn is_safe_transcript_path(path: &Path, home: &Path) -> bool {
@@ -165,20 +168,36 @@ pub fn is_safe_transcript_path(path: &Path, home: &Path) -> bool {
     if !path.is_absolute() {
         return false;
     }
-    // Reject any ParentDir (`..`) component. `Path::starts_with` is a
-    // lexical component-wise prefix check that does NOT canonicalize
-    // `..` segments — `<home>/.claude/projects/../../etc/passwd`
-    // passes `starts_with(<home>/.claude/projects)` even though
-    // `File::open` resolves it to `<home>/etc/passwd`. Refusing
-    // ParentDir components closes the traversal-bypass surface
-    // without paying the canonicalize() syscall cost on every call.
+    // Reject any ParentDir (`..`) component as a fast-path lexical
+    // check before the canonicalize syscall. `Path::starts_with` is
+    // a lexical component-wise prefix check that does NOT resolve
+    // `..` segments, so `<home>/.claude/projects/../../etc/passwd`
+    // would pass a raw prefix check.
     for component in path.components() {
         if matches!(component, std::path::Component::ParentDir) {
             return false;
         }
     }
+    // Canonicalize and compare against the canonicalized prefix.
+    // `Path::starts_with` on raw paths cannot detect symlinks: a
+    // symlink at `<home>/.claude/projects/p/session.jsonl` pointing
+    // to `/tmp/evil.jsonl` passes the raw check, then `File::open`
+    // follows the link and reads attacker-controlled content.
+    // `canonicalize` resolves every component's symlinks AND `..`
+    // segments before the prefix check, closing both traversal
+    // vectors. Failure to canonicalize (missing file, permission
+    // error, broken symlink) returns false — fail-closed per
+    // `.claude/rules/security-gates.md`.
+    let canonical_path = match path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
     let expected_prefix = home.join(".claude").join("projects");
-    path.starts_with(&expected_prefix)
+    let canonical_prefix = match expected_prefix.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    canonical_path.starts_with(&canonical_prefix)
 }
 
 /// Write a `WindowSnapshot` into the named top-level field of a

--- a/tests/hooks/stop_continue.rs
+++ b/tests/hooks/stop_continue.rs
@@ -2167,6 +2167,50 @@ fn prose_pause_allows_when_state_unparseable() {
 }
 
 #[test]
+fn prose_pause_allows_when_transcript_file_unreadable() {
+    // `is_safe_transcript_path` canonicalize succeeds on a chmod-000
+    // file (canonicalize stats components, not opens), but
+    // `last_assistant_text_and_tool_use`'s `File::open` returns
+    // Err(PermissionDenied). The function returns None and the
+    // pause check allows. Covers the File::open `.ok()?` branch in
+    // last_assistant_text_and_tool_use which became unreachable
+    // through normal validator-passes-but-file-missing paths after
+    // is_safe_transcript_path was tightened to canonicalize.
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let state_path = dir.path().join("state.json");
+    let transcript = safe_transcript_path(dir.path(), "transcript.jsonl");
+    fs::write(
+        &state_path,
+        serde_json::to_string(&prose_pause_state(
+            "flow-code",
+            "in_progress",
+            json!("auto"),
+            0,
+            "",
+        ))
+        .unwrap(),
+    )
+    .unwrap();
+    fs::write(&transcript, b"{\"type\":\"user\"}\n").unwrap();
+    fs::set_permissions(&transcript, fs::Permissions::from_mode(0o000)).unwrap();
+    struct PermGuard(std::path::PathBuf);
+    impl Drop for PermGuard {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(&self.0, fs::Permissions::from_mode(0o644));
+        }
+    }
+    let _g = PermGuard(transcript.clone());
+
+    let result = check_prose_pause_at_task_entry(
+        &state_path,
+        Some(transcript.to_str().unwrap()),
+        dir.path(),
+    );
+    assert!(!result.should_block);
+}
+
+#[test]
 fn prose_pause_allows_when_transcript_has_no_assistant_turn() {
     let dir = tempfile::tempdir().unwrap();
     let state_path = dir.path().join("state.json");

--- a/tests/hooks/transcript_walker.rs
+++ b/tests/hooks/transcript_walker.rs
@@ -390,6 +390,7 @@ fn walker_returns_false_when_file_contains_non_utf8_bytes() {
         home
     ));
     assert!(!most_recent_skill_in_user_only_set(&path, home));
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
 }
 
 #[test]
@@ -569,15 +570,14 @@ fn normalize_gate_input_strips_nul_trims_and_lowercases() {
 
 // --- recent_edit_blocked_on_shared_config ---
 //
-// Companion to validate-ask-user's shared-config carve-out. Walks
-// backward from the file tail to find the most recent shared-config
-// BLOCKED tool_result before crossing a real user turn boundary.
-// Detection signal: the literal substring
-// "is a shared configuration file" inside a `tool_result` block
-// whose `is_error: true` field is set. The substring is uniquely
-// emitted by `validate_worktree_paths::validate_shared_config` (see
-// the presence-contract test in
-// tests/hooks/validate_worktree_paths.rs).
+// Companion to validate-ask-user's shared-config carve-out.
+// Examines the most recent user-role turn in the transcript for a
+// shared-config BLOCKED tool_result. Detection signal: the literal
+// substring "is a shared configuration file that affects every
+// engineer" inside a `tool_result` block whose `is_error: true`
+// field is set. The substring is uniquely emitted by
+// `validate_worktree_paths::validate_shared_config` (see the
+// presence-contract test in tests/hooks/validate_worktree_paths.rs).
 
 #[test]
 fn helper_returns_true_when_recent_edit_was_blocked() {
@@ -673,7 +673,7 @@ fn helper_returns_false_when_transcript_path_unsafe() {
     // ParentDir traversal that escapes home.
     std::fs::create_dir_all(home.join(".claude").join("projects").join("p")).unwrap();
     let evil = home.join("evil.jsonl");
-    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file\",\"is_error\":true}]}}\n";
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n";
     std::fs::write(&evil, jsonl).unwrap();
     let traversal = home
         .join(".claude")
@@ -722,7 +722,7 @@ fn helper_handles_byte_cap_truncation() {
     // block to verify recency-window semantics for tail-bounded
     // reads.
     let path_in_window = proj.join("in_window.jsonl");
-    let block = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file\",\"is_error\":true}]}}\n";
+    let block = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n";
     let mut content_in: Vec<u8> = Vec::new();
     let padding_size = 1024 * 8; // 8 KB of padding — well within cap
     content_in.extend(std::iter::repeat_n(b'\n', padding_size));
@@ -777,7 +777,7 @@ fn helper_skips_unparseable_jsonl_lines() {
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path();
     let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
-{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file.\",\"is_error\":true}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n\
 not valid json at all\n";
     let path = crate::common::transcript_fixture(home, "p", jsonl);
     assert!(recent_edit_blocked_on_shared_config(&path, home));
@@ -815,7 +815,7 @@ fn helper_continues_past_non_tool_result_block_in_user_array() {
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path();
     let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
-{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"prefix\"},{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file.\",\"is_error\":true}]}}\n";
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"prefix\"},{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n";
     let path = crate::common::transcript_fixture(home, "p", jsonl);
     assert!(recent_edit_blocked_on_shared_config(&path, home));
 }
@@ -841,7 +841,7 @@ fn helper_finds_block_when_tool_result_content_is_text_array() {
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path();
     let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
-{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":[{\"type\":\"text\",\"text\":\"BLOCKED: foo is a shared configuration file.\"},{\"type\":\"text\",\"text\":\"trailing context\"}],\"is_error\":true}]}}\n";
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":[{\"type\":\"text\",\"text\":\"BLOCKED: foo is a shared configuration file that affects every engineer in the repository.\"},{\"type\":\"text\",\"text\":\"trailing context\"}],\"is_error\":true}]}}\n";
     let path = crate::common::transcript_fixture(home, "p", jsonl);
     assert!(recent_edit_blocked_on_shared_config(&path, home));
 }
@@ -861,6 +861,107 @@ fn helper_skips_array_text_blocks_without_text_field() {
 {\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":[{\"type\":\"image\"},{\"type\":\"text\",\"text\":\"no relevant content here\"},{\"type\":\"text\",\"text\":\"still nothing\"}],\"is_error\":true}]}}\n";
     let path = crate::common::transcript_fixture(home, "p", jsonl);
     assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_accepts_is_error_string_true() {
+    // is_truthy accepts the string "true" (case-insensitive) per
+    // .claude/rules/rust-patterns.md "Hook Input Boolean Field
+    // Tolerance". Some Claude Code wire-format variants may
+    // serialize is_error as a string.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file that affects every engineer in the repository.\",\"is_error\":\"TRUE\"}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_accepts_is_error_number_one() {
+    // is_truthy accepts non-zero numbers per the same rule —
+    // is_error: 1 (integer) is treated as truthy.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file that affects every engineer in the repository.\",\"is_error\":1}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_rejects_is_error_number_zero() {
+    // is_truthy rejects zero numbers — matches the falsy semantics.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file that affects every engineer in the repository.\",\"is_error\":0}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_rejects_is_error_string_false() {
+    // is_truthy rejects strings other than "true" / "1".
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file that affects every engineer in the repository.\",\"is_error\":\"false\"}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_rejects_is_error_null() {
+    // is_truthy rejects null and other non-bool/string/number
+    // types — falls through to the wildcard arm.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file that affects every engineer in the repository.\",\"is_error\":null}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_returns_false_when_transcript_file_unreadable() {
+    // `is_safe_transcript_path` canonicalize succeeds on a chmod-000
+    // file (canonicalize stats components, not opens), but `File::open`
+    // inside `read_capped` returns Err(PermissionDenied). The helper
+    // falls open and returns false. Covers the File::open `.ok()?`
+    // branch.
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let proj = home.join(".claude").join("projects").join("p");
+    fs::create_dir_all(&proj).unwrap();
+    let path = proj.join("session.jsonl");
+    fs::write(&path, b"{\"type\":\"user\"}\n").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+    struct PermGuard(std::path::PathBuf);
+    impl Drop for PermGuard {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(&self.0, fs::Permissions::from_mode(0o644));
+        }
+    }
+    let _g = PermGuard(path.clone());
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_iterates_past_trailing_assistant_to_user_array_turn() {
+    // Walker reverse iteration: when the LAST line is an assistant
+    // turn (after the most recent user-array tool_result), the
+    // walker continues past it (turn_type != "user") and reaches
+    // the user-array turn carrying the shared-config block. Covers
+    // the assistant-skip branch in the walker loop.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Understood.\"}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_edit_blocked_on_shared_config(&path, home));
 }
 
 #[test]

--- a/tests/hooks/transcript_walker.rs
+++ b/tests/hooks/transcript_walker.rs
@@ -12,7 +12,8 @@
 use std::fs;
 
 use flow_rs::hooks::transcript_walker::{
-    last_user_message_invokes_skill, most_recent_skill_in_user_only_set, TRANSCRIPT_BYTE_CAP,
+    last_user_message_invokes_skill, most_recent_skill_in_user_only_set,
+    recent_edit_blocked_on_shared_config, SHARED_CONFIG_BLOCK_BYTE_CAP, TRANSCRIPT_BYTE_CAP,
     USER_ONLY_SKILLS,
 };
 
@@ -564,4 +565,313 @@ fn normalize_gate_input_strips_nul_trims_and_lowercases() {
     );
     assert_eq!(normalize_gate_input(""), "");
     assert_eq!(normalize_gate_input("   "), "");
+}
+
+// --- recent_edit_blocked_on_shared_config ---
+//
+// Companion to validate-ask-user's shared-config carve-out. Walks
+// backward from the file tail to find the most recent shared-config
+// BLOCKED tool_result before crossing a real user turn boundary.
+// Detection signal: the literal substring
+// "is a shared configuration file" inside a `tool_result` block
+// whose `is_error: true` field is set. The substring is uniquely
+// emitted by `validate_worktree_paths::validate_shared_config` (see
+// the presence-contract test in
+// tests/hooks/validate_worktree_paths.rs).
+
+#[test]
+fn helper_returns_true_when_recent_edit_was_blocked() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"please update reqs\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"id\":\"toolu_01\",\"input\":{\"file_path\":\"/p/requirements.txt\",\"old_string\":\"a\",\"new_string\":\"b\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01\",\"content\":\"BLOCKED: requirements.txt is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_returns_true_when_recent_write_was_blocked() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"new gitignore\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Write\",\"id\":\"toolu_02\",\"input\":{\"file_path\":\"/p/.gitignore\",\"content\":\"foo\\n\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_02\",\"content\":\"BLOCKED: .gitignore is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_returns_false_when_no_block_in_window() {
+    // Successful Edit — tool_result content does not contain the
+    // shared-config substring and is_error is false. Helper returns
+    // false so the autonomous-phase block stands.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"edit a file\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"id\":\"toolu_03\",\"input\":{\"file_path\":\"/p/src/foo.rs\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_03\",\"content\":\"The file has been updated.\",\"is_error\":false}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_returns_false_when_block_predates_user_turn() {
+    // Block exists earlier in the transcript but a fresh real user
+    // turn (string content) intervenes. Walker hits the user turn
+    // first walking backward and returns false — the older block is
+    // outside the window.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"first request\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"id\":\"toolu_04\",\"input\":{\"file_path\":\"/p/Cargo.toml\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_04\",\"content\":\"BLOCKED: Cargo.toml is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"now do something else\"}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_returns_false_when_tool_result_not_is_error() {
+    // tool_result content contains the substring but `is_error`
+    // is false (or absent). Without is_error: true, the block did
+    // not fire — helper returns false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"edit\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"id\":\"toolu_05\",\"input\":{\"file_path\":\"/p/foo\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_05\",\"content\":\"Note: this is a shared configuration file but the edit succeeded.\",\"is_error\":false}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_returns_false_when_substring_absent() {
+    // is_error: true but the substring is absent — a different
+    // block fired (e.g., a path-canonicalization rejection from
+    // validate_worktree_paths). Helper returns false because the
+    // detection signal is the substring, not the is_error flag.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"edit\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"id\":\"toolu_06\",\"input\":{\"file_path\":\"/p/foo\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_06\",\"content\":\"BLOCKED: misplaced .flow-states/ path; canonical destination is elsewhere.\",\"is_error\":true}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_returns_false_when_transcript_path_unsafe() {
+    // Validator must reject relative paths, NUL-byte paths, and
+    // ParentDir-component paths before any I/O. Match parent
+    // helpers' rejection profile.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Relative path (validator requires absolute under home).
+    let relative = std::path::Path::new("relative/path.jsonl");
+    assert!(!recent_edit_blocked_on_shared_config(relative, home));
+    // ParentDir traversal that escapes home.
+    std::fs::create_dir_all(home.join(".claude").join("projects").join("p")).unwrap();
+    let evil = home.join("evil.jsonl");
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file\",\"is_error\":true}]}}\n";
+    std::fs::write(&evil, jsonl).unwrap();
+    let traversal = home
+        .join(".claude")
+        .join("projects")
+        .join("..")
+        .join("..")
+        .join("evil.jsonl");
+    assert!(!recent_edit_blocked_on_shared_config(&traversal, home));
+}
+
+#[test]
+fn helper_returns_false_when_transcript_missing() {
+    // File does not exist on disk — read_capped returns None and the
+    // helper falls open to false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let missing = home
+        .join(".claude")
+        .join("projects")
+        .join("p")
+        .join("nonexistent.jsonl");
+    assert!(!recent_edit_blocked_on_shared_config(&missing, home));
+}
+
+#[test]
+fn helper_returns_false_on_empty_transcript() {
+    // Empty file — no lines to walk, helper returns false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let path = crate::common::transcript_fixture(home, "p", "");
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_handles_byte_cap_truncation() {
+    // The 4 MB cap defines a backward-visibility window. A blocked
+    // tool_result inside the last `SHARED_CONFIG_BLOCK_BYTE_CAP`
+    // bytes is reachable — true. A block buried before the cap is
+    // unreachable — false (documented acceptable false-negative).
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let proj = home.join(".claude").join("projects").join("p");
+    std::fs::create_dir_all(&proj).unwrap();
+
+    // Reachable: content within the window. Place padding after the
+    // block to verify recency-window semantics for tail-bounded
+    // reads.
+    let path_in_window = proj.join("in_window.jsonl");
+    let block = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file\",\"is_error\":true}]}}\n";
+    let mut content_in: Vec<u8> = Vec::new();
+    let padding_size = 1024 * 8; // 8 KB of padding — well within cap
+    content_in.extend(std::iter::repeat_n(b'\n', padding_size));
+    content_in.extend_from_slice(block.as_bytes());
+    std::fs::write(&path_in_window, &content_in).unwrap();
+    assert!(recent_edit_blocked_on_shared_config(&path_in_window, home));
+
+    // Unreachable: block at HEAD, padding > cap pushes block out of
+    // the tail-bounded read.
+    let path_out_of_window = proj.join("out_of_window.jsonl");
+    let mut content_out: Vec<u8> = block.as_bytes().to_vec();
+    let oversized_pad = (SHARED_CONFIG_BLOCK_BYTE_CAP as usize) + 1024;
+    content_out.extend(std::iter::repeat_n(b'\n', oversized_pad));
+    std::fs::write(&path_out_of_window, &content_out).unwrap();
+    assert!(!recent_edit_blocked_on_shared_config(
+        &path_out_of_window,
+        home
+    ));
+}
+
+#[test]
+fn helper_returns_false_when_no_assistant_turn_since_user() {
+    // Only a real user turn — no assistant turn, no tool_result,
+    // no block. Walker hits the user turn boundary, returns false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hello\"}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_ignores_non_edit_write_tool_use() {
+    // A Bash tool_use (not Edit/Write) with is_error: true but no
+    // shared-config substring. The detection signal is the
+    // substring, which validate_worktree_paths emits ONLY for
+    // Edit/Write on shared-config files. Helper returns false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"run a command\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"toolu_07\",\"input\":{\"command\":\"rm -rf /\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_07\",\"content\":\"BLOCKED: rm -rf / matches deny pattern.\",\"is_error\":true}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_skips_unparseable_jsonl_lines() {
+    // A non-empty line that fails JSON parsing must be skipped via
+    // continue. The valid block on the previous line still drives
+    // the walker's true return.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file.\",\"is_error\":true}]}}\n\
+not valid json at all\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_returns_false_when_user_turn_missing_message_field() {
+    // A user-role turn without a `message` field — the content
+    // lookup returns None and the walker treats the line as a real
+    // user-turn boundary, returning false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\"}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_returns_false_when_user_content_is_number() {
+    // `content` is neither a string nor an array — for example, a
+    // number left over from a malformed write. Treated as a real
+    // user turn boundary, helper returns false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":42}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_continues_past_non_tool_result_block_in_user_array() {
+    // User-array content has a leading non-tool_result block (e.g.,
+    // a text or image block). The walker skips it via continue and
+    // finds the trailing tool_result block.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"prefix\"},{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: foo is a shared configuration file.\",\"is_error\":true}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_continues_past_tool_result_block_without_content_field() {
+    // A tool_result block with `is_error: true` but no `content`
+    // field. The walker continues past it and falls through to
+    // false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"is_error\":true}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_finds_block_when_tool_result_content_is_text_array() {
+    // tool_result.content can be an array of content blocks, each
+    // typically of type "text". The helper concatenates `text`
+    // fields and matches the substring against the joined string.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":[{\"type\":\"text\",\"text\":\"BLOCKED: foo is a shared configuration file.\"},{\"type\":\"text\",\"text\":\"trailing context\"}],\"is_error\":true}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_skips_array_text_blocks_without_text_field() {
+    // tool_result.content is an array, but content blocks vary in
+    // shape. A leading non-text block (e.g., type "image") has no
+    // `text` field so the helper's `if let Some(t)` skips it; two
+    // following text blocks are joined with a single space. None of
+    // the joined text contains the substring, so helper returns
+    // false. Exercises the join-when-not-empty branch AND the
+    // no-text-key skip branch in one test.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":[{\"type\":\"image\"},{\"type\":\"text\",\"text\":\"no relevant content here\"},{\"type\":\"text\",\"text\":\"still nothing\"}],\"is_error\":true}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+#[test]
+fn helper_continues_when_tool_result_content_is_number() {
+    // tool_result.content is neither a string nor an array — e.g.,
+    // a number from a malformed write. Helper continues past the
+    // block and returns false at the user-turn boundary.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":7,\"is_error\":true}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_edit_blocked_on_shared_config(&path, home));
 }

--- a/tests/hooks/validate_ask_user.rs
+++ b/tests/hooks/validate_ask_user.rs
@@ -997,7 +997,7 @@ fn both_carve_outs_can_apply_user_only_wins_first() {
     // there's also a tool_result-wrapped user turn carrying the
     // shared-config substring, so it returns true too.
     let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n\
-{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\",\"content\":\"BLOCKED: Cargo.toml is a shared configuration file.\",\"is_error\":true}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\",\"content\":\"BLOCKED: Cargo.toml is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n\
 {\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n";
     let transcript = carve_out_transcript_fixture(&root, jsonl);
     let payload = json!({"transcript_path": transcript.to_string_lossy()});

--- a/tests/hooks/validate_ask_user.rs
+++ b/tests/hooks/validate_ask_user.rs
@@ -790,3 +790,281 @@ fn validate_ask_user_block_persists_when_no_carve_out_during_in_progress_auto() 
     assert_eq!(output.status.code().unwrap_or(-1), 2);
     assert!(String::from_utf8_lossy(&output.stderr).contains("BLOCKED"));
 }
+
+// --- Shared-config carve-out wiring ---
+//
+// Verifies the second carve-out in `run_impl_main`: when the
+// transcript shows a recent shared-config edit block emitted by
+// `validate_worktree_paths::validate_shared_config`, the
+// AskUserQuestion that the BLOCKED message itself instructs the
+// model to call must fire even during in-progress autonomous
+// phases. Without the carve-out, the model deadlocks — one hook
+// says "ask the user" while another hook blocks AskUserQuestion.
+//
+// Tests that drive `validate(state_path)` directly (Tests 3 and 4)
+// verify pre-existing allow paths are preserved by the new wiring.
+// Tests that drive the integrated subprocess (Tests 1, 2, 5, 6, 7,
+// 8) verify the carve-out's wiring inside `run_impl_main`, since
+// the function is private and can only be exercised through the
+// real CLI.
+
+/// Build a minimal git repo + state file pair for subprocess tests.
+/// Returns the canonicalized root. The state file lands at
+/// `<root>/.flow-states/test/state.json` matching `--initial-branch=test`.
+fn shared_config_subprocess_fixture(state: &Value) -> (tempfile::TempDir, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+    Command::new("git")
+        .args(["init", "--initial-branch=test", "."])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "x@y.z"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "X"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    write_state(&root, "test", state);
+    (tmp, root)
+}
+
+/// Spawn `bin/flow hook validate-ask-user` with the given stdin
+/// payload from the given `root` cwd, returning (exit_code, stdout,
+/// stderr). HOME is set to `root` so the transcript-path validator's
+/// `<home>/.claude/projects/` prefix check resolves to the same root
+/// the transcript fixture is written under.
+fn run_validate_ask_user(root: &Path, payload: &Value) -> (i32, String, String) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["hook", "validate-ask-user"])
+        .current_dir(root)
+        .env_remove("FLOW_CI_RUNNING")
+        .env("HOME", root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(payload.to_string().as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+#[test]
+fn autonomous_block_still_fires_without_recent_shared_config_block() {
+    // Negative regression guard: when the transcript carries no
+    // shared-config block AND no user-only Skill call, the
+    // autonomous-phase block must still fire.
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "auto"}},
+    });
+    let (_tmp, root) = shared_config_subprocess_fixture(&state);
+    // Transcript: an assistant turn that ran some other tool with
+    // a non-shared-config success. No carve-out conditions met.
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"do something\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"t1\",\"input\":{\"command\":\"ls\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\",\"content\":\"file1\\nfile2\\n\",\"is_error\":false}]}}\n";
+    let transcript = carve_out_transcript_fixture(&root, jsonl);
+    let payload = json!({"transcript_path": transcript.to_string_lossy()});
+    let (code, _stdout, stderr) = run_validate_ask_user(&root, &payload);
+    assert_eq!(code, 2, "stderr: {}", stderr);
+    assert!(stderr.contains("BLOCKED"), "stderr: {}", stderr);
+}
+
+#[test]
+fn shared_config_carve_out_allows_ask_during_autonomous() {
+    // Positive case: in_progress + auto + recent shared-config
+    // BLOCKED tool_result. The carve-out fires and the
+    // AskUserQuestion is allowed to proceed (exit 0).
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "auto"}},
+    });
+    let (_tmp, root) = shared_config_subprocess_fixture(&state);
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"add a line\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"id\":\"t1\",\"input\":{\"file_path\":\"/p/requirements.txt\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\",\"content\":\"BLOCKED: requirements.txt is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n";
+    let transcript = carve_out_transcript_fixture(&root, jsonl);
+    let payload = json!({"transcript_path": transcript.to_string_lossy()});
+    let (code, _stdout, stderr) = run_validate_ask_user(&root, &payload);
+    assert_eq!(code, 0, "stderr: {}", stderr);
+}
+
+#[test]
+fn carve_out_does_not_fire_outside_in_progress_phase() {
+    // Pre-existing behavior preserved: when the current phase is
+    // not in_progress (status = "complete" here, simulating the
+    // transition window between phase_complete and phase_enter),
+    // validate's block doesn't fire and AskUserQuestion is
+    // allowed regardless of any carve-out.
+    let dir = tempfile::tempdir().unwrap();
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "complete"}},
+        "skills": {"flow-code": {"continue": "auto"}},
+    });
+    let path = write_state(dir.path(), "test", &state);
+    let (allowed, _msg, _resp) = validate(Some(&path));
+    assert!(allowed);
+}
+
+#[test]
+fn carve_out_does_not_fire_in_manual_phase() {
+    // Pre-existing behavior preserved: when in_progress but
+    // continue is manual, the autonomous-phase block doesn't
+    // fire — manual phases don't restrict AskUserQuestion. The
+    // carve-out is irrelevant here.
+    let dir = tempfile::tempdir().unwrap();
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "manual"}},
+    });
+    let path = write_state(dir.path(), "test", &state);
+    let (allowed, _msg, _resp) = validate(Some(&path));
+    assert!(allowed);
+}
+
+#[test]
+fn user_only_skill_carve_out_still_works_alongside() {
+    // The existing user-only Skill carve-out must continue to fire
+    // when the transcript shows a user-only Skill invocation but
+    // no shared-config block. Verifies the new wiring did not
+    // break the prior behavior.
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "auto"}},
+    });
+    let (_tmp, root) = shared_config_subprocess_fixture(&state);
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n";
+    let transcript = carve_out_transcript_fixture(&root, jsonl);
+    let payload = json!({"transcript_path": transcript.to_string_lossy()});
+    let (code, _stdout, stderr) = run_validate_ask_user(&root, &payload);
+    assert_eq!(code, 0, "stderr: {}", stderr);
+}
+
+#[test]
+fn both_carve_outs_can_apply_user_only_wins_first() {
+    // Regression guard for the carve-out ordering inside
+    // run_impl_main. When the transcript carries BOTH a recent
+    // user-only Skill invocation AND a shared-config tool_result
+    // block, both carve-outs return true. The integration must
+    // still allow (exit 0) — semantically the order doesn't matter
+    // since both produce the same outcome, but the test locks the
+    // path so a future refactor that swaps the order or breaks one
+    // of the branches still passes.
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "auto"}},
+    });
+    let (_tmp, root) = shared_config_subprocess_fixture(&state);
+    // Transcript walking backward: most recent assistant turn fires
+    // a user-only Skill call; an earlier turn carries a
+    // shared-config BLOCKED tool_result. The user-only walker stops
+    // at the most recent assistant turn (finds the user-only
+    // Skill, returns true). The shared-config walker stops at the
+    // most recent real user turn before any matching block — but
+    // there's also a tool_result-wrapped user turn carrying the
+    // shared-config substring, so it returns true too.
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<command-name>/flow:flow-abort</command-name>\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\",\"content\":\"BLOCKED: Cargo.toml is a shared configuration file.\",\"is_error\":true}]}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"flow:flow-abort\"}}]}}\n";
+    let transcript = carve_out_transcript_fixture(&root, jsonl);
+    let payload = json!({"transcript_path": transcript.to_string_lossy()});
+    let (code, _stdout, stderr) = run_validate_ask_user(&root, &payload);
+    assert_eq!(code, 0, "stderr: {}", stderr);
+}
+
+#[test]
+fn carve_out_respects_unsafe_transcript_path() {
+    // When transcript_path fails is_safe_transcript_path validation
+    // (relative path here), neither carve-out fires. The
+    // autonomous-phase block stays in effect and the hook exits 2.
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "auto"}},
+    });
+    let (_tmp, root) = shared_config_subprocess_fixture(&state);
+    // Relative path — validator rejects (must be absolute under
+    // <home>/.claude/projects/).
+    let payload = json!({"transcript_path": "relative/path.jsonl"});
+    let (code, _stdout, stderr) = run_validate_ask_user(&root, &payload);
+    assert_eq!(code, 2, "stderr: {}", stderr);
+    assert!(stderr.contains("BLOCKED"), "stderr: {}", stderr);
+}
+
+#[test]
+fn subprocess_integration_shared_config_carve_out_allows() {
+    // Subprocess integration test for the shared-config carve-out's
+    // happy path. Sibling to `..._block_persists_no_marker` below.
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "auto"}},
+    });
+    let (_tmp, root) = shared_config_subprocess_fixture(&state);
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"id\":\"t1\",\"input\":{\"file_path\":\"/p/.gitignore\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\",\"content\":\"BLOCKED: .gitignore is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n";
+    let transcript = carve_out_transcript_fixture(&root, jsonl);
+    let payload = json!({"transcript_path": transcript.to_string_lossy()});
+    let (code, _stdout, stderr) = run_validate_ask_user(&root, &payload);
+    assert_eq!(code, 0, "stderr: {}", stderr);
+}
+
+#[test]
+fn subprocess_integration_shared_config_block_persists_no_marker() {
+    // Sibling subprocess test for the negative case: the same
+    // setup as the happy path above EXCEPT the transcript's
+    // tool_result lacks the shared-config substring. The carve-out
+    // does NOT fire and the autonomous-phase block exits 2.
+    let state = json!({
+        "current_phase": "flow-code",
+        "branch": "test",
+        "phases": {"flow-code": {"status": "in_progress"}},
+        "skills": {"flow-code": {"continue": "auto"}},
+    });
+    let (_tmp, root) = shared_config_subprocess_fixture(&state);
+    // Successful Edit — no BLOCKED message, no carve-out.
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"id\":\"t1\",\"input\":{\"file_path\":\"/p/src/foo.rs\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\",\"content\":\"The file has been updated.\",\"is_error\":false}]}}\n";
+    let transcript = carve_out_transcript_fixture(&root, jsonl);
+    let payload = json!({"transcript_path": transcript.to_string_lossy()});
+    let (code, _stdout, stderr) = run_validate_ask_user(&root, &payload);
+    assert_eq!(code, 2, "stderr: {}", stderr);
+    assert!(stderr.contains("BLOCKED"), "stderr: {}", stderr);
+}

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -930,3 +930,30 @@ fn validate_subprocess_accepts_main_repo_flow_states_grep() {
     );
     assert_eq!(code, 0, "stderr: {}", stderr);
 }
+
+// --- Presence contract: shared-config BLOCKED phrase ---
+
+/// Presence-contract assertion that the literal substring
+/// `"is a shared configuration file"` appears in the source of
+/// `src/hooks/validate_worktree_paths.rs`. Named consumer:
+/// `crate::hooks::transcript_walker::recent_edit_blocked_on_shared_config`,
+/// which detects shared-config blocks by scanning tool_result content
+/// for this exact substring. A refactor of `validate_shared_config`'s
+/// BLOCKED message that drops the substring would silently break the
+/// validate-ask-user shared-config carve-out — the helper would
+/// return false on every transcript and the autonomous-phase block
+/// would deadlock the flow when the model tries to confirm a shared-
+/// config edit. This test is a presence contract (not a tombstone)
+/// because the assertion is positive presence, not absence.
+#[test]
+fn validate_worktree_paths_emits_shared_config_phrase() {
+    let content = std::fs::read_to_string("src/hooks/validate_worktree_paths.rs")
+        .expect("validate_worktree_paths.rs source must be readable");
+    assert!(
+        content.contains("is a shared configuration file"),
+        "src/hooks/validate_worktree_paths.rs must emit the literal \
+         substring \"is a shared configuration file\" — \
+         transcript_walker::recent_edit_blocked_on_shared_config \
+         depends on this exact phrase as its detection signal"
+    );
+}

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -934,25 +934,31 @@ fn validate_subprocess_accepts_main_repo_flow_states_grep() {
 // --- Presence contract: shared-config BLOCKED phrase ---
 
 /// Presence-contract assertion that the literal substring
-/// `"is a shared configuration file"` appears in the source of
-/// `src/hooks/validate_worktree_paths.rs`. Named consumer:
+/// `"is a shared configuration file that affects every engineer"`
+/// appears in the source of `src/hooks/validate_worktree_paths.rs`.
+/// Named consumer:
 /// `crate::hooks::transcript_walker::recent_edit_blocked_on_shared_config`,
 /// which detects shared-config blocks by scanning tool_result content
-/// for this exact substring. A refactor of `validate_shared_config`'s
-/// BLOCKED message that drops the substring would silently break the
-/// validate-ask-user shared-config carve-out — the helper would
-/// return false on every transcript and the autonomous-phase block
-/// would deadlock the flow when the model tries to confirm a shared-
-/// config edit. This test is a presence contract (not a tombstone)
-/// because the assertion is positive presence, not absence.
+/// for this exact substring. The phrase is intentionally long so the
+/// detection signal cannot accidentally match unrelated error
+/// messages (a permission-denied error, a generic "this file is
+/// shared" warning) — the suffix "that affects every engineer"
+/// scopes the match to the BLOCKED message format from
+/// `validate_shared_config`. A refactor of that BLOCKED message that
+/// drops the substring would silently break the validate-ask-user
+/// shared-config carve-out — the helper would return false on every
+/// transcript and the autonomous-phase block would deadlock the flow
+/// when the model tries to confirm a shared-config edit. This test
+/// is a presence contract (not a tombstone) because the assertion is
+/// positive presence, not absence.
 #[test]
 fn validate_worktree_paths_emits_shared_config_phrase() {
     let content = std::fs::read_to_string("src/hooks/validate_worktree_paths.rs")
         .expect("validate_worktree_paths.rs source must be readable");
     assert!(
-        content.contains("is a shared configuration file"),
+        content.contains("is a shared configuration file that affects every engineer"),
         "src/hooks/validate_worktree_paths.rs must emit the literal \
-         substring \"is a shared configuration file\" — \
+         substring \"is a shared configuration file that affects every engineer\" — \
          transcript_walker::recent_edit_blocked_on_shared_config \
          depends on this exact phrase as its detection signal"
     );


### PR DESCRIPTION
## What

#1413.

Closes #1413

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/fix-three-hook-deadlock-on/log` |
| State | `.flow-states/fix-three-hook-deadlock-on/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 35m |
| Code Review | 1h 6m |
| Learn | 3m |
| Complete | 6m |
| **Total** | **1h 52m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/fix-three-hook-deadlock-on.json</summary>

````json
{
  "schema_version": 1,
  "branch": "fix-three-hook-deadlock-on",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1414,
  "pr_url": "https://github.com/benkruger/flow/pull/1414",
  "started_at": "2026-05-09T17:34:21-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/fix-three-hook-deadlock-on/log",
    "state": ".flow-states/fix-three-hook-deadlock-on/state.json"
  },
  "session_tty": "/dev/ttys001",
  "session_id": null,
  "transcript_path": null,
  "notes": [],
  "prompt": "#1413",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-09T17:34:21-07:00",
      "completed_at": "2026-05-09T17:34:57-07:00",
      "session_started_at": null,
      "cumulative_seconds": 36,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-09T17:34:57-07:00",
        "five_hour_pct": 6,
        "seven_day_pct": 44
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-09T17:35:06-07:00",
      "completed_at": "2026-05-09T18:10:06-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2100,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T17:35:06-07:00",
        "five_hour_pct": 6,
        "seven_day_pct": 44
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-09T17:51:15-07:00",
          "five_hour_pct": 10,
          "seven_day_pct": 45
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-09T17:51:15-07:00",
          "five_hour_pct": 10,
          "seven_day_pct": 45
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-09T17:51:15-07:00",
          "five_hour_pct": 10,
          "seven_day_pct": 45
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-09T18:07:58-07:00",
          "five_hour_pct": 20,
          "seven_day_pct": 48
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-09T18:07:58-07:00",
          "five_hour_pct": 20,
          "seven_day_pct": 48
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T18:10:06-07:00",
        "five_hour_pct": 21,
        "seven_day_pct": 48
      }
    },
    "flow-review": {
      "name": "Code Review",
      "status": "complete",
      "started_at": "2026-05-09T18:10:19-07:00",
      "completed_at": "2026-05-09T19:17:11-07:00",
      "session_started_at": null,
      "cumulative_seconds": 4012,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T18:10:19-07:00",
        "five_hour_pct": 21,
        "seven_day_pct": 48
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-09T18:12:07-07:00",
          "five_hour_pct": 21,
          "seven_day_pct": 48
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-09T18:23:09-07:00",
          "five_hour_pct": 26,
          "seven_day_pct": 50
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-09T18:27:12-07:00",
          "five_hour_pct": 27,
          "seven_day_pct": 50
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-09T19:16:57-07:00",
          "five_hour_pct": 35,
          "seven_day_pct": 52
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T19:17:11-07:00",
        "five_hour_pct": 35,
        "seven_day_pct": 52
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-09T19:17:26-07:00",
      "completed_at": "2026-05-09T19:20:32-07:00",
      "session_started_at": null,
      "cumulative_seconds": 186,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-09T19:17:26-07:00",
        "five_hour_pct": 35,
        "seven_day_pct": 52
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-09T19:19:38-07:00",
          "five_hour_pct": 36,
          "seven_day_pct": 52
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-09T19:19:50-07:00",
          "five_hour_pct": 36,
          "seven_day_pct": 52
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-09T19:20:04-07:00",
          "five_hour_pct": 36,
          "seven_day_pct": 52
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-09T19:20:11-07:00",
          "five_hour_pct": 36,
          "seven_day_pct": 52
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-09T19:20:18-07:00",
          "five_hour_pct": 36,
          "seven_day_pct": 52
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T19:20:32-07:00",
        "five_hour_pct": 36,
        "seven_day_pct": 52
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-09T19:21:06-07:00",
      "completed_at": "2026-05-09T19:27:38-07:00",
      "session_started_at": null,
      "cumulative_seconds": 392,
      "visit_count": 1,
      "step_snapshots": [
        {
          "step": 2,
          "field": "complete_step",
          "captured_at": "2026-05-09T19:21:20-07:00",
          "five_hour_pct": 36,
          "seven_day_pct": 52
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-09T19:27:38-07:00",
        "five_hour_pct": 37,
        "seven_day_pct": 53
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-09T17:35:06-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-09T18:10:19-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-09T19:17:26-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-09T19:21:06-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-abort": "auto",
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    }
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-09T17:34:21-07:00",
    "five_hour_pct": 6,
    "seven_day_pct": 44
  },
  "code_task_name": "Group B: validate_ask_user wiring + rule docs",
  "code_task": 5,
  "diff_stats": {
    "files_changed": 8,
    "insertions": 865,
    "deletions": 19,
    "captured_at": "2026-05-09T18:10:06-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nLet me work through this conversation chronologically to capture the key details.\n\n## Conversation flow\n\nThe user invoked `/flow:flow-start #1413` to begin Phase 1 of a FLOW lifecycle. The issue #1413 contained a pre-decomposed plan to fix a three-hook deadlock between `validate_worktree_paths` (which blocks shared-config edits and instructs the model to call AskUserQuestion to confirm) and `validate-ask-user` (which blocks ALL AskUserQuestion calls during in-progress autonomous phases). The deadlock: two hooks contradicting each other.\n\nThe plan had 5 tasks across 2 atomic groups:\n- Group A (Tasks 1-3): Helper TDD pair + presence contract\n- Group B (Tasks 4-5): Wiring TDD pair + rule docs\n\n### Phase 1: Start (completed in <1m)\n- Initialized branch `fix-three-hook-deadlock-on`\n- CI gate clean\n- Workspace created at `/Users/ben/code/flow/.worktrees/fix-three-hook-deadlock-on`\n- PR #1414 opened\n- Plan extracted from issue body\n- Auto-advanced to Phase 2\n\n### Phase 2: Code (35m)\n**Group A (commit 3a4bdd5a):**\n- Task 1: Added `validate_worktree_paths_emits_shared_config_phrase` presence contract test in `tests/hooks/validate_worktree_paths.rs`\n- Task 2: Added 12+ unit tests in `tests/hooks/transcript_walker.rs`\n- Task 3: Added `recent_edit_blocked_on_shared_config(transcript_path: &Path, home: &Path) -> bool` in `src/hooks/transcript_walker.rs`. Added `SHARED_CONFIG_BLOCK_BYTE_CAP = 4 MB`. Generalized `read_capped(path, cap)`.\n\n**Group B (commit bc863c5b):**\n- Task 4: Added 9 wiring tests in `tests/hooks/validate_ask_user.rs`\n- Task 5: Wired the carve-out into `run_impl_main` between user-only-skill carve-out and block return. Updated 3 rule docs (autonomous-phase-discipline.md, permissions.md, user-only-skills.md).\n\n### Phase 3: Code Review (1h 6m)\nLaunched 4 agents in parallel:\n- Reviewer (returned 2 findings)\n- Pre-mortem (returned 5 findings)\n- Adversarial (created tests/test_adversarial_flow.rs, found 2 confirmed issues)\n- Documentation (returned 5 findings)\n\nTriaged into 8 real findings + 4 false positives:\n- F1.1 hook-vs-instruction.md not updated → REAL\n- F1.2/F2.5 is_truthy → REAL\n- F2.1/F2.2 Stale carve-out (scope) → REAL\n- F2.3 read_capped take(cap) → REAL\n- F2.4 cp/mv/dd injection → FALSE POSITIVE (documented Layer 3 limitation)\n- F3.1 Substring over-broad → REAL\n- F3.2 Symlink escape → REAL (security)\n- F4.1 Module doc → REAL\n- F4.2 Cap justification → FALSE POSITIVE (already documented)\n- F4.3 Substring contract in rules → FALSE POSITIVE (bureaucracy trap)\n- F4.4 Carve-out ordering comment → REAL\n- F4.5 CLAUDE.md mention → FALSE POSITIVE\n\n**Step 4 fixes (commit e02fd08e):**\n1. **Symlink fix in `is_safe_transcript_path`** (`src/window_snapshot.rs`) — added canonicalize on both input and prefix\n2. **Walker scope fix** in `recent_edit_blocked_on_shared_config` — extracted `user_turn_carries_shared_config_block` helper, walker examines only most recent user-role turn and returns\n3. **Strengthened substring** to `\"is a shared configuration file that affects every engineer\"`\n4. **`take(cap)` in read_capped** — wrapped BufReader in file.take(cap)\n5. **`is_truthy` helper** — accepts bool, string \"true\"/\"1\", non-zero numbers\n6. **Module doc updated** — 3 consumers, both byte caps\n7. **Carve-out ordering comment** — names regression test\n8. **hook-vs-instruction.md** — enumerates both carve-outs\n9. **Restored adversarial probe** to integration-branch stub via `git restore --source=main`\n\nCoverage iteration:\n- After fixes, transcript_walker had 13 missed regions (closures showing \"Unexecuted instantiation\")\n- Added 7 more tests for is_truthy variants, chmod-000 path, trailing assistant turn\n- Added chmod-000 test in `tests/hooks/stop_continue.rs` for last_assistant_text_and_tool_use\n- Got to 100/100/100\n\n### Phase 4: Learn (3m)\nLaunched learn-analyst agent. Returned \"No findings\" across all three tenants. Skipped Step 5 commit (no changes). No issues filed. Auto-advanced to Phase 5.\n\n### Phase 5: Complete (in progress)\n- complete-fast returned `path: \"ci_stale\"` (main merged into branch)\n- Set complete_step=2, self-invoked\n- Self-invocation arrived at Step 2 (Run local CI gate)\n- I ran `bin/flow ci` which succeeded with 100/100/100 (4191 tests passing in 175s)\n- Now need to continue to Step 3 (Check GitHub CI status)\n\nThe user just sent a \"TEXT ONLY\" message asking for a summary of the conversation.\n\n## Key technical details\n\n**Files modified:**\n- `src/hooks/transcript_walker.rs`: Added recent_edit_blocked_on_shared_config, user_turn_carries_shared_config_block, is_truthy helpers. Generalized read_capped. SHARED_CONFIG_BLOCK_BYTE_CAP=4MB constant.\n- `src/hooks/validate_ask_user.rs`: Added second carve-out check in run_impl_main, updated module doc, added ordering comment.\n- `src/window_snapshot.rs`: Added canonicalize step in is_safe_transcript_path.\n- `tests/hooks/transcript_walker.rs`: Added ~28+ unit tests for the new helper.\n- `tests/hooks/validate_ask_user.rs`: Added 9 wiring tests with shared_config_subprocess_fixture and run_validate_ask_user helpers.\n- `tests/hooks/validate_worktree_paths.rs`: Added presence-contract test.\n- `tests/hooks/stop_continue.rs`: Added prose_pause_allows_when_transcript_file_unreadable test.\n- `.claude/rules/autonomous-phase-discipline.md`: Added \"Shared-Config Carve-Out\" subsection.\n- `.claude/rules/permissions.md`: Added \"Autonomous-phase carve-out\" subsection.\n- `.claude/rules/user-only-skills.md`: Added paragraph about second sanctioned exception.\n- `.claude/rules/hook-vs-instruction.md`: Updated AskUserQuestion bullet to enumerate both carve-outs.\n\n**Commits in this PR:**\n1. 712a45db: Start branch\n2. 3a4bdd5a: Add transcript_walker helper for shared-config carve-out detection\n3. bc863c5b: Wire shared-config carve-out\n4. e02fd08e: Tighten shared-config carve-out (Code Review fixes)\n5. (after main merge during Phase 5)\n\n**Phase timings:**\n- Start: 36s\n- Code: 2100s (35m)\n- Code Review: 4012s (1h 6m)\n- Learn: 3m\n- Complete: in progress (currently at Step 2)\n\n**Current state:**\n- complete_step=2 was set, then self-invoke arrived at Step 2\n- Bash ci command just succeeded: 4191 tests passed, 100/100/100 coverage\n- Skill says: \"If it passes, continue to Step 3.\"\n\n**Step 3** is \"Check GitHub CI status\" via `gh pr checks <pr_number>` (PR #1414).\n\n## All user messages\n\nThe user's messages in this conversation are quite limited. The actual user input was:\n1. The initial `/flow:flow-start #1413` command (visible in <command-args>)\n\nMost messages have been from the harness invoking sub-skills (flow-start → flow-code → flow-commit → flow-code → flow-commit → flow-code → flow-review → flow-review continue-step variants → flow-commit → flow-review continue-step → flow-learn → flow-complete → flow-complete continue-step). These are not \"user messages\" in the traditional sense — they are skill invocations.\n\nSystem reminders appeared throughout (mostly task-tool reminders that I correctly ignored per the user's memory).\n\nThe final user message is the TEXT ONLY summary request.\n\n## Pending tasks\n\nThe skill at the time of the summary request had just received successful CI output and needs to:\n1. Continue to Step 3 (Check GitHub CI status via `gh pr checks 1414`)\n2. If GitHub CI passes, continue to Step 5 (since Step 4 is skipped in auto mode)\n3. Step 5: merge PR via `bin/flow complete-merge --pr 1414 --state-file ...`\n4. Step 6: cd to project root, run `bin/flow complete-finalize` with --pull\n5. Step 7: Report cleanup results\n6. Done: Print banner with summary\n\nThe skill says \"If it passes, continue to Step 3.\"\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user invoked `/flow:flow-start #1413` to start a FLOW lifecycle that fixes a three-hook deadlock. Issue #1413 carried a pre-decomposed implementation plan: `validate_worktree_paths` blocks shared-config file edits (`.gitignore`, `Cargo.toml`, etc.) and instructs the model to call `AskUserQuestion` to confirm; `validate-ask-user`'s autonomous-phase block refuses every `AskUserQuestion` during in-progress autonomous phases — so the two hooks deadlock against each other. The plan added a second carve-out in `validate-ask-user::run_impl_main` (mirroring the existing `user_only_skill_carve_out_applies` pattern) that fires when the persisted transcript shows a recent `validate_worktree_paths` BLOCKED tool_result. The user requested fully autonomous execution; the entire flow ran with `--auto` propagated through every phase.\n\n2. Key Technical Concepts:\n   - FLOW plugin 5-phase lifecycle: Start → Code → Code Review → Learn → Complete\n   - Shared-config carve-out: 2nd sanctioned exception to autonomous AskUserQuestion block (1st is user-only-skill carve-out)\n   - Transcript walker: backward JSONL walker over persisted Claude Code transcript with byte-tail-bounded read\n   - Detection signal: literal substring `\"is a shared configuration file that affects every engineer\"` (uniquely emitted by `validate_worktree_paths::validate_shared_config`)\n   - Path validation: `is_safe_transcript_path` with canonicalize for symlink-escape protection\n   - `read_capped(path, cap)` — generalized helper using `BufReader::new(file.take(cap))` for hard byte-bound\n   - `is_truthy` helper per `.claude/rules/rust-patterns.md` \"Hook Input Boolean Field Tolerance\": accepts bool, string `\"true\"`/`\"1\"`, non-zero numbers\n   - Walker scope: examines ONLY most recent user-role turn (extracted helper `user_turn_carries_shared_config_block`)\n   - Adversarial probe lifecycle: probe at `tests/test_adversarial_flow.rs` restored to integration-branch stub via `git restore --source=main`\n   - Cognitive isolation: 4 parallel agents (reviewer, pre-mortem, adversarial, documentation) in Code Review\n   - Coverage gate: 100/100/100 enforced by `--fail-under-lines/regions/functions=100`\n   - chmod-000 test pattern for File::open Err coverage after canonicalize tightening\n\n3. Files and Code Sections:\n   - **`src/hooks/transcript_walker.rs`** — central source change. Added:\n     - `pub const SHARED_CONFIG_BLOCK_BYTE_CAP: u64 = 4 * 1024 * 1024;`\n     - `pub fn recent_edit_blocked_on_shared_config(transcript_path: &Path, home: &Path) -> bool` — walks backward, stops at most recent user-role turn, returns based on `user_turn_carries_shared_config_block(&turn)`\n     - `fn user_turn_carries_shared_config_block(turn: &Value) -> bool` — checks for tool_result with `is_truthy(is_error)` AND content containing the long substring\n     - `fn is_truthy(v: Option<&Value>) -> bool` — defensive bool/string/number truthiness\n     - Generalized `fn read_capped(path: &Path, cap: u64) -> Option<String>` with `BufReader::new(file.take(cap))`\n     - Updated module doc to enumerate 3 consumers\n   - **`src/hooks/validate_ask_user.rs`** — wiring:\n     ```rust\n     let allow_shared_config = transcript_path\n         .as_deref()\n         .map(|p| recent_edit_blocked_on_shared_config(p, home))\n         .unwrap_or(false);\n     if allow_shared_config {\n         return HookAction::AllowWithMark(state_path);\n     }\n     ```\n     With inline comment naming `both_carve_outs_can_apply_user_only_wins_first` regression test. Module doc updated to \"Five outcomes\".\n   - **`src/window_snapshot.rs`** — security fix in `is_safe_transcript_path`:\n     ```rust\n     let canonical_path = match path.canonicalize() {\n         Ok(p) => p,\n         Err(_) => return false,\n     };\n     let expected_prefix = home.join(\".claude\").join(\"projects\");\n     let canonical_prefix = match expected_prefix.canonicalize() {\n         Ok(p) => p,\n         Err(_) => return false,\n     };\n     canonical_path.starts_with(&canonical_prefix)\n     ```\n   - **`tests/hooks/transcript_walker.rs`** — 28+ unit tests including chmod-000 (`helper_returns_false_when_transcript_file_unreadable`), is_truthy variants (`helper_accepts_is_error_string_true`, `helper_accepts_is_error_number_one`, `helper_rejects_is_error_number_zero`, `helper_rejects_is_error_string_false`, `helper_rejects_is_error_null`), trailing-assistant iteration (`helper_iterates_past_trailing_assistant_to_user_array_turn`)\n   - **`tests/hooks/validate_ask_user.rs`** — 9 wiring tests + helpers `shared_config_subprocess_fixture` and `run_validate_ask_user`\n   - **`tests/hooks/validate_worktree_paths.rs`** — `validate_worktree_paths_emits_shared_config_phrase` presence-contract (long substring)\n   - **`tests/hooks/stop_continue.rs`** — `prose_pause_allows_when_transcript_file_unreadable` (chmod-000 for last_assistant_text_and_tool_use after canonicalize tightening)\n   - **`.claude/rules/autonomous-phase-discipline.md`** — added \"Shared-Config Carve-Out\" subsection\n   - **`.claude/rules/permissions.md`** — added \"Autonomous-phase carve-out for the confirmation prompt\" subsection in Enforcement\n   - **`.claude/rules/user-only-skills.md`** — added paragraph in Layer 2 about second sanctioned exception\n   - **`.claude/rules/hook-vs-instruction.md`** — AskUserQuestion bullet now enumerates both carve-outs\n\n4. Errors and fixes:\n   - **Coverage gap: transcript_walker 13 missed regions** — fixed by adding chmod-000 File::open test, trailing-assistant test, is_truthy type variant tests, and updating short-form fixtures to long-form substring (`\"is a shared configuration file that affects every engineer in the repository.\"`)\n   - **Coverage gap: stop_continue 1 missed region** — canonicalize tightening made File::open Err in `last_assistant_text_and_tool_use` unreachable from existing missing-file test. Fixed by adding `prose_pause_allows_when_transcript_file_unreadable` chmod-000 test.\n   - **Adversarial probe failed with `flow_rs` and `tempfile` not found** — bin/test --file on top-level test file produces test binary without library deps. Resolved by restoring probe to integration-branch stub via `git restore --source=main tests/test_adversarial_flow.rs` per `.claude/rules/adversarial-probe-lifecycle.md` \"default is delete\".\n   - **Initial complete_fast 6 freshness_status timeouts** — environmental load. Single test in isolation passed in 2.6s. Per `.claude/rules/testing-gotchas.md` \"Distinguish Environmental Load From Flaky Tests\", proceeded.\n   - **Phantom miss attempts** — `bin/flow ci --clean` did not resolve; the actual gaps were real (closures requiring chmod-000 etc.) and resolved by adding tests.\n\n5. Problem Solving:\n   The deadlock fix shipped through 4 commits across the 5 FLOW phases, with Code Review surfacing 14 candidate findings (10 fixed, 4 dismissed as false positives). The most significant Code Review fixes addressed: a path-traversal vulnerability via symlinks under `~/.claude/projects/`, stale-block reuse from earlier session interactions allowing unrelated AskUserQuestion bypass, an over-broad detection substring that could appear in unrelated error messages, and missing defensive `is_truthy` for `is_error` field reads. Learn phase produced zero findings — every gap was caught by Code Review and remediated in this PR.\n\n6. All user messages:\n   - **Initial command:** `/flow:flow-start #1413` (with no flags — defaulted to autonomous mode based on `.flow.json` skill presets, which set every skill to `auto`)\n   - **Final TEXT ONLY summary request:** the current message asking for a thorough summary of the conversation, with explicit instructions not to call any tools.\n\n7. Pending Tasks:\n   - Continue Phase 5: Complete from where we left off after the just-completed `bin/flow ci` at Step 2. The skill instructs: \"If it passes, continue to Step 3.\"\n   - Step 3: Check GitHub CI status via `gh pr checks 1414`\n   - Step 4 (skipped in auto mode)\n   - Step 5: Merge PR via `bin/flow complete-merge --pr 1414 --state-file /Users/ben/code/flow/.flow-states/fix-three-hook-deadlock-on/state.json`\n   - Step 6: `cd /Users/ben/code/flow` then `bin/flow complete-finalize --pr 1414 --state-file ... --branch fix-three-hook-deadlock-on --worktree /Users/ben/code/flow/.worktrees/fix-three-hook-deadlock-on --pull`\n   - Step 7: Report cleanup results\n   - Done: Print COMPLETE banner with summary\n\n8. Current Work:\n   Phase 5 (Complete), Step 2. The previous session ran `complete-fast --branch fix-three-hook-deadlock-on --auto` which returned `path: \"ci_stale\"` (main was merged into branch — tree changed, CI must re-run). Set `complete_step=2`, set `_continue_context`, and self-invoked `flow:flow-complete --continue-step --auto`. The continuation arrived at Step 2 (Run local CI gate). Just ran `bin/flow ci` which returned:\n   ```\n   Summary [ 131.495s] 4191 tests run: 4191 passed, 0 skipped\n   TOTAL  25870  0  100.00%  1508  0  100.00%  16077  0  100.00%\n   === PASS (175s) ===\n   ```\n   CI is green. Per the skill: \"If it passes, continue to Step 3.\" The next action would normally be Step 3: `gh pr checks 1414`.\n\n   Mode: auto (resolved from state file `skills.flow-complete = \"auto\"`)\n   PR: #1414 (https://github.com/benkruger/flow/pull/1414)\n   Branch: `fix-three-hook-deadlock-on`\n   Project root: `/Users/ben/code/flow`\n   Worktree: `/Users/ben/code/flow/.worktrees/fix-three-hook-deadlock-on`\n   State file: `/Users/ben/code/flow/.flow-states/fix-three-hook-deadlock-on/state.json`\n   Last commit: `e02fd08e` (Code Review fixes), plus a main-merge commit from `complete-fast` ci_stale path\n   13 findings recorded in state (4 dismissed, 9 fixed)\n   No notes captured\n\n9. Optional Next Step:\n   Continue Phase 5 Complete from Step 2. The skill explicitly states: \"If it passes, continue to Step 3.\" Step 3 instruction: `gh pr checks <pr_number>` to check GitHub CI status. Direct quote from the skill at Step 2 end:\n   > \"If it passes, continue to Step 3.\"\n   \n   And from Step 3 opening:\n   > \"Check the CI status on the PR:\n   > ```bash\n   > gh pr checks <pr_number>\n   > ```\"\n   \n   With `<pr_number>` = 1414. After GitHub CI passes (or after waiting on pending), proceed through Steps 4 (skipped, auto), 5 (`complete-merge`), 6 (`cd /Users/ben/code/flow` then `complete-finalize --pull`), 7 (report cleanup), and finally print the COMPLETE banner. The full flow is mid-execution with no user intervention needed in autonomous mode.\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/fix-three-hook-deadlock-on",
  "compact_count": 6,
  "findings": [
    {
      "finding": "Transcript injection via cp/mv/dd Bash commands bypasses Layer 3 Edit/Write block on ~/.claude/projects/",
      "reason": "Pre-existing Layer 3 limitation documented in .claude/rules/user-only-skills.md 'Residual surface' subsection; not introduced by this PR. The same gap applies to the entire transcript-reading hook family (last_user_message_invokes_skill, most_recent_skill_in_user_only_set, recent_edit_blocked_on_shared_config). Tightening Layer 3 to cover Bash file-mutation commands beyond redirect is a separate concern out of scope for this PR.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:26:37-07:00"
    },
    {
      "finding": "SHARED_CONFIG_BLOCK_BYTE_CAP doc comment lacks justification for the 4MB choice",
      "reason": "False positive — the doc comment already justifies 4MB ('4 MB comfortably holds those turns even when they include large file contents in tool_use.input or tool_result.content. Using a smaller cap here than TRANSCRIPT_BYTE_CAP keeps the AskUserQuestion-blocked hot path fast'). The rationale is present at the definition site.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:26:47-07:00"
    },
    {
      "finding": "Detection substring 'is a shared configuration file' not documented as a contract in rule files",
      "reason": "False positive per review-scope.md value-vs-bureaucracy triage. The substring is documented at the helper's definition site (doc comment on recent_edit_blocked_on_shared_config) and locked by the presence-contract test in tests/hooks/validate_worktree_paths.rs. Adding the substring to rule prose duplicates information already discoverable via source doc comments and grep — bureaucracy trap that does not change behavior or prevent regression.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:26:57-07:00"
    },
    {
      "finding": "CLAUDE.md Key Files section should mention transcript_walker's role in shared-config carve-out detection",
      "reason": "False positive per review-scope.md value-vs-bureaucracy triage. CLAUDE.md's User-Only Skill Enforcement section describes the layered enforcement architecture at the right abstraction level; the new shared-config carve-out is documented in three rule files (autonomous-phase-discipline.md, permissions.md, user-only-skills.md) which CLAUDE.md cross-references via the rule corpus. A future session reading CLAUDE.md will follow the rule cross-reference to find the second carve-out — duplicating the description in CLAUDE.md adds maintenance burden without adding discovery signal.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:27:06-07:00"
    },
    {
      "finding": "Adversarial probe surfaced: substring 'is a shared configuration file' was over-broad",
      "reason": "Fixed in src/hooks/transcript_walker.rs by (a) scoping the walker to the most recent user-role turn instead of scanning the full window, and (b) lengthening the detection substring to 'is a shared configuration file that affects every engineer' which is unique to validate_worktree_paths' BLOCKED message format. Both defenses ship together: scope reduces stale-block reuse, longer substring rejects unrelated error messages that mention only the short prefix. Presence-contract test in tests/hooks/validate_worktree_paths.rs locks the longer substring.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:44:06-07:00"
    },
    {
      "finding": "Adversarial probe surfaced: is_safe_transcript_path symlink escape",
      "reason": "Fixed in src/window_snapshot.rs::is_safe_transcript_path by adding a canonicalize step on both the input path and the expected prefix before the starts_with check. The lexical prefix check followed by File::open allowed a symlink at the canonical location to escape <home>/.claude/projects/. Canonicalize resolves every component's symlinks before the prefix check, closing the traversal vector. Failure to canonicalize (missing file, permission error, broken symlink) returns false fail-closed.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:44:15-07:00"
    },
    {
      "finding": "Walker scanned full byte-cap window for shared-config blocks, allowing stale carve-out reuse",
      "reason": "Fixed in src/hooks/transcript_walker.rs::recent_edit_blocked_on_shared_config by scoping the walker to the most recent user-role turn only. Previously the walker continued past tool-result-wrapped user turns until hitting a string-content user turn, which let stale shared-config blocks from earlier in the session authorize unrelated AskUserQuestions later. The scope fix means the carve-out fires iff the most recent user-role event is the shared-config block — once any other tool_result intervenes, the carve-out no longer applies.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:44:26-07:00"
    },
    {
      "finding": "read_capped seeks to start offset but did not bound bytes consumed",
      "reason": "Fixed in src/hooks/transcript_walker.rs::read_capped by wrapping the BufReader in file.take(cap), matching the canonical byte-cap pattern documented in .claude/rules/external-input-path-construction.md. Previously a transcript that grew between metadata().len() and read_to_string would consume more than cap bytes (concurrent writers on the same transcript file). The take() wrapper hard-bounds the read at exactly cap bytes.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:44:35-07:00"
    },
    {
      "finding": "is_error read used .as_bool().unwrap_or(false) instead of is_truthy helper",
      "reason": "Fixed in src/hooks/transcript_walker.rs by extracting an is_truthy helper that accepts bool, string 'true'/'1' (case-insensitive), and non-zero numbers per .claude/rules/rust-patterns.md 'Hook Input Boolean Field Tolerance'. The helper is applied to the is_error field read in user_turn_carries_shared_config_block.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:44:45-07:00"
    },
    {
      "finding": "hook-vs-instruction.md Mechanically-Enforced Gates bullet did not list the new shared-config carve-out",
      "reason": "Fixed by updating .claude/rules/hook-vs-instruction.md to enumerate both carve-outs (user-only-skill and shared-config) under the AskUserQuestion gate bullet. The rule corpus now consistently documents the second carve-out across all four affected rule files (autonomous-phase-discipline, permissions, user-only-skills, hook-vs-instruction).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:44:53-07:00"
    },
    {
      "finding": "Module doc comment on transcript_walker.rs listed two consumers; new helper added a third",
      "reason": "Fixed by updating the module doc comment in src/hooks/transcript_walker.rs to enumerate three consumers (validate_skill, validate_ask_user user-only carve-out, validate_ask_user shared-config carve-out) and updated the Tail-bounded read section to describe both byte caps (TRANSCRIPT_BYTE_CAP and SHARED_CONFIG_BLOCK_BYTE_CAP).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:45:02-07:00"
    },
    {
      "finding": "Carve-out ordering not explained in code comment",
      "reason": "Fixed by adding an inline comment in src/hooks/validate_ask_user.rs::run_impl_main between the user-only-skill carve-out and the shared-config carve-out. The comment names the regression test (both_carve_outs_can_apply_user_only_wins_first) that locks the ordering.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T18:45:09-07:00"
    },
    {
      "finding": "Coverage gap surfaced by canonicalize change in stop_continue's last_assistant_text_and_tool_use",
      "reason": "Fixed by adding prose_pause_allows_when_transcript_file_unreadable test that exercises the File::open Err branch via chmod 000. The canonicalize tightening of is_safe_transcript_path made the previously-reachable missing-file path unreachable from existing tests, but the chmod 000 path still reaches File::open's error branch (canonicalize stats components, not opens, so it succeeds on chmod 000).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Code Review",
      "timestamp": "2026-05-09T19:14:44-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step --auto.",
  "window_at_complete": {
    "captured_at": "2026-05-09T19:27:38-07:00",
    "five_hour_pct": 37,
    "seven_day_pct": 53
  },
  "_auto_continue": "/flow:flow-complete"
}
````

</details>