### PR TITLE
Fix Per Flow Capture Start

### DIFF
--- a/src/complete_fast.rs
+++ b/src/complete_fast.rs
@@ -373,13 +373,16 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     // as object already; mutate_state re-reads under lock but cannot
     // observe a non-object here in this single-writer flow.
     //
-    // Capture the account-window snapshot adjacent to phase_enter
-    // (mirroring `phase_enter.rs:232-246`) so
+    // Capture the account-window snapshot inside the same
+    // mutate_state closure that calls phase_enter so
     // `format_complete_summary`'s `phase_delta` reads
     // `phases.flow-complete.window_at_enter` when rendering the
     // Complete row. The bare `phase_enter` mutator does not write a
     // snapshot — only the `phase-enter` subcommand wrapper does —
-    // so complete-fast's wrapper has to handle the write itself.
+    // so complete-fast's wrapper handles the write itself. The
+    // chained IndexMut is safe because `phase_enter` ran first in
+    // this closure and heals `state["phases"]` to an object if the
+    // on-disk state file held a non-object value.
     let home = crate::window_snapshot::home_dir_or_empty();
     mutate_state(&state_path, &mut |s| {
         phase_enter(s, "flow-complete", None);

--- a/src/complete_fast.rs
+++ b/src/complete_fast.rs
@@ -372,10 +372,22 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     // Phase enter + set step counters. read_state validated the file
     // as object already; mutate_state re-reads under lock but cannot
     // observe a non-object here in this single-writer flow.
+    //
+    // Capture the account-window snapshot adjacent to phase_enter
+    // (mirroring `phase_enter.rs:232-246`) so
+    // `format_complete_summary`'s `phase_delta` reads
+    // `phases.flow-complete.window_at_enter` when rendering the
+    // Complete row. The bare `phase_enter` mutator does not write a
+    // snapshot — only the `phase-enter` subcommand wrapper does —
+    // so complete-fast's wrapper has to handle the write itself.
+    let home = crate::window_snapshot::home_dir_or_empty();
     mutate_state(&state_path, &mut |s| {
         phase_enter(s, "flow-complete", None);
         s["complete_steps_total"] = json!(COMPLETE_STEPS_TOTAL);
         s["complete_step"] = json!(1);
+        let snap = crate::window_snapshot::capture_for_active_state(&home, s, &root);
+        s["phases"]["flow-complete"]["window_at_enter"] =
+            serde_json::to_value(&snap).expect("WindowSnapshot must serialize");
     })
     .expect("state file was validated as object by read_state");
 

--- a/src/complete_finalize.rs
+++ b/src/complete_finalize.rs
@@ -107,6 +107,17 @@ pub fn run_impl(args: &Args) -> Value {
         let _ = crate::lock::mutate_state(state_path, &mut |state| {
             let snap = crate::window_snapshot::capture_for_active_state(&home, state, &root);
             crate::window_snapshot::write_snapshot_into_state(state, "window_at_complete", &snap);
+            // Mirror the snapshot under the phase-scoped key so
+            // `format_complete_summary`'s `phase_delta` reads
+            // `phases.flow-complete.window_at_complete` for the
+            // Complete row. Precondition: `bin/flow phase-enter
+            // --phase flow-complete` ran upstream of this call (via
+            // `/flow:flow-complete` or `complete_fast`) and
+            // populated `phases.flow-complete` as an object. Same
+            // trust contract as `phase_enter.rs:243-245` and the
+            // sibling per-phase snapshot writes.
+            state["phases"]["flow-complete"]["window_at_complete"] =
+                serde_json::to_value(&snap).expect("WindowSnapshot must serialize");
         });
     }
 

--- a/src/complete_finalize.rs
+++ b/src/complete_finalize.rs
@@ -110,14 +110,22 @@ pub fn run_impl(args: &Args) -> Value {
             // Mirror the snapshot under the phase-scoped key so
             // `format_complete_summary`'s `phase_delta` reads
             // `phases.flow-complete.window_at_complete` for the
-            // Complete row. Precondition: `bin/flow phase-enter
-            // --phase flow-complete` ran upstream of this call (via
-            // `/flow:flow-complete` or `complete_fast`) and
-            // populated `phases.flow-complete` as an object. Same
-            // trust contract as `phase_enter.rs:243-245` and the
-            // sibling per-phase snapshot writes.
-            state["phases"]["flow-complete"]["window_at_complete"] =
-                serde_json::to_value(&snap).expect("WindowSnapshot must serialize");
+            // Complete row. Hand-edited or corrupt state files may
+            // carry non-object values at any level, so per-level
+            // object guards heal the path before the IndexMut chain
+            // per `.claude/rules/rust-patterns.md` "State Mutation
+            // Object Guards" — unguarded IndexMut on a non-object
+            // primitive (number, string, bool, array) panics.
+            if state.is_object() {
+                if !state["phases"].is_object() {
+                    state["phases"] = serde_json::json!({});
+                }
+                if !state["phases"]["flow-complete"].is_object() {
+                    state["phases"]["flow-complete"] = serde_json::json!({});
+                }
+                state["phases"]["flow-complete"]["window_at_complete"] =
+                    serde_json::to_value(&snap).expect("WindowSnapshot must serialize");
+            }
         });
     }
 

--- a/src/start_init.rs
+++ b/src/start_init.rs
@@ -307,9 +307,10 @@ fn run_impl(args: &Args, root: &Path, cwd: &Path) -> Result<Value, String> {
         // Mirror the snapshot under the phase-scoped key so
         // `format_complete_summary`'s `phase_delta` reads
         // `phases.flow-start.window_at_enter` for the Start row.
-        // `init_state` (called above) populates `phases` with an
-        // object containing `flow-start`, so the IndexMut chain
-        // cannot panic from missing scaffolding here.
+        // `init_state` ran as a subprocess immediately above and
+        // wrote a fresh state file whose `phases.flow-start` is a
+        // structured PhaseState object, so the chained IndexMut is
+        // safe in this single-writer flow.
         state["phases"]["flow-start"]["window_at_enter"] =
             serde_json::to_value(&snap).expect("WindowSnapshot must serialize");
     });

--- a/src/start_init.rs
+++ b/src/start_init.rs
@@ -304,6 +304,14 @@ fn run_impl(args: &Args, root: &Path, cwd: &Path) -> Result<Value, String> {
     let _ = crate::lock::mutate_state(&state_path, &mut |state| {
         let snap = crate::window_snapshot::capture_for_active_state(&home, state, root);
         crate::window_snapshot::write_snapshot_into_state(state, "window_at_start", &snap);
+        // Mirror the snapshot under the phase-scoped key so
+        // `format_complete_summary`'s `phase_delta` reads
+        // `phases.flow-start.window_at_enter` for the Start row.
+        // `init_state` (called above) populates `phases` with an
+        // object containing `flow-start`, so the IndexMut chain
+        // cannot panic from missing scaffolding here.
+        state["phases"]["flow-start"]["window_at_enter"] =
+            serde_json::to_value(&snap).expect("WindowSnapshot must serialize");
     });
 
     // Step 5: Label issues (best-effort)

--- a/tests/complete_fast.rs
+++ b/tests/complete_fast.rs
@@ -421,6 +421,58 @@ fn pr_state_merged_returns_already_merged_path() {
     assert_eq!(json["path"], "already_merged");
 }
 
+/// `complete_fast` writes the account-window snapshot to the
+/// phase-scoped `phases.flow-complete.window_at_enter` field when
+/// entering the Complete phase. Without this write,
+/// `format_complete_summary`'s `phase_delta` short-circuits to
+/// `None` for flow-complete because it reads
+/// `phase.window_at_enter`, leaving the Complete row in the Token
+/// Cost section with placeholder data.
+///
+/// Uses `FAKE_PR_STATE=MERGED` so complete_fast hits the
+/// `already_merged` early return immediately after the mutate_state
+/// block runs — state.json persists with the snapshot for the
+/// assertion to read.
+#[test]
+fn complete_fast_writes_phase_scoped_window_at_enter_for_flow_complete() {
+    let fx = setup("complete", "auto");
+    let output = run_complete_fast(
+        &fx.repo,
+        Some(BRANCH),
+        Some("--auto"),
+        &fx.flow_bin,
+        &fx.stubs,
+        &[("FAKE_PR_STATE", "MERGED")],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json = last_json_line(&stdout);
+    assert_eq!(json["status"], "ok", "stdout: {}", stdout);
+    assert_eq!(json["path"], "already_merged");
+
+    let state_path = fx.repo.join(".flow-states").join(BRANCH).join("state.json");
+    let content = fs::read_to_string(&state_path).expect("state file must exist");
+    let state: Value = serde_json::from_str(&content).expect("state must parse");
+
+    let phase_scoped = &state["phases"]["flow-complete"]["window_at_enter"];
+    assert!(
+        phase_scoped.is_object(),
+        "phases.flow-complete.window_at_enter must be populated; got: {}",
+        phase_scoped
+    );
+
+    // The snapshot carries `captured_at` from `now()` and (when a
+    // valid session_id was available) a session_id field. The
+    // session_id may be null on this fixture because state.json has
+    // no session_id, but captured_at must always be a non-empty
+    // string per `WindowSnapshot`'s schema.
+    let captured_at = phase_scoped["captured_at"].as_str().unwrap_or("");
+    assert!(
+        !captured_at.is_empty(),
+        "captured_at must be populated; got: {}",
+        phase_scoped
+    );
+}
+
 #[test]
 fn pr_state_closed_returns_error() {
     let fx = setup("complete", "auto");

--- a/tests/complete_finalize.rs
+++ b/tests/complete_finalize.rs
@@ -380,6 +380,152 @@ fn complete_finalize_writes_phase_scoped_window_at_complete_for_flow_complete() 
     );
 }
 
+/// Adversarial guard: when the on-disk state file has `phases`
+/// as a non-object value (hand-edited or corrupted), the new
+/// phase-scoped write must heal the path instead of panicking
+/// on the chained IndexMut. Reference: per-level object guards
+/// per `.claude/rules/rust-patterns.md` "State Mutation Object
+/// Guards".
+#[test]
+fn complete_finalize_heals_non_object_phases_without_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let parent = dir.path().canonicalize().unwrap();
+    let repo = make_repo_fixture(&parent);
+    let state_path = repo.join("external-state.json");
+    // `phases` is a JSON array — IndexMut on a string key would
+    // panic without the guard.
+    let state = json!({
+        "schema_version": 1,
+        "branch": BRANCH,
+        "repo": "test/test",
+        "pr_number": 42,
+        "phases": [],
+    });
+    fs::write(&state_path, state.to_string()).unwrap();
+    let flow_bin = parent.join("bin-flow-stub").join("flow");
+    write_success_flow_stub(&flow_bin);
+    let stubs = path_stub_dir(&parent);
+
+    let (code, _stdout, stderr) = run_complete_finalize(
+        &repo,
+        "42",
+        state_path.to_string_lossy().as_ref(),
+        BRANCH,
+        ".worktrees/test-feature",
+        false,
+        Some(&flow_bin),
+        Some(&stubs),
+    );
+
+    assert_eq!(code, 0);
+    assert!(
+        !stderr.contains("panicked at"),
+        "complete-finalize must not panic when phases is non-object; stderr={}",
+        stderr
+    );
+    // The healed phases object now carries the snapshot.
+    let content = fs::read_to_string(&state_path).expect("state must survive");
+    let state: Value = serde_json::from_str(&content).expect("state must parse");
+    assert!(
+        state["phases"]["flow-complete"]["window_at_complete"].is_object(),
+        "guard must heal phases and write the snapshot; got: {}",
+        state["phases"]
+    );
+}
+
+/// Adversarial guard: when `phases.flow-complete` is a non-object
+/// value (e.g. a hand-edited state file flattened the phase entry
+/// to a string), the new write must heal the inner level too. The
+/// outer `phases` is still a valid object here so the first guard
+/// is a no-op; the second guard does the healing.
+#[test]
+fn complete_finalize_heals_non_object_flow_complete_without_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let parent = dir.path().canonicalize().unwrap();
+    let repo = make_repo_fixture(&parent);
+    let state_path = repo.join("external-state.json");
+    let state = json!({
+        "schema_version": 1,
+        "branch": BRANCH,
+        "repo": "test/test",
+        "pr_number": 42,
+        "phases": {
+            "flow-start": {"status": "complete"},
+            "flow-code": {"status": "complete"},
+            "flow-review": {"status": "complete"},
+            "flow-learn": {"status": "complete"},
+            "flow-complete": "stringified-phase-state",
+        },
+    });
+    fs::write(&state_path, state.to_string()).unwrap();
+    let flow_bin = parent.join("bin-flow-stub").join("flow");
+    write_success_flow_stub(&flow_bin);
+    let stubs = path_stub_dir(&parent);
+
+    let (code, _stdout, stderr) = run_complete_finalize(
+        &repo,
+        "42",
+        state_path.to_string_lossy().as_ref(),
+        BRANCH,
+        ".worktrees/test-feature",
+        false,
+        Some(&flow_bin),
+        Some(&stubs),
+    );
+
+    assert_eq!(code, 0);
+    assert!(
+        !stderr.contains("panicked at"),
+        "complete-finalize must not panic when phases.flow-complete is non-object; stderr={}",
+        stderr
+    );
+    let content = fs::read_to_string(&state_path).expect("state must survive");
+    let state: Value = serde_json::from_str(&content).expect("state must parse");
+    assert!(
+        state["phases"]["flow-complete"]["window_at_complete"].is_object(),
+        "guard must heal flow-complete and write the snapshot; got: {}",
+        state["phases"]["flow-complete"]
+    );
+}
+
+/// Adversarial guard: when the entire state root is non-object
+/// (hand edit replaced the JSON object with an array or scalar),
+/// the outer `state.is_object()` guard must skip the write block
+/// entirely. The pre-existing `write_snapshot_into_state` helper
+/// already guards on `state.as_object_mut()` and silently no-ops,
+/// so the closure runs without side effects.
+#[test]
+fn complete_finalize_skips_non_object_state_without_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let parent = dir.path().canonicalize().unwrap();
+    let repo = make_repo_fixture(&parent);
+    let state_path = repo.join("external-state.json");
+    // State root is a JSON array — both write_snapshot_into_state
+    // and the new chained IndexMut must skip without panic.
+    fs::write(&state_path, "[1,2,3]").unwrap();
+    let flow_bin = parent.join("bin-flow-stub").join("flow");
+    write_success_flow_stub(&flow_bin);
+    let stubs = path_stub_dir(&parent);
+
+    let (code, _stdout, stderr) = run_complete_finalize(
+        &repo,
+        "42",
+        state_path.to_string_lossy().as_ref(),
+        BRANCH,
+        ".worktrees/test-feature",
+        false,
+        Some(&flow_bin),
+        Some(&stubs),
+    );
+
+    assert_eq!(code, 0);
+    assert!(
+        !stderr.contains("panicked at"),
+        "complete-finalize must not panic when state root is non-object; stderr={}",
+        stderr
+    );
+}
+
 #[test]
 fn finalize_pull_flag_threads_to_cleanup() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/complete_finalize.rs
+++ b/tests/complete_finalize.rs
@@ -311,6 +311,75 @@ fn finalize_slash_branch_does_not_panic() {
     );
 }
 
+/// `complete_finalize` writes the account-window snapshot to BOTH
+/// the top-level `window_at_complete` field AND the phase-scoped
+/// `phases.flow-complete.window_at_complete` field. Without the dual
+/// write, `format_complete_summary`'s `phase_delta` short-circuits
+/// for flow-complete because it reads `phase.window_at_complete`,
+/// leaving the Complete row in the Token Cost section as a
+/// placeholder.
+///
+/// Uses an external state-file path so the per-branch cleanup pass
+/// at the end of `complete_finalize` does not wipe the file before
+/// the post-run assertions.
+#[test]
+fn complete_finalize_writes_phase_scoped_window_at_complete_for_flow_complete() {
+    let dir = tempfile::tempdir().unwrap();
+    let parent = dir.path().canonicalize().unwrap();
+    let repo = make_repo_fixture(&parent);
+    let state_path = repo.join("external-state.json");
+    let state = common::make_complete_state(BRANCH, "complete", None);
+    fs::write(&state_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+    let flow_bin = parent.join("bin-flow-stub").join("flow");
+    write_success_flow_stub(&flow_bin);
+    let stubs = path_stub_dir(&parent);
+
+    let (code, _, _) = run_complete_finalize(
+        &repo,
+        "42",
+        state_path.to_string_lossy().as_ref(),
+        BRANCH,
+        ".worktrees/test-feature",
+        false,
+        Some(&flow_bin),
+        Some(&stubs),
+    );
+
+    assert_eq!(code, 0);
+
+    let content = fs::read_to_string(&state_path).expect("state file must survive");
+    let state: Value = serde_json::from_str(&content).expect("state must parse");
+
+    let top_level = &state["window_at_complete"];
+    assert!(
+        top_level.is_object(),
+        "top-level window_at_complete must be populated; got: {}",
+        top_level
+    );
+
+    let phase_scoped = &state["phases"]["flow-complete"]["window_at_complete"];
+    assert!(
+        phase_scoped.is_object(),
+        "phases.flow-complete.window_at_complete must be populated alongside the top-level write; got: {}",
+        phase_scoped
+    );
+
+    // Both writes share the same snapshot — captured_at and
+    // session_id must match because they came from the same
+    // `capture_for_active_state` call inside the same mutate_state
+    // closure.
+    assert_eq!(
+        top_level["captured_at"], phase_scoped["captured_at"],
+        "top-level and phase-scoped writes must share captured_at; top: {} phase: {}",
+        top_level["captured_at"], phase_scoped["captured_at"]
+    );
+    assert_eq!(
+        top_level["session_id"], phase_scoped["session_id"],
+        "top-level and phase-scoped writes must share session_id; top: {} phase: {}",
+        top_level["session_id"], phase_scoped["session_id"]
+    );
+}
+
 #[test]
 fn finalize_pull_flag_threads_to_cleanup() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/format_complete_summary.rs
+++ b/tests/format_complete_summary.rs
@@ -63,6 +63,84 @@ fn write_state_file(dir: &Path) -> PathBuf {
 
 use common::{add_phase_snapshots, snapshot_value};
 
+/// Integration check: when every phase has both enter and complete
+/// snapshots — the state shape the fixed `start_init`,
+/// `complete_finalize`, and `complete_fast` writers produce —
+/// `phase_delta` returns `Some(_)` for every phase, and the Token
+/// Cost section renders real token + cost data for all five rows.
+/// Without the dual write, the renderer's None branch produced a
+/// placeholder row with tokens=0 and cost=`—` for any phase whose
+/// snapshot pair was missing.
+///
+/// Depends on the fixes in Tasks 2 (start_init), 4 (complete_finalize),
+/// and 6 (complete_fast); locks in the end-to-end summary contract.
+#[test]
+fn summary_shows_data_for_all_five_phases_when_capture_complete() {
+    let mut state = all_complete_state();
+    // Populate every phase with enter+complete snapshots so
+    // `phase_delta` returns `Some(_)` for each one. The scaling
+    // factor (enter_n -> complete_n) produces a positive token
+    // delta and a positive cost delta per `snapshot_value`'s
+    // schema.
+    add_phase_snapshots(&mut state, "flow-start", 0, 5);
+    add_phase_snapshots(&mut state, "flow-code", 5, 15);
+    add_phase_snapshots(&mut state, "flow-review", 15, 20);
+    add_phase_snapshots(&mut state, "flow-learn", 20, 25);
+    add_phase_snapshots(&mut state, "flow-complete", 25, 30);
+
+    let result = format_complete_summary(&state, None);
+
+    // Scope assertions to the Token Cost subsection. The summary
+    // also contains a Timeline section with phase name + duration
+    // rows ("Start:  <1m") that share the "Start:" prefix, so a
+    // raw search would match the timing row instead of the cost
+    // row. The bounded slice ensures the cost-row assertions
+    // target the intended section only.
+    let tail_at_header = result
+        .summary
+        .split_once("Token Cost")
+        .map(|(_, tail)| tail)
+        .unwrap_or_else(|| panic!("Token Cost header missing; summary:\n{}", result.summary));
+    let token_cost_section = tail_at_header
+        .split_once("\n  Artifacts")
+        .map(|(section, _)| section)
+        .unwrap_or(tail_at_header);
+
+    // Every named phase row must render with a real cost cell, not
+    // the missing-snapshot placeholder `—`. The None branch in
+    // `token_cost_section` produces `(0, None, false, true)`,
+    // which renders the row's cost column as `—` and no `$` sign.
+    for &name in &PHASE_NAMES_LIST {
+        let row_marker = format!("{}:", name);
+        let line = token_cost_section
+            .lines()
+            .find(|l| l.trim_start().starts_with(&row_marker))
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing Token Cost row for {}; section:\n{}",
+                    name, token_cost_section
+                )
+            });
+        assert!(
+            line.contains('$'),
+            "{} row missing cost cell — phase_delta likely returned None; line: {:?}",
+            name,
+            line
+        );
+        // The em-dash placeholder lives at the cost column position.
+        // Stripping the leading "  <Name>:" prefix isolates the
+        // tokens + cost suffix; assert no em-dash appears there.
+        let suffix = line.trim_start_matches(|c: char| c.is_whitespace());
+        let after_name = suffix.trim_start_matches(&*row_marker);
+        assert!(
+            !after_name.contains('—'),
+            "{} row carries placeholder em-dash from missing-snapshot path; line: {:?}",
+            name,
+            line
+        );
+    }
+}
+
 /// Full data: every phase carries enter+complete snapshots.
 /// The Token Cost section renders header + per-phase rows + total.
 #[test]

--- a/tests/start_init.rs
+++ b/tests/start_init.rs
@@ -1185,6 +1185,65 @@ fn window_at_start_reads_cost_when_session_id_and_cost_file_present() {
     );
 }
 
+/// `start_init` writes the account-window snapshot to BOTH the
+/// top-level `window_at_start` field AND the phase-scoped
+/// `phases.flow-start.window_at_enter` field. Without the dual
+/// write, `format_complete_summary`'s `phase_delta` short-circuits
+/// to `None` for flow-start because it reads
+/// `phase.window_at_enter`, leaving the Start row in the Token Cost
+/// section with a placeholder dash for cost and zero tokens.
+#[test]
+fn start_init_writes_phase_scoped_window_at_enter_for_flow_start() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    write_flow_json(&repo, &current_plugin_version(), None);
+    let stub_dir = create_default_gh_stub(&repo);
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let home = home.canonicalize().unwrap();
+    write_capture_file(&home, "sid-phase-scoped", None);
+
+    let output = run_start_init_with_home(&repo, "phase-scoped-window", &home, &stub_dir);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    let branch = data["branch"].as_str().unwrap();
+    let state = read_state_for_branch(&repo, branch);
+
+    let top_level = &state["window_at_start"];
+    assert!(
+        top_level.is_object(),
+        "top-level window_at_start must be populated; got: {}",
+        top_level
+    );
+
+    let phase_scoped = &state["phases"]["flow-start"]["window_at_enter"];
+    assert!(
+        phase_scoped.is_object(),
+        "phases.flow-start.window_at_enter must be populated alongside the top-level write; got: {}",
+        phase_scoped
+    );
+
+    // Both writes share the same snapshot — the captured_at timestamp
+    // and session_id must match because they came from the same
+    // `capture_for_active_state` call inside the same mutate_state
+    // closure.
+    assert_eq!(
+        top_level["captured_at"], phase_scoped["captured_at"],
+        "top-level and phase-scoped writes must share captured_at; top: {} phase: {}",
+        top_level["captured_at"], phase_scoped["captured_at"]
+    );
+    assert_eq!(
+        top_level["session_id"], phase_scoped["session_id"],
+        "top-level and phase-scoped writes must share session_id; top: {} phase: {}",
+        top_level["session_id"], phase_scoped["session_id"]
+    );
+}
+
 #[test]
 fn start_init_session_id_remains_null_when_home_unset() {
     // Covers `read_captured_session`'s empty-/non-absolute-home early


### PR DESCRIPTION
## What

#1446.

Closes #1446

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/fix-per-flow-capture-start/log` |
| State | `.flow-states/fix-per-flow-capture-start/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 45m |
| Review | 33m |
| Learn | 4m |
| Complete | <1m |
| **Total** | **1h 24m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/fix-per-flow-capture-start.json</summary>

````json
{
  "schema_version": 1,
  "branch": "fix-per-flow-capture-start",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1453,
  "pr_url": "https://github.com/benkruger/flow/pull/1453",
  "started_at": "2026-05-11T07:04:46-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/fix-per-flow-capture-start/log",
    "state": ".flow-states/fix-per-flow-capture-start/state.json"
  },
  "session_tty": "/dev/ttys005",
  "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
  "transcript_path": null,
  "notes": [],
  "prompt": "#1446",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-11T07:04:46-07:00",
      "completed_at": "2026-05-11T07:05:28-07:00",
      "session_started_at": null,
      "cumulative_seconds": 42,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-11T07:05:28-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 17,
        "seven_day_pct": 98,
        "session_input_tokens": 23,
        "session_output_tokens": 4119,
        "session_cache_creation_tokens": 583831,
        "session_cache_read_tokens": 1101192,
        "session_cost_usd": 1.58528675,
        "by_model": {
          "claude-opus-4-7": {
            "input": 23,
            "output": 4119,
            "cache_create": 583831,
            "cache_read": 1101192
          }
        },
        "turn_count": 8,
        "tool_call_count": 4,
        "context_at_last_turn_tokens": 211528,
        "context_window_pct": 105.764
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-11T07:05:38-07:00",
      "completed_at": "2026-05-11T07:50:41-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2703,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T07:05:38-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 17,
        "seven_day_pct": 98,
        "session_input_tokens": 24,
        "session_output_tokens": 4285,
        "session_cache_creation_tokens": 584024,
        "session_cache_read_tokens": 1312719,
        "session_cost_usd": 1.6964115000000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 24,
            "output": 4285,
            "cache_create": 584024,
            "cache_read": 1312719
          }
        },
        "turn_count": 9,
        "tool_call_count": 5,
        "context_at_last_turn_tokens": 211721,
        "context_window_pct": 105.8605
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-11T07:23:45-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 21,
          "seven_day_pct": 99,
          "session_input_tokens": 222,
          "session_output_tokens": 58572,
          "session_cache_creation_tokens": 1387146,
          "session_cache_read_tokens": 61047721,
          "session_cost_usd": 21.836784500000007,
          "by_model": {
            "claude-opus-4-7": {
              "input": 222,
              "output": 58572,
              "cache_create": 1387146,
              "cache_read": 61047721
            }
          },
          "turn_count": 149,
          "tool_call_count": 87,
          "context_at_last_turn_tokens": 516399,
          "context_window_pct": 258.1995
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-11T07:23:45-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 21,
          "seven_day_pct": 99,
          "session_input_tokens": 222,
          "session_output_tokens": 58572,
          "session_cache_creation_tokens": 1387146,
          "session_cache_read_tokens": 61047721,
          "session_cost_usd": 21.836784500000007,
          "by_model": {
            "claude-opus-4-7": {
              "input": 222,
              "output": 58572,
              "cache_create": 1387146,
              "cache_read": 61047721
            }
          },
          "turn_count": 149,
          "tool_call_count": 87,
          "context_at_last_turn_tokens": 516399,
          "context_window_pct": 258.1995
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-11T07:34:34-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "<synthetic>",
          "five_hour_pct": 1,
          "seven_day_pct": 0,
          "session_input_tokens": 261,
          "session_output_tokens": 79860,
          "session_cache_creation_tokens": 1445637,
          "session_cache_read_tokens": 73548790,
          "session_cost_usd": 29.93587800000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 261,
              "output": 79860,
              "cache_create": 1445637,
              "cache_read": 73548790
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 174,
          "tool_call_count": 101,
          "context_at_last_turn_tokens": 0
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-11T07:34:34-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "<synthetic>",
          "five_hour_pct": 1,
          "seven_day_pct": 0,
          "session_input_tokens": 261,
          "session_output_tokens": 79860,
          "session_cache_creation_tokens": 1445637,
          "session_cache_read_tokens": 73548790,
          "session_cost_usd": 29.93587800000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 261,
              "output": 79860,
              "cache_create": 1445637,
              "cache_read": 73548790
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 174,
          "tool_call_count": 101,
          "context_at_last_turn_tokens": 0
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-11T07:40:26-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 7,
          "seven_day_pct": 2,
          "session_input_tokens": 285,
          "session_output_tokens": 84054,
          "session_cache_creation_tokens": 2503457,
          "session_cache_read_tokens": 74667512,
          "session_cost_usd": 36.460039,
          "by_model": {
            "claude-opus-4-7": {
              "input": 285,
              "output": 84054,
              "cache_create": 2503457,
              "cache_read": 74667512
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 179,
          "tool_call_count": 103,
          "context_at_last_turn_tokens": 544812,
          "context_window_pct": 272.406
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-11T07:40:26-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 7,
          "seven_day_pct": 2,
          "session_input_tokens": 285,
          "session_output_tokens": 84054,
          "session_cache_creation_tokens": 2503457,
          "session_cache_read_tokens": 74667512,
          "session_cost_usd": 36.460039,
          "by_model": {
            "claude-opus-4-7": {
              "input": 285,
              "output": 84054,
              "cache_create": 2503457,
              "cache_read": 74667512
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 179,
          "tool_call_count": 103,
          "context_at_last_turn_tokens": 544812,
          "context_window_pct": 272.406
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-11T07:49:23-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 2,
          "session_input_tokens": 333,
          "session_output_tokens": 130675,
          "session_cache_creation_tokens": 2584037,
          "session_cache_read_tokens": 97227405,
          "session_cost_usd": 50.79699725000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 333,
              "output": 130675,
              "cache_create": 2584037,
              "cache_read": 97227405
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 219,
          "tool_call_count": 126,
          "context_at_last_turn_tokens": 581849,
          "context_window_pct": 290.9245
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T07:50:41-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 2,
        "session_input_tokens": 358,
        "session_output_tokens": 134961,
        "session_cache_creation_tokens": 2622675,
        "session_cache_read_tokens": 107178016,
        "session_cost_usd": 53.88969305000003,
        "by_model": {
          "claude-opus-4-7": {
            "input": 358,
            "output": 134961,
            "cache_create": 2622675,
            "cache_read": 107178016
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 236,
        "tool_call_count": 135,
        "context_at_last_turn_tokens": 599804,
        "context_window_pct": 299.902
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-11T07:50:53-07:00",
      "completed_at": "2026-05-11T08:24:34-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2021,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T07:50:53-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 2,
        "session_input_tokens": 360,
        "session_output_tokens": 135453,
        "session_cache_creation_tokens": 2623187,
        "session_cache_read_tokens": 108377614,
        "session_cost_usd": 54.197347550000025,
        "by_model": {
          "claude-opus-4-7": {
            "input": 360,
            "output": 135453,
            "cache_create": 2623187,
            "cache_read": 108377614
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 238,
        "tool_call_count": 136,
        "context_at_last_turn_tokens": 600056,
        "context_window_pct": 300.028
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-11T07:55:34-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 11,
          "seven_day_pct": 3,
          "session_input_tokens": 364,
          "session_output_tokens": 138277,
          "session_cache_creation_tokens": 2626202,
          "session_cache_read_tokens": 110778720,
          "session_cost_usd": 55.181831800000026,
          "by_model": {
            "claude-opus-4-7": {
              "input": 364,
              "output": 138277,
              "cache_create": 2626202,
              "cache_read": 110778720
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 242,
          "tool_call_count": 138,
          "context_at_last_turn_tokens": 602703,
          "context_window_pct": 301.3515
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-11T08:10:21-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 16,
          "seven_day_pct": 4,
          "session_input_tokens": 364,
          "session_output_tokens": 138277,
          "session_cache_creation_tokens": 2626202,
          "session_cache_read_tokens": 110778720,
          "session_cost_usd": 55.181831800000026,
          "by_model": {
            "claude-opus-4-7": {
              "input": 364,
              "output": 138277,
              "cache_create": 2626202,
              "cache_read": 110778720
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 242,
          "tool_call_count": 138,
          "context_at_last_turn_tokens": 602703,
          "context_window_pct": 301.3515
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-11T08:11:08-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 16,
          "seven_day_pct": 4,
          "session_input_tokens": 364,
          "session_output_tokens": 138277,
          "session_cache_creation_tokens": 2626202,
          "session_cache_read_tokens": 110778720,
          "session_cost_usd": 55.181831800000026,
          "by_model": {
            "claude-opus-4-7": {
              "input": 364,
              "output": 138277,
              "cache_create": 2626202,
              "cache_read": 110778720
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 242,
          "tool_call_count": 138,
          "context_at_last_turn_tokens": 602703,
          "context_window_pct": 301.3515
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-11T08:24:19-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 5,
          "session_input_tokens": 364,
          "session_output_tokens": 138277,
          "session_cache_creation_tokens": 2626202,
          "session_cache_read_tokens": 110778720,
          "session_cost_usd": 55.181831800000026,
          "by_model": {
            "claude-opus-4-7": {
              "input": 364,
              "output": 138277,
              "cache_create": 2626202,
              "cache_read": 110778720
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 242,
          "tool_call_count": 138,
          "context_at_last_turn_tokens": 602703,
          "context_window_pct": 301.3515
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T08:24:34-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 5,
        "session_input_tokens": 364,
        "session_output_tokens": 138277,
        "session_cache_creation_tokens": 2626202,
        "session_cache_read_tokens": 110778720,
        "session_cost_usd": 55.181831800000026,
        "by_model": {
          "claude-opus-4-7": {
            "input": 364,
            "output": 138277,
            "cache_create": 2626202,
            "cache_read": 110778720
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 242,
        "tool_call_count": 138,
        "context_at_last_turn_tokens": 602703,
        "context_window_pct": 301.3515
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-11T08:24:52-07:00",
      "completed_at": "2026-05-11T08:29:48-07:00",
      "session_started_at": null,
      "cumulative_seconds": 296,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T08:24:52-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 5,
        "session_input_tokens": 364,
        "session_output_tokens": 138277,
        "session_cache_creation_tokens": 2626202,
        "session_cache_read_tokens": 110778720,
        "session_cost_usd": 55.181831800000026,
        "by_model": {
          "claude-opus-4-7": {
            "input": 364,
            "output": 138277,
            "cache_create": 2626202,
            "cache_read": 110778720
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 242,
        "tool_call_count": 138,
        "context_at_last_turn_tokens": 602703,
        "context_window_pct": 301.3515
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-11T08:28:35-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 5,
          "session_input_tokens": 364,
          "session_output_tokens": 138277,
          "session_cache_creation_tokens": 2626202,
          "session_cache_read_tokens": 110778720,
          "session_cost_usd": 55.181831800000026,
          "by_model": {
            "claude-opus-4-7": {
              "input": 364,
              "output": 138277,
              "cache_create": 2626202,
              "cache_read": 110778720
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 242,
          "tool_call_count": 138,
          "context_at_last_turn_tokens": 602703,
          "context_window_pct": 301.3515
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-11T08:29:01-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 5,
          "session_input_tokens": 364,
          "session_output_tokens": 138277,
          "session_cache_creation_tokens": 2626202,
          "session_cache_read_tokens": 110778720,
          "session_cost_usd": 55.181831800000026,
          "by_model": {
            "claude-opus-4-7": {
              "input": 364,
              "output": 138277,
              "cache_create": 2626202,
              "cache_read": 110778720
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 242,
          "tool_call_count": 138,
          "context_at_last_turn_tokens": 602703,
          "context_window_pct": 301.3515
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-11T08:29:17-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 5,
          "session_input_tokens": 364,
          "session_output_tokens": 138277,
          "session_cache_creation_tokens": 2626202,
          "session_cache_read_tokens": 110778720,
          "session_cost_usd": 55.181831800000026,
          "by_model": {
            "claude-opus-4-7": {
              "input": 364,
              "output": 138277,
              "cache_create": 2626202,
              "cache_read": 110778720
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 242,
          "tool_call_count": 138,
          "context_at_last_turn_tokens": 602703,
          "context_window_pct": 301.3515
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-11T08:29:29-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 5,
          "session_input_tokens": 364,
          "session_output_tokens": 138277,
          "session_cache_creation_tokens": 2626202,
          "session_cache_read_tokens": 110778720,
          "session_cost_usd": 55.181831800000026,
          "by_model": {
            "claude-opus-4-7": {
              "input": 364,
              "output": 138277,
              "cache_create": 2626202,
              "cache_read": 110778720
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 242,
          "tool_call_count": 138,
          "context_at_last_turn_tokens": 602703,
          "context_window_pct": 301.3515
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-11T08:29:36-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 5,
          "session_input_tokens": 364,
          "session_output_tokens": 138277,
          "session_cache_creation_tokens": 2626202,
          "session_cache_read_tokens": 110778720,
          "session_cost_usd": 55.181831800000026,
          "by_model": {
            "claude-opus-4-7": {
              "input": 364,
              "output": 138277,
              "cache_create": 2626202,
              "cache_read": 110778720
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 242,
          "tool_call_count": 138,
          "context_at_last_turn_tokens": 602703,
          "context_window_pct": 301.3515
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T08:29:48-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 5,
        "session_input_tokens": 364,
        "session_output_tokens": 138277,
        "session_cache_creation_tokens": 2626202,
        "session_cache_read_tokens": 110778720,
        "session_cost_usd": 55.181831800000026,
        "by_model": {
          "claude-opus-4-7": {
            "input": 364,
            "output": 138277,
            "cache_create": 2626202,
            "cache_read": 110778720
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 242,
        "tool_call_count": 138,
        "context_at_last_turn_tokens": 602703,
        "context_window_pct": 301.3515
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-11T08:30:15-07:00",
      "completed_at": "2026-05-11T08:30:38-07:00",
      "session_started_at": null,
      "cumulative_seconds": 23,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-11T08:30:38-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 5,
        "session_input_tokens": 364,
        "session_output_tokens": 138277,
        "session_cache_creation_tokens": 2626202,
        "session_cache_read_tokens": 110778720,
        "session_cost_usd": 55.181831800000026,
        "by_model": {
          "claude-opus-4-7": {
            "input": 364,
            "output": 138277,
            "cache_create": 2626202,
            "cache_read": 110778720
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 242,
        "tool_call_count": 138,
        "context_at_last_turn_tokens": 602703,
        "context_window_pct": 301.3515
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-11T07:05:38-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-11T07:50:53-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-11T08:24:52-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-11T08:30:15-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-11T07:04:46-07:00",
    "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
    "five_hour_pct": 16,
    "seven_day_pct": 97,
    "session_cost_usd": 0.0
  },
  "code_tasks_total": 7,
  "code_task_name": "Task 7: summary shows data for all five phases",
  "code_task": 7,
  "diff_stats": {
    "files_changed": 7,
    "insertions": 289,
    "deletions": 0,
    "captured_at": "2026-05-11T07:50:41-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThe user has requested a Learn phase audit of a completed FLOW feature work (PR #1453, issue #1446). The task is to apply a three-tenant analysis framework (Process gap / Rule compliance / Missing rule) to identify findings that pass a two-gate filter:\n1. Forward-facing: Would a future session understand and apply the principle?\n2. Value: Was the gap caught and remediated in this PR?\n\nI've read the plan, state file, and key commits to understand the work. The feature adds phase-scoped window snapshots to match the existing top-level ones across three callsites (start_init, complete_finalize, complete_fast) plus an integration test validating the full contract.\n\nKey observations from the artifacts:\n- Plan was clear and well-structured\n- Code phase: 7 tasks, all completed (code_task=7/7)\n- Review phase: Had findings that were triaged and fixed in Step 4\n- All commits landed cleanly (5 commits, 4 actual work + 1 Review fix)\n- State file shows one logged decision about PR #1454 landing mid-flow (defer to Review)\n- Tests were added with proper fixtures using snapshot_value and add_phase_snapshots helpers\n- Review Step 4 fix: Added per-level object guards in complete_finalize for state mutation safety\n\nThe artifacts show:\n- complete_finalize.rs: Added per-level object guards when writing phase-scoped window_at_complete\n- Test fixture in format_complete_summary_tests: summary_shows_data_for_all_five_phases_when_capture_complete validates all phases render real token data\n- Common test helpers: snapshot_value, add_phase_snapshots used by multiple test files\n\nReviewing for findings:\n1. Process gaps: The log shows one decision logged (PR #1454 mid-flow). Code phase completed cleanly. Review phase had findings but they were fixed in Step 4. No signs of workflow breakdowns.\n2. Rule violations: Need to check against project rules. The Review Step 4 fix (object guards) appears to address a correctness issue that was caught via adversarial tests.\n3. Missing rules: Reviewing whether gaps exist that aren't covered by current rules.\n\nThe key gate filters are strict — findings must:\n1. Be forward-facing (apply to future work, not just this PR)\n2. Either reveal a process/workflow gap OR represent a rule compliance issue that wasn't already remediated in this PR\n\nAnalysis of potential findings:\n- The object guards in complete_finalize were added per adversarial testing in Review Step 4 — this was caught and fixed, so it passes the value gate\n- The test fixture approach (snapshot_value with scaling) is sound and follows the test-placement rule\n- No evidence of rule violations that weren't already fixed\n- No apparent process gaps — the work followed the plan, had proper test coverage, and Review caught/fixed issues before merge\n\nGiven the strict two-gate filter and the fact that the PR appears to have executed cleanly with proper review, findings will likely be minimal or zero.\n</analysis>\n\n<summary>\n\n1. Primary Request and Intent:\n   Conduct a Learn phase audit of completed feature PR #1453 (issue #1446) using a three-tenant analysis framework:\n   - Tenant 1: Did the FLOW process work? (workflow gaps, automation gaps, friction)\n   - Tenant 2: Did Claude follow the rules? (rule compliance violations)\n   - Tenant 3: What rules should exist but don't? (missing rule gaps)\n   Apply a strict two-gate filter: only report findings that are (a) forward-facing and (b) either reveal a process gap OR represent a rule violation not already remediated in this PR.\n\n2. Key Technical Concepts:\n   - FLOW plugin five-phase lifecycle: Start → Code → Review → Learn → Complete\n   - Window snapshot capture mechanism for per-phase account-window data (tokens, cost, context usage)\n   - Phase-scoped state mutations in `.flow-states/<branch>/state.json`\n   - State mutation safety patterns: per-level object guards for non-object values\n   - Test fixtures using snapshot_value (n-scaled) and add_phase_snapshots helpers\n   - Atomicity of test+implementation pairs per plan-commit-atomicity rule\n\n3. Files and Code Sections:\n   - `/Users/ben/code/flow/.flow-states/fix-per-flow-capture-start/plan.md`\n     - Described four atomic commit groups (Tasks 1-7) adding phase-scoped snapshots\n     - Task 7 was integration test validating all five phases render token data\n   \n   - `src/complete_finalize.rs` (Review Step 4 fix)\n     - Added per-level object guards before IndexMut chain when writing phase-scoped window_at_complete\n     - Pattern: check `!state[\"phases\"].is_object()` then reset to `json!({})` before proceeding\n     - Rationale: hand-edited or corrupt state files may carry non-object values, causing panic without guards\n     - Code snippet (from `show 9d7d9445`):\n     ```rust\n     if state.is_object() {\n       if !state[\"phases\"].is_object() {\n         state[\"phases\"] = serde_json::json!({});\n       }\n       if !state[\"phases\"][\"flow-complete\"].is_object() {\n         state[\"phases\"][\"flow-complete\"] = serde_json::json!({});\n       }\n       state[\"phases\"][\"flow-complete\"][\"window_at_complete\"] = \n         serde_json::to_value(&snap).expect(\"WindowSnapshot must serialize\");\n     }\n     ```\n   \n   - `tests/format_complete_summary.rs` (Task 7 test)\n     - Test `summary_shows_data_for_all_five_phases_when_capture_complete` (line 78)\n     - Uses `add_phase_snapshots(&mut state, \"flow-X\", enter_n, complete_n)` to populate phases\n     - Asserts all five phase rows render with real cost ($) not em-dash placeholder (—)\n     - Validates contract: when all phases have enter+complete snapshots, phase_delta returns Some(_) for every phase\n   \n   - `tests/common/mod.rs`\n     - `snapshot_value(session: &str, n: i64, model: &str)` helper\n       - Scales numeric fields: session_input_tokens = n*100, session_cost_usd = n*0.01, etc.\n       - Returns WindowSnapshot-shaped JSON for test fixtures\n     - `add_phase_snapshots(state: &mut Value, key: &str, enter_n: i64, complete_n_i64)` helper\n       - Populates both window_at_enter and window_at_complete for a phase with differing n values\n\n4. Errors and fixes:\n   - Hook validation errors encountered during initial tool calls (Bash compound-command block, worktree paths)\n   - These were not code errors but tool-invocation errors — fixed by using separate Bash calls and proper absolute paths\n   - Review Step 4 identified 6 IndexMut panic-shaped adversarial probes and fixed with object guards (addressed in 9d7d9445 commit)\n   - Pre-fix tests `token_cost_section_with_no_snapshots_returns_empty` and `token_cost_section_with_partial_data_skips_unpopulated_phases` were removed per supersession rule (old buggy behavior assertion replaced by new contract tests)\n\n5. Problem Solving:\n   - Solved the core issue: three callsites (start_init, complete_finalize, complete_fast) were writing only top-level window snapshots, not phase-scoped ones, causing format_complete_summary's phase_delta to return None and render placeholder rows with `—` cost cells\n   - Solution: extend each callsite to write both top-level AND phase-scoped keys with same snapshot value\n   - complete_fast required special handling: bare phase_enter mutator had no snapshot capture, so mirrored phase_enter.rs's snapshot-capture pattern\n   - Test fixture design: Task 7 uses add_phase_snapshots with scaling factors (0→5, 5→15, 15→20, 20→25, 25→30) across five phases to produce positive deltas and verify all rows render real data\n   - Review Step 4: Adversarial testing discovered IndexMut panic risk on corrupt state; guards added to handle non-object intermediate values\n\n6. All user messages:\n   - Initial request: Conduct Learn phase audit applying three-tenant framework with strict two-gate filter; analyze FLOW process, rule compliance, and missing rule gaps\n   - Explicit constraint: \"Return only findings that pass both gates. If all categories produce zero, say so explicitly with 'No findings' markers — do NOT invent findings to fill sections.\"\n\n7. Pending Tasks:\n   - Complete the Learn phase audit analysis and produce findings in structured format (or \"No findings\" reports for empty categories)\n   - Report whether process gaps, rule violations, or missing rules were identified\n\n8. Current Work:\n   I was in the process of reading and analyzing artifacts from PR #1453 to identify findings. I had:\n   - Read the plan.md describing the four atomic groups and seven tasks\n   - Read the state.json showing cumulative timings and visit counts\n   - Read the session log showing one logged decision about PR #1454 landing mid-flow\n   - Read the Review Step 4 fix commit (9d7d9445) showing object guards added to complete_finalize\n   - Read the Task 7 test fixture (summary_shows_data_for_all_five_phases_when_capture_complete) at line 78 of format_complete_summary.rs\n   - Read the common test helpers (snapshot_value, add_phase_snapshots) to understand fixture patterns\n   - Encountered and recovered from hook validation errors (Bash compound-command syntax and worktree path restrictions)\n\n9. Optional Next Step:\n   Conduct the actual audit analysis by reviewing evidence against the three tenants and two-gate filter, then output findings in the required structured format. Based on the artifacts reviewed so far, the work appears to have executed cleanly with proper review-phase corrections already applied, suggesting findings may be minimal or zero. The next step is to complete the analysis and output the final audit report.\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/fix-per-flow-capture-start",
  "compact_count": 6,
  "findings": [
    {
      "finding": "Pre-mortem: complete_fast IndexMut panic via new chained write",
      "reason": "phase_enter runs first in the same mutate_state closure and heals state['phases'] to {} if wrong-type. phase_enter's own IndexMut on state['phases'][phase] would panic on wrong-type phases.flow-complete BEFORE the new code runs — pre-existing panic vector not introduced by this PR. complete_finalize.rs portion overlaps with Reviewer Finding 1.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T08:10:43-07:00"
    },
    {
      "finding": "Pre-mortem: filesystem I/O under exclusive mutate_state lock",
      "reason": "capture_for_active_state was already called inside mutate_state in phase_enter phase_finalize phase_transition set_timestamp start_init complete_finalize. My complete_fast change matches the documented pattern. Reads capped at TRANSCRIPT_BYTE_CAP=50MB. Restructuring 6 callsites is out of scope for this PR.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T08:10:49-07:00"
    },
    {
      "finding": "Pre-mortem: phase advanced before PR check in complete_fast",
      "reason": "The mutate_state phase_enter block was already before check_pr_status in the pre-diff code. This PR only added a snapshot write inside the same closure. Ordering is pre-existing not introduced by this change.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T08:10:55-07:00"
    },
    {
      "finding": "Pre-mortem: PR #1454 freshness-check interaction in rapid-complete flows",
      "reason": "complete_fast and complete_finalize are separate subcommand invocations separated by /flow:flow-complete skill steps (PR check mode resolution merge push). turn_count advances across those steps so the freshness branch (equal cost AND equal turn_count) does not trigger under normal flow execution.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T08:11:02-07:00"
    },
    {
      "finding": "Reviewer: missing per-level object guard for nested write in complete_finalize.rs",
      "reason": "Added per-level object guards (state.is_object check plus auto-heal for state.phases and state.phases.flow-complete) mirroring the canonical State Mutation Object Guards pattern. Confirmed by adversarial agent's 6 panic-shaped probes.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T08:22:09-07:00"
    },
    {
      "finding": "Reviewer: stale line-number citations in inline comments",
      "reason": "Replaced phase_enter.rs:232-246 and phase_enter.rs:243-245 line citations in complete_finalize.rs complete_fast.rs and start_init.rs with self-contained prose describing the invariant preserved (per phase_enter heal pattern init_state subprocess output etc).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T08:22:15-07:00"
    },
    {
      "finding": "Adversarial: 6 IndexMut panic probes against complete_finalize on non-object phases and non-object phases.flow-complete",
      "reason": "Consolidated with Reviewer Finding 1 fix. Per-level object guards added to complete_finalize.rs prevent the panic class. Added 3 regression tests in tests/complete_finalize.rs that exercise the new guard branches (non-object phases non-object flow-complete non-object state root).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T08:22:22-07:00"
    },
    {
      "finding": "Learn-analyst: undocumented snapshot_value n-scaling convention in tests/common/mod.rs",
      "reason": "Convention is already documented via the helper's doc comment which explains n-scaling rationale and consumer mapping. Function body shows the scaling formula. A separate rule file would duplicate information already discoverable via Read on the helper — bureaucracy-trap pattern per .claude/rules/review-scope.md Value-vs-Bureaucracy Triage.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-11T08:28:55-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-11T08:30:38-07:00",
    "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
    "model": "claude-opus-4-7",
    "five_hour_pct": 20,
    "seven_day_pct": 5,
    "session_input_tokens": 364,
    "session_output_tokens": 138277,
    "session_cache_creation_tokens": 2626202,
    "session_cache_read_tokens": 110778720,
    "session_cost_usd": 55.181831800000026,
    "by_model": {
      "claude-opus-4-7": {
        "input": 364,
        "output": 138277,
        "cache_create": 2626202,
        "cache_read": 110778720
      },
      "<synthetic>": {
        "input": 0,
        "output": 0,
        "cache_create": 0,
        "cache_read": 0
      }
    },
    "turn_count": 242,
    "tool_call_count": 138,
    "context_at_last_turn_tokens": 602703,
    "context_window_pct": 301.3515
  },
  "_auto_continue": "/flow:flow-complete"
}
````

</details>