### PR TITLE
Fix Token Cost Panel Showing

### DIFF
--- a/src/window_snapshot.rs
+++ b/src/window_snapshot.rs
@@ -118,9 +118,11 @@ pub fn capture_for_active_state(home: &Path, state: &Value, project_root: &Path)
     // because the file did not yet exist), derive the canonical
     // transcript location from `<home>/.claude/projects/<encoded>/
     // <session_id>.jsonl` using Claude Code's directory-encoding
-    // convention (every `/` and every `.` in the project root path
-    // becomes `-`; e.g. `/Users/ben/code/flow` →
-    // `-Users-ben-code-flow`). The derived path runs through the
+    // convention (every character that is not ASCII alphanumeric
+    // or `_` or `-` becomes `-`; e.g. `/Users/ben/code/flow` →
+    // `-Users-ben-code-flow`, `/Users/ben/My Project` →
+    // `-Users-ben-My-Project`, `/Users/ben/.claude` →
+    // `-Users-ben--claude`). The derived path runs through the
     // same `is_safe_transcript_path` validator so a hostile entry
     // under `~/.claude/projects/` cannot redirect the read.
     let transcript_path = state
@@ -148,12 +150,15 @@ pub fn capture_for_active_state(home: &Path, state: &Value, project_root: &Path)
 
 /// Derive the canonical transcript path Claude Code writes to:
 /// `<home>/.claude/projects/<encoded-project-root>/<session_id>.jsonl`.
-/// The encoding rule (confirmed by inspecting an existing
-/// `~/.claude/projects/` entry against its source project root):
-/// every `/` and every `.` in the project root path becomes `-`.
-/// `/Users/ben/code/flow` → `-Users-ben-code-flow`;
-/// `/Users/ben/.claude` → `-Users-ben--claude` (the `.` becomes a
-/// second `-`).
+/// The encoding rule (confirmed by inspecting existing
+/// `~/.claude/projects/` entries against their source project
+/// roots): every character that is not ASCII alphanumeric and not
+/// `_` and not `-` becomes `-`. Examples:
+///
+/// - `/Users/ben/code/flow` → `-Users-ben-code-flow`
+/// - `/Users/ben/.claude` → `-Users-ben--claude` (the leading `/` and the `.` each become `-`)
+/// - `/Users/ben/My Project` → `-Users-ben-My-Project` (the space becomes `-`)
+/// - `/Users/ben/code-cc-api` → `-Users-ben-code-cc-api` (the `-` characters are preserved)
 ///
 /// The result is run through `is_safe_transcript_path` by the
 /// caller, so this helper does no validation itself — it only
@@ -162,7 +167,13 @@ fn derive_transcript_path(home: &Path, project_root: &Path, session_id: &str) ->
     let encoded: String = project_root
         .to_string_lossy()
         .chars()
-        .map(|c| if c == '/' || c == '.' { '-' } else { c })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect();
     home.join(".claude")
         .join("projects")

--- a/src/window_snapshot.rs
+++ b/src/window_snapshot.rs
@@ -88,8 +88,10 @@ pub fn capture(
 /// Production binder around `capture` for the six producer call
 /// sites. Reads `session_id` and `transcript_path` from the
 /// in-memory state JSON, derives the per-session cost-file path
-/// under `<project_root>/.claude/cost/<YYYY-MM>/<session_id>.txt`,
-/// and invokes `capture` with `home` plus those paths.
+/// under `<project_root>/.claude/cost/<YYYY-MM>/<session_id>`
+/// (no extension — matches the producer in
+/// `~/.claude/statusline-command.sh`), and invokes `capture` with
+/// `home` plus those paths.
 ///
 /// Producers call this from inside `mutate_state` closures (the
 /// state JSON is already in memory) and write the returned
@@ -111,11 +113,27 @@ pub fn capture_for_active_state(home: &Path, state: &Value, project_root: &Path)
         .and_then(|v| v.as_str())
         .filter(|s| is_safe_session_id(s))
         .map(|s| s.to_string());
+    // Self-heal: when state's `transcript_path` is null (the
+    // SessionStart hook's strict validator rejected the path
+    // because the file did not yet exist), derive the canonical
+    // transcript location from `<home>/.claude/projects/<encoded>/
+    // <session_id>.jsonl` using Claude Code's directory-encoding
+    // convention (every `/` and every `.` in the project root path
+    // becomes `-`; e.g. `/Users/ben/code/flow` →
+    // `-Users-ben-code-flow`). The derived path runs through the
+    // same `is_safe_transcript_path` validator so a hostile entry
+    // under `~/.claude/projects/` cannot redirect the read.
     let transcript_path = state
         .get("transcript_path")
         .and_then(|v| v.as_str())
         .map(PathBuf::from)
-        .filter(|p| is_safe_transcript_path(p, home));
+        .filter(|p| is_safe_transcript_path(p, home))
+        .or_else(|| {
+            session_id
+                .as_ref()
+                .map(|sid| derive_transcript_path(home, project_root, sid))
+                .filter(|p| is_safe_transcript_path(p, home))
+        });
     let cost_path = session_id
         .as_ref()
         .map(|sid| cost_file_path(project_root, sid));
@@ -126,6 +144,30 @@ pub fn capture_for_active_state(home: &Path, state: &Value, project_root: &Path)
         session_id.as_deref(),
         now,
     )
+}
+
+/// Derive the canonical transcript path Claude Code writes to:
+/// `<home>/.claude/projects/<encoded-project-root>/<session_id>.jsonl`.
+/// The encoding rule (confirmed by inspecting an existing
+/// `~/.claude/projects/` entry against its source project root):
+/// every `/` and every `.` in the project root path becomes `-`.
+/// `/Users/ben/code/flow` → `-Users-ben-code-flow`;
+/// `/Users/ben/.claude` → `-Users-ben--claude` (the `.` becomes a
+/// second `-`).
+///
+/// The result is run through `is_safe_transcript_path` by the
+/// caller, so this helper does no validation itself — it only
+/// builds the candidate `PathBuf`.
+fn derive_transcript_path(home: &Path, project_root: &Path, session_id: &str) -> PathBuf {
+    let encoded: String = project_root
+        .to_string_lossy()
+        .chars()
+        .map(|c| if c == '/' || c == '.' { '-' } else { c })
+        .collect();
+    home.join(".claude")
+        .join("projects")
+        .join(encoded)
+        .join(format!("{}.jsonl", session_id))
 }
 
 /// Maximum accepted length for a `session_id`. Real Claude Code
@@ -295,7 +337,9 @@ pub fn home_dir_or_empty() -> PathBuf {
 }
 
 /// Resolve the per-session cost-file path
-/// `<project_root>/.claude/cost/<YYYY-MM>/<session_id>.txt`. The
+/// `<project_root>/.claude/cost/<YYYY-MM>/<session_id>`. No
+/// extension — the producer in `~/.claude/statusline-command.sh`
+/// writes the file as `$cost_dir/$session_id` (line 32). The
 /// month folder mirrors `tui_data::load_account_metrics` so the
 /// snapshot reads the same file that account-monthly aggregation
 /// already reads.
@@ -306,7 +350,7 @@ fn cost_file_path(project_root: &Path, session_id: &str) -> PathBuf {
         .join(".claude")
         .join("cost")
         .join(year_month)
-        .join(format!("{}.txt", session_id))
+        .join(session_id)
 }
 
 /// Read `~/.claude/rate-limits.json` and extract the two pct fields.

--- a/tests/hooks/capture_session.rs
+++ b/tests/hooks/capture_session.rs
@@ -448,3 +448,41 @@ fn capture_session_replaces_existing_symlink_at_capture_path() {
         serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
     assert_eq!(parsed["session_id"], "abc-123");
 }
+
+/// Regression: at SessionStart the transcript JSONL typically does
+/// not yet exist on disk — `is_safe_transcript_path` runs
+/// `canonicalize()` to defeat symlink traversal, and that syscall
+/// fails on missing files. The hook must store `transcript_path`
+/// as null in that case (not weaken the validator). Self-healing
+/// happens later in `capture_for_active_state` once the file
+/// exists. This test guards the strict-validator contract so a
+/// future "loosen the validator" attempt does not silently weaken
+/// symlink-escape defense.
+#[test]
+fn capture_session_stores_null_when_transcript_file_does_not_exist_yet() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().canonicalize().unwrap();
+    // Build a transcript_path that is shape-valid (absolute, under
+    // ~/.claude/projects/, no `..` components) but the file does not
+    // exist on disk. canonicalize() fails → validator returns false
+    // → hook stores null.
+    let projects_dir = home.join(".claude").join("projects").join("-tmp-abc");
+    fs::create_dir_all(&projects_dir).unwrap();
+    let transcript = projects_dir.join("nonexistent-session.jsonl");
+    assert!(!transcript.exists());
+    let stdin = format!(
+        r#"{{"session_id":"valid-sid","transcript_path":"{}"}}"#,
+        transcript.to_string_lossy()
+    );
+    let code = run_capture_session(Some(&home), stdin.as_bytes());
+    assert_eq!(code, Some(0));
+    let path = capture_file(&home);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(parsed["session_id"], "valid-sid");
+    assert!(
+        parsed["transcript_path"].is_null(),
+        "missing-file transcript_path must serialize as null; got: {}",
+        parsed["transcript_path"]
+    );
+}

--- a/tests/start_init.rs
+++ b/tests/start_init.rs
@@ -1334,13 +1334,14 @@ fn cost_per_flow_token_cost_section_renders_phase_delta_end_to_end() {
 
     // Plant a transcript file at the canonical Claude Code location
     // `<home>/.claude/projects/<encoded-project-root>/<session_id>.jsonl`.
-    // Encoding rule: every `/` and every `.` in the project root path
-    // becomes `-`. The subprocess running start-init canonicalizes
-    // project_root (`/var/...` → `/private/var/...` on macOS), so the
-    // encoded directory must be derived from the canonical form too.
-    // The capture file written by `write_capture_file` above does
-    // NOT carry transcript_path (the file did not yet exist at
-    // SessionStart), so this exercises the self-healing fallback in
+    // Encoding rule: every character that is not ASCII alphanumeric
+    // and not `_` and not `-` becomes `-`. The subprocess running
+    // start-init canonicalizes project_root (`/var/...` →
+    // `/private/var/...` on macOS), so the encoded directory must
+    // be derived from the canonical form too. The capture file
+    // written by `write_capture_file` above does NOT carry
+    // transcript_path (the file did not yet exist at SessionStart),
+    // so this exercises the self-healing fallback in
     // `capture_for_active_state`: with `transcript_path` null in
     // state, the snapshot derives the path from session_id +
     // project_root and reads token usage from the transcript.
@@ -1348,7 +1349,13 @@ fn cost_per_flow_token_cost_section_renders_phase_delta_end_to_end() {
     let encoded_root: String = canonical_repo
         .to_string_lossy()
         .chars()
-        .map(|c| if c == '/' || c == '.' { '-' } else { c })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect();
     let projects_dir = home.join(".claude").join("projects").join(&encoded_root);
     fs::create_dir_all(&projects_dir).unwrap();

--- a/tests/start_init.rs
+++ b/tests/start_init.rs
@@ -1152,13 +1152,15 @@ fn window_at_start_reads_cost_when_session_id_and_cost_file_present() {
     let session_id = "cost-test-sid";
     write_capture_file(&home, session_id, None);
 
-    // Pre-create the cost file at <repo>/.claude/cost/<YYYY-MM>/<session_id>.txt.
-    // The year-month component matches `chrono::Local::now().format("%Y-%m")`
-    // which is what `cost_file_path` in src/window_snapshot.rs computes.
+    // Pre-create the cost file at <repo>/.claude/cost/<YYYY-MM>/<session_id>
+    // (no extension — matches the producer in
+    // `~/.claude/statusline-command.sh`). The year-month component matches
+    // `chrono::Local::now().format("%Y-%m")` which is what `cost_file_path`
+    // in src/window_snapshot.rs computes.
     let year_month = chrono::Local::now().format("%Y-%m").to_string();
     let cost_dir = repo.join(".claude").join("cost").join(&year_month);
     fs::create_dir_all(&cost_dir).unwrap();
-    fs::write(cost_dir.join(format!("{}.txt", session_id)), "1.42\n").unwrap();
+    fs::write(cost_dir.join(session_id), "1.42\n").unwrap();
 
     let output = run_start_init_with_home(&repo, "cost-test", &home, &stub_dir);
     assert_eq!(
@@ -1319,15 +1321,40 @@ fn cost_per_flow_token_cost_section_renders_phase_delta_end_to_end() {
     let session_id = "cost-flow-sid";
     write_capture_file(&home, session_id, None);
 
-    // Pre-create the cost file at <repo>/.claude/cost/<YYYY-MM>/<session_id>.txt
-    // with an initial value. capture_for_active_state reads this file
-    // when start-init writes window_at_start, so this seeds the start
-    // anchor with cost=1.00.
+    // Pre-create the cost file at <repo>/.claude/cost/<YYYY-MM>/<session_id>
+    // (no extension — matches the producer in
+    // `~/.claude/statusline-command.sh`) with an initial value.
+    // capture_for_active_state reads this file when start-init writes
+    // window_at_start, so this seeds the start anchor with cost=1.00.
     let year_month = Local::now().format("%Y-%m").to_string();
     let cost_dir = repo.join(".claude").join("cost").join(&year_month);
     fs::create_dir_all(&cost_dir).unwrap();
-    let cost_file = cost_dir.join(format!("{}.txt", session_id));
+    let cost_file = cost_dir.join(session_id);
     fs::write(&cost_file, "1.00\n").unwrap();
+
+    // Plant a transcript file at the canonical Claude Code location
+    // `<home>/.claude/projects/<encoded-project-root>/<session_id>.jsonl`.
+    // Encoding rule: every `/` and every `.` in the project root path
+    // becomes `-`. The subprocess running start-init canonicalizes
+    // project_root (`/var/...` → `/private/var/...` on macOS), so the
+    // encoded directory must be derived from the canonical form too.
+    // The capture file written by `write_capture_file` above does
+    // NOT carry transcript_path (the file did not yet exist at
+    // SessionStart), so this exercises the self-healing fallback in
+    // `capture_for_active_state`: with `transcript_path` null in
+    // state, the snapshot derives the path from session_id +
+    // project_root and reads token usage from the transcript.
+    let canonical_repo = repo.canonicalize().unwrap();
+    let encoded_root: String = canonical_repo
+        .to_string_lossy()
+        .chars()
+        .map(|c| if c == '/' || c == '.' { '-' } else { c })
+        .collect();
+    let projects_dir = home.join(".claude").join("projects").join(&encoded_root);
+    fs::create_dir_all(&projects_dir).unwrap();
+    let transcript_path = projects_dir.join(format!("{}.jsonl", session_id));
+    let transcript_line = r#"{"type":"assistant","message":{"model":"claude-opus-4-7","role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":300,"output_tokens":100,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#;
+    fs::write(&transcript_path, format!("{}\n", transcript_line)).unwrap();
 
     let output = run_start_init_with_home(&repo, "cost-flow-test", &home, &stub_dir);
     assert_eq!(
@@ -1349,6 +1376,17 @@ fn cost_per_flow_token_cost_section_renders_phase_delta_end_to_end() {
             .expect("start cost populated"),
         1.00,
         "window_at_start cost must reflect the pre-flow cost file value"
+    );
+    // Confirm the start anchor also carries token usage — the
+    // self-healing transcript fallback in `capture_for_active_state`
+    // discovered the planted transcript at the canonical path,
+    // bypassed the null `transcript_path` in state, and read the
+    // assistant turn. Without the fix, this field stays None and
+    // the Token Cost panel renders zeros.
+    assert_eq!(
+        state["window_at_start"]["session_input_tokens"].as_i64(),
+        Some(300),
+        "window_at_start tokens must reflect the planted transcript via self-heal"
     );
 
     // Simulate cost accruing during the Code phase: bump the
@@ -1419,6 +1457,16 @@ fn cost_per_flow_token_cost_section_renders_phase_delta_end_to_end() {
     assert!(
         !code_row.contains("—"),
         "Code row must NOT show the em-dash placeholder when cost is fully populated; got: {:?}",
+        code_row
+    );
+    // The mocked window_at_enter (input=100) and window_at_complete
+    // (input=500) produce a 400-token delta. Locking that in proves
+    // the Code row renders non-zero tokens — the visual signal that
+    // tells a user the panel is healthy. Pre-fix, the panel showed
+    // zeros across every phase (issue #1431).
+    assert!(
+        code_row.contains("400"),
+        "Code row must show the non-zero token delta (input 100 → 500 = 400); got: {:?}",
         code_row
     );
 }

--- a/tests/window_snapshot.rs
+++ b/tests/window_snapshot.rs
@@ -970,12 +970,20 @@ fn capture_for_active_state_reads_cost_file_without_txt_extension() {
 
 /// Encode a project-root path the way Claude Code names the
 /// per-project transcript directory under `~/.claude/projects/`:
-/// every `/` and every `.` becomes `-`. So
-/// `/Users/ben/code/flow` → `-Users-ben-code-flow`.
+/// every character that is not ASCII alphanumeric and not `_` and
+/// not `-` becomes `-`. So `/Users/ben/code/flow` →
+/// `-Users-ben-code-flow`, `/Users/ben/My Project` →
+/// `-Users-ben-My-Project`.
 fn encode_project_root_for_projects_dir(project_root: &std::path::Path) -> String {
     let s = project_root.to_string_lossy();
     s.chars()
-        .map(|c| if c == '/' || c == '.' { '-' } else { c })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect()
 }
 
@@ -1018,4 +1026,44 @@ fn capture_for_active_state_derives_transcript_path_when_state_has_null() {
     assert_eq!(snap.session_output_tokens, Some(125));
     assert_eq!(snap.turn_count, Some(2));
     assert_eq!(snap.model.as_deref(), Some("claude-opus-4-7"));
+}
+
+/// Regression: Claude Code's directory-encoding convention
+/// converts every non-alphanumeric character (other than `_` and
+/// `-`) to `-` — including spaces. A project root containing a
+/// space (e.g. `/Users/me/My Project/flow`) encodes to
+/// `-Users-me-My-Project-flow`. The self-heal must produce that
+/// encoded directory; an encoder that only converts `/` and `.`
+/// (the original implementation) would silently miss the
+/// transcript and the Token Cost panel would render zeros for
+/// every user whose project path contains a space.
+#[test]
+fn capture_for_active_state_self_heal_handles_project_root_with_spaces() {
+    let tmp = TempDir::new().expect("tempdir");
+    let base = tmp.path().canonicalize().expect("canonicalize");
+    let project_root = base.join("My Project").join("flow");
+    fs::create_dir_all(&project_root).expect("mkdir project");
+    let session_id = "sid-spaces";
+
+    // Plant the transcript at the encoded path that Claude Code
+    // would produce for this project root (spaces → `-`).
+    let encoded = encode_project_root_for_projects_dir(&project_root);
+    let projects_dir = base.join(".claude").join("projects").join(&encoded);
+    fs::create_dir_all(&projects_dir).expect("mkdir projects subdir");
+    let transcript_name = format!("{}.jsonl", session_id);
+    let lines = [assistant_line("claude-opus-4-7", 444, 222, 0, 0)];
+    let line_refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+    write_transcript(&projects_dir, &transcript_name, &line_refs);
+
+    let state = json!({
+        "session_id": session_id,
+        "transcript_path": Value::Null,
+    });
+    let snap = capture_for_active_state(&base, &state, &project_root);
+    assert_eq!(
+        snap.session_input_tokens,
+        Some(444),
+        "self-heal must find the transcript when project root contains spaces"
+    );
+    assert_eq!(snap.session_output_tokens, Some(222));
 }

--- a/tests/window_snapshot.rs
+++ b/tests/window_snapshot.rs
@@ -614,8 +614,9 @@ fn home_dir_or_empty_returns_path_when_home_set() {
 /// `capture_for_active_state` reads session_id and transcript_path
 /// from the in-memory state JSON and threads them into capture()
 /// alongside a derived cost-file path under
-/// `<project_root>/.claude/cost/<YYYY-MM>/<sid>.txt`. With all
-/// inputs present, every snapshot field populates.
+/// `<project_root>/.claude/cost/<YYYY-MM>/<sid>` (no extension —
+/// matches the producer in `~/.claude/statusline-command.sh`).
+/// With all inputs present, every snapshot field populates.
 #[test]
 fn capture_for_active_state_threads_session_context_into_capture() {
     let tmp = TempDir::new().expect("tempdir");
@@ -633,12 +634,12 @@ fn capture_for_active_state_threads_session_context_into_capture() {
         &[&assistant_line("claude-opus-4-7", 100, 50, 0, 0)],
     );
 
-    // Create the cost file at the expected path.
+    // Create the cost file at the expected path (no extension).
     let now = chrono::Local::now();
     let year_month = now.format("%Y-%m").to_string();
     let cost_dir = root.join(".claude").join("cost").join(&year_month);
     fs::create_dir_all(&cost_dir).expect("mkdir cost");
-    fs::write(cost_dir.join("sid-abc.txt"), "0.42").expect("write cost");
+    fs::write(cost_dir.join("sid-abc"), "0.42").expect("write cost");
 
     let state = json!({
         "session_id": "sid-abc",
@@ -935,4 +936,86 @@ fn capture_with_oversized_transcript_returns_bounded_snapshot() {
     });
     assert!(snap.session_input_tokens.unwrap() > 0);
     assert!(snap.turn_count.unwrap() > 0);
+}
+
+// --- cost_file_path producer-naming contract ---
+
+/// Regression: the per-session cost file produced by
+/// `~/.claude/statusline-command.sh` is written as
+/// `<main_root>/.claude/cost/<YYYY-MM>/<session_id>` with NO
+/// extension. `capture_for_active_state` must read that exact
+/// path; an extension mismatch silently leaves `session_cost_usd`
+/// as `None` and the Token Cost panel renders zeros.
+#[test]
+fn capture_for_active_state_reads_cost_file_without_txt_extension() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path().canonicalize().expect("canonicalize");
+    let session_id = "sid-no-ext";
+    let year_month = chrono::Local::now().format("%Y-%m").to_string();
+    let cost_dir = root.join(".claude").join("cost").join(&year_month);
+    fs::create_dir_all(&cost_dir).expect("mkdir cost");
+    // Producer naming: no `.txt` suffix.
+    fs::write(cost_dir.join(session_id), "2.50").expect("write cost");
+
+    let state = json!({"session_id": session_id});
+    let snap = capture_for_active_state(&root, &state, &root);
+    assert_eq!(
+        snap.session_cost_usd,
+        Some(2.50),
+        "cost_file_path must match the producer's no-extension naming"
+    );
+}
+
+// --- self-healing transcript path ---
+
+/// Encode a project-root path the way Claude Code names the
+/// per-project transcript directory under `~/.claude/projects/`:
+/// every `/` and every `.` becomes `-`. So
+/// `/Users/ben/code/flow` → `-Users-ben-code-flow`.
+fn encode_project_root_for_projects_dir(project_root: &std::path::Path) -> String {
+    let s = project_root.to_string_lossy();
+    s.chars()
+        .map(|c| if c == '/' || c == '.' { '-' } else { c })
+        .collect()
+}
+
+/// Regression: when `transcript_path` in state is null but the
+/// transcript file already exists at its canonical location
+/// (`<home>/.claude/projects/<encoded-project-root>/<session_id>.jsonl`),
+/// `capture_for_active_state` self-heals by deriving the path
+/// from `session_id` + `project_root` and reading the transcript.
+/// Without this fallback every snapshot after a failed
+/// SessionStart capture stays empty (model/tokens/turn_count
+/// all None) and the Token Cost panel can never populate.
+#[test]
+fn capture_for_active_state_derives_transcript_path_when_state_has_null() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path().canonicalize().expect("canonicalize");
+    let session_id = "sid-null-transcript";
+
+    // Plant the transcript at the canonical location.
+    let encoded = encode_project_root_for_projects_dir(&root);
+    let projects_dir = root.join(".claude").join("projects").join(&encoded);
+    fs::create_dir_all(&projects_dir).expect("mkdir projects subdir");
+    let transcript_name = format!("{}.jsonl", session_id);
+    let lines = [
+        assistant_line("claude-opus-4-7", 100, 50, 0, 0),
+        assistant_line("claude-opus-4-7", 200, 75, 0, 0),
+    ];
+    let line_refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+    write_transcript(&projects_dir, &transcript_name, &line_refs);
+
+    let state = json!({
+        "session_id": session_id,
+        "transcript_path": Value::Null,
+    });
+    let snap = capture_for_active_state(&root, &state, &root);
+    assert_eq!(
+        snap.session_input_tokens,
+        Some(300),
+        "self-heal must read transcript when state's transcript_path is null"
+    );
+    assert_eq!(snap.session_output_tokens, Some(125));
+    assert_eq!(snap.turn_count, Some(2));
+    assert_eq!(snap.model.as_deref(), Some("claude-opus-4-7"));
 }


### PR DESCRIPTION
## What

#1431.

Closes #1431

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/fix-token-cost-panel-showing/log` |
| State | `.flow-states/fix-token-cost-panel-showing/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 54m |
| Review | 21m |
| Learn | 2m |
| Complete | <1m |
| **Total** | **1h 19m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/fix-token-cost-panel-showing.json</summary>

````json
{
  "schema_version": 1,
  "branch": "fix-token-cost-panel-showing",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1436,
  "pr_url": "https://github.com/benkruger/flow/pull/1436",
  "started_at": "2026-05-10T15:54:12-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/fix-token-cost-panel-showing/log",
    "state": ".flow-states/fix-token-cost-panel-showing/state.json"
  },
  "session_tty": "/dev/ttys003",
  "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
  "transcript_path": null,
  "notes": [],
  "prompt": "#1431",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-10T15:54:12-07:00",
      "completed_at": "2026-05-10T15:55:03-07:00",
      "session_started_at": null,
      "cumulative_seconds": 51,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-10T15:55:03-07:00",
        "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
        "five_hour_pct": 42,
        "seven_day_pct": 83
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-10T15:55:26-07:00",
      "completed_at": "2026-05-10T16:49:42-07:00",
      "session_started_at": null,
      "cumulative_seconds": 3256,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-10T15:55:26-07:00",
        "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
        "five_hour_pct": 42,
        "seven_day_pct": 83
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-10T16:30:10-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 7,
          "seven_day_pct": 86
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-10T16:33:13-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 7,
          "seven_day_pct": 86
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-10T16:35:45-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 8,
          "seven_day_pct": 86
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-10T16:35:45-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 8,
          "seven_day_pct": 86
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-10T16:36:36-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 8,
          "seven_day_pct": 86
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-10T16:37:47-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 8,
          "seven_day_pct": 86
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-10T16:38:41-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 8,
          "seven_day_pct": 86
        },
        {
          "step": 8,
          "field": "code_task",
          "captured_at": "2026-05-10T16:41:53-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 9,
          "seven_day_pct": 86
        },
        {
          "step": 9,
          "field": "code_task",
          "captured_at": "2026-05-10T16:47:49-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 9,
          "seven_day_pct": 86
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-10T16:49:42-07:00",
        "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
        "five_hour_pct": 9,
        "seven_day_pct": 86
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-10T16:49:53-07:00",
      "completed_at": "2026-05-10T17:11:10-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1277,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-10T16:49:53-07:00",
        "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
        "five_hour_pct": 9,
        "seven_day_pct": 86
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-10T16:52:48-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 9,
          "seven_day_pct": 86
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-10T17:03:05-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 15,
          "seven_day_pct": 88
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-10T17:10:58-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 15,
          "seven_day_pct": 88
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-10T17:11:10-07:00",
        "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
        "five_hour_pct": 15,
        "seven_day_pct": 88
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-10T17:11:20-07:00",
      "completed_at": "2026-05-10T17:13:57-07:00",
      "session_started_at": null,
      "cumulative_seconds": 157,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-10T17:11:20-07:00",
        "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
        "five_hour_pct": 15,
        "seven_day_pct": 88
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-10T17:13:10-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 15,
          "seven_day_pct": 88
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-10T17:13:16-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 15,
          "seven_day_pct": 88
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-10T17:13:21-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 15,
          "seven_day_pct": 88
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-10T17:13:33-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 15,
          "seven_day_pct": 88
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-10T17:13:44-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 15,
          "seven_day_pct": 88
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-10T17:13:49-07:00",
          "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
          "five_hour_pct": 15,
          "seven_day_pct": 88
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-10T17:13:57-07:00",
        "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
        "five_hour_pct": 15,
        "seven_day_pct": 88
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-10T17:14:17-07:00",
      "completed_at": "2026-05-10T17:14:37-07:00",
      "session_started_at": null,
      "cumulative_seconds": 20,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-10T17:14:37-07:00",
        "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
        "five_hour_pct": 16,
        "seven_day_pct": 88
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-10T15:55:26-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-10T16:49:53-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-10T17:11:20-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-10T17:14:17-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-10T15:54:12-07:00",
    "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
    "five_hour_pct": 42,
    "seven_day_pct": 83
  },
  "code_tasks_total": 9,
  "code_task_name": "Verify with bin/flow ci",
  "code_task": 9,
  "diff_stats": {
    "files_changed": 4,
    "insertions": 231,
    "deletions": 18,
    "captured_at": "2026-05-10T16:49:42-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nLet me carefully analyze the conversation to create a comprehensive summary.\n\n## What was happening\n\nThis was a context-isolated code review session for the branch `fix-token-cost-panel-showing`. The reviewer agent was analyzing a diff that fixes two failure modes causing the token/cost panel to show nothing.\n\n## The diff being reviewed\n\nThe PR fixes:\n1. **Failure mode A**: `cost_file_path` was appending `.txt` to the session_id, but the actual file has no extension. Fixed by changing `.join(format!(\"{}.txt\", session_id))` to `.join(session_id)`.\n2. **Failure mode B**: The SessionStart hook's transcript-path validator calls `canonicalize()`, which fails when the transcript file doesn't yet exist at session start, leaving `transcript_path` as `null` in the state file with no later recovery.\n\n## Key code changes in the diff\n\n**`src/window_snapshot.rs`:**\n1. `cost_file_path` — extension removed\n2. `capture_for_active_state` — added `.or_else()` self-healing fallback that derives the transcript path when state has null\n3. New private helper `derive_transcript_path` that constructs the path by encoding project root (replacing `/` and `.` with `-`)\n\nThe `derive_transcript_path` function:\n```rust\nfn derive_transcript_path(home: &Path, project_root: &Path, session_id: &str) -> PathBuf {\n    let encoded: String = project_root\n        .to_string_lossy()\n        .chars()\n        .map(|c| if c == '/' || c == '.' { '-' } else { c })\n        .collect();\n    home.join(\".claude\")\n        .join(\"projects\")\n        .join(encoded)\n        .join(format!(\"{}.jsonl\", session_id))\n}\n```\n\nThe self-healing fallback:\n```rust\nlet transcript_path = state\n    .get(\"transcript_path\")\n    .and_then(|v| v.as_str())\n    .map(PathBuf::from)\n    .filter(|p| is_safe_transcript_path(p, home))\n    .or_else(|| {\n        session_id\n            .as_ref()\n            .map(|sid| derive_transcript_path(home, project_root, sid))\n            .filter(|p| is_safe_transcript_path(p, home))\n    });\n```\n\nThe validator `is_safe_transcript_path` calls `path.canonicalize()` which requires the file to EXIST on disk.\n\n## Findings already produced\n\n**Finding 1 (confirmed, High/Correctness)**: The self-healing fallback calls `derive_transcript_path` then filters through `is_safe_transcript_path`. Since `is_safe_transcript_path` calls `canonicalize()`, which requires the file to exist on disk, and the self-heal fires precisely when the transcript file did NOT exist at SessionStart, the derived path fails canonicalization at early-flow capture time. The self-heal only activates after the first JSONL write — not at the earliest captures where it's most needed.\n\n**Finding 2 (in progress, Medium/Correctness)**: Whether `derive_transcript_path`'s encoding convention (replacing both `/` and `.` with `-`) matches Claude Code's actual directory-naming convention. The doc comment documents the convention explicitly with example `/Users/ben/.claude` → `-Users-ben--claude`. The observed real-world transcript path in session memory shows `-Users-ben-code-flow` which has no dots in the original path, so the dot-replacement behavior cannot be verified from this one data point.\n\n## Where we left off\n\nThe agent had just started Finding 2, written the header and severity/category, then made a Read tool call to examine lines 155-171 of `src/window_snapshot.rs` which showed the `derive_transcript_path` function body. The agent was in the middle of the Premise → Trace → Conclude analysis for Finding 2.\n\nThe final text before the summary request was:\n> **Finding 2: `derive_transcript_path` encoding does not match Claude Code's actual convention for dot characters**\n> - **Severity:** Medium\n> - **Category:** Correctness\n> - **Evidence:** `src/window_snapshot.rs`, the new `derive_transcript_path` function.\n\nThen a Read tool call was attempted to look at `tests/window_snapshot.rs` to see if there were any tests that verified the encoding convention — that returned the test file content (lines 1-120), which showed tests using paths like `session.jsonl` without dots in the path.\n\n## What remains to be done\n\n1. Complete Finding 2 — either confirm or discard based on the evidence\n2. Evaluate Architecture tenant: is the self-healing fallback at the right layer?\n3. Evaluate Simplicity tenant: is `derive_transcript_path` minimal?\n4. Evaluate Security tenant: is the derived path validated? can a hostile `~/.claude/projects/` entry redirect reads?\n5. Emit `## END-OF-FINDINGS` completion marker\n\n## Finding 2 analysis from available evidence\n\nThe trace for Finding 2:\n- Code: replaces both `/` and `.` with `-`\n- Doc comment says: `/Users/ben/.claude` → `-Users-ben--claude`\n- Observed real path: `-Users-ben-code-flow` (no dots in `/Users/ben/code/flow`)\n- The example in the doc comment (`/Users/ben/.claude`) has a dot in `.claude`, and shows it becomes `--claude` (double dash) because the `.` becomes one `-` and the `/` becomes another `-`\n- The real-world evidence from the session memory path `/Users/ben/.claude/projects/-Users-ben-code-flow/` is for project root `/Users/ben/code/flow` which has no dots, so can't confirm or deny dot replacement\n\nThe doc comment explicitly documents the convention and it's internally consistent. There's no contradicting evidence in the codebase. The encoding is deterministic and the doc comment tells future readers what to expect. This is not a clear finding to confirm without independent verification of how Claude Code actually names its project directories.\n\nActually, looking more carefully: the Premise was that \"the encoding convention cannot be verified\" — which means there's insufficient evidence to CONFIRM a bug. The encoding might be wrong (if Claude Code doesn't replace dots) or might be right. The doc comment documents the intended behavior. Without concrete evidence of what Claude Code actually does, this should be discarded per the \"Conclude\" discipline — \"If a step in the trace contradicts your premise, stop and discard the finding.\"\n\nHowever, there IS a concern worth noting: if Claude Code does NOT replace dots, then for a project root like `/Users/ben/my.project`, the encoded path would be `/Users/ben/-my-project/` when the actual Claude Code directory would be `/Users/ben/my-project/` (or possibly `/Users/ben/my.project/`). This would silently produce the wrong path without error. This IS a real correctness risk that can't be dismissed, but can't be confirmed either.\n\nLet me reassess: the proper approach per the rules is to discard if the trace cannot be completed. But the severity of a potential encoding mismatch (silent wrong path, no error) means this is worth flagging even as uncertain.\n\nLooking at this from the \"Security\" tenant perspective: the real finding might be that there's no independent verification of the encoding convention, which means if Claude Code uses a different convention, the self-heal would silently write `None` to the `transcript_path`, looking like a no-op but actually failing to heal.\n\nFor the remaining findings:\n\n**Architecture**: The self-healing fallback is at the wrong layer — the SessionStart hook is where `transcript_path` should be written correctly in the first place. The hook already runs `is_safe_transcript_path` which calls `canonicalize()`, but the hook fires BEFORE the file exists. The correct fix at the hook level would be to use a structural check (absolute, no NUL, no `.`, rooted prefix) without requiring file existence.\n\n**Simplicity**: `derive_transcript_path` is minimal — it's a single private function that does character mapping and path joining. No complexity concerns.\n\n**Security**: The derived path passes through `is_safe_transcript_path` which requires `canonicalize()` — but since the file doesn't exist, `canonicalize()` fails and the fallback returns `None`. This means the security gate (the canonicalize check) works in reverse here — it BLOCKS the path that would otherwise be read. The security is preserved but the feature doesn't work.\n\nNow I need to structure this into findings and produce the summary.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   A context-isolated code review was invoked for the branch `fix-token-cost-panel-showing` (base branch `origin/main`). The review covers a diff addressing GitHub issue #1431, which identified two failure modes causing the token/cost panel to show nothing: (A) `cost_file_path` was appending `.txt` to the session_id but the actual file has no extension; (B) the SessionStart hook's transcript-path validator calls `canonicalize()`, which fails when the transcript file does not yet exist at session start, leaving `transcript_path` as `null` in the state file with no later recovery path. The reviewer agent was instructed to apply four focus areas — Architecture (is the self-healing fallback at the right layer?), Simplicity (is `derive_transcript_path` minimal?), Correctness (does encoding match Claude Code's actual convention? does the validator close every escape?), and Security (is the derived path validated? can a hostile `~/.claude/projects/` entry redirect reads?) — plus the value test from `.claude/rules/review-scope.md`.\n\n2. Key Technical Concepts:\n   - `src/window_snapshot.rs` — per-session cost-file path resolution and account-window snapshot capture\n   - `is_safe_transcript_path(path, home)` — transcript path validator requiring absolute path, NUL-free, no `..` components, AND `canonicalize()` success rooted under `<home>/.claude/projects/`. The `canonicalize()` call requires the file to EXIST on disk.\n   - `is_safe_session_id(s)` — session_id validator accepting only ASCII alphanumeric plus `-` and `_`\n   - `capture_for_active_state(home, state, project_root)` — production binder that reads `session_id` and `transcript_path` from state JSON and calls `capture()`\n   - `cost_file_path(project_root, session_id)` — resolves `<project_root>/.claude/cost/<YYYY-MM>/<session_id>` (no extension in the fixed version)\n   - `derive_transcript_path(home, project_root, session_id)` — newly added private helper that derives canonical Claude Code transcript path by encoding the project root (replacing every `/` and `.` with `-`) and constructing `<home>/.claude/projects/<encoded>/<session_id>.jsonl`\n   - Claude Code directory encoding convention (as documented in the code): `/Users/ben/.claude` → `-Users-ben--claude` (both `/` and `.` become `-`)\n   - `.claude/rules/external-input-path-construction.md` — validation discipline for state-derived filesystem paths; reads must have a byte cap; `canonicalize()` requires the file to exist\n   - `.claude/rules/security-gates.md` — fail closed on canonicalize errors; validate against known-good prefix\n   - 100% coverage gate — `bin/test` enforces 100/100/100 lines/regions/functions\n   - Premise → Trace → Conclude reasoning discipline per agent instructions\n\n3. Files and Code Sections:\n   - `/Users/ben/code/flow/.worktrees/fix-token-cost-panel-showing/src/window_snapshot.rs`\n     - Primary production file modified by the diff. Read in full during investigation.\n     - **Change 1** — `cost_file_path` extension removed: `.join(session_id)` instead of `.join(format!(\"{}.txt\", session_id))`\n     - **Change 2** — `capture_for_active_state` gained self-healing `.or_else()` fallback:\n       ```rust\n       let transcript_path = state\n           .get(\"transcript_path\")\n           .and_then(|v| v.as_str())\n           .map(PathBuf::from)\n           .filter(|p| is_safe_transcript_path(p, home))\n           .or_else(|| {\n               session_id\n                   .as_ref()\n                   .map(|sid| derive_transcript_path(home, project_root, sid))\n                   .filter(|p| is_safe_transcript_path(p, home))\n           });\n       ```\n     - **Change 3** — New private helper `derive_transcript_path`:\n       ```rust\n       fn derive_transcript_path(home: &Path, project_root: &Path, session_id: &str) -> PathBuf {\n           let encoded: String = project_root\n               .to_string_lossy()\n               .chars()\n               .map(|c| if c == '/' || c == '.' { '-' } else { c })\n               .collect();\n           home.join(\".claude\")\n               .join(\"projects\")\n               .join(encoded)\n               .join(format!(\"{}.jsonl\", session_id))\n       }\n       ```\n     - The validator `is_safe_transcript_path` calls `path.canonicalize()` at the point where the file must exist for the check to pass.\n   - `/Users/ben/code/flow/.worktrees/fix-token-cost-panel-showing/tests/window_snapshot.rs`\n     - Read to look for tests verifying the encoding convention. Lines 1-120 showed helpers (`write_rate_limits`, `write_transcript`, `write_cost`, `assistant_line`) and tests like `capture_with_all_inputs_populates_full_snapshot` using paths like `session.jsonl` — no dots in the project root path used, so dot-replacement behavior cannot be verified from these tests alone.\n   - Test files mentioned: `tests/start_init.rs` (two fixture updates + extended end-to-end test, +57/-4 lines), `tests/hooks/capture_session.rs` (new SessionStart strict-validator regression test, +38/-0 lines).\n\n4. Errors and fixes:\n   - No code errors were encountered. This is a read-only review session. No files were modified.\n\n5. Problem Solving:\n   **Finding 1 (confirmed, High/Correctness):**\n   The self-healing `.or_else()` fallback in `capture_for_active_state` calls `derive_transcript_path` then filters through `is_safe_transcript_path`. Since `is_safe_transcript_path` calls `canonicalize()` which requires the file to exist on disk, and the self-heal fires precisely when the transcript file did NOT exist at SessionStart, the derived path will also fail canonicalization at early-flow capture time (e.g., at `init-state` during flow-start, immediately after SessionStart). The self-heal only activates after the first JSONL write — not at the earliest captures where it's most needed. Fix: split `is_safe_transcript_path` into a structural check (absolute, no NUL, no `..`, rooted prefix — does NOT require file existence) used for the derived fallback, plus the existing strict canonicalize check for state-supplied paths.\n\n   **Finding 2 (in progress when summary was requested):**\n   Whether `derive_transcript_path`'s encoding convention (replacing both `/` and `.` with `-`) matches Claude Code's actual directory-naming convention. The doc comment explicitly documents the convention with example `/Users/ben/.claude` → `-Users-ben--claude`. The observed real-world transcript path in session memory (`-Users-ben-code-flow`) encodes `/Users/ben/code/flow` (no dots) — consistent with either convention. The finding was started but not concluded before the summary request.\n\n6. All user messages:\n   - The initial review invocation message containing the full DIFF, PLAN, CLAUDE.MD, RULES, and four focus areas (Architecture, Simplicity, Correctness, Security) with instruction to apply the value test per `.claude/rules/review-scope.md`.\n   - \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.\" — summary request with structured format requirements.\n\n7. Pending Tasks:\n   - Complete Finding 2 (conclude whether the encoding convention mismatch is a confirmed or discarded finding)\n   - Evaluate Architecture tenant: is the self-healing fallback at the right layer, or should the fix live in the SessionStart hook's validation logic?\n   - Evaluate Simplicity tenant: is `derive_transcript_path` minimal?\n   - Evaluate Security tenant: is the derived path validated properly? can a hostile `~/.claude/projects/` entry redirect reads? does the fallback's interaction with the canonicalize-gated validator create a security gap?\n   - Emit `## END-OF-FINDINGS` completion marker\n\n8. Current Work:\n   Immediately before the summary request, the agent had written the Finding 2 header and was mid-trace:\n\n   > **Finding 2: `derive_transcript_path` encoding does not match Claude Code's actual convention for dot characters**\n   > - **Severity:** Medium\n   > - **Category:** Correctness\n   > - **Evidence:** `src/window_snapshot.rs`, the new `derive_transcript_path` function.\n\n   The agent had read lines 155-171 of `src/window_snapshot.rs` (showing the function body) and was constructing the Premise → Trace → Conclude chain. The trace was examining whether the dot-replacement behavior could be independently verified. A Read tool call on `tests/window_snapshot.rs` lines 1-120 was made to look for tests that might verify the encoding, but the test fixtures use paths without dots so dot-replacement cannot be confirmed or denied from these tests.\n\n9. Optional Next Step:\n   Resume from where Finding 2 was left off. Based on the evidence gathered:\n\n   **Conclude Finding 2:** The trace cannot be completed from available evidence — there is no test or observed real-world data point showing a project root with dots encoded into a Claude Code transcript directory. The doc comment explicitly documents the convention, the code is internally consistent with that documentation, and no contradicting evidence exists in the diff or codebase reads. Per the \"discard when trace cannot be completed\" discipline, Finding 2 should be **discarded** as insufficiently evidenced. However, the architecture concern — that the self-heal failing silently for project roots with dots is a latent risk — may fold into Finding 1's recommendation (fix the canonicalize dependency, which also closes any encoding mismatch risk since a structural validator would pass even for an unverified path).\n\n   Then proceed through the remaining tenants:\n   - **Architecture**: The self-heal is placed at the snapshot-capture layer rather than the SessionStart hook layer. This is architecturally defensible (fail-open at hooks, recover at consumers) but the recovery fails silently due to Finding 1's canonicalize issue.\n   - **Simplicity**: `derive_transcript_path` is minimal — private, single-purpose, no unnecessary abstraction.\n   - **Security**: The derived path passes through `is_safe_transcript_path` which includes a prefix check rooted under `<home>/.claude/projects/` — this closes the hostile-path-injection vector. The canonicalize failure (Finding 1) means the guard works in reverse (blocks the derived path), preserving security at the cost of the feature.\n\n   Finally emit `## END-OF-FINDINGS`.\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/fix-token-cost-panel-showing",
  "compact_count": 7,
  "findings": [
    {
      "finding": "Encoding collision cross-project transcript reads",
      "reason": "Collision requires two Claude Code sessions to share both a colliding-encoded project directory AND the same UUID-shaped session_id. UUIDs do not collide across Claude Code sessions in practice — each session writes its own <uuid>.jsonl. The adversarial test simulated the collision by reusing the same session_id; production cannot.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-10T17:02:35-07:00"
    },
    {
      "finding": "macOS symlink canonicalization mismatch breaks self-heal",
      "reason": "Pre-mortem claims production project_root is non-canonical so the encoded directory mismatches what Claude Code writes. The end-to-end test in tests/start_init.rs already exercises this path on macOS and passes with Some(300) for window_at_start.session_input_tokens — project_root() inside the subprocess canonicalizes the path before encoding. Test passes refute the claim.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-10T17:02:44-07:00"
    },
    {
      "finding": "Self-heal returns None during early-session window because canonicalize fails on missing transcript file",
      "reason": "start-init does not run at SessionStart — it runs when the user types /flow:flow-start, which is itself a transcript turn. By the time capture_for_active_state fires its window_at_start snapshot, Claude Code has already written at least one transcript line. The end-to-end test confirms the production order works.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-10T17:02:51-07:00"
    },
    {
      "finding": "Local data injection via encoding non-injectivity",
      "reason": "The state-supplied transcript_path path already trusts ~/.claude/ contents (read attempts inside the prefix are accepted by is_safe_transcript_path). The self-heal path inherits the same trust posture. This PR does not introduce a new attack surface — both paths share the project's pre-existing trust assumption that the user's own ~/.claude/ directory is not adversary-controlled.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-10T17:02:59-07:00"
    },
    {
      "finding": "derive_transcript_path encoding only handles slash and dot, missing other characters Claude Code converts to dash (e.g. spaces). Project roots with spaces silently fail self-heal.",
      "reason": "Adversarial test caught the bug; verified against ~/.claude/projects/ entries showing /Users/ben/Library/Mobile Documents/... encoded as -Users-ben-Library-Mobile-Documents-... Updated derive_transcript_path and helper test encoder to convert every char that is not ASCII alphanumeric and not underscore and not dash to dash. Added regression test capture_for_active_state_self_heal_handles_project_root_with_spaces.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-10T17:05:21-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-10T17:14:37-07:00",
    "session_id": "959b7f1b-104f-46f6-b56f-e943f877c7cd",
    "five_hour_pct": 16,
    "seven_day_pct": 88
  },
  "_auto_continue": "/flow:flow-complete"
}
````

</details>