### PR TITLE
Show Per Phase Token Cost

### DIFF
--- a/.claude/rules/subprocess-argument-escaping.md
+++ b/.claude/rules/subprocess-argument-escaping.md
@@ -4,9 +4,9 @@ When a value sourced from outside the process (state file, git
 output, user config, parsed JSON, env var, CLI arg) is interpolated
 into a string that another interpreter will parse — AppleScript via
 `osascript`, shell via `bash -c`, SQL via a query string, regex,
-JSON, etc. — the value MUST be escaped according to that
-interpreter's literal-syntax rules before interpolation. Raw
-`format!` interpolation is an injection vector.
+JSON, GitHub Markdown table cells, etc. — the value MUST be escaped
+according to that interpreter's literal-syntax rules before
+interpolation. Raw `format!` interpolation is an injection vector.
 
 ## Why
 
@@ -28,11 +28,13 @@ escape helper before `format!`. The escape helper:
 
 1. **Names the target language** in its function name —
    `escape_applescript_string`, `escape_shell_arg`,
-   `escape_sql_literal`, etc. Generic "sanitize" or "clean" helpers
-   are a smell.
+   `escape_sql_literal`, `escape_markdown_cell`, etc. Generic
+   "sanitize" or "clean" helpers are a smell.
 2. **Has a doc comment that names the structural characters** for
    that language. AppleScript's are `\` and `"`. Shell's are the
    full operator set plus quotes. SQL's depend on the dialect.
+   GitHub Markdown table cells use `|` as the column delimiter
+   and `\n`/`\r` as the row delimiter.
 3. **Is exhaustively unit-tested** against:
    - the empty input,
    - input containing only safe chars,
@@ -52,6 +54,13 @@ double-quoted literals) with a leading backslash. Adversarial tests
 prove the injection substring `" then do shell script` cannot
 appear unescaped in the output for a malicious input.
 
+A sibling reference is `escape_markdown_cell` in
+`src/render_pr_body.rs`, used by `format_cost_table` to render
+session-derived model names inside the GitHub Markdown table.
+It escapes `|`, `\`, `\n`, and `\r` — preventing a model name
+with a literal pipe from injecting an extra column, and a model
+name with a newline from breaking the row onto two lines.
+
 ## Where This Applies
 
 - **`osascript -e <script>`** — escape AppleScript string literals
@@ -68,6 +77,13 @@ appear unescaped in the output for a malicious input.
   `regex::escape`.
 - **Any external value reaching a shell command via `bash -c`** —
   use a quoting helper or restructure to avoid `bash -c`.
+- **`format!("| {} | {} |", name, value)` rendering to GitHub
+  Markdown** — escape `|`, `\`, `\n`, `\r` in every external
+  string interpolated into a table cell. An unescaped pipe in a
+  cell value injects an extra column delimiter and breaks the
+  table; an unescaped newline ends the table row early. The
+  reference helper is `escape_markdown_cell` in
+  `src/render_pr_body.rs`.
 
 ## Plan-Phase Trigger
 

--- a/docs/phases/phase-5-complete.md
+++ b/docs/phases/phase-5-complete.md
@@ -94,7 +94,7 @@ rather than stranding the shell in a deleted directory.
 
 - Phase transition complete (records timing)
 - PR body rendering (What, Artifacts, Plan, DAG Analysis, Phase
-  Timings, State File, Session Log, Issues Filed)
+  Timings, Token Cost, State File, Session Log, Issues Filed)
 - Close referenced GitHub issues from the start prompt
 - Generate business-friendly summary (feature name, prompt,
   per-phase timeline, artifact counts)

--- a/skills/flow-complete/SKILL.md
+++ b/skills/flow-complete/SKILL.md
@@ -701,9 +701,10 @@ notify-slack, worktree removal, state file deletion, and git pull —
 all best-effort in a single call.
 
 The render-pr-body step produces the PR body with all sections —
-What, Artifacts, Plan, DAG Analysis, Phase Timings, State File,
-Session Log, and Issues Filed — from the state file and available
-artifact files. Sections with missing data are omitted automatically.
+What, Artifacts, Plan, DAG Analysis, Phase Timings, Token Cost,
+State File, Session Log, and Issues Filed — from the state file and
+available artifact files. Sections with missing data are omitted
+automatically.
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow complete-finalize --pr <pr_number> --state-file <project_root>/.flow-states/<branch>/state.json --branch <branch> --worktree <worktree_path> --pull

--- a/src/format_complete_summary.rs
+++ b/src/format_complete_summary.rs
@@ -144,11 +144,22 @@ pub fn compute_cost_breakdown(state: &Value) -> Option<CostBreakdown> {
         let Some(phase_v) = phases_obj.get(key) else {
             continue;
         };
-        let status = phase_v
+        // Normalize the status string before the gate decision per
+        // `.claude/rules/security-gates.md` "Normalize Before
+        // Comparing". A hand-edited or corrupted state file may
+        // carry case-drifted ("PENDING") or whitespace-padded
+        // (" pending ") variants, and an empty string is
+        // semantically equivalent to a missing field. All three
+        // shapes collapse to the canonical "pending" so the gate
+        // produces the same row decision regardless of input
+        // shape.
+        let status_norm = phase_v
             .get("status")
             .and_then(|s| s.as_str())
-            .unwrap_or("pending");
-        if status == "pending" {
+            .map(|s| s.trim().to_ascii_lowercase())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "pending".to_string());
+        if status_norm == "pending" {
             // Phase never started — produce no row to keep noise bounded.
             continue;
         }

--- a/src/format_complete_summary.rs
+++ b/src/format_complete_summary.rs
@@ -1,5 +1,13 @@
 //! Complete phase "Done" banner formatter.
 //!
+//! Two consumers share the Token Cost computation. The terminal
+//! banner formatter (`token_cost_section`, called from
+//! [`format_complete_summary`]) renders the fixed-width separator
+//! block printed at the end of every flow. The PR-body markdown
+//! formatter in `crate::render_pr_body::format_cost_table` renders
+//! the same data as a GitHub Markdown table. Both consume the
+//! structured intermediate produced by [`compute_cost_breakdown`].
+//!
 //! Tests live in `tests/format_complete_summary.rs` per
 //! `.claude/rules/test-placement.md` — no inline `#[cfg(test)]`
 //! block in this file.
@@ -60,24 +68,60 @@ fn outcome_label(outcome: &str) -> &'static str {
     }
 }
 
-/// Render the Token Cost section from `state.phases.<phase>.window_at_*`
+/// One row of Token Cost data describing a single phase's
+/// contribution. `cost == None` signals that the phase had no
+/// complete cost-pair (either endpoint missing or both `None`).
+/// `row_partial` is set whenever the underlying snapshot pair could
+/// not produce a full delta (parse error, missing `window_at_enter`,
+/// or a partial fold inside `phase_delta`).
+#[derive(Debug, Clone)]
+pub struct CostRow {
+    pub phase_name: String,
+    pub tokens: i64,
+    pub cost: Option<f64>,
+    pub reset_observed: bool,
+    pub row_partial: bool,
+}
+
+/// Structured Token Cost breakdown shared by the terminal banner
+/// formatter ([`token_cost_section`]) and the PR-body Markdown
+/// formatter (`crate::render_pr_body::format_cost_table`). Both
+/// formatters consume the same data so per-phase rows, totals, the
+/// by-model rollup, and the reset-anywhere flag stay consistent
+/// across surfaces.
+///
+/// `total_partial == true` indicates at least one row contributed
+/// `None` cost OR an upstream partial fold; renderers mark the total
+/// with `*` so users see the value is approximate.
+#[derive(Debug, Clone)]
+pub struct CostBreakdown {
+    pub rows: Vec<CostRow>,
+    pub total_tokens: i64,
+    pub total_cost: Option<f64>,
+    pub total_partial: bool,
+    pub by_model: IndexMap<String, ModelTokens>,
+    pub reset_observed_anywhere: bool,
+}
+
+/// Compute the Token Cost breakdown from `state.phases.<phase>.window_at_*`
 /// snapshots via `window_deltas::phase_delta`.
 ///
-/// Per-phase rendering rules (issue #1410):
+/// Per-phase rules:
 ///
 /// - Each phase whose `status` is not `"pending"` produces a row,
 ///   even when its delta is unknown — silent skip on parse error or
 ///   missing `window_at_enter` was the chief cause of the
-///   never-rendered Token Cost section. Unknown cost is shown as
-///   `—`; the row is marked `*` when the phase contributed without
+///   never-rendered Token Cost section. Unknown cost is `None`; the
+///   row is marked `row_partial` when the phase contributed without
 ///   a complete cost-pair.
-/// - The section header is omitted only when every phase is
-///   `"pending"`. Any non-pending phase forces the header so users
-///   see whatever data is available.
-/// - The total line uses the same Some/None formatting as per-phase
-///   rows; an `*` suffix marks the total as approximate when any
-///   phase contributed `None` cost.
-fn token_cost_section(state: &Value) -> Vec<String> {
+/// - Returns `None` when no row accumulates (every phase is
+///   `"pending"`, the `phases` map is empty, or no phase key
+///   appears in `PHASE_ORDER`). Renderers omit the section in
+///   that case.
+/// - `total_cost` uses Option-add semantics: `Some` contributions
+///   sum into the running total; `None` contributions flip
+///   `total_partial` so renderers mark the total as approximate.
+pub fn compute_cost_breakdown(state: &Value) -> Option<CostBreakdown> {
     let names = phase_config::phase_names();
 
     let phases_obj = state
@@ -86,15 +130,14 @@ fn token_cost_section(state: &Value) -> Vec<String> {
         .cloned()
         .unwrap_or_default();
     if phases_obj.is_empty() {
-        return Vec::new();
+        return None;
     }
 
-    // Per-phase row tuple: (display_name, tokens, cost, reset, partial).
-    let mut phase_rows: Vec<(String, i64, Option<f64>, bool, bool)> = Vec::new();
+    let mut rows: Vec<CostRow> = Vec::new();
     let mut total_tokens: i64 = 0;
     let mut total_cost: Option<f64> = None;
     let mut total_partial = false;
-    let mut combined_by_model: IndexMap<String, ModelTokens> = IndexMap::new();
+    let mut by_model: IndexMap<String, ModelTokens> = IndexMap::new();
     let mut reset_observed_anywhere = false;
 
     for &key in PHASE_ORDER {
@@ -106,7 +149,7 @@ fn token_cost_section(state: &Value) -> Vec<String> {
             .and_then(|s| s.as_str())
             .unwrap_or("pending");
         if status == "pending" {
-            // Phase never started — render no row to keep noise bounded.
+            // Phase never started — produce no row to keep noise bounded.
             continue;
         }
         // `phase_config::phase_names()` is keyed by PHASE_ORDER, so
@@ -137,7 +180,7 @@ fn token_cost_section(state: &Value) -> Vec<String> {
                     reset_observed_anywhere = true;
                 }
                 for (model, mt) in &r.by_model_delta {
-                    let entry = combined_by_model.entry(model.clone()).or_default();
+                    let entry = by_model.entry(model.clone()).or_default();
                     entry.input = entry.input.saturating_add(mt.input);
                     entry.output = entry.output.saturating_add(mt.output);
                     entry.cache_create = entry.cache_create.saturating_add(mt.cache_create);
@@ -161,47 +204,76 @@ fn token_cost_section(state: &Value) -> Vec<String> {
         if row_partial {
             total_partial = true;
         }
-        phase_rows.push((name, tokens, cost, reset, row_partial));
+        rows.push(CostRow {
+            phase_name: name,
+            tokens,
+            cost,
+            reset_observed: reset,
+            row_partial,
+        });
     }
 
-    if phase_rows.is_empty() {
-        return Vec::new();
+    if rows.is_empty() {
+        return None;
     }
+
+    Some(CostBreakdown {
+        rows,
+        total_tokens,
+        total_cost,
+        total_partial,
+        by_model,
+        reset_observed_anywhere,
+    })
+}
+
+/// Render the terminal Token Cost block from [`CostBreakdown`].
+///
+/// Returns an empty Vec when no breakdown is available (no phase has
+/// run yet, or the `phases` map is empty). The rendered output is the
+/// fixed-width separator block shown at the end of every flow:
+/// header, per-phase rows, separator, total, optional By Model
+/// sub-block, optional reset / partial footnotes, trailing blank line.
+fn token_cost_section(state: &Value) -> Vec<String> {
+    let breakdown = match compute_cost_breakdown(state) {
+        Some(b) => b,
+        None => return Vec::new(),
+    };
 
     let mut lines = Vec::new();
     lines.push("  Token Cost".to_string());
     lines.push(format!("  {}", "─".repeat(28)));
-    for (name, tokens, cost, reset, partial) in &phase_rows {
-        let reset_marker = if *reset { " ↻" } else { "" };
-        let partial_marker = if *partial { "*" } else { "" };
-        let cost_str = match cost {
+    for row in &breakdown.rows {
+        let reset_marker = if row.reset_observed { " ↻" } else { "" };
+        let partial_marker = if row.row_partial { "*" } else { "" };
+        let cost_str = match row.cost {
             Some(c) => format!("${:.3}{}", c, partial_marker),
             None => "—".to_string(),
         };
         lines.push(format!(
             "  {:<16} {:>8}  {}{}",
-            format!("{}:", name),
-            format_tokens(*tokens),
+            format!("{}:", row.phase_name),
+            format_tokens(row.tokens),
             cost_str,
             reset_marker
         ));
     }
     lines.push(format!("  {}", "─".repeat(28)));
-    let total_partial_marker = if total_partial { "*" } else { "" };
-    let total_cost_str = match total_cost {
+    let total_partial_marker = if breakdown.total_partial { "*" } else { "" };
+    let total_cost_str = match breakdown.total_cost {
         Some(c) => format!("${:.3}{}", c, total_partial_marker),
         None => "—".to_string(),
     };
     lines.push(format!(
         "  {:<16} {:>8}  {}",
         "Total:",
-        format_tokens(total_tokens),
+        format_tokens(breakdown.total_tokens),
         total_cost_str
     ));
-    if combined_by_model.len() >= 2 {
+    if breakdown.by_model.len() >= 2 {
         lines.push(String::new());
         lines.push("  By Model".to_string());
-        for (model, mt) in &combined_by_model {
+        for (model, mt) in &breakdown.by_model {
             let total_model = mt
                 .input
                 .saturating_add(mt.output)
@@ -214,11 +286,11 @@ fn token_cost_section(state: &Value) -> Vec<String> {
             ));
         }
     }
-    if reset_observed_anywhere {
+    if breakdown.reset_observed_anywhere {
         lines.push(String::new());
         lines.push("  ↻ rate-limit window reset observed mid-flow".to_string());
     }
-    if total_partial {
+    if breakdown.total_partial {
         lines.push(String::new());
         lines.push("  * cost partial — some phases had no cost data".to_string());
     }

--- a/src/render_pr_body.rs
+++ b/src/render_pr_body.rs
@@ -79,6 +79,29 @@ fn build_artifacts(state: &serde_json::Value) -> Vec<String> {
     items
 }
 
+/// Escape a value that flows into a GitHub Markdown table cell.
+///
+/// Per `.claude/rules/subprocess-argument-escaping.md`, external
+/// strings interpolated into a structural-syntax target must be
+/// escaped. Markdown table cells use `|` as the column delimiter
+/// and `\n`/`\r` as the row delimiter — a model name or other
+/// snapshot-derived string that carries any of these characters
+/// would break the table structure when rendered on GitHub.
+/// `\` is also escaped so a value ending in `\` cannot escape
+/// the closing pipe.
+fn escape_markdown_cell(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '|' => out.push_str("\\|"),
+            '\n' | '\r' => out.push(' '),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
 /// Build the Token Cost markdown table from state snapshots.
 ///
 /// Calls [`compute_cost_breakdown`] to fold each phase's window
@@ -130,17 +153,25 @@ pub fn format_cost_table(state: &serde_json::Value) -> String {
         ));
     }
 
-    let total_cost_cell = match breakdown.total_cost {
-        Some(c) => {
-            let partial_marker = if breakdown.total_partial { "*" } else { "" };
-            format!("${:.3}{}", c, partial_marker)
-        }
-        None => "—".to_string(),
+    // The Total cost cell is wrapped in bold delimiters, so the
+    // partial marker `*` must be appended OUTSIDE the closing
+    // `**` and escaped as `\*` — otherwise the trailing
+    // asterisks form `**$X.YYY***`, which GitHub Markdown can
+    // parse ambiguously as bold+emphasis or strong+literal.
+    // Bold the dollar value alone; emit the marker as a
+    // backslash-escaped literal star after the bold wrapper.
+    let (total_cost_bold, total_partial_suffix) = match breakdown.total_cost {
+        Some(c) => (
+            format!("${:.3}", c),
+            if breakdown.total_partial { "\\*" } else { "" },
+        ),
+        None => ("—".to_string(), ""),
     };
     lines.push(format!(
-        "| **Total** | **{}** | **{}** |",
+        "| **Total** | **{}** | **{}**{} |",
         format_tokens(breakdown.total_tokens),
-        total_cost_cell
+        total_cost_bold,
+        total_partial_suffix
     ));
 
     if breakdown.by_model.len() >= 2 {
@@ -153,7 +184,13 @@ pub fn format_cost_table(state: &serde_json::Value) -> String {
                 .saturating_add(mt.output)
                 .saturating_add(mt.cache_create)
                 .saturating_add(mt.cache_read);
-            lines.push(format!("| {} | {} |", model, format_tokens(total_model)));
+            // Escape the model name — it is a state-derived
+            // string and may carry `|` from session capture data.
+            lines.push(format!(
+                "| {} | {} |",
+                escape_markdown_cell(model),
+                format_tokens(total_model)
+            ));
         }
     }
 

--- a/src/render_pr_body.rs
+++ b/src/render_pr_body.rs
@@ -4,11 +4,12 @@ use clap::Parser;
 use serde_json::json;
 
 use crate::flow_paths::FlowPaths;
+use crate::format_complete_summary::compute_cost_breakdown;
 use crate::format_issues_summary::format_issues_summary;
 use crate::format_pr_timings::format_timings_table;
 use crate::git::{current_branch, project_root};
 use crate::update_pr_body::{build_details_block, build_plain_section, gh_set_body};
-use crate::utils::extract_issue_numbers;
+use crate::utils::{extract_issue_numbers, format_tokens};
 
 /// Resolve a file path, handling both absolute and relative paths.
 ///
@@ -76,6 +77,96 @@ fn build_artifacts(state: &serde_json::Value) -> Vec<String> {
         }
     }
     items
+}
+
+/// Build the Token Cost markdown table from state snapshots.
+///
+/// Calls [`compute_cost_breakdown`] to fold each phase's window
+/// snapshots into per-row token / cost / reset / by-model data, then
+/// renders the result as a GitHub Markdown table consumed by
+/// [`render_body`]. Returns an empty string when the breakdown is
+/// `None` (no phase has run yet, or the `phases` map is empty) so
+/// [`render_body`] can omit the section.
+///
+/// Format:
+///
+/// - `| Phase | Tokens | Cost |` header + `|-------|--------|------|`
+///   separator.
+/// - One row per `CostRow`. Cost cell is `${:.3}` with a `*` suffix
+///   when `row_partial`; the em-dash `—` is used when `cost == None`.
+///   A trailing ` ↻` marks rows whose snapshot pair observed a
+///   rate-limit window reset.
+/// - Bold `| **Total** | **<tokens>** | **<cost>** |` row with the
+///   same Some/None/partial rules.
+/// - When `by_model.len() >= 2`, a `| Model | Tokens |` sub-table
+///   follows after a blank line.
+/// - Trailing italic footnotes explain the reset and partial markers
+///   when set.
+pub fn format_cost_table(state: &serde_json::Value) -> String {
+    let breakdown = match compute_cost_breakdown(state) {
+        Some(b) => b,
+        None => return String::new(),
+    };
+
+    let mut lines = Vec::new();
+    lines.push("| Phase | Tokens | Cost |".to_string());
+    lines.push("|-------|--------|------|".to_string());
+
+    for row in &breakdown.rows {
+        let cost_cell = match row.cost {
+            Some(c) => {
+                let partial_marker = if row.row_partial { "*" } else { "" };
+                format!("${:.3}{}", c, partial_marker)
+            }
+            None => "—".to_string(),
+        };
+        let reset_marker = if row.reset_observed { " ↻" } else { "" };
+        lines.push(format!(
+            "| {} | {} | {}{} |",
+            row.phase_name,
+            format_tokens(row.tokens),
+            cost_cell,
+            reset_marker
+        ));
+    }
+
+    let total_cost_cell = match breakdown.total_cost {
+        Some(c) => {
+            let partial_marker = if breakdown.total_partial { "*" } else { "" };
+            format!("${:.3}{}", c, partial_marker)
+        }
+        None => "—".to_string(),
+    };
+    lines.push(format!(
+        "| **Total** | **{}** | **{}** |",
+        format_tokens(breakdown.total_tokens),
+        total_cost_cell
+    ));
+
+    if breakdown.by_model.len() >= 2 {
+        lines.push(String::new());
+        lines.push("| Model | Tokens |".to_string());
+        lines.push("|-------|--------|".to_string());
+        for (model, mt) in &breakdown.by_model {
+            let total_model = mt
+                .input
+                .saturating_add(mt.output)
+                .saturating_add(mt.cache_create)
+                .saturating_add(mt.cache_read);
+            lines.push(format!("| {} | {} |", model, format_tokens(total_model)));
+        }
+    }
+
+    if breakdown.reset_observed_anywhere {
+        lines.push(String::new());
+        lines.push("*↻ rate-limit window reset observed mid-flow.*".to_string());
+    }
+    if breakdown.total_partial {
+        lines.push(String::new());
+        lines.push("*Partial: some phases had no cost data.*".to_string());
+    }
+
+    lines.join("\n")
 }
 
 /// Render the complete PR body from state and artifact files.

--- a/src/render_pr_body.rs
+++ b/src/render_pr_body.rs
@@ -263,6 +263,14 @@ pub fn render_body(state: &serde_json::Value, project_dir: &Path) -> Result<Stri
     sections.push(build_plain_section("Phase Timings", &timings_table));
     section_names.push("Phase Timings".to_string());
 
+    // 5b. Token Cost (conditional — only when at least one phase
+    // contributes a row via `compute_cost_breakdown`)
+    let cost_table = format_cost_table(state);
+    if !cost_table.is_empty() {
+        sections.push(build_plain_section("Token Cost", &cost_table));
+        section_names.push("Token Cost".to_string());
+    }
+
     // 6. State File (always)
     let state_json = serde_json::to_string_pretty(state).unwrap_or_default();
     let branch = state

--- a/tests/format_complete_summary.rs
+++ b/tests/format_complete_summary.rs
@@ -671,6 +671,52 @@ fn compute_cost_breakdown_accumulates_by_model() {
     );
 }
 
+/// Per `.claude/rules/security-gates.md` "Normalize Before
+/// Comparing", the status comparison in `compute_cost_breakdown`
+/// must accept case- and whitespace-drifted variants of
+/// `"pending"` (`"PENDING"`, `"Pending"`, `" pending"`,
+/// `"pending "`). State files can be hand-edited or carry
+/// case-drifted values; an un-normalized comparison would flip
+/// those phases from "pending" to "active" and produce phantom
+/// rows.
+#[test]
+fn compute_cost_breakdown_normalizes_status_case_and_whitespace() {
+    let mut state = all_complete_state();
+    state["phases"]["flow-start"]["status"] = json!("PENDING");
+    state["phases"]["flow-code"]["status"] = json!("Pending");
+    state["phases"]["flow-review"]["status"] = json!("pending ");
+    state["phases"]["flow-learn"]["status"] = json!(" pending");
+    state["phases"]["flow-complete"]["status"] = json!("pending");
+
+    assert!(
+        compute_cost_breakdown(&state).is_none(),
+        "every phase is a case/whitespace variant of pending; breakdown should be None"
+    );
+}
+
+/// Empty-string status is semantically equivalent to "missing
+/// field" — it must be treated as pending so no row is produced.
+/// Without this collapse, a hand-edited state file that clears
+/// the status field to `""` flips the phase to "active" and
+/// produces a phantom row.
+#[test]
+fn compute_cost_breakdown_treats_empty_string_status_as_pending() {
+    let mut state = all_complete_state();
+    // Only flow-code carries the empty-string status; the other
+    // phases stay "complete" so they would contribute rows if
+    // the gate is correct. We want to verify the empty-string
+    // status specifically skips flow-code.
+    for key in ["flow-start", "flow-review", "flow-learn", "flow-complete"] {
+        state["phases"][key]["status"] = json!("pending");
+    }
+    state["phases"]["flow-code"]["status"] = json!("");
+
+    assert!(
+        compute_cost_breakdown(&state).is_none(),
+        "empty-string status must be treated as pending; got non-empty breakdown"
+    );
+}
+
 // --- basic summary ---
 
 #[test]

--- a/tests/format_complete_summary.rs
+++ b/tests/format_complete_summary.rs
@@ -9,7 +9,9 @@
 
 use std::path::{Path, PathBuf};
 
-use flow_rs::format_complete_summary::{format_complete_summary, run_impl, run_impl_main, Args};
+use flow_rs::format_complete_summary::{
+    compute_cost_breakdown, format_complete_summary, run_impl, run_impl_main, Args,
+};
 use serde_json::{json, Value};
 
 mod common;
@@ -539,6 +541,133 @@ fn format_complete_summary_renders_dash_for_frozen_cost_pattern() {
         result.summary.contains("cost partial"),
         "footnote must appear when any phase contributes None cost; summary:\n{}",
         result.summary
+    );
+}
+
+// --- compute_cost_breakdown structural API ---
+//
+// The structured intermediate `compute_cost_breakdown` returns the
+// Token Cost data needed by two formatters: the terminal banner
+// (existing `token_cost_section`) and the new PR-body markdown table
+// (Task 4 `format_cost_table`). Tests below drive each branch of the
+// extracted helper directly so coverage of the structural API is
+// independent of the formatter that consumes it.
+
+/// Full state with snapshots for every phase produces five rows and
+/// totals that match the per-phase sums.
+#[test]
+fn compute_cost_breakdown_full_data_returns_all_five_phase_rows() {
+    let mut state = all_complete_state();
+    add_phase_snapshots(&mut state, "flow-start", 0, 5);
+    add_phase_snapshots(&mut state, "flow-code", 5, 15);
+    add_phase_snapshots(&mut state, "flow-review", 15, 20);
+    add_phase_snapshots(&mut state, "flow-learn", 20, 25);
+    add_phase_snapshots(&mut state, "flow-complete", 25, 30);
+
+    let breakdown = compute_cost_breakdown(&state).expect("breakdown");
+    assert_eq!(breakdown.rows.len(), 5, "five phase rows");
+
+    let summed_tokens: i64 = breakdown.rows.iter().map(|r| r.tokens).sum();
+    assert_eq!(breakdown.total_tokens, summed_tokens, "totals match sum");
+
+    let summed_cost: f64 = breakdown.rows.iter().filter_map(|r| r.cost).sum();
+    assert!(
+        (breakdown.total_cost.unwrap_or(0.0) - summed_cost).abs() < 1e-9,
+        "total_cost matches sum of per-row costs"
+    );
+}
+
+/// Phases map is `{}` → no rows accumulate → return None.
+#[test]
+fn compute_cost_breakdown_returns_none_when_phases_empty() {
+    let mut state = all_complete_state();
+    state["phases"] = json!({});
+    assert!(compute_cost_breakdown(&state).is_none());
+}
+
+/// Every phase status is "pending" → no row contributes → return None.
+#[test]
+fn compute_cost_breakdown_returns_none_when_all_phases_pending() {
+    let mut state = all_complete_state();
+    for key in [
+        "flow-start",
+        "flow-code",
+        "flow-review",
+        "flow-learn",
+        "flow-complete",
+    ] {
+        state["phases"][key]["status"] = json!("pending");
+    }
+    assert!(compute_cost_breakdown(&state).is_none());
+}
+
+/// A phase whose enter snapshot has `session_cost_usd = null` produces
+/// a row with `cost = None` and flips `total_partial`.
+#[test]
+fn compute_cost_breakdown_marks_partial_when_cost_missing() {
+    let mut state = all_complete_state();
+    let mut enter = snapshot_value("S1", 1, "claude-opus-4-7");
+    let complete = snapshot_value("S1", 5, "claude-opus-4-7");
+    enter["session_cost_usd"] = json!(null);
+    state["phases"]["flow-code"]["window_at_enter"] = enter;
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+    // Drop the other phases so flow-code is the only contributor.
+    for key in ["flow-start", "flow-review", "flow-learn", "flow-complete"] {
+        state["phases"][key]["status"] = json!("pending");
+    }
+
+    let breakdown = compute_cost_breakdown(&state).expect("breakdown");
+    assert!(breakdown.total_partial, "partial marker set");
+    let row = breakdown
+        .rows
+        .iter()
+        .find(|r| r.phase_name == "Code")
+        .expect("Code row present");
+    assert!(row.cost.is_none(), "Code row cost is None");
+}
+
+/// A phase whose snapshot pair shows the 5h pct dropping between
+/// enter and complete records a window reset.
+#[test]
+fn compute_cost_breakdown_records_reset_observed() {
+    let mut state = all_complete_state();
+    let mut enter = snapshot_value("S1", 80, "claude-opus-4-7");
+    let mut complete = snapshot_value("S1", 5, "claude-opus-4-7");
+    // Force token growth so the row carries a non-trivial delta.
+    enter["session_input_tokens"] = json!(100);
+    complete["session_input_tokens"] = json!(500);
+    state["phases"]["flow-code"]["window_at_enter"] = enter;
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+
+    let breakdown = compute_cost_breakdown(&state).expect("breakdown");
+    assert!(breakdown.reset_observed_anywhere, "anywhere flag set");
+    let row = breakdown
+        .rows
+        .iter()
+        .find(|r| r.phase_name == "Code")
+        .expect("Code row present");
+    assert!(row.reset_observed, "Code row reset flag set");
+}
+
+/// Multi-model snapshots accumulate per-model tokens in `by_model`.
+#[test]
+fn compute_cost_breakdown_accumulates_by_model() {
+    let mut state = all_complete_state();
+    state["phases"]["flow-code"]["window_at_enter"] = snapshot_value("S1", 0, "claude-opus-4-7");
+    let mut complete_v = snapshot_value("S1", 50, "claude-opus-4-7");
+    complete_v["by_model"]["claude-sonnet-4-6"] = json!({
+        "input": 1000, "output": 500, "cache_create": 0, "cache_read": 0
+    });
+    state["phases"]["flow-code"]["window_at_complete"] = complete_v;
+
+    let breakdown = compute_cost_breakdown(&state).expect("breakdown");
+    assert!(
+        breakdown.by_model.contains_key("claude-opus-4-7"),
+        "opus key present"
+    );
+    assert!(
+        breakdown.by_model.contains_key("claude-sonnet-4-6"),
+        "sonnet key present"
     );
 }
 

--- a/tests/render_pr_body.rs
+++ b/tests/render_pr_body.rs
@@ -339,6 +339,173 @@ fn cost_table_omits_by_model_subtable_when_single_model() {
     );
 }
 
+/// Model names flow from snapshot data (`by_model` keys are
+/// session-captured strings). A model name containing the
+/// Markdown table delimiter `|` must be escaped or the rendered
+/// `| Model | Tokens |` row breaks the table structure — extra
+/// pipe characters produce phantom columns and misaligned cells
+/// on GitHub. Per `.claude/rules/subprocess-argument-escaping.md`,
+/// external strings interpolated into a structural-syntax target
+/// must be escaped before interpolation.
+#[test]
+fn cost_table_escapes_pipe_in_model_name() {
+    let mut state = make_test_state();
+    for key in PHASE_ORDER {
+        state["phases"][key]["status"] = json!("complete");
+    }
+    state["phases"]["flow-code"]["window_at_enter"] = snapshot_value("S1", 0, "claude-opus-4-7");
+    let mut complete = snapshot_value("S1", 50, "claude-opus-4-7");
+    // Two models so the by-model sub-table renders; the second
+    // model carries a literal `|` in its name.
+    complete["by_model"]["claude|injected-evil"] = json!({
+        "input": 1000, "output": 500, "cache_create": 0, "cache_read": 0
+    });
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+
+    let table = format_cost_table(&state);
+    let evil_row = table
+        .lines()
+        .find(|l| l.contains("injected-evil"))
+        .unwrap_or_else(|| panic!("injected model row missing; table:\n{}", table));
+    // The escape produces `claude\|injected-evil` — GitHub
+    // Markdown's parser treats `\|` inside a table cell as a
+    // literal pipe character and ignores it as a column
+    // delimiter. The rendered cell shows `claude|injected-evil`.
+    assert!(
+        evil_row.contains("claude\\|injected-evil"),
+        "escaped model name must appear in row; got: {:?}",
+        evil_row
+    );
+    // Count UNESCAPED pipes — those preceded by a backslash do
+    // not act as column delimiters. A 2-column markdown table
+    // row has exactly 3 unescaped pipes: leading, separator,
+    // trailing.
+    let bytes = evil_row.as_bytes();
+    let mut unescaped_pipes = 0;
+    for i in 0..bytes.len() {
+        if bytes[i] == b'|' && (i == 0 || bytes[i - 1] != b'\\') {
+            unescaped_pipes += 1;
+        }
+    }
+    assert_eq!(
+        unescaped_pipes, 3,
+        "by-model row must have exactly 3 unescaped pipes; found {} in row {:?}",
+        unescaped_pipes, evil_row
+    );
+}
+
+/// A model name ending in `\` must have the backslash escaped
+/// in the Markdown cell — otherwise the following pipe column
+/// delimiter would be parsed as an escaped pipe and the cell
+/// would absorb the next column's content.
+#[test]
+fn cost_table_escapes_backslash_in_model_name() {
+    let mut state = make_test_state();
+    for key in PHASE_ORDER {
+        state["phases"][key]["status"] = json!("complete");
+    }
+    state["phases"]["flow-code"]["window_at_enter"] = snapshot_value("S1", 0, "claude-opus-4-7");
+    let mut complete = snapshot_value("S1", 50, "claude-opus-4-7");
+    complete["by_model"]["claude\\"] = json!({
+        "input": 100, "output": 50, "cache_create": 0, "cache_read": 0
+    });
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+
+    let table = format_cost_table(&state);
+    // The escape produces `claude\\` (a literal backslash
+    // doubled) — GitHub Markdown renders `\\` as a single
+    // literal backslash inside a cell.
+    assert!(
+        table.contains("| claude\\\\ |"),
+        "backslash in model name must be escaped as `\\\\`; table:\n{}",
+        table
+    );
+}
+
+/// A model name containing `\n` or `\r` must NOT inject a line
+/// break into the Markdown table — newlines inside cells break
+/// the table structure on GitHub. The escape collapses them to
+/// spaces so the row stays on a single line.
+#[test]
+fn cost_table_escapes_newline_in_model_name() {
+    let mut state = make_test_state();
+    for key in PHASE_ORDER {
+        state["phases"][key]["status"] = json!("complete");
+    }
+    state["phases"]["flow-code"]["window_at_enter"] = snapshot_value("S1", 0, "claude-opus-4-7");
+    let mut complete = snapshot_value("S1", 50, "claude-opus-4-7");
+    complete["by_model"]["claude\nrogue\rmodel"] = json!({
+        "input": 100, "output": 50, "cache_create": 0, "cache_read": 0
+    });
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+
+    let table = format_cost_table(&state);
+    let rogue_row = table
+        .lines()
+        .find(|l| l.contains("rogue"))
+        .unwrap_or_else(|| panic!("rogue-model row missing; table:\n{}", table));
+    // After escape, the row must NOT contain any literal newline
+    // or carriage return — both should be replaced with spaces.
+    assert!(
+        !rogue_row.contains('\n'),
+        "row must not contain literal newline; row: {:?}",
+        rogue_row
+    );
+    assert!(
+        !rogue_row.contains('\r'),
+        "row must not contain literal carriage return; row: {:?}",
+        rogue_row
+    );
+    // The model name's three segments should appear as
+    // space-separated tokens on the same line.
+    assert!(
+        rogue_row.contains("claude rogue model"),
+        "escaped model name segments must appear on one line; row: {:?}",
+        rogue_row
+    );
+}
+
+/// The Total cost cell is bold-wrapped (`**$X.YYY**`). When
+/// `total_partial == true` AND cost is Some, the partial marker
+/// `*` must NOT land between the closing `**` and the trailing
+/// pipe — that produces `**$X.YYY***`, which GitHub Markdown can
+/// parse ambiguously as bold+emphasis. Escape the marker as
+/// `\*` and place it AFTER the bold wrapper so the cell renders
+/// unambiguously as bold value + literal asterisk.
+#[test]
+fn cost_table_total_partial_marker_does_not_produce_triple_asterisk() {
+    let mut state = make_test_state();
+    for key in PHASE_ORDER {
+        state["phases"][key]["status"] = json!("complete");
+    }
+    add_phase_snapshots(&mut state, "flow-start", 0, 5);
+    // flow-code's enter has null cost → total_partial flips on.
+    let mut enter = snapshot_value("S1", 1, "claude-opus-4-7");
+    let complete = snapshot_value("S1", 5, "claude-opus-4-7");
+    enter["session_cost_usd"] = json!(null);
+    state["phases"]["flow-code"]["window_at_enter"] = enter;
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+
+    let table = format_cost_table(&state);
+    let total_row = table
+        .lines()
+        .find(|l| l.contains("**Total**"))
+        .expect("Total row");
+    assert!(
+        !total_row.contains("***"),
+        "Total row must not produce three consecutive asterisks; row: {:?}",
+        total_row
+    );
+    // The fix places the partial marker as `\*` after the bold
+    // wrapper, so the row contains the escape sequence rather
+    // than a bare trailing star inside the bold delimiters.
+    assert!(
+        total_row.contains("\\*"),
+        "Total row must carry the escaped partial marker `\\*` after the bold wrapper; row: {:?}",
+        total_row
+    );
+}
+
 /// A phase whose multi-session snapshot fold produces
 /// `Some(cost)` AND `row_partial == true` renders the per-row
 /// cost cell as `${:.3}*` — the dollar value with the partial

--- a/tests/render_pr_body.rs
+++ b/tests/render_pr_body.rs
@@ -812,6 +812,146 @@ fn section_order() {
     assert_eq!(positions, sorted, "Sections out of order");
 }
 
+// --- render_body Token Cost section integration ---
+
+/// Full state with snapshots → render_body splices a `## Token Cost`
+/// section between `## Phase Timings` and `## State File`.
+#[test]
+fn render_body_includes_token_cost_section_with_cost_data() {
+    let state = full_cost_state();
+    let dir = tempfile::tempdir().unwrap();
+    let body = render_body(&state, dir.path()).unwrap();
+
+    assert!(
+        body.contains("## Token Cost"),
+        "Token Cost section header must appear; body:\n{}",
+        body
+    );
+    let token_pos = body
+        .find("## Token Cost")
+        .expect("Token Cost section position");
+    let timings_pos = body
+        .find("## Phase Timings")
+        .expect("Phase Timings position");
+    let state_pos = body.find("## State File").expect("State File position");
+    assert!(
+        timings_pos < token_pos && token_pos < state_pos,
+        "Token Cost must sit between Phase Timings and State File"
+    );
+}
+
+/// State without window snapshots → format_cost_table returns empty
+/// → render_body omits the section. Other sections still render in
+/// the canonical order.
+#[test]
+fn render_body_omits_token_cost_section_when_no_data() {
+    let mut state = make_test_state();
+    state["phases"] = json!({});
+    let dir = tempfile::tempdir().unwrap();
+    let body = render_body(&state, dir.path()).unwrap();
+
+    assert!(
+        !body.contains("## Token Cost"),
+        "Token Cost section must NOT appear when no snapshot data; body:\n{}",
+        body
+    );
+    let what_pos = body.find("## What").expect("What position");
+    let artifacts_pos = body.find("## Artifacts").expect("Artifacts position");
+    let timings_pos = body
+        .find("## Phase Timings")
+        .expect("Phase Timings position");
+    let state_pos = body.find("## State File").expect("State File position");
+    assert!(
+        what_pos < artifacts_pos && artifacts_pos < timings_pos && timings_pos < state_pos,
+        "core sections must remain in canonical order even without Token Cost"
+    );
+}
+
+/// All eight optional sections rendered together: their `## `
+/// heading positions must follow the canonical order
+/// What < Artifacts < Plan < DAG Analysis < Phase Timings <
+/// Token Cost < State File < Session Log < Issues Filed.
+#[test]
+fn render_body_token_cost_section_order_invariant() {
+    let mut state = full_cost_state();
+    let dir = tempfile::tempdir().unwrap();
+
+    let plan_file = dir.path().join("plan.md");
+    fs::write(&plan_file, "Plan").unwrap();
+    let dag_file = dir.path().join("dag.md");
+    fs::write(&dag_file, "DAG").unwrap();
+    let branch_log_dir = dir.path().join(".flow-states").join("test-feature");
+    fs::create_dir_all(&branch_log_dir).unwrap();
+    fs::write(branch_log_dir.join("log"), "log entry").unwrap();
+    state["plan_file"] = json!(plan_file.to_string_lossy().to_string());
+    state["dag_file"] = json!(dag_file.to_string_lossy().to_string());
+    state["transcript_path"] = json!("/path/to/session.jsonl");
+    state["issues_filed"] = json!([{
+        "label": "Tech Debt",
+        "title": "Issue",
+        "url": "https://github.com/t/t/issues/1",
+        "phase_name": "Learn"
+    }]);
+
+    let body = render_body(&state, dir.path()).unwrap();
+
+    let headings = [
+        "## What",
+        "## Artifacts",
+        "## Plan",
+        "## DAG Analysis",
+        "## Phase Timings",
+        "## Token Cost",
+        "## State File",
+        "## Session Log",
+        "## Issues Filed",
+    ];
+    let positions: Vec<usize> = headings
+        .iter()
+        .map(|h| {
+            body.find(h)
+                .unwrap_or_else(|| panic!("missing heading {} in body:\n{}", h, body))
+        })
+        .collect();
+    let mut sorted = positions.clone();
+    sorted.sort();
+    assert_eq!(
+        positions, sorted,
+        "Token Cost out of order; body:\n{}",
+        body
+    );
+}
+
+/// The Token Cost section is rendered as a plain section (`## Token
+/// Cost\n\n<table>`), not wrapped in a `<details>` collapsible block.
+#[test]
+fn render_body_token_cost_uses_plain_section_format() {
+    let state = full_cost_state();
+    let dir = tempfile::tempdir().unwrap();
+    let body = render_body(&state, dir.path()).unwrap();
+
+    let token_pos = body
+        .find("## Token Cost")
+        .expect("Token Cost section position");
+    let after_token = &body[token_pos..];
+    let next_section = after_token[1..]
+        .find("\n## ")
+        .map(|i| i + 1)
+        .unwrap_or(after_token.len());
+    let token_section = &after_token[..next_section];
+
+    assert!(
+        !token_section.contains("<details>"),
+        "Token Cost section must be plain markdown, not wrapped in <details>; section:\n{}",
+        token_section
+    );
+    assert!(
+        token_section.starts_with("## Token Cost\n\n"),
+        "Token Cost section must start with `## Token Cost\\n\\n`; section starts:\n{:?}",
+        &token_section[..token_section.len().min(80)]
+    );
+}
+
 #[test]
 fn no_issues_no_section() {
     let mut state = make_test_state();

--- a/tests/render_pr_body.rs
+++ b/tests/render_pr_body.rs
@@ -10,10 +10,12 @@ use std::fs;
 use std::path::Path;
 use std::process::{Command, Output};
 
-use common::{create_gh_stub, create_git_repo_with_remote, parse_output};
+use common::{
+    add_phase_snapshots, create_gh_stub, create_git_repo_with_remote, parse_output, snapshot_value,
+};
 use flow_rs::format_pr_timings::format_timings_table;
 use flow_rs::phase_config::PHASE_ORDER;
-use flow_rs::render_pr_body::render_body;
+use flow_rs::render_pr_body::{format_cost_table, render_body};
 use serde_json::{json, Value};
 
 // --- Fixtures ---
@@ -144,6 +146,287 @@ fn timings_table_float_cumulative_seconds() {
     let table = format_timings_table(&state, true);
     assert!(table.contains("| Start | 2m |"));
     assert!(table.contains("| **Total** | **2m** |"));
+}
+
+// --- format_cost_table ---
+//
+// The Markdown formatter consumes the same `CostBreakdown` the
+// terminal banner does. Tests below mirror the structural shape:
+// header, per-phase rows, bold total, em-dash placeholders, partial /
+// reset markers, optional By Model sub-table, empty-on-None.
+
+fn full_cost_state() -> Value {
+    let mut state = make_test_state();
+    for key in PHASE_ORDER {
+        state["phases"][key]["status"] = json!("complete");
+    }
+    add_phase_snapshots(&mut state, "flow-start", 0, 5);
+    add_phase_snapshots(&mut state, "flow-code", 5, 15);
+    add_phase_snapshots(&mut state, "flow-review", 15, 20);
+    add_phase_snapshots(&mut state, "flow-learn", 20, 25);
+    add_phase_snapshots(&mut state, "flow-complete", 25, 30);
+    state
+}
+
+/// Header and separator lead the table — `| Phase | Tokens | Cost |`
+/// then the markdown alignment row.
+#[test]
+fn cost_table_renders_header_and_separator() {
+    let state = full_cost_state();
+    let table = format_cost_table(&state);
+    assert!(
+        table.starts_with("| Phase | Tokens | Cost |\n|-------|--------|------|"),
+        "header + separator must lead the table; got:\n{}",
+        table
+    );
+}
+
+/// Each non-pending phase appears as a `| <name> | ... | ... |` row.
+#[test]
+fn cost_table_renders_per_phase_rows() {
+    let state = full_cost_state();
+    let table = format_cost_table(&state);
+    for name in ["Start", "Code", "Review", "Learn", "Complete"] {
+        assert!(
+            table.contains(&format!("| {} |", name)),
+            "phase row for {} missing; table:\n{}",
+            name,
+            table
+        );
+    }
+}
+
+/// The final data row is the bold Total row.
+#[test]
+fn cost_table_total_row_is_bold() {
+    let state = full_cost_state();
+    let table = format_cost_table(&state);
+    assert!(
+        table.contains("| **Total** | **"),
+        "bold Total row must appear; table:\n{}",
+        table
+    );
+}
+
+/// A phase row whose cost is `None` renders the em-dash placeholder
+/// in the Cost cell.
+#[test]
+fn cost_table_uses_em_dash_for_unknown_cost() {
+    let mut state = make_test_state();
+    for key in PHASE_ORDER {
+        state["phases"][key]["status"] = json!("complete");
+    }
+    let mut enter = snapshot_value("S1", 1, "claude-opus-4-7");
+    let complete = snapshot_value("S1", 5, "claude-opus-4-7");
+    enter["session_cost_usd"] = json!(null);
+    state["phases"]["flow-code"]["window_at_enter"] = enter;
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+
+    let table = format_cost_table(&state);
+    let code_row = table
+        .lines()
+        .find(|l| l.starts_with("| Code |"))
+        .unwrap_or_else(|| panic!("Code row missing; table:\n{}", table));
+    assert!(
+        code_row.contains("—"),
+        "Code row must carry em-dash for unknown cost; row: {:?}",
+        code_row
+    );
+}
+
+/// When any phase contributes `None` cost, the Total's cost cell
+/// ends with the `*` partial marker.
+#[test]
+fn cost_table_appends_partial_marker_in_total() {
+    let mut state = make_test_state();
+    for key in PHASE_ORDER {
+        state["phases"][key]["status"] = json!("complete");
+    }
+    add_phase_snapshots(&mut state, "flow-start", 0, 5);
+    // flow-code's enter has cost None → cost_delta_usd None → total_partial.
+    let mut enter = snapshot_value("S1", 1, "claude-opus-4-7");
+    let complete = snapshot_value("S1", 5, "claude-opus-4-7");
+    enter["session_cost_usd"] = json!(null);
+    state["phases"]["flow-code"]["window_at_enter"] = enter;
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+
+    let table = format_cost_table(&state);
+    let total_row = table
+        .lines()
+        .find(|l| l.contains("**Total**"))
+        .expect("Total row");
+    assert!(
+        total_row.contains("*"),
+        "Total row cost cell must carry the partial marker; row: {:?}",
+        total_row
+    );
+}
+
+/// A phase whose snapshot pair shows the 5h pct dropping between
+/// enter and complete renders the reset marker `↻` in that row's
+/// Cost cell.
+#[test]
+fn cost_table_appends_reset_marker_per_row() {
+    let mut state = make_test_state();
+    for key in PHASE_ORDER {
+        state["phases"][key]["status"] = json!("complete");
+    }
+    let mut enter = snapshot_value("S1", 80, "claude-opus-4-7");
+    let mut complete = snapshot_value("S1", 5, "claude-opus-4-7");
+    enter["session_input_tokens"] = json!(100);
+    complete["session_input_tokens"] = json!(500);
+    state["phases"]["flow-code"]["window_at_enter"] = enter;
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+
+    let table = format_cost_table(&state);
+    let code_row = table
+        .lines()
+        .find(|l| l.starts_with("| Code |"))
+        .expect("Code row");
+    assert!(
+        code_row.contains("↻"),
+        "Code row must carry the reset marker; row: {:?}",
+        code_row
+    );
+}
+
+/// A multi-model breakdown renders a `| Model | Tokens |` sub-table
+/// after the per-phase table.
+#[test]
+fn cost_table_includes_by_model_subtable_when_multi_model() {
+    let mut state = make_test_state();
+    for key in PHASE_ORDER {
+        state["phases"][key]["status"] = json!("complete");
+    }
+    state["phases"]["flow-code"]["window_at_enter"] = snapshot_value("S1", 0, "claude-opus-4-7");
+    let mut complete = snapshot_value("S1", 50, "claude-opus-4-7");
+    complete["by_model"]["claude-sonnet-4-6"] = json!({
+        "input": 1000, "output": 500, "cache_create": 0, "cache_read": 0
+    });
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+
+    let table = format_cost_table(&state);
+    assert!(
+        table.contains("| Model | Tokens |"),
+        "By Model sub-table header missing; table:\n{}",
+        table
+    );
+    assert!(
+        table.contains("claude-opus-4-7"),
+        "opus row missing in sub-table"
+    );
+    assert!(
+        table.contains("claude-sonnet-4-6"),
+        "sonnet row missing in sub-table"
+    );
+}
+
+/// A single-model breakdown skips the `| Model | Tokens |` sub-table
+/// (a one-row breakdown adds no signal).
+#[test]
+fn cost_table_omits_by_model_subtable_when_single_model() {
+    let mut state = make_test_state();
+    for key in PHASE_ORDER {
+        state["phases"][key]["status"] = json!("complete");
+    }
+    add_phase_snapshots(&mut state, "flow-code", 0, 5);
+
+    let table = format_cost_table(&state);
+    assert!(
+        !table.contains("| Model | Tokens |"),
+        "single-model breakdown must suppress sub-table; table:\n{}",
+        table
+    );
+}
+
+/// A phase whose multi-session snapshot fold produces
+/// `Some(cost)` AND `row_partial == true` renders the per-row
+/// cost cell as `${:.3}*` — the dollar value with the partial
+/// marker suffix. The fold groups by `session_id`: session S1
+/// (enter + step0) contributes a Some cost delta; session S2
+/// (step1 + complete-with-null-cost) contributes a None delta
+/// that flips `total_partial` while leaving the running `Some`
+/// cost in place.
+#[test]
+fn cost_table_appends_partial_marker_to_row_when_cost_partial() {
+    let mut state = make_test_state();
+    for key in PHASE_ORDER {
+        state["phases"][key]["status"] = json!("complete");
+    }
+    let enter = snapshot_value("S1", 1, "claude-opus-4-7");
+    let step0 = snapshot_value("S1", 5, "claude-opus-4-7");
+    let step1 = snapshot_value("S2", 2, "claude-opus-4-7");
+    let mut complete = snapshot_value("S2", 6, "claude-opus-4-7");
+    complete["session_cost_usd"] = json!(null);
+    state["phases"]["flow-code"]["window_at_enter"] = enter;
+    state["phases"]["flow-code"]["window_at_complete"] = complete;
+    state["phases"]["flow-code"]["step_snapshots"] = json!([
+        {
+            "step": 1,
+            "field": "code_task",
+            "captured_at": step0["captured_at"],
+            "session_id": step0["session_id"],
+            "model": step0["model"],
+            "five_hour_pct": step0["five_hour_pct"],
+            "seven_day_pct": step0["seven_day_pct"],
+            "session_input_tokens": step0["session_input_tokens"],
+            "session_output_tokens": step0["session_output_tokens"],
+            "session_cache_creation_tokens": step0["session_cache_creation_tokens"],
+            "session_cache_read_tokens": step0["session_cache_read_tokens"],
+            "session_cost_usd": step0["session_cost_usd"],
+            "by_model": step0["by_model"],
+            "turn_count": step0["turn_count"],
+            "tool_call_count": step0["tool_call_count"],
+            "context_at_last_turn_tokens": step0["context_at_last_turn_tokens"],
+            "context_window_pct": step0["context_window_pct"],
+        },
+        {
+            "step": 2,
+            "field": "code_task",
+            "captured_at": step1["captured_at"],
+            "session_id": step1["session_id"],
+            "model": step1["model"],
+            "five_hour_pct": step1["five_hour_pct"],
+            "seven_day_pct": step1["seven_day_pct"],
+            "session_input_tokens": step1["session_input_tokens"],
+            "session_output_tokens": step1["session_output_tokens"],
+            "session_cache_creation_tokens": step1["session_cache_creation_tokens"],
+            "session_cache_read_tokens": step1["session_cache_read_tokens"],
+            "session_cost_usd": step1["session_cost_usd"],
+            "by_model": step1["by_model"],
+            "turn_count": step1["turn_count"],
+            "tool_call_count": step1["tool_call_count"],
+            "context_at_last_turn_tokens": step1["context_at_last_turn_tokens"],
+            "context_window_pct": step1["context_window_pct"],
+        },
+    ]);
+
+    let table = format_cost_table(&state);
+    let code_row = table
+        .lines()
+        .find(|l| l.starts_with("| Code |"))
+        .unwrap_or_else(|| panic!("Code row missing; table:\n{}", table));
+    assert!(
+        code_row.contains('$'),
+        "Code row must carry $ cost cell when Some(cost); row: {:?}",
+        code_row
+    );
+    assert!(
+        code_row.contains('*'),
+        "Code row must carry the * partial marker when row_partial; row: {:?}",
+        code_row
+    );
+}
+
+/// Empty phases map → `compute_cost_breakdown` returns None →
+/// `format_cost_table` returns an empty string so renderers can omit
+/// the section.
+#[test]
+fn cost_table_returns_empty_when_breakdown_none() {
+    let mut state = make_test_state();
+    state["phases"] = json!({});
+    let table = format_cost_table(&state);
+    assert_eq!(table, "", "expected empty string; got: {:?}", table);
 }
 
 // --- render_body ---


### PR DESCRIPTION
## What

#1472.

Closes #1472

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/show-per-phase-token-cost/log` |
| State | `.flow-states/show-per-phase-token-cost/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 34m |
| Review | 26m |
| Learn | 7m |
| Complete | <1m |
| **Total** | **1h 10m** |

<!-- end:Phase Timings -->

## State File

<details>
<summary>.flow-states/show-per-phase-token-cost.json</summary>

```json
{
  "schema_version": 1,
  "branch": "show-per-phase-token-cost",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1473,
  "pr_url": "https://github.com/benkruger/flow/pull/1473",
  "started_at": "2026-05-11T17:15:35-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/show-per-phase-token-cost/log",
    "state": ".flow-states/show-per-phase-token-cost/state.json"
  },
  "session_tty": "/dev/ttys005",
  "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
  "transcript_path": null,
  "notes": [],
  "prompt": "#1472",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-11T17:15:35-07:00",
      "completed_at": "2026-05-11T17:16:14-07:00",
      "session_started_at": null,
      "cumulative_seconds": 39,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T17:15:35-07:00",
        "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
        "model": "claude-opus-4-7",
        "five_hour_pct": 56,
        "seven_day_pct": 37,
        "session_input_tokens": 19,
        "session_output_tokens": 3174,
        "session_cache_creation_tokens": 588504,
        "session_cache_read_tokens": 260337,
        "session_cost_usd": 10.501150750000004,
        "by_model": {
          "claude-opus-4-7": {
            "input": 19,
            "output": 3174,
            "cache_create": 588504,
            "cache_read": 260337
          }
        },
        "turn_count": 4,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 213019,
        "context_window_pct": 106.5095
      },
      "window_at_complete": {
        "captured_at": "2026-05-11T17:16:14-07:00",
        "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
        "model": "claude-opus-4-7",
        "five_hour_pct": 56,
        "seven_day_pct": 37,
        "session_input_tokens": 32,
        "session_output_tokens": 5921,
        "session_cache_creation_tokens": 592484,
        "session_cache_read_tokens": 3039956,
        "session_cost_usd": 11.296545750000003,
        "by_model": {
          "claude-opus-4-7": {
            "input": 32,
            "output": 5921,
            "cache_create": 592484,
            "cache_read": 3039956
          }
        },
        "turn_count": 17,
        "tool_call_count": 9,
        "context_at_last_turn_tokens": 215145,
        "context_window_pct": 107.5725
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-11T17:16:26-07:00",
      "completed_at": "2026-05-11T17:50:44-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2058,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T17:16:26-07:00",
        "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
        "model": "claude-opus-4-7",
        "five_hour_pct": 57,
        "seven_day_pct": 37,
        "session_input_tokens": 49,
        "session_output_tokens": 7065,
        "session_cache_creation_tokens": 619253,
        "session_cache_read_tokens": 4116288,
        "session_cost_usd": 11.579565500000006,
        "by_model": {
          "claude-opus-4-7": {
            "input": 49,
            "output": 7065,
            "cache_create": 619253,
            "cache_read": 4116288
          }
        },
        "turn_count": 22,
        "tool_call_count": 11,
        "context_at_last_turn_tokens": 224140,
        "context_window_pct": 112.07
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-11T17:19:50-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 59,
          "seven_day_pct": 37,
          "session_input_tokens": 90,
          "session_output_tokens": 30260,
          "session_cache_creation_tokens": 1308797,
          "session_cache_read_tokens": 20840668,
          "session_cost_usd": 18.3196895,
          "by_model": {
            "claude-opus-4-7": {
              "input": 90,
              "output": 30260,
              "cache_create": 1308797,
              "cache_read": 20840668
            }
          },
          "turn_count": 63,
          "tool_call_count": 34,
          "context_at_last_turn_tokens": 487978,
          "context_window_pct": 243.989
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-11T17:22:34-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 60,
          "seven_day_pct": 37,
          "session_input_tokens": 104,
          "session_output_tokens": 58921,
          "session_cache_creation_tokens": 1348112,
          "session_cache_read_tokens": 27750438,
          "session_cost_usd": 20.19705,
          "by_model": {
            "claude-opus-4-7": {
              "input": 104,
              "output": 58921,
              "cache_create": 1348112,
              "cache_read": 27750438
            }
          },
          "turn_count": 77,
          "tool_call_count": 40,
          "context_at_last_turn_tokens": 504948,
          "context_window_pct": 252.474
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-11T17:29:25-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 64,
          "seven_day_pct": 38,
          "session_input_tokens": 173,
          "session_output_tokens": 88145,
          "session_cache_creation_tokens": 1448423,
          "session_cache_read_tokens": 49614638,
          "session_cost_usd": 26.18947374999999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 173,
              "output": 88145,
              "cache_create": 1448423,
              "cache_read": 49614638
            }
          },
          "turn_count": 119,
          "tool_call_count": 61,
          "context_at_last_turn_tokens": 545433,
          "context_window_pct": 272.7165
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-11T17:40:16-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 3,
          "seven_day_pct": 39,
          "session_input_tokens": 217,
          "session_output_tokens": 138045,
          "session_cache_creation_tokens": 1526248,
          "session_cache_read_tokens": 74376173,
          "session_cost_usd": 32.49520149999999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 217,
              "output": 138045,
              "cache_create": 1526248,
              "cache_read": 74376173
            }
          },
          "turn_count": 163,
          "tool_call_count": 81,
          "context_at_last_turn_tokens": 580936,
          "context_window_pct": 290.468
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-11T17:42:20-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 3,
          "seven_day_pct": 39,
          "session_input_tokens": 258,
          "session_output_tokens": 153559,
          "session_cache_creation_tokens": 1572448,
          "session_cache_read_tokens": 87930180,
          "session_cost_usd": 36.92361249999999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 258,
              "output": 153559,
              "cache_create": 1572448,
              "cache_read": 87930180
            }
          },
          "turn_count": 186,
          "tool_call_count": 95,
          "context_at_last_turn_tokens": 604594,
          "context_window_pct": 302.297
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-11T17:46:13-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 41,
          "session_input_tokens": 279,
          "session_output_tokens": 161200,
          "session_cache_creation_tokens": 1596206,
          "session_cache_read_tokens": 100678756,
          "session_cost_usd": 40.413720999999995,
          "by_model": {
            "claude-opus-4-7": {
              "input": 279,
              "output": 161200,
              "cache_create": 1596206,
              "cache_read": 100678756
            }
          },
          "turn_count": 207,
          "tool_call_count": 106,
          "context_at_last_turn_tokens": 614308,
          "context_window_pct": 307.154
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-11T17:49:56-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 10,
          "seven_day_pct": 41,
          "session_input_tokens": 321,
          "session_output_tokens": 170564,
          "session_cache_creation_tokens": 1637282,
          "session_cache_read_tokens": 115672821,
          "session_cost_usd": 45.016223,
          "by_model": {
            "claude-opus-4-7": {
              "input": 321,
              "output": 170564,
              "cache_create": 1637282,
              "cache_read": 115672821
            }
          },
          "turn_count": 231,
          "tool_call_count": 120,
          "context_at_last_turn_tokens": 635792,
          "context_window_pct": 317.896
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T17:50:44-07:00",
        "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
        "model": "claude-opus-4-7",
        "five_hour_pct": 10,
        "seven_day_pct": 41,
        "session_input_tokens": 357,
        "session_output_tokens": 174144,
        "session_cache_creation_tokens": 1674173,
        "session_cache_read_tokens": 123994499,
        "session_cost_usd": 47.705957999999995,
        "by_model": {
          "claude-opus-4-7": {
            "input": 357,
            "output": 174144,
            "cache_create": 1674173,
            "cache_read": 123994499
          }
        },
        "turn_count": 244,
        "tool_call_count": 128,
        "context_at_last_turn_tokens": 650128,
        "context_window_pct": 325.064
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-11T17:50:56-07:00",
      "completed_at": "2026-05-11T18:17:41-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1605,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T17:50:56-07:00",
        "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
        "model": "claude-opus-4-7",
        "five_hour_pct": 11,
        "seven_day_pct": 41,
        "session_input_tokens": 369,
        "session_output_tokens": 175006,
        "session_cache_creation_tokens": 1702151,
        "session_cache_read_tokens": 126595411,
        "session_cost_usd": 48.45442224999999,
        "by_model": {
          "claude-opus-4-7": {
            "input": 369,
            "output": 175006,
            "cache_create": 1702151,
            "cache_read": 126595411
          }
        },
        "turn_count": 248,
        "tool_call_count": 130,
        "context_at_last_turn_tokens": 664121,
        "context_window_pct": 332.0605
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-11T17:52:29-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 12,
          "seven_day_pct": 42,
          "session_input_tokens": 386,
          "session_output_tokens": 179754,
          "session_cache_creation_tokens": 1710231,
          "session_cache_read_tokens": 137910427,
          "session_cost_usd": 52.21328399999999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 386,
              "output": 179754,
              "cache_create": 1710231,
              "cache_read": 137910427
            }
          },
          "turn_count": 265,
          "tool_call_count": 141,
          "context_at_last_turn_tokens": 669040,
          "context_window_pct": 334.52
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-11T17:59:40-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 16,
          "seven_day_pct": 43,
          "session_input_tokens": 7492,
          "session_output_tokens": 242037,
          "session_cache_creation_tokens": 1746109,
          "session_cache_read_tokens": 143264005,
          "session_cost_usd": 65.56314944999997,
          "by_model": {
            "claude-opus-4-7": {
              "input": 7492,
              "output": 242037,
              "cache_create": 1746109,
              "cache_read": 143264005
            }
          },
          "turn_count": 273,
          "tool_call_count": 146,
          "context_at_last_turn_tokens": 683084,
          "context_window_pct": 341.542
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-11T18:01:46-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 18,
          "seven_day_pct": 43,
          "session_input_tokens": 7502,
          "session_output_tokens": 247341,
          "session_cache_creation_tokens": 1777619,
          "session_cache_read_tokens": 150201154,
          "session_cost_usd": 68.88971044999997,
          "by_model": {
            "claude-opus-4-7": {
              "input": 7502,
              "output": 247341,
              "cache_create": 1777619,
              "cache_read": 150201154
            }
          },
          "turn_count": 283,
          "tool_call_count": 155,
          "context_at_last_turn_tokens": 698362,
          "context_window_pct": 349.181
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-11T18:17:31-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 22,
          "seven_day_pct": 44,
          "session_input_tokens": 7587,
          "session_output_tokens": 312632,
          "session_cache_creation_tokens": 4103599,
          "session_cache_read_tokens": 193363859,
          "session_cost_usd": 86.19448544999995,
          "by_model": {
            "claude-opus-4-7": {
              "input": 7587,
              "output": 312632,
              "cache_create": 4103599,
              "cache_read": 193363859
            }
          },
          "turn_count": 345,
          "tool_call_count": 188,
          "context_at_last_turn_tokens": 756745,
          "context_window_pct": 378.3725
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T18:17:41-07:00",
        "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
        "model": "claude-opus-4-7",
        "five_hour_pct": 22,
        "seven_day_pct": 44,
        "session_input_tokens": 7606,
        "session_output_tokens": 313405,
        "session_cache_creation_tokens": 4145056,
        "session_cache_read_tokens": 196392257,
        "session_cost_usd": 87.04792019999995,
        "by_model": {
          "claude-opus-4-7": {
            "input": 7606,
            "output": 313405,
            "cache_create": 4145056,
            "cache_read": 196392257
          }
        },
        "turn_count": 349,
        "tool_call_count": 190,
        "context_at_last_turn_tokens": 770885,
        "context_window_pct": 385.4425
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-11T18:17:53-07:00",
      "completed_at": "2026-05-11T18:25:41-07:00",
      "session_started_at": null,
      "cumulative_seconds": 468,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T18:17:53-07:00",
        "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
        "model": "claude-opus-4-7",
        "five_hour_pct": 22,
        "seven_day_pct": 44,
        "session_input_tokens": 7618,
        "session_output_tokens": 314277,
        "session_cache_creation_tokens": 4167780,
        "session_cache_read_tokens": 199476315,
        "session_cost_usd": 87.90087719999995,
        "by_model": {
          "claude-opus-4-7": {
            "input": 7618,
            "output": 314277,
            "cache_create": 4167780,
            "cache_read": 199476315
          }
        },
        "turn_count": 353,
        "tool_call_count": 192,
        "context_at_last_turn_tokens": 782246,
        "context_window_pct": 391.123
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-11T18:21:30-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 24,
          "seven_day_pct": 45,
          "session_input_tokens": 7643,
          "session_output_tokens": 329034,
          "session_cache_creation_tokens": 4210396,
          "session_cache_read_tokens": 219232476,
          "session_cost_usd": 95.50958889999995,
          "by_model": {
            "claude-opus-4-7": {
              "input": 7643,
              "output": 329034,
              "cache_create": 4210396,
              "cache_read": 219232476
            }
          },
          "turn_count": 378,
          "tool_call_count": 209,
          "context_at_last_turn_tokens": 804506,
          "context_window_pct": 402.253
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-11T18:21:38-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 24,
          "seven_day_pct": 45,
          "session_input_tokens": 7644,
          "session_output_tokens": 329156,
          "session_cache_creation_tokens": 4210558,
          "session_cache_read_tokens": 220036981,
          "session_cost_usd": 95.91590889999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 7644,
              "output": 329156,
              "cache_create": 4210558,
              "cache_read": 220036981
            }
          },
          "turn_count": 379,
          "tool_call_count": 210,
          "context_at_last_turn_tokens": 804668,
          "context_window_pct": 402.334
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-11T18:22:37-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 24,
          "seven_day_pct": 45,
          "session_input_tokens": 7653,
          "session_output_tokens": 334758,
          "session_cache_creation_tokens": 4218520,
          "session_cache_read_tokens": 227300797,
          "session_cost_usd": 98.44980414999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 7653,
              "output": 334758,
              "cache_create": 4218520,
              "cache_read": 227300797
            }
          },
          "turn_count": 388,
          "tool_call_count": 216,
          "context_at_last_turn_tokens": 810005,
          "context_window_pct": 405.0025
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-11T18:25:12-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 24,
          "seven_day_pct": 45,
          "session_input_tokens": 7675,
          "session_output_tokens": 338708,
          "session_cache_creation_tokens": 4233290,
          "session_cache_read_tokens": 238689786,
          "session_cost_usd": 102.21655464999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 7675,
              "output": 338708,
              "cache_create": 4233290,
              "cache_read": 238689786
            }
          },
          "turn_count": 402,
          "tool_call_count": 225,
          "context_at_last_turn_tokens": 818155,
          "context_window_pct": 409.0775
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-11T18:25:28-07:00",
          "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
          "model": "claude-opus-4-7",
          "five_hour_pct": 24,
          "seven_day_pct": 45,
          "session_input_tokens": 7694,
          "session_output_tokens": 339782,
          "session_cache_creation_tokens": 4266659,
          "session_cache_read_tokens": 241963833,
          "session_cost_usd": 103.11708839999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 7694,
              "output": 339782,
              "cache_create": 4266659,
              "cache_read": 241963833
            }
          },
          "turn_count": 406,
          "tool_call_count": 227,
          "context_at_last_turn_tokens": 829601,
          "context_window_pct": 414.8005
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-11T18:25:41-07:00",
        "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
        "model": "claude-opus-4-7",
        "five_hour_pct": 24,
        "seven_day_pct": 45,
        "session_input_tokens": 7696,
        "session_output_tokens": 341334,
        "session_cache_creation_tokens": 4267399,
        "session_cache_read_tokens": 243623023,
        "session_cost_usd": 103.55360339999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 7696,
            "output": 341334,
            "cache_create": 4267399,
            "cache_read": 243623023
          }
        },
        "turn_count": 408,
        "tool_call_count": 228,
        "context_at_last_turn_tokens": 829966,
        "context_window_pct": 414.983
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-11T18:26:03-07:00",
      "completed_at": "2026-05-11T18:26:33-07:00",
      "session_started_at": null,
      "cumulative_seconds": 30,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-11T18:26:03-07:00",
        "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
        "model": "claude-opus-4-7",
        "five_hour_pct": 27,
        "seven_day_pct": 46,
        "session_input_tokens": 7710,
        "session_output_tokens": 342920,
        "session_cache_creation_tokens": 4294839,
        "session_cache_read_tokens": 248631255,
        "session_cost_usd": 104.91127139999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 7710,
            "output": 342920,
            "cache_create": 4294839,
            "cache_read": 248631255
          }
        },
        "turn_count": 414,
        "tool_call_count": 231,
        "context_at_last_turn_tokens": 843686,
        "context_window_pct": 421.843
      },
      "window_at_complete": {
        "captured_at": "2026-05-11T18:26:33-07:00",
        "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
        "model": "claude-opus-4-7",
        "five_hour_pct": 27,
        "seven_day_pct": 46,
        "session_input_tokens": 7713,
        "session_output_tokens": 343428,
        "session_cache_creation_tokens": 4296087,
        "session_cache_read_tokens": 251162854,
        "session_cost_usd": 105.76888839999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 7713,
            "output": 343428,
            "cache_create": 4296087,
            "cache_read": 251162854
          }
        },
        "turn_count": 417,
        "tool_call_count": 233,
        "context_at_last_turn_tokens": 844390,
        "context_window_pct": 422.195
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-11T17:16:26-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-11T17:50:56-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-11T18:17:53-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-11T18:26:03-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-11T17:15:35-07:00",
    "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
    "model": "claude-opus-4-7",
    "five_hour_pct": 56,
    "seven_day_pct": 37,
    "session_input_tokens": 19,
    "session_output_tokens": 3174,
    "session_cache_creation_tokens": 588504,
    "session_cache_read_tokens": 260337,
    "session_cost_usd": 10.501150750000004,
    "by_model": {
      "claude-opus-4-7": {
        "input": 19,
        "output": 3174,
        "cache_create": 588504,
        "cache_read": 260337
      }
    },
    "turn_count": 4,
    "tool_call_count": 2,
    "context_at_last_turn_tokens": 213019,
    "context_window_pct": 106.5095
  },
  "code_tasks_total": 7,
  "code_task_name": "Verify 100/100/100 coverage and full CI green",
  "code_task": 7,
  "diff_stats": {
    "files_changed": 6,
    "insertions": 765,
    "deletions": 41,
    "captured_at": "2026-05-11T17:50:44-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nLet me trace through this conversation chronologically to understand what has occurred:\n\n1. The user initiated a Learn phase audit for PR #1473 (show-per-phase-token-cost branch) on the FLOW project.\n\n2. The user provided extensive context through a system message containing:\n   - The FRAMING section explaining the two-gate test for findings (forward-facing + value-based)\n   - References to specific artifacts to read: full-diff.diff, state.json, plan.md, CLAUDE.md, and rules files\n   - An explicit request to audit three tenants:\n     * Process gap (FLOW workflow breaks/misses)\n     * Rule compliance (session violations)\n     * Missing rule (new classes of mistakes not covered)\n   - A specific question about markdown-cell escape patterns and subprocess-argument-escaping rule\n\n3. I then made tool calls (Read operations) to:\n   - Read the full diff from `/Users/ben/code/flow/.flow-states/show-per-phase-token-cost/full-diff.diff`\n   - Read the state.json file\n   - Read the plan.md file\n   - Attempt to read CLAUDE.md and browse the rules directory\n\n4. Through those reads, I discovered:\n   - The PR modified src/format_complete_summary.rs, src/render_pr_body.rs, and added comprehensive tests\n   - It extracted a CostBreakdown struct and compute_cost_breakdown function\n   - It added a new format_cost_table function for markdown rendering\n   - The state.json showed the session executed all 7 code tasks\n   - The plan.md outlined the implementation approach in detail\n   - The review findings showed 11 total findings: 3 fixed, 8 dismissed, with three \"real findings\" caught and remediated\n\n5. After reading these files, I began analyzing the code against the Learn phase audit tenants and the specific question about subprocess-argument-escaping and markdown.\n\n6. I identified several observations:\n   - `format_cost_table` is declared `pub fn` but only has same-module production callers (rule violation)\n   - The inline comment `// 5b. Token Cost` uses non-standard numbering\n   - The code implements markdown table formatting with escape patterns for pipe characters\n   - The subprocess-argument-escaping rule mentions AppleScript, shell, SQL, regex, JSON but NOT Markdown\n\n7. However, the user then issued a CRITICAL instruction:\n   - \"Respond with TEXT ONLY. Do NOT call any tools.\"\n   - \"You already have all the context you need in the conversation above.\"\n   - \"Tool calls will be REJECTED and will waste your only turn — you will fail the task.\"\n   - The user is asking for a summary of the conversation, not findings.\n\nThis changes the task entirely. The user is NOT asking me to complete the Learn phase audit. Instead, they're asking me to summarize what has happened in this conversation so far—the reads I made, the artifacts I accessed, and the analysis I was conducting.\n\nThe current request is for a summary following a specific template with 9 sections.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user initiated a Learn phase audit for PR #1473 on the FLOW repository (branch: show-per-phase-token-cost). The explicit task was to audit the PR against three tenants: (1) Process gap—did the FLOW workflow break or miss something, (2) Rule compliance—did this session violate any rules, and (3) Missing rule—is there a class of mistake this PR illustrates that no rule covers. Specific attention was requested for the markdown-cell escape pattern in the context of the subprocess-argument-escaping rule, which currently mentions AppleScript, shell, SQL, and regex but NOT Markdown. The user applied a two-gate test for findings: forward-facing (would a future session understand and apply this?) and value-based (was the gap caught and remediated in this PR?).\n\n2. Key Technical Concepts:\n   - FLOW workflow phases: Start, Code, Review, Learn, Complete\n   - Two-gate test for findings (forward-facing and value-based filtering)\n   - Three-tenant audit framework (Process gap, Rule compliance, Missing rule)\n   - CostBreakdown structured intermediate pattern\n   - Markdown table rendering with escape patterns\n   - Subprocess argument escaping and injection prevention\n   - PR #1473 scope: extracting token cost computation into reusable intermediate for dual formatters (terminal and Markdown)\n   - State file mutations and phase status tracking\n   - Test placement rules and public function exposure (bright-line test)\n\n3. Files and Code Sections:\n   - `/Users/ben/code/flow/.flow-states/show-per-phase-token-cost/full-diff.diff` (766 lines)\n     - Primary diff file showing all changes to the PR\n     - Modified files: docs/phases/phase-5-complete.md, skills/flow-complete/SKILL.md, src/format_complete_summary.rs, src/render_pr_body.rs, tests/format_complete_summary.rs, tests/render_pr_body.rs\n   \n   - `/Users/ben/code/flow/.flow-states/show-per-phase-token-cost/state.json`\n     - Session state showing all 7 code tasks completed\n     - Review phase completed with 11 total findings (3 fixed in-PR, 8 dismissed)\n     - Three \"real findings\" from review: markdown pipe injection, triple-asterisk ambiguity, status normalization gap\n   \n   - `/Users/ben/code/flow/.flow-states/show-per-phase-token-cost/plan.md`\n     - Implementation plan with Context, Exploration, Risks, Approach, Dependency Graph, and Tasks sections\n     - 7 tasks organized in TDD pairs: test tasks (1, 3, 5) paired with implementation tasks (2, 4, 6), plus verification task 7\n     - Detailed per-file exploration identifying CostBreakdown extraction pattern and dual-formatter pattern\n   \n   - `src/format_complete_summary.rs` (key extractions):\n     - New CostRow struct: `pub struct CostRow { pub phase_name: String, pub tokens: i64, pub cost: Option<f64>, pub reset_observed: bool, pub row_partial: bool }`\n     - New CostBreakdown struct with rows, total_tokens, total_cost, total_partial, by_model, reset_observed_anywhere\n     - Extracted `pub fn compute_cost_breakdown(state: &Value) -> Option<CostBreakdown>` from inline logic previously in token_cost_section\n     - Refactored token_cost_section to delegate to compute_cost_breakdown and format the result\n   \n   - `src/render_pr_body.rs` (key additions):\n     - New `pub fn format_cost_table(state: &serde_json::Value) -> String` function\n     - Markdown table formatter with header, per-row data, bold total row\n     - Cost cell formatting with `${:.3}` for costs, `—` for None values\n     - Partial marker (`*`) and reset marker (`↻`) handling\n     - By-model sub-table when >= 2 models\n     - Integrated into render_body between Phase Timings and State File sections\n   \n   - `tests/format_complete_summary.rs` (new tests):\n     - 6 compute_cost_breakdown_* tests covering: full data, empty phases, all pending, partial cost, reset observed, multi-model\n   \n   - `tests/render_pr_body.rs` (new tests):\n     - 9 cost_table_* tests (header, per-phase rows, bold total, em-dash, partial marker, reset marker, by-model subtable, single-model omit, empty return)\n     - 1 bonus test: cost_table_appends_partial_marker_to_row_when_cost_partial (multi-session folding scenario)\n     - 4 render_body integration tests (Token Cost section inclusion, omission, section order invariant, plain section format)\n\n4. Errors and fixes:\n   No errors were encountered or reported by the user. The conversation proceeded smoothly through artifact reading and analysis initiation.\n\n5. Problem Solving:\n   The primary analytical work involved:\n   - Tracing the CostBreakdown extraction pattern and verifying terminal output byte-identity (pure code motion, no format changes)\n   - Identifying the shared intermediate pattern between two formatters (terminal banner and Markdown table)\n   - Analyzing the public surface exposure of CostRow, CostBreakdown, and format_cost_table against the bright-line test in test-placement.md\n   - Examining escape handling for markdown pipe characters and reset markers\n   - Cross-checking all plan-named tests against the diff (6 + 9 + 4 = 19 tests plus 1 bonus = 20 total)\n   - Reviewing section ordering invariant enforcement through render_body integration tests\n   - Analyzing the relationship between terminal and markdown formatters for consistency in cost/reset/partial marker placement\n\n6. All user messages:\n   - Initial message containing FRAMING (two-gate test), diff/state/plan references, explicit three-tenant audit request, and specific subprocess-argument-escaping question\n   - CRITICAL follow-up message instructing \"TEXT ONLY, do NOT call any tools\" and requesting a conversation summary following a specific 9-section template\n\n7. Pending Tasks:\n   No pending tasks have been explicitly assigned beyond the original Learn phase audit request, which appears to have been superseded by the summary request.\n\n8. Current Work:\n   The conversation was in the initial analysis phase of a Learn phase audit for PR #1473. Tool calls had been made to read the full diff, state.json, plan.md, and began reading the rules directory to understand the context. The analysis had progressed to examining the code against the two-gate test and three-tenant audit framework. Specific observations were being formulated regarding: (1) the pub visibility of format_cost_table relative to the bright-line test, (2) the markdown escape pattern and its relationship to subprocess-argument-escaping rule, and (3) the consistency of cost/reset/partial marker placement between terminal and markdown formatters. The work was interrupted by the user's instruction to provide a text-only summary instead of continuing the Learn phase audit.\n\n9. Optional Next Step:\n   Once the summary is complete and delivered, the appropriate next step would be to await user confirmation on whether to resume the full Learn phase audit (completing the three-tenant analysis with explicit \"No findings\" markers per FRAMING instructions) or to proceed with a different task. The user's most recent explicit instruction was: \"Your task is to create a detailed summary of the conversation so far\" followed by a specific 9-section template requirement. No subsequent tasks have been assigned beyond this summary request.\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/show-per-phase-token-cost",
  "compact_count": 4,
  "findings": [
    {
      "finding": "Reviewer: format_cost_table declared pub",
      "reason": "Matches the established pattern for sibling formatters (format_timings_table, format_issues_summary, format_complete_summary) — all pub and consumed by render_body or in-module run_impl. The bright-line test in test-placement.md gates on a thin production wrapper as the only non-test caller; render_body is a substantive function. Sweeping the broader pattern is out of scope.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T18:00:08-07:00"
    },
    {
      "finding": "Reviewer: non-sequential section numbering 5b",
      "reason": "Intentional — 5b signals an inserted section without renumbering downstream comments (6/7/8). Renumbering would churn three more lines for no behavioral win.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T18:00:14-07:00"
    },
    {
      "finding": "Pre-mortem: PR body GitHub character limit",
      "reason": "Pre-existing concern — the State File details block already serializes the full state JSON which dominates the body size. This PR adds a small Token Cost section. Truncation/rearchitecture is out-of-scope and predates this PR.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T18:00:21-07:00"
    },
    {
      "finding": "Documentation: section order drift in flow-complete SKILL and phase-5 doc",
      "reason": "Agent misread the diff. Token Cost lands between Phase Timings and State File in render_body — exactly what both updated docs say.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T18:01:15-07:00"
    },
    {
      "finding": "Documentation: public types lack doc comments",
      "reason": "Both CostRow and CostBreakdown have doc comments in the diff explaining cost None/Some semantics, row_partial, total_partial, and reset_observed_anywhere. The agent missed the doc comments.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T18:01:21-07:00"
    },
    {
      "finding": "Documentation: CLAUDE.md Key Files missing entry",
      "reason": "src/render_pr_body.rs predates this PR — only format_cost_table was added, its purpose is documented in the module doc + function doc + the file lives where grep finds it. Bureaucracy-trap shape per review-scope.md.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T18:01:29-07:00"
    },
    {
      "finding": "Documentation: compute_cost_breakdown doc comment incomplete",
      "reason": "Doc comment explicitly covers None return, partial-cost semantics, and the per-phase rules. The by_model accumulation and reset_observed semantics are documented on the CostBreakdown struct fields themselves. Restating at function level is bureaucracy-trap shape.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T18:01:35-07:00"
    },
    {
      "finding": "Documentation: two-formatter relationship underdocumented",
      "reason": "Module doc explicitly names both token_cost_section AND crate::render_pr_body::format_cost_table as the two consumers, and notes both consume compute_cost_breakdown's structured intermediate. Agent missed the existing module doc.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T18:01:41-07:00"
    },
    {
      "finding": "Markdown pipe injection via unescaped model name in format_cost_table by-model sub-table",
      "reason": "Added escape_markdown_cell helper that escapes pipe, backslash, newline, and carriage return; applied at the by-model row interpolation. Regression test cost_table_escapes_pipe_in_model_name covers the pipe case; cost_table_escapes_backslash_in_model_name and cost_table_escapes_newline_in_model_name cover the remaining branches.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T18:12:22-07:00"
    },
    {
      "finding": "Triple-asterisk ambiguity in Total row when total_partial flips with Some cost",
      "reason": "Refactored the Total row format so the partial marker is escaped as a backslash-asterisk literal AFTER the bold wrapper. The cost value is bold-wrapped alone, then the escaped marker is appended outside the closing bold delimiters. Regression test cost_table_total_partial_marker_does_not_produce_triple_asterisk locks the shape against three consecutive asterisks in the rendered row.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T18:14:20-07:00"
    },
    {
      "finding": "Phase status case sensitivity and empty-string handling in compute_cost_breakdown",
      "reason": "Normalized the status comparison per .claude/rules/security-gates.md — trim whitespace, ASCII-lowercase, and treat empty string as missing field (collapses to pending fallback). Regression tests compute_cost_breakdown_normalizes_status_case_and_whitespace and compute_cost_breakdown_treats_empty_string_status_as_pending cover both classes.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-11T18:14:28-07:00"
    },
    {
      "finding": "Learn: format_cost_table pub for testing",
      "reason": "Already triaged during Review Step 3. The function matches the established sibling pattern — format_timings_table, format_issues_summary, format_complete_summary are all pub and consumed by render_body or in-module run_impl. The bright-line test gates on a thin production wrapper as the only non-test caller; render_body is substantive. Sweeping the broader pattern is out of scope.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-11T18:21:10-07:00"
    },
    {
      "finding": "Learn: cross-formatter marker consistency could drift",
      "reason": "Terminal and Markdown formatters share compute_cost_breakdown as the data source — that IS the consistency contract. The visual placement differs intentionally: terminal uses a fixed-width separator block with footer notes; Markdown uses table cells with reset markers inline per the row layout. Different media, different conventions. Extracting marker logic into a shared helper would duplicate information already in the structured intermediate.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-11T18:21:18-07:00"
    },
    {
      "finding": "Learn: plan Task 7 phrasing too loose for no-waivers hard-gate",
      "reason": "Agent misread the plan. Task 7 in plan.md explicitly includes the iteration clause: If coverage falls below the gate, return to the relevant test task and add coverage. No waivers per no-waivers.md. The plan already complies.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-11T18:21:24-07:00"
    },
    {
      "finding": "Missing rule: Markdown table-cell escape was not enumerated in subprocess-argument-escaping.md",
      "reason": "The rule listed AppleScript, shell, SQL, regex, and JSON as target languages but did not include GitHub Markdown table cells. This PR adds escape_markdown_cell in src/render_pr_body.rs; the rule now documents Markdown as a target language with pipe, backslash, newline, and carriage return as the structural characters, plus a reference to the new helper.",
      "outcome": "rule_clarified",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-11T18:22:22-07:00",
      "path": ".claude/rules/subprocess-argument-escaping.md"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-11T18:26:33-07:00",
    "session_id": "92068c07-e9c6-49d8-9558-89e738736b42",
    "model": "claude-opus-4-7",
    "five_hour_pct": 27,
    "seven_day_pct": 46,
    "session_input_tokens": 7713,
    "session_output_tokens": 343428,
    "session_cache_creation_tokens": 4296087,
    "session_cache_read_tokens": 251162854,
    "session_cost_usd": 105.76888839999998,
    "by_model": {
      "claude-opus-4-7": {
        "input": 7713,
        "output": 343428,
        "cache_create": 4296087,
        "cache_read": 251162854
      }
    },
    "turn_count": 417,
    "tool_call_count": 233,
    "context_at_last_turn_tokens": 844390,
    "context_window_pct": 422.195
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>