### PR TITLE
Record Agent Return Fails Phase

### DIFF
--- a/src/hooks/capture_session.rs
+++ b/src/hooks/capture_session.rs
@@ -21,7 +21,9 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
-use crate::session_metrics::{home_dir_or_empty, is_safe_session_id, is_safe_transcript_path};
+use crate::session_metrics::{
+    home_dir_or_empty, is_safe_session_id, is_safe_transcript_path_structural,
+};
 
 /// Capture-file payload byte cap per
 /// `.claude/rules/external-input-path-construction.md` "Enforce a
@@ -57,11 +59,14 @@ pub(crate) fn capture_file_path(home: &Path) -> PathBuf {
 ///    and parses as JSON.
 /// 3. `session_id` matches [`is_safe_session_id`].
 /// 4. `transcript_path` is either absent OR matches
-///    [`is_safe_transcript_path`] against `home`.
-///
-/// Returns `None` on any failure path — fail-open semantics so a
-/// malformed or missing capture file leaves the caller's state
-/// untouched.
+///    [`is_safe_transcript_path_structural`] against `home`. The
+///    structural variant accepts shape-valid paths whose JSONL file
+///    does not yet exist on disk, so flow-start at SessionStart time
+///    seeds a real `transcript_path` into the state file instead of
+///    leaving it null (issue #1525). Symlink-escape is closed by
+///    every read-time consumer (transcript walkers) via
+///    `is_safe_transcript_path`'s canonicalize step before any
+///    `File::open`.
 pub(crate) fn read_captured_session(home: &Path) -> Option<(String, Option<String>)> {
     if home.as_os_str().is_empty() || !home.is_absolute() {
         return None;
@@ -82,7 +87,7 @@ pub(crate) fn read_captured_session(home: &Path) -> Option<(String, Option<Strin
         .get("transcript_path")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .filter(|tp| is_safe_transcript_path(Path::new(tp), home));
+        .filter(|tp| is_safe_transcript_path_structural(Path::new(tp), home));
     Some((session_id, transcript_path))
 }
 
@@ -107,7 +112,7 @@ pub fn run() {
         .get("transcript_path")
         .and_then(|v| v.as_str())
         .map(PathBuf::from)
-        .filter(|p| is_safe_transcript_path(p, &home))
+        .filter(|p| is_safe_transcript_path_structural(p, &home))
         .map(|p| p.to_string_lossy().to_string());
     let payload = json!({
         "session_id": session_id,

--- a/src/session_metrics.rs
+++ b/src/session_metrics.rs
@@ -134,7 +134,67 @@ pub fn is_safe_session_id(s: &str) -> bool {
 /// Per `.claude/rules/external-input-path-construction.md`, the same
 /// validator runs at every state-derived path-construction site so
 /// the prefix-containment contract is enforced once.
+///
+/// Composes [`is_safe_transcript_path_structural`] for the stateless
+/// shape checks then performs the canonicalize step. Read-time
+/// callers (transcript walkers, anything that will `File::open` the
+/// path) use this wrapper so symlink-escape is closed at the
+/// open boundary. Write-time-shape callers (the SessionStart
+/// capture hook and the flow-start round-trip reader) use
+/// `is_safe_transcript_path_structural` directly because the file
+/// is not guaranteed to exist yet at write time and canonicalize
+/// would fail-closed on the missing file.
 pub fn is_safe_transcript_path(path: &Path, home: &Path) -> bool {
+    if !is_safe_transcript_path_structural(path, home) {
+        return false;
+    }
+    // Canonicalize and compare against the canonicalized prefix.
+    // `Path::starts_with` on raw paths cannot detect symlinks: a
+    // symlink at `<home>/.claude/projects/p/session.jsonl` pointing
+    // to `/tmp/evil.jsonl` passes the raw check, then `File::open`
+    // follows the link and reads attacker-controlled content.
+    // `canonicalize` resolves every component's symlinks AND `..`
+    // segments before the prefix check, closing both traversal
+    // vectors. The structural lexical-prefix check above guarantees
+    // `expected_prefix` is a strict ancestor of `path`, so when
+    // `path.canonicalize()` succeeds the prefix canonicalizes too
+    // — both Err arms are folded into one branch via tuple
+    // destructuring so the unreachable prefix-only-fail case does
+    // not surface as an uncovered region. Any Err returns false
+    // — fail-closed per `.claude/rules/security-gates.md`.
+    let expected_prefix = home.join(".claude").join("projects");
+    let (Ok(canonical_path), Ok(canonical_prefix)) =
+        (path.canonicalize(), expected_prefix.canonicalize())
+    else {
+        return false;
+    };
+    canonical_path.starts_with(&canonical_prefix)
+}
+
+/// Structural-shape validator for `transcript_path` strings that
+/// run BEFORE the file is guaranteed to exist. Rejects empty
+/// paths, paths containing a NUL byte, relative paths, paths with
+/// any `..` (ParentDir) component, and paths whose lexical prefix
+/// is not `<home>/.claude/projects/`. Performs NO syscalls — no
+/// `canonicalize`, no `File::open`, no `metadata` — so it returns
+/// true for shape-valid paths even when the JSONL file has not
+/// yet been created.
+///
+/// Production consumers: SessionStart capture (`run` in
+/// `src/hooks/capture_session.rs`) and the flow-start round-trip
+/// reader (`read_captured_session` in the same module). Both
+/// receive a path from Claude Code BEFORE the transcript JSONL is
+/// guaranteed to exist; the structural shape is the strongest
+/// invariant they can enforce at write time.
+///
+/// Symlink-escape is intentionally not addressed here. Defense
+/// happens at every read-time callsite via the canonical wrapper
+/// `is_safe_transcript_path`, which adds the `canonicalize` +
+/// canonical-prefix match before any `File::open`. Storing a
+/// symlink-shaped string in the capture file is inert until a
+/// read-time consumer opens the path, and every such consumer
+/// re-validates.
+pub fn is_safe_transcript_path_structural(path: &Path, home: &Path) -> bool {
     if path.as_os_str().is_empty() {
         return false;
     }
@@ -145,35 +205,21 @@ pub fn is_safe_transcript_path(path: &Path, home: &Path) -> bool {
         return false;
     }
     // Reject any ParentDir (`..`) component as a fast-path lexical
-    // check before the canonicalize syscall. `Path::starts_with` is
-    // a lexical component-wise prefix check that does NOT resolve
-    // `..` segments, so `<home>/.claude/projects/../../etc/passwd`
-    // would pass a raw prefix check.
+    // check. The `starts_with` prefix check below is component-wise
+    // and does NOT resolve `..` segments, so
+    // `<home>/.claude/projects/../../etc/passwd` would otherwise
+    // pass the prefix check.
     for component in path.components() {
         if matches!(component, std::path::Component::ParentDir) {
             return false;
         }
     }
-    // Canonicalize and compare against the canonicalized prefix.
-    // `Path::starts_with` on raw paths cannot detect symlinks: a
-    // symlink at `<home>/.claude/projects/p/session.jsonl` pointing
-    // to `/tmp/evil.jsonl` passes the raw check, then `File::open`
-    // follows the link and reads attacker-controlled content.
-    // `canonicalize` resolves every component's symlinks AND `..`
-    // segments before the prefix check, closing both traversal
-    // vectors. Failure to canonicalize (missing file, permission
-    // error, broken symlink) returns false — fail-closed per
-    // `.claude/rules/security-gates.md`.
-    let canonical_path = match path.canonicalize() {
-        Ok(p) => p,
-        Err(_) => return false,
-    };
+    // Lexical prefix containment. The canonical wrapper redoes
+    // this with canonicalized paths so symlink-shaped escapes
+    // cannot defeat the read-time gate; the structural variant
+    // accepts the lexical match alone because no syscall follows.
     let expected_prefix = home.join(".claude").join("projects");
-    let canonical_prefix = match expected_prefix.canonicalize() {
-        Ok(p) => p,
-        Err(_) => return false,
-    };
-    canonical_path.starts_with(&canonical_prefix)
+    path.starts_with(&expected_prefix)
 }
 
 /// Write a `WindowSnapshot` into the named top-level field of a

--- a/tests/commands/init_state.rs
+++ b/tests/commands/init_state.rs
@@ -570,6 +570,52 @@ fn captured_session_with_transcript_path_seeds_both_fields() {
     assert_eq!(state["transcript_path"], transcript_str);
 }
 
+/// Regression for issue #1525 (read-time half): `read_captured_session`
+/// must accept a `transcript_path` whose underlying JSONL file does
+/// not yet exist, so the round-trip through `seed_session_id_from_capture`
+/// seeds it into the new state file. The write side already produced
+/// the capture file with the non-existent path (see
+/// `tests/hooks/capture_session.rs::run_persists_transcript_path_when_jsonl_does_not_exist`);
+/// this test pins the symmetric reader contract so a future "tighten
+/// the read-time filter" attempt re-introduces the bug it would
+/// silently. Drives the read path through the `init-state` subcommand
+/// because `read_captured_session` is `pub(crate)` and inaccessible
+/// from integration tests; the subcommand persists the function's
+/// transcript_path output into the state file, which the test then
+/// observes directly.
+#[test]
+fn captured_session_with_nonexistent_transcript_path_still_seeds_both_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_project(dir.path(), "rails", None);
+    let claude_dir = dir.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    // Build an absolute transcript path under HOME/.claude/projects/
+    // BUT do not create the JSONL file. The structural validator
+    // accepts the shape; the canonical validator (used at read-time
+    // hook callsites) still rejects via canonicalize when those hooks
+    // later try to open the file. This test pins the structural
+    // accept side of the split.
+    let projects = claude_dir.join("projects").join("-test-missing");
+    fs::create_dir_all(&projects).unwrap();
+    let transcript = projects.join("not-yet-created.jsonl");
+    assert!(!transcript.exists(), "fixture must not create the JSONL");
+    let transcript_str = transcript.to_string_lossy().to_string();
+    let payload = json!({
+        "session_id": "sid-missing-jsonl",
+        "transcript_path": transcript_str,
+    });
+    fs::write(
+        claude_dir.join("flow-current-session.json"),
+        payload.to_string(),
+    )
+    .unwrap();
+
+    run_init_state(dir.path(), &["seed missing transcript test"]);
+    let state = read_state_file(dir.path(), "seed-missing-transcript-test");
+    assert_eq!(state["session_id"], "sid-missing-jsonl");
+    assert_eq!(state["transcript_path"], transcript_str);
+}
+
 // --- Issue-title naming and duplicate detection (PR #823) ---
 
 #[test]

--- a/tests/hooks/capture_session.rs
+++ b/tests/hooks/capture_session.rs
@@ -449,23 +449,32 @@ fn capture_session_replaces_existing_symlink_at_capture_path() {
     assert_eq!(parsed["session_id"], "abc-123");
 }
 
-/// Regression: at SessionStart the transcript JSONL typically does
-/// not yet exist on disk — `is_safe_transcript_path` runs
-/// `canonicalize()` to defeat symlink traversal, and that syscall
-/// fails on missing files. The hook must store `transcript_path`
-/// as null in that case (not weaken the validator). Self-healing
-/// happens later in `capture_for_active_state` once the file
-/// exists. This test guards the strict-validator contract so a
-/// future "loosen the validator" attempt does not silently weaken
-/// symlink-escape defense.
+/// Regression for issue #1525: SessionStart hooks receive a
+/// `transcript_path` from Claude Code BEFORE the JSONL file is
+/// created on disk. The capture must persist the path so the
+/// flow-start round-trip can seed `transcript_path` into the new
+/// state file; downstream `record-agent-return` then has a real
+/// path to verify the agent's tool_use/tool_result pair against.
+/// Without this, `transcript_path` stays null at state init and
+/// `record-agent-return` reports `transcript_path_invalid` (which
+/// the failure-classifier maps to `phase_marker_not_found`,
+/// silently skipping every Review and Learn agent).
+///
+/// Replaces the prior `capture_session_stores_null_when_transcript_file_does_not_exist_yet`
+/// test, which asserted the inverse (null storage) — that
+/// assertion locked in the bug this fix removes. The Plan-phase
+/// Risk #3 accepts the trade-off: read-time hooks still canonicalize
+/// before opening, so storing a symlink-shaped path string here is
+/// inert until a consumer opens it (and every consumer re-validates).
 #[test]
-fn capture_session_stores_null_when_transcript_file_does_not_exist_yet() {
+fn run_persists_transcript_path_when_jsonl_does_not_exist() {
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path().canonicalize().unwrap();
     // Build a transcript_path that is shape-valid (absolute, under
-    // ~/.claude/projects/, no `..` components) but the file does not
-    // exist on disk. canonicalize() fails → validator returns false
-    // → hook stores null.
+    // ~/.claude/projects/, no `..` components) but the JSONL file
+    // does not exist on disk yet. The structural validator must
+    // accept the path so the hook persists it; self-healing through
+    // canonicalize happens later at read-time hook callsites.
     let projects_dir = home.join(".claude").join("projects").join("-tmp-abc");
     fs::create_dir_all(&projects_dir).unwrap();
     let transcript = projects_dir.join("nonexistent-session.jsonl");
@@ -480,9 +489,10 @@ fn capture_session_stores_null_when_transcript_file_does_not_exist_yet() {
     let parsed: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
     assert_eq!(parsed["session_id"], "valid-sid");
-    assert!(
-        parsed["transcript_path"].is_null(),
-        "missing-file transcript_path must serialize as null; got: {}",
+    assert_eq!(
+        parsed["transcript_path"].as_str(),
+        Some(transcript.to_string_lossy().as_ref()),
+        "structural-validator-accepted path must be persisted verbatim; got: {}",
         parsed["transcript_path"]
     );
 }

--- a/tests/hooks/capture_session.rs
+++ b/tests/hooks/capture_session.rs
@@ -449,23 +449,26 @@ fn capture_session_replaces_existing_symlink_at_capture_path() {
     assert_eq!(parsed["session_id"], "abc-123");
 }
 
-/// Regression for issue #1525: SessionStart hooks receive a
-/// `transcript_path` from Claude Code BEFORE the JSONL file is
-/// created on disk. The capture must persist the path so the
-/// flow-start round-trip can seed `transcript_path` into the new
-/// state file; downstream `record-agent-return` then has a real
-/// path to verify the agent's tool_use/tool_result pair against.
-/// Without this, `transcript_path` stays null at state init and
-/// `record-agent-return` reports `transcript_path_invalid` (which
-/// the failure-classifier maps to `phase_marker_not_found`,
-/// silently skipping every Review and Learn agent).
+/// Asserts that `capture_session::run` persists `transcript_path`
+/// verbatim when the JSONL file the path references does not yet
+/// exist on disk. SessionStart hooks receive `transcript_path` from
+/// Claude Code before the JSONL is created; the structural
+/// validator accepts shape-valid paths regardless of file existence
+/// so the round-trip through `seed_session_id_from_capture` seeds a
+/// real path into the new state file. Downstream
+/// `record-agent-return` then has a transcript_path to verify agent
+/// invocations against — if `transcript_path` were null at state
+/// init, `record-agent-return` would report
+/// `transcript_path_invalid`, the failure-classifier would map that
+/// to `phase_marker_not_found`, and every Review and Learn agent
+/// invocation would silently skip phase-finalize accounting.
 ///
-/// Replaces the prior `capture_session_stores_null_when_transcript_file_does_not_exist_yet`
-/// test, which asserted the inverse (null storage) — that
-/// assertion locked in the bug this fix removes. The Plan-phase
-/// Risk #3 accepts the trade-off: read-time hooks still canonicalize
-/// before opening, so storing a symlink-shaped path string here is
-/// inert until a consumer opens it (and every consumer re-validates).
+/// Symlink-escape stays closed at every read-time consumer: the
+/// transcript walkers in `src/hooks/transcript_walker.rs` and the
+/// `record_agent_return::resolve_transcript_path` callsite
+/// re-validate via the canonical wrapper before any `File::open`.
+/// Storing a shape-valid path string in the capture file is inert
+/// until one of those read-time consumers opens it.
 #[test]
 fn run_persists_transcript_path_when_jsonl_does_not_exist() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/session_metrics.rs
+++ b/tests/session_metrics.rs
@@ -15,7 +15,8 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 
 use flow_rs::session_metrics::{
-    append_step_snapshot, capture, home_dir_or_empty, write_snapshot_into_state,
+    append_step_snapshot, capture, home_dir_or_empty, is_safe_transcript_path,
+    is_safe_transcript_path_structural, write_snapshot_into_state,
 };
 use serde_json::{json, Value};
 
@@ -569,4 +570,139 @@ fn home_dir_or_empty_returns_path_when_home_set() {
     // Empty acceptable when HOME unset; function's contract is
     // "no panic" rather than "non-empty".
     let _ = home.as_os_str();
+}
+
+// --- is_safe_transcript_path_structural ---
+
+/// The regression case for issue #1525: the structural validator
+/// accepts a path that is shape-valid (absolute, under
+/// `<home>/.claude/projects/`, no NUL, no ParentDir component)
+/// even when the underlying JSONL file does not yet exist on
+/// disk. SessionStart hooks receive a transcript_path before
+/// Claude Code creates the file; the canonical validator's
+/// `canonicalize()` call fails on the missing file and rejects
+/// the path, causing transcript_path to persist as null and
+/// downstream `record-agent-return` to report
+/// `phase_marker_not_found`.
+#[test]
+fn is_safe_transcript_path_structural_accepts_nonexistent_path_under_projects() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().canonicalize().expect("canonicalize");
+    let projects = home.join(".claude").join("projects").join("proj");
+    fs::create_dir_all(&projects).expect("mkdir projects");
+    let transcript = projects.join("session.jsonl");
+    assert!(!transcript.exists(), "fixture must not create the JSONL");
+
+    assert!(
+        is_safe_transcript_path_structural(&transcript, &home),
+        "structural validator must accept a non-existent path under <home>/.claude/projects/"
+    );
+}
+
+/// Empty path fails the structural validator. Same first guard
+/// as the canonical validator; rejection-class parity.
+#[test]
+fn is_safe_transcript_path_structural_rejects_empty() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().canonicalize().expect("canonicalize");
+    let empty = PathBuf::from("");
+    assert!(!is_safe_transcript_path_structural(&empty, &home));
+}
+
+/// Path containing a NUL byte fails the structural validator.
+/// Defends against `format!`/path-construction shapes where a
+/// NUL truncates syscall semantics in implementation-defined
+/// ways.
+#[test]
+fn is_safe_transcript_path_structural_rejects_nul_byte() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().canonicalize().expect("canonicalize");
+    let path = PathBuf::from("/tmp/contains\0nul.jsonl");
+    assert!(!is_safe_transcript_path_structural(&path, &home));
+}
+
+/// Relative path fails the structural validator. Production
+/// callers must pass absolute paths so prefix-containment is
+/// well-defined.
+#[test]
+fn is_safe_transcript_path_structural_rejects_relative() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().canonicalize().expect("canonicalize");
+    let rel = PathBuf::from("relative/session.jsonl");
+    assert!(!is_safe_transcript_path_structural(&rel, &home));
+}
+
+/// Path containing a `..` ParentDir component fails the
+/// structural validator. The lexical `starts_with` check below
+/// does not resolve `..`, so `<home>/.claude/projects/../../etc/passwd`
+/// would otherwise pass the prefix check and reach a file open.
+#[test]
+fn is_safe_transcript_path_structural_rejects_parent_dir_component() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().canonicalize().expect("canonicalize");
+    let escape = home
+        .join(".claude")
+        .join("projects")
+        .join("..")
+        .join("..")
+        .join("etc")
+        .join("passwd");
+    assert!(!is_safe_transcript_path_structural(&escape, &home));
+}
+
+/// Absolute path that does not sit under `<home>/.claude/projects/`
+/// fails the structural validator. The lexical prefix check
+/// must reject paths outside the expected directory tree even
+/// when canonicalize would have produced the same rejection
+/// for an existing file.
+#[test]
+fn is_safe_transcript_path_structural_rejects_path_outside_projects_prefix() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().canonicalize().expect("canonicalize");
+    let outside = PathBuf::from("/etc/passwd");
+    assert!(!is_safe_transcript_path_structural(&outside, &home));
+}
+
+// --- is_safe_transcript_path (canonical wrapper) ---
+
+/// The canonical wrapper short-circuits when the structural check
+/// rejects the input. Exercises the `if !structural { return false }`
+/// branch with a path that fails structural validation so neither
+/// canonicalize syscall runs.
+#[test]
+fn is_safe_transcript_path_rejects_when_structural_fails() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().canonicalize().expect("canonicalize");
+    let empty = PathBuf::from("");
+    assert!(!is_safe_transcript_path(&empty, &home));
+}
+
+/// The canonical wrapper accepts a path that is shape-valid AND
+/// exists on disk under `<home>/.claude/projects/`. Exercises the
+/// success path through both canonicalize calls and the final
+/// `starts_with` check.
+#[test]
+fn is_safe_transcript_path_accepts_existing_path_under_projects() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().canonicalize().expect("canonicalize");
+    let projects = home.join(".claude").join("projects").join("proj");
+    fs::create_dir_all(&projects).expect("mkdir projects");
+    let transcript = projects.join("session.jsonl");
+    fs::write(&transcript, b"").expect("write transcript");
+    assert!(is_safe_transcript_path(&transcript, &home));
+}
+
+/// The canonical wrapper rejects a shape-valid path whose
+/// underlying file does not exist on disk — `canonicalize` on the
+/// path fails. Exercises the `Err(_) => return false` arm of the
+/// first canonicalize match.
+#[test]
+fn is_safe_transcript_path_rejects_when_path_canonicalize_fails() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().canonicalize().expect("canonicalize");
+    let projects = home.join(".claude").join("projects").join("proj");
+    fs::create_dir_all(&projects).expect("mkdir projects");
+    let transcript = projects.join("session.jsonl");
+    assert!(!transcript.exists());
+    assert!(!is_safe_transcript_path(&transcript, &home));
 }


### PR DESCRIPTION
## What

#1525.

Closes #1525

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/record-agent-return-fails-phase/log` |
| State | `.flow-states/record-agent-return-fails-phase/state.json` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 32m |
| Review | 29m |
| Learn | 3m |
| Complete | <1m |
| **Total** | **1h 5m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 2.6M | $0.862 |
| Code | 128.8M | $41.246 |
| Review | 65.1M | $46.005 |
| Learn | 17.9M | $5.699 |
| Complete | 3.5M | $0.883 |
| **Total** | **217.9M** | **$94.695** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **Reviewer: Plan deviation not logged**
  - Dismissed — Three bin/flow log entries were created during Code phase before the commits (test rename in tests/commands/init_state.rs, file location change, and existing-test deletion under Task 5). The commit message body for the Task 3+4+5 atomic commit explicitly names the Task 4 rename. The deviation IS logged at both surfaces; reviewer did not see them because the agent's input contract excludes the state log file and earlier commit messages.
- ✗ **Pre-mortem: macOS HOME symlink causes structural validator to silently reject**
  - Dismissed — The /Users directory is NOT symlinked on macOS — only /tmp, /var, /etc are symlinks at the root. Standard production HOME is /Users/&lt;user&gt; which equals the canonical form. Claude Code passes the same non-canonical prefix to capture_session via stdin; both home and transcript_path share the same prefix. The lexical starts_with check works correctly. The pre-mortem's claim that production transcripts are '/private/Users/...' is factually wrong for macOS.
- ✗ **Pre-mortem: structural validator symlink-defense not mechanically enforced**
  - Dismissed — The new is_safe_transcript_path_structural's own doc comment explicitly names the contract: 'Symlink-escape is intentionally not addressed here. Defense happens at every read-time callsite via the canonical wrapper is_safe_transcript_path'. A future caller reading the function they are about to call sees this. Per value-vs-bureaucracy in review-scope.md, a contract test would duplicate doc-discoverable information without preventing any class of regression the doc comment already warns about.
- ✗ **Documentation: CLAUDE.md Key Files needs two-tier validator naming**
  - Dismissed — The existing Key Files entry for src/session_metrics.rs already says 'session-id and transcript-path validators' (plural). Per .claude/rules/review-scope.md value-vs-bureaucracy test for Tenant 6 borderline cases: both function doc comments explain the two-tier design; grep finds either function instantly. A future reader who finds either function via grep sees the design in the doc comments without consulting CLAUDE.md.
- ✗ **Documentation: is_safe_transcript_path doc comment mechanics not forward-facing**
  - Dismissed — The current canonical wrapper doc comment explicitly states 'Read-time callers (transcript walkers, anything that will File::open the path) use this wrapper so symlink-escape is closed at the open boundary. Write-time-shape callers (the SessionStart capture hook and the flow-start round-trip reader) use is_safe_transcript_path_structural directly because the file is not guaranteed to exist yet at write time.' That IS the forward-facing contract — describes which to use when, not implementation sequencing.
- ✗ **Documentation: two-validator design rationale needs module-level block**
  - Dismissed — Both function doc comments already explain the two-tier design: the canonical wrapper's doc names the composition relationship and when to use it; the structural function's doc names the production consumers, the rejection classes, and the read-time symlink-escape closure. Adding a module-level 'Section: Two-Tier Design' block above would restate information the per-function docs already carry — per .claude/rules/review-scope.md value-vs-bureaucracy, classify as redundant documentation.
- ✓ **Backward-facing comment in tests/hooks/capture_session.rs doc for run_persists_transcript_path_when_jsonl_does_not_exist**
  - Fixed — Rewrote the doc comment forward-facing per .claude/rules/comment-quality.md. The new comment describes what the test asserts (capture_session::run persists transcript_path verbatim when JSONL does not exist), why it matters (downstream record-agent-return needs a real transcript_path), and where symlink-escape stays closed (read-time consumers re-validate via the canonical wrapper). No parity reference to the deleted test, no 'before the fix' narrative, no planning-artifact citation.

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/record-agent-return-fails-phase.json</summary>

```json
{
  "schema_version": 1,
  "branch": "record-agent-return-fails-phase",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1527,
  "pr_url": "https://github.com/benkruger/flow/pull/1527",
  "started_at": "2026-05-12T21:30:27-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/record-agent-return-fails-phase/log",
    "state": ".flow-states/record-agent-return-fails-phase/state.json"
  },
  "session_tty": "/dev/ttys006",
  "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
  "transcript_path": null,
  "notes": [],
  "prompt": "#1525",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-12T21:30:27-07:00",
      "completed_at": "2026-05-12T21:31:10-07:00",
      "session_started_at": null,
      "cumulative_seconds": 43,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-12T21:30:27-07:00",
        "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
        "model": "claude-opus-4-7",
        "five_hour_pct": 25,
        "seven_day_pct": 23,
        "session_input_tokens": 21,
        "session_output_tokens": 5615,
        "session_cache_creation_tokens": 642295,
        "session_cache_read_tokens": 736343,
        "session_cost_usd": 6.359546250000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 21,
            "output": 5615,
            "cache_create": 642295,
            "cache_read": 736343
          }
        },
        "turn_count": 6,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 231908,
        "context_window_pct": 115.954
      },
      "window_at_complete": {
        "captured_at": "2026-05-12T21:31:10-07:00",
        "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
        "model": "claude-opus-4-7",
        "five_hour_pct": 25,
        "seven_day_pct": 23,
        "session_input_tokens": 32,
        "session_output_tokens": 7979,
        "session_cache_creation_tokens": 645734,
        "session_cache_read_tokens": 3295640,
        "session_cost_usd": 7.221709750000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 32,
            "output": 7979,
            "cache_create": 645734,
            "cache_read": 3295640
          }
        },
        "turn_count": 17,
        "tool_call_count": 10,
        "context_at_last_turn_tokens": 234056,
        "context_window_pct": 117.028
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-12T21:31:20-07:00",
      "completed_at": "2026-05-12T22:03:33-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1933,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-12T21:31:20-07:00",
        "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
        "model": "claude-opus-4-7",
        "five_hour_pct": 25,
        "seven_day_pct": 23,
        "session_input_tokens": 44,
        "session_output_tokens": 8803,
        "session_cache_creation_tokens": 663726,
        "session_cache_read_tokens": 4232270,
        "session_cost_usd": 7.522422250000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 44,
            "output": 8803,
            "cache_create": 663726,
            "cache_read": 4232270
          }
        },
        "turn_count": 21,
        "tool_call_count": 12,
        "context_at_last_turn_tokens": 243056,
        "context_window_pct": 121.528
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-12T21:34:46-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 26,
          "seven_day_pct": 24,
          "session_input_tokens": 87,
          "session_output_tokens": 29700,
          "session_cache_creation_tokens": 1339893,
          "session_cache_read_tokens": 21678210,
          "session_cost_usd": 14.67538125,
          "by_model": {
            "claude-opus-4-7": {
              "input": 87,
              "output": 29700,
              "cache_create": 1339893,
              "cache_read": 21678210
            }
          },
          "turn_count": 64,
          "tool_call_count": 38,
          "context_at_last_turn_tokens": 481556,
          "context_window_pct": 240.778
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-12T21:53:26-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 35,
          "seven_day_pct": 26,
          "session_input_tokens": 175,
          "session_output_tokens": 138888,
          "session_cache_creation_tokens": 1603122,
          "session_cache_read_tokens": 69007652,
          "session_cost_usd": 30.12904499999999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 175,
              "output": 138888,
              "cache_create": 1603122,
              "cache_read": 69007652
            }
          },
          "turn_count": 152,
          "tool_call_count": 88,
          "context_at_last_turn_tokens": 610413,
          "context_window_pct": 305.2065
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-12T21:56:02-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 37,
          "seven_day_pct": 26,
          "session_input_tokens": 233,
          "session_output_tokens": 160292,
          "session_cache_creation_tokens": 1664551,
          "session_cache_read_tokens": 91457397,
          "session_cost_usd": 36.1223275,
          "by_model": {
            "claude-opus-4-7": {
              "input": 233,
              "output": 160292,
              "cache_create": 1664551,
              "cache_read": 91457397
            }
          },
          "turn_count": 188,
          "tool_call_count": 106,
          "context_at_last_turn_tokens": 638865,
          "context_window_pct": 319.4325
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-12T21:58:06-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 37,
          "seven_day_pct": 27,
          "session_input_tokens": 251,
          "session_output_tokens": 179345,
          "session_cache_creation_tokens": 1691918,
          "session_cache_read_tokens": 103079451,
          "session_cost_usd": 39.66096675,
          "by_model": {
            "claude-opus-4-7": {
              "input": 251,
              "output": 179345,
              "cache_create": 1691918,
              "cache_read": 103079451
            }
          },
          "turn_count": 206,
          "tool_call_count": 116,
          "context_at_last_turn_tokens": 654460,
          "context_window_pct": 327.23
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-12T21:59:42-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 38,
          "seven_day_pct": 27,
          "session_input_tokens": 264,
          "session_output_tokens": 184192,
          "session_cache_creation_tokens": 1708803,
          "session_cache_read_tokens": 111610715,
          "session_cost_usd": 42.41959975,
          "by_model": {
            "claude-opus-4-7": {
              "input": 264,
              "output": 184192,
              "cache_create": 1708803,
              "cache_read": 111610715
            }
          },
          "turn_count": 219,
          "tool_call_count": 124,
          "context_at_last_turn_tokens": 663724,
          "context_window_pct": 331.862
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-12T22:03:33-07:00",
        "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
        "model": "claude-opus-4-7",
        "five_hour_pct": 40,
        "seven_day_pct": 27,
        "session_input_tokens": 312,
        "session_output_tokens": 195407,
        "session_cache_creation_tokens": 1753102,
        "session_cache_read_tokens": 131791118,
        "session_cost_usd": 48.768597000000014,
        "by_model": {
          "claude-opus-4-7": {
            "input": 312,
            "output": 195407,
            "cache_create": 1753102,
            "cache_read": 131791118
          }
        },
        "turn_count": 249,
        "tool_call_count": 142,
        "context_at_last_turn_tokens": 687559,
        "context_window_pct": 343.7795
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-12T22:03:43-07:00",
      "completed_at": "2026-05-12T22:33:04-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1761,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-12T22:03:43-07:00",
        "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
        "model": "claude-opus-4-7",
        "five_hour_pct": 40,
        "seven_day_pct": 27,
        "session_input_tokens": 319,
        "session_output_tokens": 196026,
        "session_cache_creation_tokens": 1769216,
        "session_cache_read_tokens": 133853969,
        "session_cost_usd": 49.565229750000015,
        "by_model": {
          "claude-opus-4-7": {
            "input": 319,
            "output": 196026,
            "cache_create": 1769216,
            "cache_read": 133853969
          }
        },
        "turn_count": 252,
        "tool_call_count": 144,
        "context_at_last_turn_tokens": 703500,
        "context_window_pct": 351.75
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-12T22:05:04-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 40,
          "seven_day_pct": 27,
          "session_input_tokens": 331,
          "session_output_tokens": 198397,
          "session_cache_creation_tokens": 1772045,
          "session_cache_read_tokens": 142308362,
          "session_cost_usd": 53.14570625000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 331,
              "output": 198397,
              "cache_create": 1772045,
              "cache_read": 142308362
            }
          },
          "turn_count": 264,
          "tool_call_count": 154,
          "context_at_last_turn_tokens": 705964,
          "context_window_pct": 352.982
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-12T22:24:41-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 52,
          "seven_day_pct": 31,
          "session_input_tokens": 417,
          "session_output_tokens": 246005,
          "session_cache_creation_tokens": 1937028,
          "session_cache_read_tokens": 161162088,
          "session_cost_usd": 82.76917500000006,
          "by_model": {
            "claude-opus-4-7": {
              "input": 417,
              "output": 246005,
              "cache_create": 1937028,
              "cache_read": 161162088
            }
          },
          "turn_count": 290,
          "tool_call_count": 169,
          "context_at_last_turn_tokens": 752999,
          "context_window_pct": 376.4995
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-12T22:26:30-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 52,
          "seven_day_pct": 31,
          "session_input_tokens": 442,
          "session_output_tokens": 264622,
          "session_cache_creation_tokens": 1991613,
          "session_cache_read_tokens": 168819110,
          "session_cost_usd": 86.17600025000006,
          "by_model": {
            "claude-opus-4-7": {
              "input": 442,
              "output": 264622,
              "cache_create": 1991613,
              "cache_read": 168819110
            }
          },
          "turn_count": 300,
          "tool_call_count": 177,
          "context_at_last_turn_tokens": 776324,
          "context_window_pct": 388.162
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-12T22:32:49-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 53,
          "seven_day_pct": 31,
          "session_input_tokens": 498,
          "session_output_tokens": 282325,
          "session_cache_creation_tokens": 2094449,
          "session_cache_read_tokens": 195241560,
          "session_cost_usd": 94.64304225000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 498,
              "output": 282325,
              "cache_create": 2094449,
              "cache_read": 195241560
            }
          },
          "turn_count": 333,
          "tool_call_count": 197,
          "context_at_last_turn_tokens": 817072,
          "context_window_pct": 408.536
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-12T22:12:24-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-12T22:12:33-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-12T22:12:40-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-12T22:24:32-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-12T22:33:04-07:00",
        "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
        "model": "claude-opus-4-7",
        "five_hour_pct": 53,
        "seven_day_pct": 31,
        "session_input_tokens": 517,
        "session_output_tokens": 283284,
        "session_cache_creation_tokens": 2141814,
        "session_cache_read_tokens": 198511269,
        "session_cost_usd": 95.57066700000004,
        "by_model": {
          "claude-opus-4-7": {
            "input": 517,
            "output": 283284,
            "cache_create": 2141814,
            "cache_read": 198511269
          }
        },
        "turn_count": 337,
        "tool_call_count": 199,
        "context_at_last_turn_tokens": 833182,
        "context_window_pct": 416.591
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-12T22:33:19-07:00",
      "completed_at": "2026-05-12T22:36:24-07:00",
      "session_started_at": null,
      "cumulative_seconds": 185,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-12T22:33:19-07:00",
        "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
        "model": "claude-opus-4-7",
        "five_hour_pct": 53,
        "seven_day_pct": 31,
        "session_input_tokens": 529,
        "session_output_tokens": 284108,
        "session_cache_creation_tokens": 2169028,
        "session_cache_read_tokens": 201844639,
        "session_cost_usd": 96.49938325000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 529,
            "output": 284108,
            "cache_create": 2169028,
            "cache_read": 201844639
          }
        },
        "turn_count": 341,
        "tool_call_count": 201,
        "context_at_last_turn_tokens": 846788,
        "context_window_pct": 423.394
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-12T22:35:26-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-12T22:35:31-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 53,
          "seven_day_pct": 31,
          "session_input_tokens": 540,
          "session_output_tokens": 288194,
          "session_cache_creation_tokens": 2183849,
          "session_cache_read_tokens": 211177495,
          "session_cost_usd": 99.60337235000004,
          "by_model": {
            "claude-opus-4-7": {
              "input": 540,
              "output": 288194,
              "cache_create": 2183849,
              "cache_read": 211177495
            }
          },
          "turn_count": 352,
          "tool_call_count": 207,
          "context_at_last_turn_tokens": 852535,
          "context_window_pct": 426.2675
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-12T22:35:46-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 53,
          "seven_day_pct": 31,
          "session_input_tokens": 541,
          "session_output_tokens": 288313,
          "session_cache_creation_tokens": 2184039,
          "session_cache_read_tokens": 212030029,
          "session_cost_usd": 100.03380685000003,
          "by_model": {
            "claude-opus-4-7": {
              "input": 541,
              "output": 288313,
              "cache_create": 2184039,
              "cache_read": 212030029
            }
          },
          "turn_count": 353,
          "tool_call_count": 208,
          "context_at_last_turn_tokens": 852725,
          "context_window_pct": 426.3625
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-12T22:35:58-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 53,
          "seven_day_pct": 31,
          "session_input_tokens": 544,
          "session_output_tokens": 288818,
          "session_cache_creation_tokens": 2184582,
          "session_cache_read_tokens": 214588360,
          "session_cost_usd": 100.89682035000006,
          "by_model": {
            "claude-opus-4-7": {
              "input": 544,
              "output": 288818,
              "cache_create": 2184582,
              "cache_read": 214588360
            }
          },
          "turn_count": 356,
          "tool_call_count": 210,
          "context_at_last_turn_tokens": 853109,
          "context_window_pct": 426.5545
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-12T22:36:03-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 53,
          "seven_day_pct": 31,
          "session_input_tokens": 546,
          "session_output_tokens": 289132,
          "session_cache_creation_tokens": 2184900,
          "session_cache_read_tokens": 216294576,
          "session_cost_usd": 101.32829810000004,
          "by_model": {
            "claude-opus-4-7": {
              "input": 546,
              "output": 289132,
              "cache_create": 2184900,
              "cache_read": 216294576
            }
          },
          "turn_count": 358,
          "tool_call_count": 211,
          "context_at_last_turn_tokens": 853268,
          "context_window_pct": 426.634
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-12T22:36:10-07:00",
          "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
          "model": "claude-opus-4-7",
          "five_hour_pct": 53,
          "seven_day_pct": 31,
          "session_input_tokens": 548,
          "session_output_tokens": 289420,
          "session_cache_creation_tokens": 2185618,
          "session_cache_read_tokens": 218001110,
          "session_cost_usd": 101.76078035000006,
          "by_model": {
            "claude-opus-4-7": {
              "input": 548,
              "output": 289420,
              "cache_create": 2185618,
              "cache_read": 218001110
            }
          },
          "turn_count": 360,
          "tool_call_count": 212,
          "context_at_last_turn_tokens": 853627,
          "context_window_pct": 426.8135
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-12T22:36:24-07:00",
        "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
        "model": "claude-opus-4-7",
        "five_hour_pct": 53,
        "seven_day_pct": 31,
        "session_input_tokens": 550,
        "session_output_tokens": 290186,
        "session_cache_creation_tokens": 2185986,
        "session_cache_read_tokens": 219708362,
        "session_cost_usd": 102.19832335000008,
        "by_model": {
          "claude-opus-4-7": {
            "input": 550,
            "output": 290186,
            "cache_create": 2185986,
            "cache_read": 219708362
          }
        },
        "turn_count": 362,
        "tool_call_count": 213,
        "context_at_last_turn_tokens": 853811,
        "context_window_pct": 426.9055
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-12T22:36:55-07:00",
      "completed_at": "2026-05-12T22:37:26-07:00",
      "session_started_at": null,
      "cumulative_seconds": 31,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-12T22:36:55-07:00",
        "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
        "model": "claude-opus-4-7",
        "five_hour_pct": 53,
        "seven_day_pct": 31,
        "session_input_tokens": 565,
        "session_output_tokens": 293633,
        "session_cache_creation_tokens": 2214126,
        "session_cache_read_tokens": 225713074,
        "session_cost_usd": 103.60534635000006,
        "by_model": {
          "claude-opus-4-7": {
            "input": 565,
            "output": 293633,
            "cache_create": 2214126,
            "cache_read": 225713074
          }
        },
        "turn_count": 369,
        "tool_call_count": 216,
        "context_at_last_turn_tokens": 867669,
        "context_window_pct": 433.8345
      },
      "window_at_complete": {
        "captured_at": "2026-05-12T22:37:26-07:00",
        "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
        "model": "claude-opus-4-7",
        "five_hour_pct": 53,
        "seven_day_pct": 31,
        "session_input_tokens": 569,
        "session_output_tokens": 294390,
        "session_cache_creation_tokens": 2215640,
        "session_cache_read_tokens": 229184131,
        "session_cost_usd": 104.48804185000006,
        "by_model": {
          "claude-opus-4-7": {
            "input": 569,
            "output": 294390,
            "cache_create": 2215640,
            "cache_read": 229184131
          }
        },
        "turn_count": 373,
        "tool_call_count": 218,
        "context_at_last_turn_tokens": 868413,
        "context_window_pct": 434.2065
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-12T21:31:20-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-12T22:03:43-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-12T22:33:19-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-12T22:36:55-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-12T21:30:27-07:00",
    "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
    "model": "claude-opus-4-7",
    "five_hour_pct": 25,
    "seven_day_pct": 23,
    "session_input_tokens": 21,
    "session_output_tokens": 5615,
    "session_cache_creation_tokens": 642295,
    "session_cache_read_tokens": 736343,
    "session_cost_usd": 6.359546250000001,
    "by_model": {
      "claude-opus-4-7": {
        "input": 21,
        "output": 5615,
        "cache_create": 642295,
        "cache_read": 736343
      }
    },
    "turn_count": 6,
    "tool_call_count": 3,
    "context_at_last_turn_tokens": 231908,
    "context_window_pct": 115.954
  },
  "code_tasks_total": 5,
  "code_task_name": "Switch capture_session writers to is_safe_transcript_path_structural",
  "code_task": 5,
  "diff_stats": {
    "files_changed": 5,
    "insertions": 291,
    "deletions": 48,
    "captured_at": "2026-05-12T22:03:33-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThe user has invoked the learn-analyst agent for the branch `record-agent-return-fails-phase`. I am operating as a compliance auditor reviewing a completed feature against three tenants: process gaps, rule compliance, and missing rules. The session data shows this is a PR (#1527) that addresses issue #1525, which was about `record-agent-return` failing with `phase_marker_not_found` when `transcript_path` is null at state init.\n\nThe key artifacts provided are:\n1. Full plan.md showing a 5-task refactor splitting one validator into two (structural + canonical)\n2. State file showing all phases complete except Learn (in progress)\n3. Session log showing three plan deviations logged during Code phase and one rule-drift deferral during Review\n4. Full diff showing changes to capture_session.rs, session_metrics.rs, and tests\n\nThe task is to produce findings across three categories:\n- Tenant 1: Process gaps (workflow shortcomings not remediated in PR)\n- Tenant 2: Rule compliance (violations and their enforcement level)\n- Tenant 3: Missing rules (patterns observed across PRs that should be codified)\n\nFrom the state file findings array, I can see:\n- 1 finding was fixed (backward-facing test comment)\n- 6 findings were dismissed (with specific rationales showing the reviewer agent's reasoning)\n\nThe pre-mortem agent's two findings were dismissed:\n1. macOS HOME symlink issue - dismissed because `/Users` is NOT symlinked on macOS (only `/tmp`, `/var`, `/etc` are)\n2. Structural validator symlink defense - dismissed because the doc comment already names the contract\n\nThree Review findings were dismissed as backward-facing or redundant documentation.\n\nThe plan deviations logged during Code:\n1. Line 20: Task 5 test deletion was needed (plan didn't account for existing test asserting bug)\n2. Lines 21-22: Task 4 test location changed from capture_session.rs to init_state.rs due to visibility of pub(crate) function\n3. Line 22: Task 4 test was renamed to match existing test naming pattern\n\nThe rule drift on line 27: flow-release changes landed on main mid-flow, but decision was to defer (incidental, wide blast radius, unrelated to this PR's diff).\n\nThe applicability of the two-gate test from the framing:\n1. Forward-facing: findings must make sense to a future session\n2. Value: findings must describe gaps NOT already remediated in PR\n\nMost findings should be filtered out because:\n- The backward-facing comment was already fixed in Step 4\n- Pre-mortem findings were dismissed with technical explanations showing they're not real gaps\n- Documentation findings were dismissed as redundant\n- Plan deviations were documented in the log, which counts as remediation\n\nThe key insight: this PR had high Review engagement (pre-mortem auto-thrashed twice, multiple agents returned), multiple plan deviations were explicitly logged, and aggressive Review triage dismissed 6 findings. The session metadata shows normal workflow with no hidden infrastructure gaps.\n\nFor Tenant 1 (process gaps), I need to look for workflow shortcomings that were NOT remediated. The pre-mortem's macOS symlink claim was incorrect (user data shows /Users is not symlinked on macOS), so there's no process gap there. The plan deviation around test deletion was logged. Nothing suggests FLOW process failures.\n\nFor Tenant 2 (rule compliance), I need to check if rules were violated. The test deviation (deletion of a test that asserted buggy behavior) is actually correct per `.claude/rules/supersession.md` - when code is made redundant, delete it. The comment rewrite was caught and fixed. Nothing suggests clear rule violations that weren't handled.\n\nFor Tenant 3 (missing rules), I need patterns across multiple PRs. The only visible pattern is the test-deletion scenario, but that's already covered by supersession rule.\n\nThe state file shows `transcript_path: null` in the state JSON itself (line 19), which is a red flag - this is AT state init, during Learn phase. But wait, that's expected at Learn entry because this is a fresh session. The issue #1525 was about SessionStart time when capture_session runs BEFORE Claude Code creates the JSONL.\n\nActually, looking more carefully at the state file, line 19 shows `\"transcript_path\": null` but this is the state file that was initialized at flow-start. The fix in this PR is about NOT nulling it out at state init time. So the test `captured_session_with_nonexistent_transcript_path_still_seeds_both_fields` verifies the path gets persisted despite missing JSONL. This test passing means the fix worked.\n\nGiven all this, I should produce sparse findings - the framing explicitly states \"Most Learn phases produce zero findings\" and to filter aggressively. The backward-facing comment was already fixed. The pre-mortem findings were technical errors, not process gaps. The Review triage was thorough.\n\nI need to check: did the system already close all gaps, OR are there Tenant 1/2/3 findings that fall through?\n\nLooking at the findings array carefully:\n- The backward-facing comment fix landed in Step 4 (outcome: fixed) - this was a Real finding that was remediated\n- The other 6 findings were dismissed with specific technical rationales\n\nSo there are no open findings being carried forward. The question is: are there findings I should identify that the Review session missed?\n\nThe key audit question: was any gap caught and remediated in this PR? If yes per the value-gate, drop it.\n\nThe backward-facing comment was caught by Documentation agent and fixed in Step 4 - it was already closed.\n\nRemaining question: are there Tenant 1/2/3 gaps that slipped past Review?\n\nLooking at the PR itself: the substantive changes are clean, well-tested, properly documented. The test deletion was correct (supersession). The plan deviations were logged. The rule drift was explicitly deferred with reasoning.\n\nMy conclusion: this PR should have zero findings. The system worked as designed - Review caught issues, triage dismissed false positives, and real findings were fixed in Step 4.\n\nI should produce \"No findings\" markers for all three tenants with brief explanations of what was checked.\n</analysis>\n\n<summary>\n\n1. Primary Request and Intent:\n   As the learn-analyst agent for the flow-learn phase on branch `record-agent-return-fails-phase`, I am tasked with performing a compliance audit of the completed feature against three tenants: (1) Process gaps - identifying FLOW workflow shortcomings exposed but NOT remediated in the PR; (2) Rule compliance - auditing violations of project rules and assessing enforcement levels (Unclear vs Ignored); (3) Missing rules - identifying patterns across multiple PRs that should be codified. The user provides explicit filtering criteria: only report findings that (a) are forward-facing (would make sense to a future session) and (b) describe gaps NOT already caught and remediated in this PR. The framing explicitly states \"Most Learn phases produce zero findings\" and prioritizes filtering over finding-generation.\n\n2. Key Technical Concepts:\n   - Two-tier transcript_path validator pattern: `is_safe_transcript_path_structural` (stateless, lexical-only checks, accepts non-existent files) and `is_safe_transcript_path` (canonical wrapper adding canonicalize + prefix-comparison for read-time symlink-escape closure)\n   - SessionStart hook timing: capture_session receives transcript_path BEFORE Claude Code creates the JSONL file; canonical validator's canonicalize() fails on missing files, causing silent null storage and downstream `record-agent-return` failures\n   - Defense-in-depth architectural claim: structural validator performs no syscalls (write-time safe), canonical validator canonicalizes before any File::open (read-time safe)\n   - Regression issue #1525: `record-agent-return` reporting `transcript_path_invalid` (mapped to `phase_marker_not_found` by failure-classifier), silently skipping Review and Learn agents on every macOS FLOW user (pre-mortem's claim disproved by Review triage)\n   - Supersession pattern: test `capture_session_stores_null_when_transcript_file_does_not_exist_yet` asserted buggy behavior (storing null); replaced by `run_persists_transcript_path_when_jsonl_does_not_exist` asserting fix (persisting path)\n\n3. Files and Code Sections:\n   - `/Users/ben/code/flow/.flow-states/record-agent-return-fails-phase/plan.md`:\n      - 5-task implementation plan with TDD pairs split across two commits (Tasks 1+2 together, Tasks 3+4+5 together per \"Optimization-Driven Batching\")\n      - Critical Risk #3 names the trade-off: \"Loosening write-time validation to structural-only means a hostile payload containing a symlink-shaped path could be persisted; read-time hooks still canonicalize, so actual file read remains safe\"\n      - Exploration names 10 callsites: 8 in transcript_walker.rs (read-time, require canonical), 2 in capture_session.rs (write-time, can use structural)\n   \n   - `/Users/ben/code/flow/.flow-states/record-agent-return-fails-phase/full-diff.diff`:\n      - src/hooks/capture_session.rs lines 9-12: Import changed from `is_safe_transcript_path` to `is_safe_transcript_path_structural`\n      - src/hooks/capture_session.rs lines 25-32: read_captured_session doc comment updated to explain structural variant accepts non-existent paths, symlink-escape closed by read-time callers via canonical wrapper\n      - src/hooks/capture_session.rs line 40: `.filter(|tp| is_safe_transcript_path(...))` → `.filter(|tp| is_safe_transcript_path_structural(...))`\n      - src/hooks/capture_session.rs line 50: `.filter(|p| is_safe_transcript_path(...))` → `.filter(|p| is_safe_transcript_path_structural(...))`\n      - src/session_metrics.rs lines 72-97: Canonical `is_safe_transcript_path` refactored to call structural variant first, then adds canonicalize + canonical-prefix match via tuple destructure (lines 90-96)\n      - src/session_metrics.rs lines 99-168: New `is_safe_transcript_path_structural` function with doc comment naming rejection classes (empty, NUL, relative, ParentDir, prefix-escape), production consumers (SessionStart capture_session, flow-start read_captured_session), and intentional symlink-escape deferral to read-time callers\n      - tests/hooks/capture_session.rs lines 262-291: Test renamed from `capture_session_stores_null_when_transcript_file_does_not_exist_yet` (asserted null) to `run_persists_transcript_path_when_jsonl_does_not_exist` (asserts path persisted); doc comment rewritten forward-facing\n      - tests/commands/init_state.rs lines 192-223: New test `captured_session_with_nonexistent_transcript_path_still_seeds_both_fields` drives read_captured_session through init-state subcommand (pub(crate) visibility workaround) to verify structural validator accepts non-existent path\n      - tests/session_metrics.rs lines 311-445: 8 new tests for structural validator (positive + 5 rejection classes) and 3 tests for canonical wrapper (short-circuit, success, missing-file rejection)\n   \n   - `/Users/ben/code/flow/.flow-states/record-agent-return-fails-phase/state.json`:\n      - Phase completion timeline: flow-start (43s), flow-code (1933s, 5 code tasks), flow-review (1761s, 1 visit), flow-learn (in_progress)\n      - Review agents_returned: all 4 required agents returned (reviewer, adversarial, documentation, pre-mortem)\n      - 7 findings recorded in Review: 1 fixed (backward-facing comment), 6 dismissed with specific technical rationales\n   \n   - `/Users/ben/code/flow/.flow-states/record-agent-return-fails-phase/log`:\n      - Lines 20-22: Three plan deviations logged during Code phase\n        - Task 5 test deletion: existing test `capture_session_stores_null_when_transcript_file_does_not_exist_yet` asserted bug; must be deleted when callsite swap turns it false\n        - Task 4 test location: `read_captured_session` is pub(crate); moved test from capture_session.rs to init_state.rs alongside sibling `captured_session_with_transcript_path_seeds_both_fields`\n        - Task 4 test rename: renamed to match existing pattern `captured_session_with_<input>_seeds_<result>`\n      - Line 27: Rule drift deferral during Review - flow-release commit-window changes landed on main mid-flow; decision to defer (incidental, wide blast radius, unrelated to this PR's src/session_metrics.rs changes)\n\n4. Errors and fixes:\n   - Pre-mortem agent autocompact-thrash (state file shows 2 retries before success on 3rd attempt): caused by large diff context in initial agent prompt; fixed by re-invocation with tightly-constrained scope per cognitive-isolation.md\n   - Pre-mortem false positives on macOS symlink issue: agent claimed `/Users` is symlinked on macOS causing lexical `starts_with` to fail; dismissed by Review triage as factually incorrect (only `/tmp`, `/var`, `/etc` are symlinked at macOS root; production HOME is `/Users/<user>` matching both home_dir_or_empty() and Claude Code's stdin value)\n   - Documentation agent finding on \"Key Files needs two-tier validator naming\": dismissed as redundant because existing plural entry already covers both functions and per-function doc comments explain the two-tier design\n\n5. Problem Solving:\n   - Solved: Regression in issue #1525 where transcript_path persisted as null at state init because canonical validator's canonicalize() fails on non-existent JSONL files, causing record-agent-return to report transcript_path_invalid. Solution: split validator into structural (write-time, no syscalls) and canonical (read-time, adds canonicalize + symlink-escape). Test deletion handled per supersession rule (buggy test asserted null; new test asserts path persisted).\n   - Solved: Visibility issue with pub(crate) read_captured_session function; test moved from capture_session.rs to init_state.rs alongside sibling test, using init-state subcommand as the callsite boundary per .claude/rules/test-placement.md\n   - Solved: Plan deviation around test naming; aligned with existing pattern to maintain consistency\n   - Identified and deferred: Rule drift (flow-release changes on main mid-flow) — decision to defer with explicit rationale (incidental, unrelated to this PR's code surface)\n\n6. All user messages:\n   - Single system-initiated message: Framing instructions for learn-analyst agent with three tenants (process gaps, rule compliance, missing rules), two-gate filtering test (forward-facing + value), explicit statement \"Most Learn phases produce zero findings\", and budget management directive (\"Reserve the remainder for analysis\")\n   - No additional user prose messages beyond context setup; user interaction is implicit via artifact provision\n\n7. Pending Tasks:\n   - Complete flow-learn phase by producing structured findings (or \"No findings\" markers) across three tenants\n   - Emit `## END-OF-FINDINGS` completion marker as final output\n   - Parent session will then call `bin/flow record-agent-return --branch record-agent-return-fails-phase --agent learn-analyst --phase flow-learn` to record return via transcript verification\n\n8. Current Work:\n   Reading and analyzing all provided artifacts (plan.md, state.json, full-diff.diff, session log) to audit compliance across three tenants. The session shows a clean 5-task refactor with high Review engagement (4 agents returned, 7 findings processed, 1 fixed in Step 4, 6 dismissed with technical rationales). Code changes are targeted to src/session_metrics.rs (validator split) and src/hooks/capture_session.rs (callsite swap), with comprehensive test coverage added. Plan deviations were documented in session log. Rule drift was explicitly deferred. The state of findings is: backward-facing comment already fixed, pre-mortem false positives already dismissed, documentation redundancies already dismissed.\n\n9. Optional Next Step:\n   Produce final findings output following the three-tenant structure. Based on the audit evidence:\n   - Tenant 1 (Process gaps): No findings — Review caught all issues, plan deviations were logged, rule drift was deferred with explicit rationale\n   - Tenant 2 (Rule compliance): No findings — test deletion aligns with supersession rule, comment rewrite was caught and fixed in Step 4, no rule violations visible\n   - Tenant 3 (Missing rules): No findings — the test-deletion pattern is covered by existing supersession rule\n\n   Emit explicit \"No findings\" markers for all three categories per the framing's statement that \"Return only findings that pass both gates. If all categories produce zero, say so explicitly with 'No findings' markers — do NOT invent findings to fill sections.\"\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/record-agent-return-fails-phase",
  "compact_count": 12,
  "findings": [
    {
      "finding": "Reviewer: Plan deviation not logged",
      "reason": "Three bin/flow log entries were created during Code phase before the commits (test rename in tests/commands/init_state.rs, file location change, and existing-test deletion under Task 5). The commit message body for the Task 3+4+5 atomic commit explicitly names the Task 4 rename. The deviation IS logged at both surfaces; reviewer did not see them because the agent's input contract excludes the state log file and earlier commit messages.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-12T22:25:46-07:00"
    },
    {
      "finding": "Pre-mortem: macOS HOME symlink causes structural validator to silently reject",
      "reason": "The /Users directory is NOT symlinked on macOS — only /tmp, /var, /etc are symlinks at the root. Standard production HOME is /Users/<user> which equals the canonical form. Claude Code passes the same non-canonical prefix to capture_session via stdin; both home and transcript_path share the same prefix. The lexical starts_with check works correctly. The pre-mortem's claim that production transcripts are '/private/Users/...' is factually wrong for macOS.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-12T22:25:56-07:00"
    },
    {
      "finding": "Pre-mortem: structural validator symlink-defense not mechanically enforced",
      "reason": "The new is_safe_transcript_path_structural's own doc comment explicitly names the contract: 'Symlink-escape is intentionally not addressed here. Defense happens at every read-time callsite via the canonical wrapper is_safe_transcript_path'. A future caller reading the function they are about to call sees this. Per value-vs-bureaucracy in review-scope.md, a contract test would duplicate doc-discoverable information without preventing any class of regression the doc comment already warns about.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-12T22:26:03-07:00"
    },
    {
      "finding": "Documentation: CLAUDE.md Key Files needs two-tier validator naming",
      "reason": "The existing Key Files entry for src/session_metrics.rs already says 'session-id and transcript-path validators' (plural). Per .claude/rules/review-scope.md value-vs-bureaucracy test for Tenant 6 borderline cases: both function doc comments explain the two-tier design; grep finds either function instantly. A future reader who finds either function via grep sees the design in the doc comments without consulting CLAUDE.md.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-12T22:26:11-07:00"
    },
    {
      "finding": "Documentation: is_safe_transcript_path doc comment mechanics not forward-facing",
      "reason": "The current canonical wrapper doc comment explicitly states 'Read-time callers (transcript walkers, anything that will File::open the path) use this wrapper so symlink-escape is closed at the open boundary. Write-time-shape callers (the SessionStart capture hook and the flow-start round-trip reader) use is_safe_transcript_path_structural directly because the file is not guaranteed to exist yet at write time.' That IS the forward-facing contract — describes which to use when, not implementation sequencing.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-12T22:26:18-07:00"
    },
    {
      "finding": "Documentation: two-validator design rationale needs module-level block",
      "reason": "Both function doc comments already explain the two-tier design: the canonical wrapper's doc names the composition relationship and when to use it; the structural function's doc names the production consumers, the rejection classes, and the read-time symlink-escape closure. Adding a module-level 'Section: Two-Tier Design' block above would restate information the per-function docs already carry — per .claude/rules/review-scope.md value-vs-bureaucracy, classify as redundant documentation.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-12T22:26:24-07:00"
    },
    {
      "finding": "Backward-facing comment in tests/hooks/capture_session.rs doc for run_persists_transcript_path_when_jsonl_does_not_exist",
      "reason": "Rewrote the doc comment forward-facing per .claude/rules/comment-quality.md. The new comment describes what the test asserts (capture_session::run persists transcript_path verbatim when JSONL does not exist), why it matters (downstream record-agent-return needs a real transcript_path), and where symlink-escape stays closed (read-time consumers re-validate via the canonical wrapper). No parity reference to the deleted test, no 'before the fix' narrative, no planning-artifact citation.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-12T22:27:01-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-12T22:37:26-07:00",
    "session_id": "6ec23b36-e1b6-458e-96c0-043f06f49743",
    "model": "claude-opus-4-7",
    "five_hour_pct": 53,
    "seven_day_pct": 31,
    "session_input_tokens": 569,
    "session_output_tokens": 294390,
    "session_cache_creation_tokens": 2215640,
    "session_cache_read_tokens": 229184131,
    "session_cost_usd": 104.48804185000006,
    "by_model": {
      "claude-opus-4-7": {
        "input": 569,
        "output": 294390,
        "cache_create": 2215640,
        "cache_read": 229184131
      }
    },
    "turn_count": 373,
    "tool_call_count": 218,
    "context_at_last_turn_tokens": 868413,
    "context_window_pct": 434.2065
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>