### PR TITLE
Pair Delta Emits 0000

### DIFF
--- a/src/window_deltas.rs
+++ b/src/window_deltas.rs
@@ -263,8 +263,32 @@ fn pair_delta(start: &WindowSnapshot, end: &WindowSnapshot) -> DeltaReport {
     // value. Any missing endpoint produces `None` so renderers can
     // mark the partial-data span with `—` instead of inventing a
     // number from a cumulative session total.
-    let cost_delta_usd = match (start.session_cost_usd, end.session_cost_usd) {
-        (Some(s), Some(e)) => Some(e - s),
+    //
+    // The freshness check guards against the frozen-statusline
+    // pattern: the source file `~/.claude/cost/<YYYY-MM>/<session_id>`
+    // is refreshed only when Claude Code redraws its statusline.
+    // During autonomous Skill→Skill chains the statusline never
+    // fires, so both endpoints sample the same stale value and a
+    // raw `e - s` would produce a misleading `Some(0.0)`. When
+    // costs are equal AND `turn_count` is also equal, no new
+    // assistant turn crossed the boundary — that is the frozen
+    // signature. Emit `None` so the renderer shows `—`. When
+    // `turn_count` advanced, the equal-cost case is a real-zero
+    // (cached responses); emit `Some(0.0)`. When `turn_count` is
+    // absent on either side, fall back conservatively to `None`.
+    let cost_delta_usd = match (
+        start.session_cost_usd,
+        end.session_cost_usd,
+        start.turn_count,
+        end.turn_count,
+    ) {
+        (Some(s), Some(e), Some(ts), Some(te)) => {
+            if (e - s).abs() < f64::EPSILON && ts == te {
+                None
+            } else {
+                Some(e - s)
+            }
+        }
         _ => None,
     };
     let (five_hour_pct_delta, five_reset) =

--- a/tests/format_complete_summary.rs
+++ b/tests/format_complete_summary.rs
@@ -399,6 +399,71 @@ fn token_cost_section_total_marks_partial_when_any_unknown() {
     );
 }
 
+/// End-to-end render of the frozen statusline-cost pattern from
+/// issue #1447. When a phase's enter and complete snapshots
+/// share the same `session_cost_usd` AND the same `turn_count`,
+/// the cost source file was frozen across the boundary —
+/// `pair_delta` emits `None` so this renderer prints `—` instead
+/// of the misleading `$0.000`. The phase row falls through the
+/// `None` arm at `src/format_complete_summary.rs:179`, and the
+/// `* cost partial` footnote at `src/format_complete_summary.rs:223`
+/// appears because at least one phase contributed `None` cost.
+#[test]
+fn format_complete_summary_renders_dash_for_frozen_cost_pattern() {
+    let mut state = all_complete_state();
+    // Code phase: real cost data — costs differ between enter and
+    // complete, so pair_delta returns Some(cost diff).
+    add_phase_snapshots(&mut state, "flow-code", 0, 5);
+    // Review phase: frozen pattern — enter and complete share the
+    // same n, so session_cost_usd and turn_count match on both
+    // sides. pair_delta returns None for cost.
+    add_phase_snapshots(&mut state, "flow-review", 7, 7);
+    // Learn phase: frozen pattern — same shape as Review.
+    add_phase_snapshots(&mut state, "flow-learn", 9, 9);
+
+    let result = format_complete_summary(&state, None);
+
+    assert!(result.summary.contains("Token Cost"), "section header");
+    // The summary contains both a phase timeline (with rows like
+    // `Review: 12m`) and the Token Cost section (with rows like
+    // `Review:  <tokens>  <cost>`). The cost row is the one we
+    // need to inspect, so bound the search to the Token Cost
+    // section between its header and the closing separator.
+    let after_header = result
+        .summary
+        .split_once("Token Cost")
+        .map(|(_, rest)| rest)
+        .expect("Token Cost header must appear");
+    let token_section = after_header
+        .split_once("\n\n")
+        .map(|(section, _)| section)
+        .unwrap_or(after_header);
+    for phase_label in ["Review:", "Learn:"] {
+        let row = token_section
+            .lines()
+            .find(|line| line.contains(phase_label))
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing `{}` row in Token Cost section:\n{}",
+                    phase_label, token_section
+                )
+            });
+        assert!(
+            row.ends_with('—'),
+            "row for `{}` must end in the em-dash that signals frozen cost; got `{}`",
+            phase_label,
+            row
+        );
+    }
+    // The frozen rows contributed None cost, so the total carries
+    // the partial marker and the footnote appears.
+    assert!(
+        result.summary.contains("cost partial"),
+        "footnote must appear when any phase contributes None cost; summary:\n{}",
+        result.summary
+    );
+}
+
 // --- basic summary ---
 
 #[test]

--- a/tests/window_deltas.rs
+++ b/tests/window_deltas.rs
@@ -463,6 +463,112 @@ fn pair_delta_cost_both_missing_returns_none() {
     assert_eq!(report.cost_delta_usd, None);
 }
 
+// --- pair_delta cost freshness check (issue #1447) ---
+//
+// When two snapshots read the same frozen statusline-cost file
+// AND no new turn crossed the boundary, the (Some, Some) arm
+// produces `None` so the renderer shows `—` instead of a
+// misleading `$0.000`. The five tests below cover every branch
+// of the freshness check inside the `(Some, Some, Some, Some)`
+// arm of the four-tuple match.
+
+/// Both endpoints have identical cost AND identical turn_count:
+/// the statusline file is frozen — no new turn crossed the
+/// boundary so cost could not have advanced. Emit `None` so the
+/// renderer shows `—` rather than the misleading `$0.000`.
+#[test]
+fn pair_delta_emits_none_cost_when_both_cost_and_turn_count_equal() {
+    let mut enter = snap("S1", 0);
+    let mut complete = snap("S1", 0);
+    enter.session_cost_usd = Some(11.125);
+    complete.session_cost_usd = Some(11.125);
+    enter.turn_count = Some(42);
+    complete.turn_count = Some(42);
+    let phase = phase_with_snapshots(Some(enter), vec![], Some(complete));
+    let report = phase_delta(&phase).expect("populated");
+    assert_eq!(
+        report.cost_delta_usd, None,
+        "frozen-statusline pattern (equal cost AND equal turn_count) must emit None"
+    );
+}
+
+/// Equal cost but turn_count advanced: a real turn ran across
+/// the boundary, so the equal cost is the real-zero case
+/// (cached responses contributed no cost). Emit `Some(0.0)` —
+/// do not misclassify as frozen.
+#[test]
+fn pair_delta_emits_some_cost_when_turn_count_advanced() {
+    let mut enter = snap("S1", 0);
+    let mut complete = snap("S1", 0);
+    enter.session_cost_usd = Some(11.125);
+    complete.session_cost_usd = Some(11.125);
+    enter.turn_count = Some(42);
+    complete.turn_count = Some(43);
+    let phase = phase_with_snapshots(Some(enter), vec![], Some(complete));
+    let report = phase_delta(&phase).expect("populated");
+    assert_eq!(
+        report.cost_delta_usd,
+        Some(0.0),
+        "real-zero (equal cost but turn_count advanced) must emit Some(0.0)"
+    );
+}
+
+/// Costs differ: the happy path. Emit `Some(end - start)`
+/// regardless of turn_count.
+#[test]
+fn pair_delta_emits_some_cost_when_costs_differ() {
+    let mut enter = snap("S1", 0);
+    let mut complete = snap("S1", 0);
+    enter.session_cost_usd = Some(1.0);
+    complete.session_cost_usd = Some(1.5);
+    enter.turn_count = Some(10);
+    complete.turn_count = Some(12);
+    let phase = phase_with_snapshots(Some(enter), vec![], Some(complete));
+    let report = phase_delta(&phase).expect("populated");
+    assert_eq!(
+        report.cost_delta_usd,
+        Some(0.5),
+        "differing costs must emit Some(end - start)"
+    );
+}
+
+/// Start `turn_count` is None: the freshness signal is
+/// unavailable. Conservative fallback emits `None` so the
+/// renderer shows `—` rather than risk a misleading `$0.000`
+/// from a possibly-stale file.
+#[test]
+fn pair_delta_emits_none_cost_when_turn_count_missing_on_start() {
+    let mut enter = snap("S1", 0);
+    let mut complete = snap("S1", 0);
+    enter.session_cost_usd = Some(11.125);
+    complete.session_cost_usd = Some(11.125);
+    enter.turn_count = None;
+    complete.turn_count = Some(42);
+    let phase = phase_with_snapshots(Some(enter), vec![], Some(complete));
+    let report = phase_delta(&phase).expect("populated");
+    assert_eq!(
+        report.cost_delta_usd, None,
+        "missing start turn_count must emit None (conservative fallback)"
+    );
+}
+
+/// End `turn_count` is None: symmetric conservative fallback.
+#[test]
+fn pair_delta_emits_none_cost_when_turn_count_missing_on_end() {
+    let mut enter = snap("S1", 0);
+    let mut complete = snap("S1", 0);
+    enter.session_cost_usd = Some(11.125);
+    complete.session_cost_usd = Some(11.125);
+    enter.turn_count = Some(42);
+    complete.turn_count = None;
+    let phase = phase_with_snapshots(Some(enter), vec![], Some(complete));
+    let report = phase_delta(&phase).expect("populated");
+    assert_eq!(
+        report.cost_delta_usd, None,
+        "missing end turn_count must emit None (symmetric conservative fallback)"
+    );
+}
+
 /// pct_delta_with_reset: when `start` is None and `end` is Some,
 /// returns Some(0) without marking a reset (no anchor to compare
 /// against).


### PR DESCRIPTION
## What

#1447.

Closes #1447

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/pair-delta-emits-0000/log` |
| State | `.flow-states/pair-delta-emits-0000/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 17m |
| Review | 25m |
| Learn | 1m |
| Complete | <1m |
| **Total** | **44m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/pair-delta-emits-0000.json</summary>

```json
{
  "schema_version": 1,
  "branch": "pair-delta-emits-0000",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1454,
  "pr_url": "https://github.com/benkruger/flow/pull/1454",
  "started_at": "2026-05-11T07:05:15-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/pair-delta-emits-0000/log",
    "state": ".flow-states/pair-delta-emits-0000/state.json"
  },
  "session_tty": "/dev/ttys006",
  "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
  "transcript_path": null,
  "notes": [],
  "prompt": "#1447",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-11T07:05:15-07:00",
      "completed_at": "2026-05-11T07:05:56-07:00",
      "session_started_at": null,
      "cumulative_seconds": 41,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-11T07:05:56-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 17,
        "seven_day_pct": 98,
        "session_input_tokens": 29,
        "session_output_tokens": 5135,
        "session_cache_creation_tokens": 585378,
        "session_cache_read_tokens": 2373506,
        "session_cost_usd": 2.1424285,
        "by_model": {
          "claude-opus-4-7": {
            "input": 29,
            "output": 5135,
            "cache_create": 585378,
            "cache_read": 2373506
          }
        },
        "turn_count": 14,
        "tool_call_count": 9,
        "context_at_last_turn_tokens": 212747,
        "context_window_pct": 106.3735
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-11T07:06:10-07:00",
      "completed_at": "2026-05-11T07:23:10-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1020,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T07:06:10-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 18,
        "seven_day_pct": 98,
        "session_input_tokens": 36,
        "session_output_tokens": 5749,
        "session_cache_creation_tokens": 594721,
        "session_cache_read_tokens": 3012020,
        "session_cost_usd": 2.42121125,
        "by_model": {
          "claude-opus-4-7": {
            "input": 36,
            "output": 5749,
            "cache_create": 594721,
            "cache_read": 3012020
          }
        },
        "turn_count": 17,
        "tool_call_count": 11,
        "context_at_last_turn_tokens": 221818,
        "context_window_pct": 110.909
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-11T07:14:27-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 19,
          "seven_day_pct": 98,
          "session_input_tokens": 93,
          "session_output_tokens": 35404,
          "session_cache_creation_tokens": 1237595,
          "session_cache_read_tokens": 25298070,
          "session_cost_usd": 9.640853000000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 93,
              "output": 35404,
              "cache_create": 1237595,
              "cache_read": 25298070
            }
          },
          "turn_count": 74,
          "tool_call_count": 39,
          "context_at_last_turn_tokens": 445623,
          "context_window_pct": 222.8115
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-11T07:14:27-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 19,
          "seven_day_pct": 98,
          "session_input_tokens": 93,
          "session_output_tokens": 35404,
          "session_cache_creation_tokens": 1237595,
          "session_cache_read_tokens": 25298070,
          "session_cost_usd": 9.640853000000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 93,
              "output": 35404,
              "cache_create": 1237595,
              "cache_read": 25298070
            }
          },
          "turn_count": 74,
          "tool_call_count": 39,
          "context_at_last_turn_tokens": 445623,
          "context_window_pct": 222.8115
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-11T07:14:27-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 19,
          "seven_day_pct": 98,
          "session_input_tokens": 93,
          "session_output_tokens": 35404,
          "session_cache_creation_tokens": 1237595,
          "session_cache_read_tokens": 25298070,
          "session_cost_usd": 9.640853000000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 93,
              "output": 35404,
              "cache_create": 1237595,
              "cache_read": 25298070
            }
          },
          "turn_count": 74,
          "tool_call_count": 39,
          "context_at_last_turn_tokens": 445623,
          "context_window_pct": 222.8115
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-11T07:14:27-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 19,
          "seven_day_pct": 98,
          "session_input_tokens": 93,
          "session_output_tokens": 35404,
          "session_cache_creation_tokens": 1237595,
          "session_cache_read_tokens": 25298070,
          "session_cost_usd": 9.640853000000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 93,
              "output": 35404,
              "cache_create": 1237595,
              "cache_read": 25298070
            }
          },
          "turn_count": 74,
          "tool_call_count": 39,
          "context_at_last_turn_tokens": 445623,
          "context_window_pct": 222.8115
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-11T07:14:27-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 19,
          "seven_day_pct": 98,
          "session_input_tokens": 93,
          "session_output_tokens": 35404,
          "session_cache_creation_tokens": 1237595,
          "session_cache_read_tokens": 25298070,
          "session_cost_usd": 9.640853000000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 93,
              "output": 35404,
              "cache_create": 1237595,
              "cache_read": 25298070
            }
          },
          "turn_count": 74,
          "tool_call_count": 39,
          "context_at_last_turn_tokens": 445623,
          "context_window_pct": 222.8115
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-11T07:14:27-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 19,
          "seven_day_pct": 98,
          "session_input_tokens": 93,
          "session_output_tokens": 35404,
          "session_cache_creation_tokens": 1237595,
          "session_cache_read_tokens": 25298070,
          "session_cost_usd": 9.640853000000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 93,
              "output": 35404,
              "cache_create": 1237595,
              "cache_read": 25298070
            }
          },
          "turn_count": 74,
          "tool_call_count": 39,
          "context_at_last_turn_tokens": 445623,
          "context_window_pct": 222.8115
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-11T07:21:36-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 21,
          "seven_day_pct": 99,
          "session_input_tokens": 164,
          "session_output_tokens": 52170,
          "session_cache_creation_tokens": 1322181,
          "session_cache_read_tokens": 47575393,
          "session_cost_usd": 17.07278775,
          "by_model": {
            "claude-opus-4-7": {
              "input": 164,
              "output": 52170,
              "cache_create": 1322181,
              "cache_read": 47575393
            }
          },
          "turn_count": 122,
          "tool_call_count": 69,
          "context_at_last_turn_tokens": 486636,
          "context_window_pct": 243.318
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T07:23:10-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 21,
        "seven_day_pct": 99,
        "session_input_tokens": 204,
        "session_output_tokens": 56636,
        "session_cache_creation_tokens": 1362337,
        "session_cache_read_tokens": 55936595,
        "session_cost_usd": 20.19467850000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 204,
            "output": 56636,
            "cache_create": 1362337,
            "cache_read": 55936595
          }
        },
        "turn_count": 139,
        "tool_call_count": 81,
        "context_at_last_turn_tokens": 503695,
        "context_window_pct": 251.8475
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-11T07:23:21-07:00",
      "completed_at": "2026-05-11T07:48:27-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1506,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T07:23:21-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 21,
        "seven_day_pct": 99,
        "session_input_tokens": 216,
        "session_output_tokens": 57486,
        "session_cache_creation_tokens": 1386015,
        "session_cache_read_tokens": 57951729,
        "session_cost_usd": 20.78311075000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 216,
            "output": 57486,
            "cache_create": 1386015,
            "cache_read": 57951729
          }
        },
        "turn_count": 143,
        "tool_call_count": 83,
        "context_at_last_turn_tokens": 515538,
        "context_window_pct": 257.769
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-11T07:25:04-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 21,
          "seven_day_pct": 99,
          "session_input_tokens": 240,
          "session_output_tokens": 63403,
          "session_cache_creation_tokens": 1400561,
          "session_cache_read_tokens": 70380992,
          "session_cost_usd": 24.800263500000007,
          "by_model": {
            "claude-opus-4-7": {
              "input": 240,
              "output": 63403,
              "cache_create": 1400561,
              "cache_read": 70380992
            }
          },
          "turn_count": 167,
          "tool_call_count": 98,
          "context_at_last_turn_tokens": 523709,
          "context_window_pct": 261.8545
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-11T07:43:24-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 2,
          "session_input_tokens": 289,
          "session_output_tokens": 111956,
          "session_cache_creation_tokens": 2514768,
          "session_cache_read_tokens": 76860194,
          "session_cost_usd": 44.441404000000006,
          "by_model": {
            "claude-opus-4-7": {
              "input": 289,
              "output": 111956,
              "cache_create": 2514768,
              "cache_read": 76860194
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 183,
          "tool_call_count": 105,
          "context_at_last_turn_tokens": 551568,
          "context_window_pct": 275.784
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-11T07:44:57-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 2,
          "session_input_tokens": 306,
          "session_output_tokens": 120379,
          "session_cache_creation_tokens": 2550378,
          "session_cache_read_tokens": 86394858,
          "session_cost_usd": 48.0230905,
          "by_model": {
            "claude-opus-4-7": {
              "input": 306,
              "output": 120379,
              "cache_create": 2550378,
              "cache_read": 86394858
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 200,
          "tool_call_count": 117,
          "context_at_last_turn_tokens": 566220,
          "context_window_pct": 283.11
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-11T07:48:16-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 2,
          "session_input_tokens": 317,
          "session_output_tokens": 127103,
          "session_cache_creation_tokens": 2560630,
          "session_cache_read_tokens": 92632286,
          "session_cost_usd": 49.237547000000006,
          "by_model": {
            "claude-opus-4-7": {
              "input": 317,
              "output": 127103,
              "cache_create": 2560630,
              "cache_read": 92632286
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 211,
          "tool_call_count": 121,
          "context_at_last_turn_tokens": 569860,
          "context_window_pct": 284.93
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T07:48:27-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 2,
        "session_input_tokens": 318,
        "session_output_tokens": 127241,
        "session_cache_creation_tokens": 2560815,
        "session_cache_read_tokens": 93202145,
        "session_cost_usd": 49.52708775000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 318,
            "output": 127241,
            "cache_create": 2560815,
            "cache_read": 93202145
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 212,
        "tool_call_count": 122,
        "context_at_last_turn_tokens": 570045,
        "context_window_pct": 285.0225
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-11T07:48:41-07:00",
      "completed_at": "2026-05-11T07:50:23-07:00",
      "session_started_at": null,
      "cumulative_seconds": 102,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T07:48:41-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 2,
        "session_input_tokens": 330,
        "session_output_tokens": 128089,
        "session_cache_creation_tokens": 2583363,
        "session_cache_read_tokens": 95482679,
        "session_cost_usd": 50.17831375000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 330,
            "output": 128089,
            "cache_create": 2583363,
            "cache_read": 95482679
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 216,
        "tool_call_count": 124,
        "context_at_last_turn_tokens": 581323,
        "context_window_pct": 290.6615
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-11T07:49:45-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 2,
          "session_input_tokens": 336,
          "session_output_tokens": 131752,
          "session_cache_creation_tokens": 2593490,
          "session_cache_read_tokens": 98972949,
          "session_cost_usd": 51.409642550000015,
          "by_model": {
            "claude-opus-4-7": {
              "input": 336,
              "output": 131752,
              "cache_create": 2593490,
              "cache_read": 98972949
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 222,
          "tool_call_count": 127,
          "context_at_last_turn_tokens": 585000,
          "context_window_pct": 292.5
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-11T07:49:51-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 2,
          "session_input_tokens": 338,
          "session_output_tokens": 132078,
          "session_cache_creation_tokens": 2594612,
          "session_cache_read_tokens": 100142947,
          "session_cost_usd": 51.709728300000016,
          "by_model": {
            "claude-opus-4-7": {
              "input": 338,
              "output": 132078,
              "cache_create": 2594612,
              "cache_read": 100142947
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 224,
          "tool_call_count": 128,
          "context_at_last_turn_tokens": 585561,
          "context_window_pct": 292.7805
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-11T07:50:04-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 2,
          "session_input_tokens": 341,
          "session_output_tokens": 132549,
          "session_cache_creation_tokens": 2595224,
          "session_cache_read_tokens": 101899830,
          "session_cost_usd": 52.305381050000015,
          "by_model": {
            "claude-opus-4-7": {
              "input": 341,
              "output": 132549,
              "cache_create": 2595224,
              "cache_read": 101899830
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 227,
          "tool_call_count": 130,
          "context_at_last_turn_tokens": 585970,
          "context_window_pct": 292.985
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-11T07:50:09-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 2,
          "session_input_tokens": 343,
          "session_output_tokens": 132887,
          "session_cache_creation_tokens": 2595550,
          "session_cache_read_tokens": 103071768,
          "session_cost_usd": 52.60361430000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 343,
              "output": 132887,
              "cache_create": 2595550,
              "cache_read": 103071768
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 229,
          "tool_call_count": 131,
          "context_at_last_turn_tokens": 586133,
          "context_window_pct": 293.0665
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-11T07:50:15-07:00",
          "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 2,
          "session_input_tokens": 344,
          "session_output_tokens": 133015,
          "session_cache_creation_tokens": 2595759,
          "session_cache_read_tokens": 103657900,
          "session_cost_usd": 52.90119155000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 344,
              "output": 133015,
              "cache_create": 2595759,
              "cache_read": 103657900
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 230,
          "tool_call_count": 132,
          "context_at_last_turn_tokens": 586342,
          "context_window_pct": 293.171
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T07:50:23-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 2,
        "session_input_tokens": 346,
        "session_output_tokens": 134007,
        "session_cache_creation_tokens": 2596095,
        "session_cache_read_tokens": 104830582,
        "session_cost_usd": 53.207817050000024,
        "by_model": {
          "claude-opus-4-7": {
            "input": 346,
            "output": 134007,
            "cache_create": 2596095,
            "cache_read": 104830582
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 232,
        "tool_call_count": 133,
        "context_at_last_turn_tokens": 586510,
        "context_window_pct": 293.255
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-11T07:50:45-07:00",
      "completed_at": "2026-05-11T07:51:07-07:00",
      "session_started_at": null,
      "cumulative_seconds": 22,
      "visit_count": 1,
      "window_at_complete": {
        "captured_at": "2026-05-11T07:51:07-07:00",
        "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 3,
        "session_input_tokens": 363,
        "session_output_tokens": 135953,
        "session_cache_creation_tokens": 2624073,
        "session_cache_read_tokens": 110178147,
        "session_cost_usd": 54.81013405000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 363,
            "output": 135953,
            "cache_create": 2624073,
            "cache_read": 110178147
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 241,
        "tool_call_count": 138,
        "context_at_last_turn_tokens": 600574,
        "context_window_pct": 300.287
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-11T07:06:10-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-11T07:23:21-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-11T07:48:41-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-11T07:50:45-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-11T07:05:15-07:00",
    "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
    "model": "claude-opus-4-7",
    "five_hour_pct": 17,
    "seven_day_pct": 98,
    "session_input_tokens": 19,
    "session_output_tokens": 3256,
    "session_cache_creation_tokens": 582731,
    "session_cache_read_tokens": 257459,
    "session_cost_usd": 1.36099975,
    "by_model": {
      "claude-opus-4-7": {
        "input": 19,
        "output": 3256,
        "cache_create": 582731,
        "cache_read": 257459
      }
    },
    "turn_count": 4,
    "tool_call_count": 2,
    "context_at_last_turn_tokens": 210878,
    "context_window_pct": 105.439
  },
  "code_tasks_total": 7,
  "code_task_name": "Test — summary renders dash for frozen cost pattern end-to-end",
  "code_task": 7,
  "diff_stats": {
    "files_changed": 3,
    "insertions": 197,
    "deletions": 2,
    "captured_at": "2026-05-11T07:23:10-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThe user made a single explicit request at the beginning: \"You are a new team member reading this PR for the first time. The substantive diff (whitespace-only changes filtered) is below, along with a NARROWED LIST of doc paths likely affected by this PR (under the DOC_PATHS header). Read each listed doc path and check it against the diff for drift. Do NOT walk the full worktree docs/ tree — the listed paths are exhaustive for documentation drift in this PR. Investigate the codebase for comprehension barriers as usual.\"\n\nThe user provided:\n- A specific diff showing changes to `src/window_deltas.rs` (lines 262-293)\n- A CLAUDE.md file path to review: `/Users/ben/code/flow/.worktrees/pair-delta-emits-0000/CLAUDE.md`\n- Specific instructions to check the diff against CLAUDE.md for drift\n- Instructions to verify that the inline doc comment on the match arm is forward-facing per `.claude/rules/forward-facing-authoring.md`\n- Instructions to check maintainability of the comment and test fixtures for a cold-start reader\n\nThe user then added at the very end: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.\" This is a constraint on how I should respond to this current message.\n\nMy approach was to read the three referenced files:\n1. The CLAUDE.md file at the specified path\n2. The source code around line 262 in window_deltas.rs (read lines 260-310 to get context)\n3. The test file tests/window_deltas.rs to understand test coverage\n\nI successfully retrieved and analyzed:\n- CLAUDE.md (277 lines total) - a comprehensive documentation of the FLOW project structure\n- window_deltas.rs source code showing the modified match statement for cost_delta_usd\n- tests/window_deltas.rs (746 lines total) showing comprehensive test coverage including 5 named tests specifically covering the new freshness check logic\n\nKey findings from my analysis:\n1. The diff modifies the `pair_delta` function to add a freshness check that guards against the \"frozen-statusline pattern\"\n2. The new code checks whether `turn_count` advanced between endpoints to distinguish between frozen (stale) cost values and real zero cost from cached responses\n3. The inline comment (lines 267-278) explains this logic in detail\n4. CLAUDE.md does not reference `pair_delta` by name, but does discuss window snapshots, state fields, and session cost in the \"Account-window snapshots\" section (lines 195-196)\n5. Five named tests were added: `pair_delta_emits_none_cost_when_both_cost_and_turn_count_equal`, `pair_delta_emits_some_cost_when_turn_count_advanced`, `pair_delta_emits_some_cost_when_costs_differ`, `pair_delta_emits_none_cost_when_turn_count_missing_on_start`, `pair_delta_emits_none_cost_when_turn_count_missing_on_end`\n\nI did not encounter any errors during the analysis. The documentation does not appear to be stale relative to the diff - the change is a subtle behavioral refinement to cost reporting logic, and CLAUDE.md's treatment of snapshots remains accurate.\n\nThe user has now asked me to summarize the conversation in text-only format without using any tools.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user requested a PR review focused on documentation drift detection. Specifically:\n   - Read the substantive diff from `src/window_deltas.rs` (lines 262-293) showing changes to the `pair_delta` function's cost delta calculation\n   - Check the CLAUDE.md file at `/Users/ben/code/flow/.worktrees/pair-delta-emits-0000/CLAUDE.md` for any drift introduced by this diff\n   - Verify that the inline doc comment on the match arm is forward-facing per `.claude/rules/forward-facing-authoring.md`\n   - Assess maintainability of the comment and test fixtures for a new reader\n   - Do NOT walk the full docs/ tree (only review the specified narrowed doc path)\n   - Investigate the codebase for comprehension barriers\n\n2. Key Technical Concepts:\n   - The \"frozen-statusline pattern\" in Claude Code where the cost tracking file is stale during autonomous Skill→Skill chains\n   - Delta reporting logic for cost calculations between window snapshots\n   - Distinction between missing endpoints (None values) vs. equal endpoints (no advancement)\n   - The role of `turn_count` as a freshness signal to detect whether new assistant turns crossed the snapshot boundary\n   - Fail-safe/conservative behavior: emitting None when cost data is uncertain\n   - Window snapshot architecture as the underlying data structure for state tracking\n\n3. Files and Code Sections:\n   - `/Users/ben/code/flow/.worktrees/pair-delta-emits-0000/CLAUDE.md` (277 lines)\n     - Comprehensive documentation of FLOW project structure, architecture, and conventions\n     - Contains \"Account-window snapshots\" section (lines 195-196) that describes snapshot capture and usage\n     - This section accurately describes the snapshot mechanism and remains current with the diff\n   \n   - `/Users/ben/code/flow/.worktrees/pair-delta-emits-0000/src/window_deltas.rs` (lines 260-293)\n     - The modified `pair_delta` function showing the new cost_delta_usd logic\n     - Old code (lines 265-266): Simple (Some(s), Some(e)) => Some(e - s) pattern\n     - New code (lines 279-293): Extended match tuple with (start.session_cost_usd, end.session_cost_usd, start.turn_count, end.turn_count)\n     - Freshness check (lines 286-287): if (e - s).abs() < f64::EPSILON && ts == te { None } else { Some(e - s) }\n     - Inline comment (lines 267-278) explaining the frozen-statusline pattern and how turn_count advancement disambiguates\n   \n   - `/Users/ben/code/flow/.worktrees/pair-delta-emits-0000/tests/window_deltas.rs` (746 lines)\n     - Comprehensive test coverage including five named tests specifically for the new freshness check (lines 466-570)\n     - Test names: `pair_delta_emits_none_cost_when_both_cost_and_turn_count_equal`, `pair_delta_emits_some_cost_when_turn_count_advanced`, `pair_delta_emits_some_cost_when_costs_differ`, `pair_delta_emits_none_cost_when_turn_count_missing_on_start`, `pair_delta_emits_none_cost_when_turn_count_missing_on_end`\n     - Tests also cover the cross-session cost aggregation scenario (lines 393-402)\n     - Test fixtures clearly document the frozen-statusline pattern as a regression being guarded against\n\n4. Errors and fixes:\n   - No errors were encountered during the review process\n   - All file reads succeeded and provided complete context\n\n5. Problem Solving:\n   The core problem being solved by this diff is distinguishing between two scenarios when cost values are equal between snapshots:\n   1. Frozen statusline: Both endpoints sampled from a stale file (no new turn ran) → emit None so renderer shows \"—\"\n   2. Real zero: A new turn ran but cached responses cost nothing (turn_count advanced) → emit Some(0.0)\n   \n   The solution adds turn_count as a freshness signal. When costs are equal AND turn_count is also equal, the statusline file is provably frozen (no new assistant turn). When costs are equal BUT turn_count advanced, at least one new turn ran, making the zero cost real.\n   \n   Conservative fallback: When turn_count is missing on either endpoint, emit None rather than risk a misleading fabricated delta.\n\n6. All user messages:\n   - \"You are a new team member reading this PR for the first time. The substantive diff (whitespace-only changes filtered) is below, along with a NARROWED LIST of doc paths likely affected by this PR (under the DOC_PATHS header). Read each listed doc path and check it against the diff for drift. Do NOT walk the full worktree docs/ tree — the listed paths are exhaustive for documentation drift in this PR. Investigate the codebase for comprehension barriers as usual.\"\n   - The user provided the diff showing the window_deltas.rs changes\n   - \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.\"\n\n7. Pending Tasks:\n   - The user has not explicitly requested any pending tasks to be completed\n   - The user has requested a summary of the conversation in text-only format (current task)\n\n8. Current Work:\n   The user has requested I provide a text-only summary of the entire conversation without using any tools. They are asking me to document what analysis was performed on the PR diff and the CLAUDE.md file for drift detection.\n\n9. Optional Next Step:\n   No next step is needed. The user's explicit request was to review the PR for documentation drift and provide a summary in text-only format. That task is now being completed with this summary. No further action is requested beyond this summary completion.\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/pair-delta-emits-0000",
  "compact_count": 4,
  "findings": [
    {
      "finding": "pair_delta returns None when costs differ but turn_count is missing on either endpoint, silently dropping a knowable cost delta",
      "reason": "Plan Risk 3 and Acceptance Criteria explicitly chose None whenever turn_count is missing on either side as the conservative fallback. The plan rationale: when the freshness signal is unavailable, any cost reading may be unreliable regardless of whether values differ. Tests 4 and 5 cover the equal-cost subcase; the differing-cost subcase falls under the same plan-chosen invariant. Behavior matches the plan documented design — not a bug.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T07:43:39-07:00"
    },
    {
      "finding": "Equal cost with advanced turn_count emits Some(0.0), misrepresenting a lagging cost file as a real-zero phase",
      "reason": "Plan Risk 2 explicitly chose Some(0.0) for the equal-cost plus advanced-turn case as the real-zero interpretation (heavy prompt-cache hits). Tested in Task 2. The plan considered and rejected mtime-based freshness for cross-filesystem reliability; turn_count is the chosen signal. The agent alternative interpretation requires a different design which is out of scope for this PR.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T07:43:46-07:00"
    },
    {
      "finding": "NaN on end endpoint produces Some(NaN) cost delta",
      "reason": "session_cost_usd is parsed via serde_json which rejects NaN and Infinity in standard JSON. The field reads directly from an external cumulative cost file containing decimal numbers; no production path can place NaN into the field. Per tests-guard-real-regressions: tests must guard a real regression path with a named consumer.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T07:43:54-07:00"
    },
    {
      "finding": "NaN on start endpoint produces Some(NaN) cost delta",
      "reason": "Symmetric case to NaN-on-end. Same dismissal rationale: serde_json rejects NaN in JSON, and the cumulative cost file producer writes decimal numbers only. NaN cannot enter session_cost_usd through any reachable production path.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T07:44:00-07:00"
    },
    {
      "finding": "Positive infinity on end endpoint produces Some(Infinity) cost delta",
      "reason": "Infinity cannot enter session_cost_usd through JSON parsing — serde_json rejects Infinity in standard JSON. The cost file is written by an external shell statusline producer that emits decimal numbers from a cumulative accumulator; no production path emits Infinity into the source.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T07:44:07-07:00"
    },
    {
      "finding": "Both endpoints Infinity plus equal turn_count emits Some(NaN) instead of detecting frozen pattern",
      "reason": "Same unreachable-input dismissal: Infinity cannot enter session_cost_usd via JSON parsing. The frozen-pattern detection invariant only needs to hold for input values that can actually reach the function.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T07:44:15-07:00"
    },
    {
      "finding": "Negative cost delta (end less than start) emitted as Some(negative)",
      "reason": "Within-session same-file cost is monotonic by design. deltas_from_snapshots groups snapshots by session_id before invoking pair_delta, so both endpoints read from the same cost file produced by statusline-command.sh, which only writes increasing values. Cross-session deltas (where the cost file path differs) are not computed by pair_delta. Negative within-session deltas are not reachable from any production state — the fixture violates the same-session monotonic invariant.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T07:44:21-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-11T07:51:07-07:00",
    "session_id": "d5dd6436-8be3-44fb-a53e-678d717eccab",
    "model": "claude-opus-4-7",
    "five_hour_pct": 9,
    "seven_day_pct": 3,
    "session_input_tokens": 363,
    "session_output_tokens": 135953,
    "session_cache_creation_tokens": 2624073,
    "session_cache_read_tokens": 110178147,
    "session_cost_usd": 54.81013405000002,
    "by_model": {
      "claude-opus-4-7": {
        "input": 363,
        "output": 135953,
        "cache_create": 2624073,
        "cache_read": 110178147
      },
      "<synthetic>": {
        "input": 0,
        "output": 0,
        "cache_create": 0,
        "cache_read": 0
      }
    },
    "turn_count": 241,
    "tool_call_count": 138,
    "context_at_last_turn_tokens": 600574,
    "context_window_pct": 300.287
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>