### PR TITLE
Have The Ask User Hook

### DIFF
--- a/src/hooks/validate_ask_user.rs
+++ b/src/hooks/validate_ask_user.rs
@@ -192,8 +192,13 @@ pub fn user_only_skill_carve_out_applies(transcript_path: Option<&Path>, home: &
 /// side effect in `run()`.
 #[derive(Debug)]
 enum HookAction {
-    /// Exit 0, no side effects. Used when the hook cannot resolve a
-    /// state file (no stdin input, no branch, slash branch).
+    /// Exit 0, emits `{"permissionDecision":"defer"}` on stdout, no
+    /// state-file side effects. Used when the hook cannot resolve a
+    /// state file (no stdin input, no branch, slash branch). The
+    /// explicit defer signal tells Claude Code the hook has no
+    /// opinion on this tool call, routing it through normal
+    /// permission handling without relying on empty-stdout implicit
+    /// semantics.
     Allow,
     /// Exit 2, stderr message. Autonomous-phase block.
     Block(String),
@@ -293,7 +298,10 @@ pub fn run() {
     let root = project_root();
     let home = home_dir_or_empty();
     match run_impl_main(hook_input, branch, &root, &home) {
-        HookAction::Allow => std::process::exit(0),
+        HookAction::Allow => {
+            println!("{}", json!({"permissionDecision": "defer"}));
+            std::process::exit(0);
+        }
         HookAction::Block(msg) => {
             eprintln!("{}", msg);
             std::process::exit(2);

--- a/src/hooks/validate_ask_user.rs
+++ b/src/hooks/validate_ask_user.rs
@@ -35,8 +35,14 @@
 //!    is set and the block did not fire. Answers the AskUserQuestion
 //!    with the successor skill command so phase transitions advance
 //!    even if the skill's HARD-GATE was ignored.
-//! 5. **Allow** (exit 0, no stdout) — otherwise. The tool call passes
-//!    through to Claude Code's normal permission system.
+//! 5. **Allow** (exit 0, stdout: `{"permissionDecision":"defer"}`) —
+//!    otherwise. The explicit defer signal tells Claude Code the hook
+//!    has no opinion on this tool call, routing it through normal
+//!    permission handling without relying on empty-stdout implicit
+//!    semantics. Both the no-state-file `Allow` arm and the
+//!    state-file-found `AllowWithMark` arm emit the same defer
+//!    payload; the `AllowWithMark` arm additionally writes the
+//!    `_blocked` timestamp to the state file before exiting.
 
 use std::path::{Path, PathBuf};
 
@@ -204,7 +210,14 @@ enum HookAction {
     Block(String),
     /// Exit 0, stdout JSON answer. `_auto_continue` auto-answer.
     AutoAnswer(Value),
-    /// Exit 0, call `set_blocked` on the given state path.
+    /// Exit 0, emits `{"permissionDecision":"defer"}` on stdout, and
+    /// calls `set_blocked` on the given state path so the state file
+    /// records that an AskUserQuestion was delivered. Used when the
+    /// hook resolved a state file and `validate` returned allow with
+    /// no auto-continue (or when a carve-out suppressed an autonomous-
+    /// phase block). The defer payload matches the `Allow` arm so
+    /// every "no opinion" outcome surfaces the same explicit signal
+    /// to Claude Code.
     AllowWithMark(std::path::PathBuf),
 }
 
@@ -312,6 +325,7 @@ pub fn run() {
         }
         HookAction::AllowWithMark(state_path) => {
             set_blocked(&state_path);
+            println!("{}", json!({"permissionDecision": "defer"}));
             std::process::exit(0);
         }
     }

--- a/tests/hooks/validate_ask_user.rs
+++ b/tests/hooks/validate_ask_user.rs
@@ -459,34 +459,48 @@ fn run_hook(cwd: &Path, stdin_input: &str) -> (i32, String, String) {
     )
 }
 
-/// `run()` exits 0 when the cwd isn't a git repo (current_branch None)
-/// or the state file doesn't exist. Exercises the real-subprocess
-/// wrapper.
+/// `run()` exits 0 and emits an explicit defer permission decision
+/// on stdout when the cwd isn't a git repo (current_branch None) or
+/// the state file doesn't exist. Exercises the real-subprocess
+/// wrapper plus the `HookAction::Allow` defer-emission contract.
 #[test]
 fn run_subprocess_exits_0_outside_git_repo() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path().canonicalize().unwrap();
-    let (code, _stdout, _stderr) = run_hook(&root, "{}");
+    let (code, stdout, _stderr) = run_hook(&root, "{}");
     assert_eq!(code, 0);
+    assert!(
+        stdout.contains("\"permissionDecision\":\"defer\""),
+        "expected explicit defer signal on stdout, got: {}",
+        stdout
+    );
 }
 
-/// `run()` exits 0 when stdin is not valid JSON. Exercises
-/// `run_impl_main`'s `hook_input is None` early-return at line 220
-/// of src/hooks/validate_ask_user.rs — `read_hook_input()` returns
-/// None on parse failure.
+/// `run()` exits 0 and emits an explicit defer permission decision
+/// when stdin is not valid JSON. Exercises `run_impl_main`'s
+/// `hook_input is None` early-return — `read_hook_input()` returns
+/// None on parse failure, which routes through `HookAction::Allow`
+/// and the defer-emission contract.
 #[test]
 fn run_subprocess_exits_0_when_stdin_unparseable() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path().canonicalize().unwrap();
-    let (code, _stdout, _stderr) = run_hook(&root, "not valid json");
+    let (code, stdout, _stderr) = run_hook(&root, "not valid json");
     assert_eq!(code, 0);
+    assert!(
+        stdout.contains("\"permissionDecision\":\"defer\""),
+        "expected explicit defer signal on stdout, got: {}",
+        stdout
+    );
 }
 
-/// `run()` exits 0 when the current git branch contains a `/` (e.g.
-/// `feature/foo`). Exercises `run_impl_main`'s `FlowPaths::try_new
-/// returns None` early-return at line 232 — slash-containing branches
-/// are valid git branches but invalid for FLOW's flat state-file
-/// layout, so the hook treats them as "no active flow".
+/// `run()` exits 0 and emits an explicit defer permission decision
+/// when the current git branch contains a `/` (e.g. `feature/foo`).
+/// Exercises `run_impl_main`'s `FlowPaths::try_new returns None`
+/// early-return — slash-containing branches are valid git branches
+/// but invalid for FLOW's flat state-file layout, so the hook
+/// treats them as "no active flow" and routes through
+/// `HookAction::Allow` with the defer-emission contract.
 #[test]
 fn run_subprocess_exits_0_when_branch_has_slash() {
     let dir = tempfile::tempdir().unwrap();
@@ -516,8 +530,13 @@ fn run_subprocess_exits_0_when_branch_has_slash() {
         .current_dir(&root)
         .output()
         .unwrap();
-    let (code, _stdout, _stderr) = run_hook(&root, "{}");
+    let (code, stdout, _stderr) = run_hook(&root, "{}");
     assert_eq!(code, 0);
+    assert!(
+        stdout.contains("\"permissionDecision\":\"defer\""),
+        "expected explicit defer signal on stdout, got: {}",
+        stdout
+    );
 }
 
 // Direct `run_impl_main` / `HookAction` tests removed — the decision

--- a/tests/hooks/validate_ask_user.rs
+++ b/tests/hooks/validate_ask_user.rs
@@ -665,8 +665,13 @@ fn run_subprocess_sets_blocked_on_allow_path() {
     let state = json!({"current_phase": "flow-code", "branch": "test"});
     let state_path = write_state(&root, "test", &state);
 
-    let (code, _stdout, _stderr) = run_hook(&root, "{}");
+    let (code, stdout, _stderr) = run_hook(&root, "{}");
     assert_eq!(code, 0);
+    assert!(
+        stdout.contains("\"permissionDecision\":\"defer\""),
+        "expected explicit defer signal on stdout from AllowWithMark path, got: {}",
+        stdout
+    );
     let updated: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
     assert!(updated.get("_blocked").is_some(), "state: {:?}", updated);
 }


### PR DESCRIPTION
## What

#1464.

Closes #1464

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/have-the-ask-user-hook/log` |
| State | `.flow-states/have-the-ask-user-hook/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 9m |
| Review | 15m |
| Learn | 3m |
| Complete | <1m |
| **Total** | **29m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/have-the-ask-user-hook.json</summary>

```json
{
  "schema_version": 1,
  "branch": "have-the-ask-user-hook",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1465,
  "pr_url": "https://github.com/benkruger/flow/pull/1465",
  "started_at": "2026-05-11T11:56:57-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/have-the-ask-user-hook/log",
    "state": ".flow-states/have-the-ask-user-hook/state.json"
  },
  "session_tty": "/dev/ttys006",
  "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
  "transcript_path": null,
  "notes": [],
  "prompt": "#1464",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-11T11:56:57-07:00",
      "completed_at": "2026-05-11T11:57:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 46,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T11:56:57-07:00",
        "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
        "five_hour_pct": 59,
        "seven_day_pct": 16,
        "session_cost_usd": 5.276417949999998
      },
      "window_at_complete": {
        "captured_at": "2026-05-11T11:57:43-07:00",
        "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
        "model": "claude-opus-4-7",
        "five_hour_pct": 60,
        "seven_day_pct": 16,
        "session_input_tokens": 21,
        "session_output_tokens": 1477,
        "session_cache_creation_tokens": 578903,
        "session_cache_read_tokens": 673757,
        "session_cost_usd": 6.719482199999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 21,
            "output": 1477,
            "cache_create": 578903,
            "cache_read": 673757
          }
        },
        "turn_count": 6,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 209102,
        "context_window_pct": 104.551
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-11T11:57:54-07:00",
      "completed_at": "2026-05-11T12:07:04-07:00",
      "session_started_at": null,
      "cumulative_seconds": 550,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T11:57:54-07:00",
        "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
        "model": "claude-opus-4-7",
        "five_hour_pct": 60,
        "seven_day_pct": 16,
        "session_input_tokens": 21,
        "session_output_tokens": 1477,
        "session_cache_creation_tokens": 578903,
        "session_cache_read_tokens": 673757,
        "session_cost_usd": 6.719482199999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 21,
            "output": 1477,
            "cache_create": 578903,
            "cache_read": 673757
          }
        },
        "turn_count": 6,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 209102,
        "context_window_pct": 104.551
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-11T12:01:11-07:00",
          "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
          "model": "claude-opus-4-7",
          "five_hour_pct": 61,
          "seven_day_pct": 16,
          "session_input_tokens": 21,
          "session_output_tokens": 1477,
          "session_cache_creation_tokens": 578903,
          "session_cache_read_tokens": 673757,
          "session_cost_usd": 6.719482199999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 21,
              "output": 1477,
              "cache_create": 578903,
              "cache_read": 673757
            }
          },
          "turn_count": 6,
          "tool_call_count": 3,
          "context_at_last_turn_tokens": 209102,
          "context_window_pct": 104.551
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-11T12:05:39-07:00",
          "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
          "model": "claude-opus-4-7",
          "five_hour_pct": 62,
          "seven_day_pct": 16,
          "session_input_tokens": 72,
          "session_output_tokens": 26612,
          "session_cache_creation_tokens": 634995,
          "session_cache_read_tokens": 4155547,
          "session_cost_usd": 9.645365749999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 72,
              "output": 26612,
              "cache_create": 634995,
              "cache_read": 4155547
            }
          },
          "turn_count": 22,
          "tool_call_count": 10,
          "context_at_last_turn_tokens": 235113,
          "context_window_pct": 117.5565
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T12:07:04-07:00",
        "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
        "model": "claude-opus-4-7",
        "five_hour_pct": 64,
        "seven_day_pct": 17,
        "session_input_tokens": 72,
        "session_output_tokens": 26612,
        "session_cache_creation_tokens": 634995,
        "session_cache_read_tokens": 4155547,
        "session_cost_usd": 9.645365749999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 72,
            "output": 26612,
            "cache_create": 634995,
            "cache_read": 4155547
          }
        },
        "turn_count": 22,
        "tool_call_count": 10,
        "context_at_last_turn_tokens": 235113,
        "context_window_pct": 117.5565
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-11T12:07:15-07:00",
      "completed_at": "2026-05-11T12:23:02-07:00",
      "session_started_at": null,
      "cumulative_seconds": 947,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T12:07:15-07:00",
        "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
        "model": "claude-opus-4-7",
        "five_hour_pct": 62,
        "seven_day_pct": 16,
        "session_input_tokens": 72,
        "session_output_tokens": 26612,
        "session_cache_creation_tokens": 634995,
        "session_cache_read_tokens": 4155547,
        "session_cost_usd": 9.645365749999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 72,
            "output": 26612,
            "cache_create": 634995,
            "cache_read": 4155547
          }
        },
        "turn_count": 22,
        "tool_call_count": 10,
        "context_at_last_turn_tokens": 235113,
        "context_window_pct": 117.5565
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-11T12:09:42-07:00",
          "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
          "model": "claude-opus-4-7",
          "five_hour_pct": 67,
          "seven_day_pct": 18,
          "session_input_tokens": 59806,
          "session_output_tokens": 57763,
          "session_cache_creation_tokens": 762808,
          "session_cache_read_tokens": 8216121,
          "session_cost_usd": 10.518740749999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 59806,
              "output": 57763,
              "cache_create": 762808,
              "cache_read": 8216121
            }
          },
          "turn_count": 39,
          "tool_call_count": 20,
          "context_at_last_turn_tokens": 275752,
          "context_window_pct": 137.876
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-11T12:15:40-07:00",
          "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
          "model": "claude-opus-4-7",
          "five_hour_pct": 74,
          "seven_day_pct": 20,
          "session_input_tokens": 63471,
          "session_output_tokens": 143426,
          "session_cache_creation_tokens": 911436,
          "session_cache_read_tokens": 11634366,
          "session_cost_usd": 12.188290499999995,
          "by_model": {
            "claude-opus-4-7": {
              "input": 63471,
              "output": 143426,
              "cache_create": 911436,
              "cache_read": 11634366
            }
          },
          "turn_count": 51,
          "tool_call_count": 24,
          "context_at_last_turn_tokens": 309589,
          "context_window_pct": 154.7945
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-11T12:16:37-07:00",
          "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
          "model": "claude-opus-4-7",
          "five_hour_pct": 76,
          "seven_day_pct": 20,
          "session_input_tokens": 63471,
          "session_output_tokens": 143426,
          "session_cache_creation_tokens": 911436,
          "session_cache_read_tokens": 11634366,
          "session_cost_usd": 12.188290499999995,
          "by_model": {
            "claude-opus-4-7": {
              "input": 63471,
              "output": 143426,
              "cache_create": 911436,
              "cache_read": 11634366
            }
          },
          "turn_count": 51,
          "tool_call_count": 24,
          "context_at_last_turn_tokens": 309589,
          "context_window_pct": 154.7945
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-11T12:22:50-07:00",
          "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
          "model": "claude-opus-4-7",
          "five_hour_pct": 79,
          "seven_day_pct": 21,
          "session_input_tokens": 63492,
          "session_output_tokens": 173176,
          "session_cache_creation_tokens": 972500,
          "session_cache_read_tokens": 15241784,
          "session_cost_usd": 13.779730999999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 63492,
              "output": 173176,
              "cache_create": 972500,
              "cache_read": 15241784
            }
          },
          "turn_count": 62,
          "tool_call_count": 30,
          "context_at_last_turn_tokens": 336972,
          "context_window_pct": 168.486
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T12:23:02-07:00",
        "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
        "model": "claude-opus-4-7",
        "five_hour_pct": 79,
        "seven_day_pct": 21,
        "session_input_tokens": 63492,
        "session_output_tokens": 173176,
        "session_cache_creation_tokens": 972500,
        "session_cache_read_tokens": 15241784,
        "session_cost_usd": 13.779730999999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 63492,
            "output": 173176,
            "cache_create": 972500,
            "cache_read": 15241784
          }
        },
        "turn_count": 62,
        "tool_call_count": 30,
        "context_at_last_turn_tokens": 336972,
        "context_window_pct": 168.486
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-11T12:23:13-07:00",
      "completed_at": "2026-05-11T12:26:21-07:00",
      "session_started_at": null,
      "cumulative_seconds": 188,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T12:23:13-07:00",
        "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
        "model": "claude-opus-4-7",
        "five_hour_pct": 79,
        "seven_day_pct": 21,
        "session_input_tokens": 63492,
        "session_output_tokens": 173176,
        "session_cache_creation_tokens": 972500,
        "session_cache_read_tokens": 15241784,
        "session_cost_usd": 13.779730999999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 63492,
            "output": 173176,
            "cache_create": 972500,
            "cache_read": 15241784
          }
        },
        "turn_count": 62,
        "tool_call_count": 30,
        "context_at_last_turn_tokens": 336972,
        "context_window_pct": 168.486
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-11T12:25:35-07:00",
          "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
          "model": "claude-opus-4-7",
          "five_hour_pct": 80,
          "seven_day_pct": 21,
          "session_input_tokens": 63492,
          "session_output_tokens": 173176,
          "session_cache_creation_tokens": 972500,
          "session_cache_read_tokens": 15241784,
          "session_cost_usd": 13.779730999999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 63492,
              "output": 173176,
              "cache_create": 972500,
              "cache_read": 15241784
            }
          },
          "turn_count": 62,
          "tool_call_count": 30,
          "context_at_last_turn_tokens": 336972,
          "context_window_pct": 168.486
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-11T12:25:42-07:00",
          "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
          "model": "claude-opus-4-7",
          "five_hour_pct": 80,
          "seven_day_pct": 21,
          "session_input_tokens": 63492,
          "session_output_tokens": 173176,
          "session_cache_creation_tokens": 972500,
          "session_cache_read_tokens": 15241784,
          "session_cost_usd": 13.779730999999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 63492,
              "output": 173176,
              "cache_create": 972500,
              "cache_read": 15241784
            }
          },
          "turn_count": 62,
          "tool_call_count": 30,
          "context_at_last_turn_tokens": 336972,
          "context_window_pct": 168.486
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-11T12:25:57-07:00",
          "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
          "model": "claude-opus-4-7",
          "five_hour_pct": 80,
          "seven_day_pct": 21,
          "session_input_tokens": 63492,
          "session_output_tokens": 173176,
          "session_cache_creation_tokens": 972500,
          "session_cache_read_tokens": 15241784,
          "session_cost_usd": 13.779730999999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 63492,
              "output": 173176,
              "cache_create": 972500,
              "cache_read": 15241784
            }
          },
          "turn_count": 62,
          "tool_call_count": 30,
          "context_at_last_turn_tokens": 336972,
          "context_window_pct": 168.486
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-11T12:26:02-07:00",
          "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
          "model": "claude-opus-4-7",
          "five_hour_pct": 80,
          "seven_day_pct": 21,
          "session_input_tokens": 63492,
          "session_output_tokens": 173176,
          "session_cache_creation_tokens": 972500,
          "session_cache_read_tokens": 15241784,
          "session_cost_usd": 13.779730999999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 63492,
              "output": 173176,
              "cache_create": 972500,
              "cache_read": 15241784
            }
          },
          "turn_count": 62,
          "tool_call_count": 30,
          "context_at_last_turn_tokens": 336972,
          "context_window_pct": 168.486
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-11T12:26:09-07:00",
          "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
          "model": "claude-opus-4-7",
          "five_hour_pct": 81,
          "seven_day_pct": 21,
          "session_input_tokens": 63492,
          "session_output_tokens": 173176,
          "session_cache_creation_tokens": 972500,
          "session_cache_read_tokens": 15241784,
          "session_cost_usd": 13.779730999999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 63492,
              "output": 173176,
              "cache_create": 972500,
              "cache_read": 15241784
            }
          },
          "turn_count": 62,
          "tool_call_count": 30,
          "context_at_last_turn_tokens": 336972,
          "context_window_pct": 168.486
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T12:26:21-07:00",
        "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
        "model": "claude-opus-4-7",
        "five_hour_pct": 81,
        "seven_day_pct": 21,
        "session_input_tokens": 63492,
        "session_output_tokens": 173176,
        "session_cache_creation_tokens": 972500,
        "session_cache_read_tokens": 15241784,
        "session_cost_usd": 13.779730999999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 63492,
            "output": 173176,
            "cache_create": 972500,
            "cache_read": 15241784
          }
        },
        "turn_count": 62,
        "tool_call_count": 30,
        "context_at_last_turn_tokens": 336972,
        "context_window_pct": 168.486
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-11T12:26:45-07:00",
      "completed_at": "2026-05-11T12:27:08-07:00",
      "session_started_at": null,
      "cumulative_seconds": 23,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T12:26:45-07:00",
        "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
        "model": "claude-opus-4-7",
        "five_hour_pct": 81,
        "seven_day_pct": 21,
        "session_input_tokens": 63492,
        "session_output_tokens": 173176,
        "session_cache_creation_tokens": 972500,
        "session_cache_read_tokens": 15241784,
        "session_cost_usd": 13.779730999999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 63492,
            "output": 173176,
            "cache_create": 972500,
            "cache_read": 15241784
          }
        },
        "turn_count": 62,
        "tool_call_count": 30,
        "context_at_last_turn_tokens": 336972,
        "context_window_pct": 168.486
      },
      "window_at_complete": {
        "captured_at": "2026-05-11T12:27:08-07:00",
        "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
        "model": "claude-opus-4-7",
        "five_hour_pct": 81,
        "seven_day_pct": 21,
        "session_input_tokens": 63492,
        "session_output_tokens": 173176,
        "session_cache_creation_tokens": 972500,
        "session_cache_read_tokens": 15241784,
        "session_cost_usd": 13.779730999999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 63492,
            "output": 173176,
            "cache_create": 972500,
            "cache_read": 15241784
          }
        },
        "turn_count": 62,
        "tool_call_count": 30,
        "context_at_last_turn_tokens": 336972,
        "context_window_pct": 168.486
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-11T11:57:54-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-11T12:07:15-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-11T12:23:13-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-11T12:26:45-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-plan": {
      "continue": "auto",
      "dag": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-11T11:56:57-07:00",
    "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
    "five_hour_pct": 59,
    "seven_day_pct": 16,
    "session_cost_usd": 5.276417949999998
  },
  "code_tasks_total": 2,
  "code_task_name": "Make Allow path emit explicit defer JSON; update doc comment",
  "code_task": 2,
  "diff_stats": {
    "files_changed": 2,
    "insertions": 45,
    "deletions": 18,
    "captured_at": "2026-05-11T12:07:04-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThe user's primary request is to create a summary of this conversation so far. They have provided explicit instructions that I must NOT use any tools - all tool calls will be rejected. They want the response in plain text with two sections: <analysis> and <summary>.\n\nLooking at the conversation history, there's a single long user message that comprises the entire conversation. This message is a detailed frame-setting for a PR analysis task. The user describes:\n\n1. A PR branch called \"have-the-ask-user-hook\" that modifies the FLOW plugin's validate-ask-user PreToolUse hook\n2. The goal is to have the hook explicitly emit `{\"permissionDecision\":\"defer\"}` instead of relying on implicit \"exit 0 with no stdout\" semantics\n3. The issue being addressed is #1464\n4. Two commits land in this PR (01a920c2 and 10bfe044)\n5. The diff affects two files: src/hooks/validate_ask_user.rs and tests/hooks/validate_ask_user.rs\n\nThe user then explicitly states: \"FRAMING: Most Learn phases produce zero findings. Your job is to filter, not to find things to say. Apply the two-gate test to every candidate finding before reporting it\"\n\nThe two-gate test is:\n1. Forward-facing — would a future session understand and apply the principle?\n2. Value — was the gap caught and remediated in this PR? If yes, drop.\n\nThe user then provides extensive context including:\n- Detailed diff statistics\n- Summary of behavioral changes\n- State file data about the flow execution\n- Specific compliance and process angles to consider (5 specific questions)\n- References to the plan file and project CLAUDE.md\n- Complete rule files from the project (approximately 50+ .claude/rules files)\n\nThen the user provides a CRITICAL instruction: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.\"\n\nThis is the actual request - they want a summary of this conversation in the specified format, without tool calls.\n\nThe conversation is somewhat unusual because it's primarily a one-way information dump from the user establishing context for what appears to be a PR review/analysis task. There are no previous assistant responses to summarize, no code edits made, no errors encountered (yet). This is a context-setting phase.\n\nThe user's actual task appears to be asking me to perform a Learn phase analysis on this PR, applying the two-gate test to filter findings. However, the IMMEDIATE request is just for a summary of the conversation.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user requests a detailed summary of the conversation so far. They explicitly state this must be done using TEXT ONLY with no tool calls whatsoever. They provide a specific format structure with nine required sections: Primary Request and Intent, Key Technical Concepts, Files and Code Sections, Errors and fixes, Problem Solving, All user messages, Pending Tasks, Current Work, and Optional Next Step.\n\n   The underlying context provided by the user establishes a PR analysis scenario for \"have-the-ask-user-hook\" branch in the FLOW plugin project. The goal is to filter findings using a two-gate test: (1) Forward-facing principle applicability, and (2) Value determination (was the gap already remediated in the PR?). The user emphasizes \"No findings\" is often the correct answer.\n\n2. Key Technical Concepts:\n   - FLOW plugin: A Claude Code plugin implementing a 5-phase development lifecycle (Start, Code, Review, Learn, Complete)\n   - PreToolUse hook: Validation mechanism that runs before tool execution (validate-ask-user specifically)\n   - Permission decision semantics: Explicit vs. implicit contract about hook behavior (\"defer\" signal)\n   - Two-gate filtering: Methodology for determining whether findings warrant reporting\n   - Cognitive isolation: Sub-agent design patterns with context budget and truncation recovery\n   - Plan-commit atomicity: Discipline around atomic commit groups and task counter incrementation\n   - Autonomous phase discipline: Rules preventing user pauses during auto-continue flows\n   - Review scope: Real findings fixed in PR, false positives dismissed\n   - JSON serialization with IndexMap for key order preservation\n   - State file mutation and corruption resilience patterns\n\n3. Files and Code Sections:\n   - src/hooks/validate_ask_user.rs: The central module being modified\n      - Contains HookAction enum with Allow, AllowWithMark, Block, and AutoAnswer variants\n      - Module doc comment item 5 lists five outcomes (Block, User-only skill carve-out, Shared-config carve-out, Auto-answer, Allow)\n      - Allow variant changed to emit `{\"permissionDecision\":\"defer\"}` before exit(0)\n      - AllowWithMark variant similarly emits defer after set_blocked call\n      - validate() function returns (allowed, message, hook_response)\n      - run() function matches on HookAction and translates to exit codes and stdio effects\n      - set_blocked() function writes _blocked timestamp to state file\n   - tests/hooks/validate_ask_user.rs: Integration tests for the hook\n      - run_subprocess_exits_0_outside_git_repo: Tests Allow path when no git repo, now asserts defer signal\n      - run_subprocess_exits_0_when_stdin_unparseable: Tests Allow path with bad stdin, now asserts defer\n      - run_subprocess_exits_0_when_branch_has_slash: Tests Allow path with slash in branch name, now asserts defer\n      - run_subprocess_sets_blocked_on_allow_path: Tests AllowWithMark path, gained stdout defer assertion\n      - Additional carve-out tests for user-only skills and shared-config edits\n   - config.json: Shows claude_code_audited field currently set to \"2.1.138\"\n   - .claude/rules/ directory: 50+ rule files defining project discipline across:\n      - security-gates.md, external-input-validation.md, external-input-path-construction.md\n      - hook-state-timing.md, autonomous-phase-discipline.md, user-only-skills.md\n      - plan-commit-atomicity.md, code-task-counter.md, scope-expansion.md\n      - review-scope.md, always-verify.md, forward-facing-authoring.md\n      - test-placement.md, tombstone-tests.md, and many others\n      - These define the framework for PR analysis and rule compliance\n\n4. Errors and fixes:\n   No errors have occurred. This is the initial context-setting message, so no attempted fixes have been made.\n\n5. Problem Solving:\n   No problems have been solved yet. This is a framing/context-setting phase where the user establishes the analytical framework and constraints for subsequent work.\n\n6. All user messages:\n   - Primary message (the entire conversation): Provides PR context for \"have-the-ask-user-hook\" branch, describes the two-gate filtering test, establishes that \"no findings\" is often correct, provides branch SHA, diff statistics, summary of behavioral changes, state file data, five specific compliance angles to consider, and references to plan file and extensive rule documentation.\n   - Secondary message: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.\" followed by explicit instructions to provide summary in specified format with nine sections.\n\n7. Pending Tasks:\n   - Perform Learn phase analysis on the \"have-the-ask-user-hook\" PR using the two-gate test framework\n   - Evaluate five specific compliance and process angles provided by the user\n   - Determine whether findings exist that pass both gates, with explicit expectation that zero findings may be the correct answer\n\n8. Current Work:\n   No work has been performed yet. The conversation consists entirely of context-setting and framing from the user. No code analysis, modifications, or evaluations have been attempted. The user is establishing the ground rules and providing comprehensive background material before actual analysis begins.\n\n9. Optional Next Step:\n   Once the user confirms they have received this summary and are ready to proceed, the next step would be to begin the actual PR analysis using the two-gate filter methodology. This would involve:\n   - Examining the two commits (01a920c2 and 10bfe044) in detail\n   - Evaluating the specific compliance angles mentioned (Plan scope decisions, scope expansion handling per rules, version bump handling, adversarial probe lifecycle, context budget management)\n   - Applying the two-gate test to determine which findings warrant reporting\n   - Preparing findings organized by category (Process gaps, Rule compliance, Missing rules) with only those passing both gates included\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/have-the-ask-user-hook",
  "compact_count": 5,
  "findings": [
    {
      "finding": "Pre-mortem F2: defer may not be valid permissionDecision value",
      "reason": "claude_code_audited field in config.json is 2.1.138, well past the 2.1.89 release that introduced the explicit defer value. The plan's premise is verified by the audited version field; defer is the documented Claude Code hook protocol value.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T12:16:04-07:00"
    },
    {
      "finding": "Documentation: HookAction::Allow variant doc comment needs updating",
      "reason": "The diff already rewrites the variant doc comment with the new defer-emission description (src/hooks/validate_ask_user.rs lines 195-202). The agent flagged this as a required update without verifying the diff content; the update is present.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T12:16:10-07:00"
    },
    {
      "finding": "Documentation: CLAUDE.md Permission Invariant section needs expansion to describe defer outcome",
      "reason": "The agent cited no specific stale claim in CLAUDE.md — only that the section 'should be updated to provide a complete picture'. Per .claude/rules/review-scope.md Value-vs-Bureaucracy Finding Triage, this fails the discoverability test: CLAUDE.md's Permission Invariant section currently describes the hook's user-visible behavior (blocks AskUserQuestion during in-progress autonomous phases). Internal HookAction variants are an implementation detail captured in the source module's doc comment. Expanding CLAUDE.md to enumerate internal variants is bureaucracy-trap restatement of source-local doc that the source already owns.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T12:16:18-07:00"
    },
    {
      "finding": "Maintainability: inline comment needed at the println call site explaining why defer",
      "reason": "The HookAction::Allow variant doc comment (rewritten in this PR) is two lines above the call site and explicitly explains why defer is emitted ('tells Claude Code the hook has no opinion on this tool call, routing it through normal permission handling without relying on empty-stdout implicit semantics'). Adding another comment at the println would duplicate that explanation. Per .claude/rules/comment-quality.md, comments should be added only when the WHY is non-obvious — here the WHY is already documented adjacent to the call.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T12:16:25-07:00"
    },
    {
      "finding": "Module-level doc comment item 5 says 'Allow (exit 0, no stdout)'",
      "reason": "Stale after this PR adds defer-emission to the Allow arm. Rewrote item 5 to describe the defer payload and extended the description to cover AllowWithMark symmetry.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T12:18:49-07:00"
    },
    {
      "finding": "AllowWithMark path exits 0 silently while Allow now emits defer JSON",
      "reason": "Divergent stdout contract for two no-opinion outcomes. Pre-mortem flagged the AllowWithMark path as the dominant active-flow allow case; adversarial probe proved it via run_subprocess_sets_blocked_on_allow_path / allow_with_mark_path_also_emits_defer_signal. Fixed by emitting the defer JSON from the AllowWithMark arm before exiting 0, updating the variant doc comment, and extending the existing AllowWithMark test (run_subprocess_sets_blocked_on_allow_path) to assert the defer stdout substring. Adversarial probe emptied per .claude/rules/adversarial-probe-lifecycle.md default reconciliation.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T12:18:57-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-11T12:27:08-07:00",
    "session_id": "3280c08d-7299-4d3c-b87c-18cd58aee4fc",
    "model": "claude-opus-4-7",
    "five_hour_pct": 81,
    "seven_day_pct": 21,
    "session_input_tokens": 63492,
    "session_output_tokens": 173176,
    "session_cache_creation_tokens": 972500,
    "session_cache_read_tokens": 15241784,
    "session_cost_usd": 13.779730999999998,
    "by_model": {
      "claude-opus-4-7": {
        "input": 63492,
        "output": 173176,
        "cache_create": 972500,
        "cache_read": 15241784
      }
    },
    "turn_count": 62,
    "tool_call_count": 30,
    "context_at_last_turn_tokens": 336972,
    "context_window_pct": 168.486
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>