### PR TITLE
Plugin Docs And Setup Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The FLOW binary is built from source on first use. From your terminal — not Cl
 ```bash
 brew install rust
 xcode-select --install
-bash ~/.claude/plugins/cache/benkruger/flow/flow/bin/setup
+bash ~/.claude/plugins/cache/flow-marketplace/flow/2.0.1/bin/setup
 ```
 
 Then initialize in your project (once per project, and again after each FLOW upgrade):

--- a/docs/index.html
+++ b/docs/index.html
@@ -1158,7 +1158,7 @@
       <p>The FLOW binary is built from source on first use. Install Rust and a C compiler once per machine, then run the bundled setup script to compile the release binary. The commands below assume macOS; Linux and WSL support are not yet implemented.</p>
       <div class="install-block"><span class="prompt">$ </span>brew install rust
 <span class="prompt">$ </span>xcode-select --install
-<span class="prompt">$ </span>bash ~/.claude/plugins/cache/benkruger/flow/flow/bin/setup</div>
+<span class="prompt">$ </span>bash ~/.claude/plugins/cache/flow-marketplace/flow/2.0.1/bin/setup</div>
 
       <div class="step-label">step 03 — initialize in your project</div>
       <div class="install-block"><span class="prompt">$ </span>/flow-prime</div>

--- a/src/bump_version.rs
+++ b/src/bump_version.rs
@@ -89,6 +89,29 @@ pub fn bump_skill(path: &Path, old: &str, new: &str) -> Result<bool, String> {
     Ok(true)
 }
 
+/// Replace `flow-marketplace/flow/<old>/bin/setup` with the new-version
+/// form in a file (README.md and docs/index.html). Returns true if any
+/// replacement was made. The pattern is bounded by
+/// `flow-marketplace/flow/` on the left and `/bin/setup` on the right
+/// so the version segment cannot collide with other version-like
+/// substrings in the file.
+pub fn bump_install_path(path: &Path, old: &str, new: &str) -> Result<bool, String> {
+    let text = match fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) => return Err(format!("Failed to read {}: {}", path.display(), e)),
+    };
+    let old_pattern = format!("flow-marketplace/flow/{}/bin/setup", old);
+    let new_pattern = format!("flow-marketplace/flow/{}/bin/setup", new);
+    let updated = text.replace(&old_pattern, &new_pattern);
+    if updated == text {
+        return Ok(false);
+    }
+    if let Err(e) = fs::write(path, &updated) {
+        return Err(format!("Failed to write {}: {}", path.display(), e));
+    }
+    Ok(true)
+}
+
 /// Orchestrate the full version bump across all files.
 ///
 /// Returns Ok(summary_text) on success, Err(error_text) on failure.
@@ -161,6 +184,18 @@ pub fn run_impl(version: Option<&str>, repo_root: &Path) -> Result<String, Strin
         .join("SKILL.md");
     if release_skill.exists() && bump_skill(&release_skill, &old_version, new_version)? {
         changed.push(".claude/skills/flow-release/SKILL.md".to_string());
+    }
+
+    // 5. README.md install-path version segment.
+    let readme = repo_root.join("README.md");
+    if readme.exists() && bump_install_path(&readme, &old_version, new_version)? {
+        changed.push("README.md".to_string());
+    }
+
+    // 6. docs/index.html install-path version segment.
+    let docs_index = repo_root.join("docs").join("index.html");
+    if docs_index.exists() && bump_install_path(&docs_index, &old_version, new_version)? {
+        changed.push("docs/index.html".to_string());
     }
 
     let mut output = format!("Bumped {} -> {}\n", old_version, new_version);

--- a/tests/bump_version.rs
+++ b/tests/bump_version.rs
@@ -6,7 +6,8 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use flow_rs::bump_version::{
-    bump_json, bump_skill, read_current_version, run_impl, run_impl_main, validate_version,
+    bump_install_path, bump_json, bump_skill, read_current_version, run_impl, run_impl_main,
+    validate_version,
 };
 
 /// Build a fake plugin root with `flow-phases.json` so `plugin_root()`
@@ -336,6 +337,64 @@ fn bump_skill_missing_file_errors() {
     assert!(err.contains("Failed to read"));
 }
 
+// --- bump_install_path ---
+
+#[test]
+fn bump_install_path_replaces_version_segment() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("README.md");
+    fs::write(
+        &path,
+        "prereqs\nbash ~/.claude/plugins/cache/flow-marketplace/flow/1.0.0/bin/setup\nmore\n",
+    )
+    .unwrap();
+    let changed = bump_install_path(&path, "1.0.0", "2.0.0").unwrap();
+    assert!(changed);
+    let contents = fs::read_to_string(&path).unwrap();
+    assert!(contents.contains("flow-marketplace/flow/2.0.0/bin/setup"));
+    assert!(!contents.contains("flow-marketplace/flow/1.0.0/bin/setup"));
+}
+
+#[test]
+fn bump_install_path_no_change_when_segment_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("README.md");
+    fs::write(&path, "no install path here\n").unwrap();
+    let changed = bump_install_path(&path, "1.0.0", "2.0.0").unwrap();
+    assert!(!changed);
+}
+
+#[test]
+fn bump_install_path_missing_file_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let err = bump_install_path(&dir.path().join("nonexistent.md"), "1.0.0", "2.0.0").unwrap_err();
+    assert!(err.contains("Failed to read"));
+}
+
+#[test]
+fn bump_install_path_write_failure_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let readonly = dir.path().join("readonly");
+    fs::create_dir_all(&readonly).unwrap();
+    let path = readonly.join("README.md");
+    fs::write(
+        &path,
+        "bash ~/.claude/plugins/cache/flow-marketplace/flow/1.0.0/bin/setup\n",
+    )
+    .unwrap();
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_readonly(true);
+    fs::set_permissions(&path, perms).unwrap();
+
+    let err = bump_install_path(&path, "1.0.0", "2.0.0").unwrap_err();
+    assert!(err.contains("Failed to write"));
+
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    #[allow(clippy::permissions_set_readonly_false)]
+    perms.set_readonly(false);
+    fs::set_permissions(&path, perms).unwrap();
+}
+
 #[test]
 fn run_impl_skills_dir_is_file_errors() {
     let (_dir, root) = setup_repo("1.0.0");
@@ -467,4 +526,100 @@ fn run_impl_propagates_bump_skill_err_on_release_skill() {
     #[allow(clippy::permissions_set_readonly_false)]
     perms.set_readonly(false);
     fs::set_permissions(&release_skill, perms).unwrap();
+}
+
+// --- run_impl install-path wiring ---
+
+#[test]
+fn run_impl_bumps_install_path_in_readme_when_present() {
+    let (_dir, root) = setup_repo("1.0.0");
+    fs::write(
+        root.join("README.md"),
+        "prereqs\nbash ~/.claude/plugins/cache/flow-marketplace/flow/1.0.0/bin/setup\n",
+    )
+    .unwrap();
+    let output = run_impl(Some("2.0.0"), &root).unwrap();
+    assert!(output.contains("README.md"));
+    let contents = fs::read_to_string(root.join("README.md")).unwrap();
+    assert!(contents.contains("flow-marketplace/flow/2.0.0/bin/setup"));
+    assert!(!contents.contains("flow-marketplace/flow/1.0.0/bin/setup"));
+}
+
+#[test]
+fn run_impl_bumps_install_path_in_docs_index_html_when_present() {
+    let (_dir, root) = setup_repo("1.0.0");
+    let docs_dir = root.join("docs");
+    fs::create_dir_all(&docs_dir).unwrap();
+    fs::write(
+        docs_dir.join("index.html"),
+        "<div>bash ~/.claude/plugins/cache/flow-marketplace/flow/1.0.0/bin/setup</div>\n",
+    )
+    .unwrap();
+    let output = run_impl(Some("2.0.0"), &root).unwrap();
+    assert!(output.contains("docs/index.html"));
+    let contents = fs::read_to_string(docs_dir.join("index.html")).unwrap();
+    assert!(contents.contains("flow-marketplace/flow/2.0.0/bin/setup"));
+    assert!(!contents.contains("flow-marketplace/flow/1.0.0/bin/setup"));
+}
+
+#[test]
+fn run_impl_readme_no_match_skips_push() {
+    let (_dir, root) = setup_repo("1.0.0");
+    fs::write(root.join("README.md"), "no install path here\n").unwrap();
+    let output = run_impl(Some("2.0.0"), &root).unwrap();
+    assert!(!output.contains("README.md"));
+}
+
+#[test]
+fn run_impl_docs_index_html_no_match_skips_push() {
+    let (_dir, root) = setup_repo("1.0.0");
+    let docs_dir = root.join("docs");
+    fs::create_dir_all(&docs_dir).unwrap();
+    fs::write(docs_dir.join("index.html"), "<div>no install path</div>\n").unwrap();
+    let output = run_impl(Some("2.0.0"), &root).unwrap();
+    assert!(!output.contains("docs/index.html"));
+}
+
+#[test]
+fn run_impl_propagates_bump_install_path_err_on_readme() {
+    let (_dir, root) = setup_repo("1.0.0");
+    let readme = root.join("README.md");
+    fs::write(
+        &readme,
+        "bash ~/.claude/plugins/cache/flow-marketplace/flow/1.0.0/bin/setup\n",
+    )
+    .unwrap();
+    let mut perms = fs::metadata(&readme).unwrap().permissions();
+    perms.set_readonly(true);
+    fs::set_permissions(&readme, perms).unwrap();
+    let err = run_impl(Some("2.0.0"), &root).unwrap_err();
+    assert!(err.contains("Failed to write"));
+
+    let mut perms = fs::metadata(&readme).unwrap().permissions();
+    #[allow(clippy::permissions_set_readonly_false)]
+    perms.set_readonly(false);
+    fs::set_permissions(&readme, perms).unwrap();
+}
+
+#[test]
+fn run_impl_propagates_bump_install_path_err_on_docs_index_html() {
+    let (_dir, root) = setup_repo("1.0.0");
+    let docs_dir = root.join("docs");
+    fs::create_dir_all(&docs_dir).unwrap();
+    let docs_index = docs_dir.join("index.html");
+    fs::write(
+        &docs_index,
+        "<div>bash ~/.claude/plugins/cache/flow-marketplace/flow/1.0.0/bin/setup</div>\n",
+    )
+    .unwrap();
+    let mut perms = fs::metadata(&docs_index).unwrap().permissions();
+    perms.set_readonly(true);
+    fs::set_permissions(&docs_index, perms).unwrap();
+    let err = run_impl(Some("2.0.0"), &root).unwrap_err();
+    assert!(err.contains("Failed to write"));
+
+    let mut perms = fs::metadata(&docs_index).unwrap().permissions();
+    #[allow(clippy::permissions_set_readonly_false)]
+    perms.set_readonly(false);
+    fs::set_permissions(&docs_index, perms).unwrap();
 }

--- a/tests/docs_sync.rs
+++ b/tests/docs_sync.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::fs;
 
 use regex::Regex;
+use serde_json::Value;
 
 /// Returns a map of phase_key → 1-indexed phase number.
 fn phase_number() -> HashMap<String, usize> {
@@ -78,16 +79,27 @@ fn assert_covers_key_features(content: &str, source_label: &str) {
 // --- Install-flow docs sync ---
 
 /// README.md and docs/index.html must both reference the install-flow
-/// prerequisites and the bin/setup invocation. Guards against the two
-/// docs drifting (one updated, the other not) and against accidental
-/// removal of a prereq line or the setup-script reference.
+/// prerequisites and the bin/setup invocation under the exact cache
+/// path Claude Code emits: `flow-marketplace/<plugin>/<version>/bin/setup`.
+/// The version segment is read from `.claude-plugin/marketplace.json`
+/// `plugins[0].version` so a release that bumps the version without
+/// updating these doc literals fails CI. The two prereq lines guard
+/// against accidental removal of the macOS toolchain hints.
 #[test]
 fn install_docs_contain_setup_step() {
+    let marketplace: Value = serde_json::from_str(
+        &fs::read_to_string(common::repo_root().join(".claude-plugin/marketplace.json"))
+            .expect("read marketplace.json"),
+    )
+    .expect("parse marketplace.json");
+    let version = marketplace["plugins"][0]["version"]
+        .as_str()
+        .expect("marketplace.json plugins[0].version");
+    let expected_path = format!("flow-marketplace/flow/{}/bin/setup", version);
     let required = [
         "brew install rust",
         "xcode-select --install",
-        "bin/setup",
-        ".claude/plugins/cache",
+        expected_path.as_str(),
     ];
     let sources = [
         ("README.md", common::repo_root().join("README.md")),

--- a/tests/docs_sync.rs
+++ b/tests/docs_sync.rs
@@ -85,6 +85,13 @@ fn assert_covers_key_features(content: &str, source_label: &str) {
 /// `plugins[0].version` so a release that bumps the version without
 /// updating these doc literals fails CI. The two prereq lines guard
 /// against accidental removal of the macOS toolchain hints.
+///
+/// In addition to asserting the current version's literal appears, the
+/// test rejects ANY `flow-marketplace/flow/<seg>/bin/setup` where
+/// `<seg>` is not the current `plugins[0].version` — so a stale
+/// previous-version reference left behind by `bump_install_path` (which
+/// only rewrites the exact prior version it was passed) is caught at
+/// CI time rather than shipping silently to the docs site.
 #[test]
 fn install_docs_contain_setup_step() {
     let marketplace: Value = serde_json::from_str(
@@ -101,6 +108,8 @@ fn install_docs_contain_setup_step() {
         "xcode-select --install",
         expected_path.as_str(),
     ];
+    let stale_version_re =
+        Regex::new(r"flow-marketplace/flow/([^/]+)/bin/setup").expect("compile install-path regex");
     let sources = [
         ("README.md", common::repo_root().join("README.md")),
         ("docs/index.html", common::docs_dir().join("index.html")),
@@ -113,6 +122,15 @@ fn install_docs_contain_setup_step() {
                 "{} must contain '{}' (install-flow docs sync)",
                 label,
                 snippet
+            );
+        }
+        for cap in stale_version_re.captures_iter(&content) {
+            let seg = &cap[1];
+            assert_eq!(
+                seg, version,
+                "{} contains stale install path with version segment '{}'; expected '{}' \
+                 (run `make bump NEW=<v>` to refresh, or remove the stale reference)",
+                label, seg, version
             );
         }
     }


### PR DESCRIPTION
## What

/flow:flow-start #1538.

Closes #1538

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/plugin-docs-and-setup-commands/log` |
| State | `.flow-states/plugin-docs-and-setup-commands/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/ccd57aa1-d0c0-42da-a72f-3ca331fc218b.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 19m |
| Review | 16m |
| Learn | 2m |
| Complete | <1m |
| **Total** | **40m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 2.3M | $0.861 |
| Code | 79.4M | $27.431 |
| Review | 57.6M | $30.808 |
| Learn | 18.0M | $5.981 |
| Complete | 2.3M | $0.780 |
| **Total** | **159.6M** | **$65.862** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **Pre-mortem: Partial disk corruption on mid-bump write failure**
  - Dismissed — Mirror-inherited from sibling pattern (bump_skill, bump_json). Every prior run_impl file-target has the same non-transactional shape per .claude/rules/mirror-pattern-rule-audit.md. Cross-cutting refactor out of scope.
- ✗ **Pre-mortem: Silent no-op if flow-marketplace directory name ever changes**
  - Dismissed — The strengthened install_docs_contain_setup_step test from this PR catches the no-op scenario on next CI run. Future-event speculation; the PR's own gate covers it.
- ✗ **Pre-mortem: install_docs_contain_setup_step panics with misleading message on malformed marketplace.json**
  - Dismissed — New test uses descriptive .expect(...). Sibling test at tests/structural.rs:122 uses bare .unwrap() — new test is strictly better. Malformed marketplace.json fails multiple tests simultaneously.
- ✗ **Adversarial: run_impl leaves stale unrelated-version references in README/docs**
  - Dismissed — bump_install_path mirrors bump_skill/bump_json exact-old-only pattern by plan design. Cross-cutting sweep-all-versions is a different feature.
- ✗ **Adversarial: bump_install_path accepts empty old without validation**
  - Dismissed — Production caller (run_impl) validates upstream via validate_version. No other production consumer. Per external-input-validation.md Guaranteed-valid classification.
- ✗ **Adversarial: bump_install_path accepts slash-containing old**
  - Dismissed — validate_version rejects slash-containing input upstream in run_impl; no other production consumer. Same as empty-old finding.
- ✗ **Adversarial: run_impl does not warn when bumped file already contains new version**
  - Dismissed — Sibling-pattern inheritance (bump_skill, bump_json have same property). Recoverable via review.
- ✗ **Adversarial: run_impl silently skips non-semver version segments like dev**
  - Dismissed — Variant of stale-version finding; same mirror-inherited design. Out of scope per plan.
- ✗ **Documentation: Missing CLAUDE.md Key Files entry for src/bump_version.rs**
  - Dismissed — src/bump_version.rs is pre-existing (modified, not created). bump_install_path has clear doc comment naming boundary semantics. Bureaucracy-trap shape per review-scope.md Value-vs-Bureaucracy triage.
- ✓ **Adversarial: install_docs_contain_setup_step lacks old-version absence assertion**
  - Fixed — Strengthened install_docs_contain_setup_step in tests/docs_sync.rs with a regex scan asserting every flow-marketplace/flow/&lt;seg&gt;/bin/setup occurrence in README.md and docs/index.html carries the current plugins[0].version. Stale prior-version references that bump_install_path's exact-old-match cannot scrub now fail CI.

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/plugin-docs-and-setup-commands.json</summary>

```json
{
  "schema_version": 1,
  "branch": "plugin-docs-and-setup-commands",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1539,
  "pr_url": "https://github.com/benkruger/flow/pull/1539",
  "started_at": "2026-05-13T14:34:42-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/plugin-docs-and-setup-commands/log",
    "state": ".flow-states/plugin-docs-and-setup-commands/state.json"
  },
  "session_tty": "/dev/ttys000",
  "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/ccd57aa1-d0c0-42da-a72f-3ca331fc218b.jsonl",
  "notes": [],
  "prompt": "/flow:flow-start #1538",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-13T14:34:42-07:00",
      "completed_at": "2026-05-13T14:35:33-07:00",
      "session_started_at": null,
      "cumulative_seconds": 51,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-13T14:34:42-07:00",
        "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 5,
        "seven_day_pct": 40,
        "session_input_tokens": 31,
        "session_output_tokens": 5374,
        "session_cache_creation_tokens": 437897,
        "session_cache_read_tokens": 937463,
        "session_cost_usd": 16.64431499999999,
        "by_model": {
          "claude-opus-4-7": {
            "input": 31,
            "output": 5374,
            "cache_create": 437897,
            "cache_read": 937463
          }
        },
        "turn_count": 6,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 232769,
        "context_window_pct": 116.3845
      },
      "window_at_complete": {
        "captured_at": "2026-05-13T14:35:33-07:00",
        "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 5,
        "seven_day_pct": 40,
        "session_input_tokens": 41,
        "session_output_tokens": 7337,
        "session_cache_creation_tokens": 440797,
        "session_cache_read_tokens": 3272565,
        "session_cost_usd": 17.505403749999992,
        "by_model": {
          "claude-opus-4-7": {
            "input": 41,
            "output": 7337,
            "cache_create": 440797,
            "cache_read": 3272565
          }
        },
        "turn_count": 16,
        "tool_call_count": 10,
        "context_at_last_turn_tokens": 234806,
        "context_window_pct": 117.403
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-13T14:35:42-07:00",
      "completed_at": "2026-05-13T14:55:15-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1173,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-13T14:35:42-07:00",
        "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 5,
        "seven_day_pct": 40,
        "session_input_tokens": 53,
        "session_output_tokens": 8149,
        "session_cache_creation_tokens": 458789,
        "session_cache_read_tokens": 4212195,
        "session_cost_usd": 17.80671624999999,
        "by_model": {
          "claude-opus-4-7": {
            "input": 53,
            "output": 8149,
            "cache_create": 458789,
            "cache_read": 4212195
          }
        },
        "turn_count": 20,
        "tool_call_count": 12,
        "context_at_last_turn_tokens": 243806,
        "context_window_pct": 121.903
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-13T14:42:09-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 7,
          "seven_day_pct": 41,
          "session_input_tokens": 112,
          "session_output_tokens": 31839,
          "session_cache_creation_tokens": 1901451,
          "session_cache_read_tokens": 24060657,
          "session_cost_usd": 28.128563249999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 112,
              "output": 31839,
              "cache_create": 1901451,
              "cache_read": 24060657
            }
          },
          "turn_count": 69,
          "tool_call_count": 39,
          "context_at_last_turn_tokens": 489994,
          "context_window_pct": 244.997
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-13T14:42:09-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 7,
          "seven_day_pct": 41,
          "session_input_tokens": 112,
          "session_output_tokens": 31839,
          "session_cache_creation_tokens": 1901451,
          "session_cache_read_tokens": 24060657,
          "session_cost_usd": 28.128563249999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 112,
              "output": 31839,
              "cache_create": 1901451,
              "cache_read": 24060657
            }
          },
          "turn_count": 69,
          "tool_call_count": 39,
          "context_at_last_turn_tokens": 489994,
          "context_window_pct": 244.997
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-13T14:42:09-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 7,
          "seven_day_pct": 41,
          "session_input_tokens": 112,
          "session_output_tokens": 31839,
          "session_cache_creation_tokens": 1901451,
          "session_cache_read_tokens": 24060657,
          "session_cost_usd": 28.128563249999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 112,
              "output": 31839,
              "cache_create": 1901451,
              "cache_read": 24060657
            }
          },
          "turn_count": 69,
          "tool_call_count": 39,
          "context_at_last_turn_tokens": 489994,
          "context_window_pct": 244.997
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-13T14:42:09-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 7,
          "seven_day_pct": 41,
          "session_input_tokens": 112,
          "session_output_tokens": 31839,
          "session_cache_creation_tokens": 1901451,
          "session_cache_read_tokens": 24060657,
          "session_cost_usd": 28.128563249999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 112,
              "output": 31839,
              "cache_create": 1901451,
              "cache_read": 24060657
            }
          },
          "turn_count": 69,
          "tool_call_count": 39,
          "context_at_last_turn_tokens": 489994,
          "context_window_pct": 244.997
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-13T14:44:47-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 7,
          "seven_day_pct": 41,
          "session_input_tokens": 174,
          "session_output_tokens": 48951,
          "session_cache_creation_tokens": 1992454,
          "session_cache_read_tokens": 41703284,
          "session_cost_usd": 33.60542375000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 174,
              "output": 48951,
              "cache_create": 1992454,
              "cache_read": 41703284
            }
          },
          "turn_count": 104,
          "tool_call_count": 59,
          "context_at_last_turn_tokens": 528226,
          "context_window_pct": 264.113
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-13T14:45:49-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 7,
          "seven_day_pct": 41,
          "session_input_tokens": 180,
          "session_output_tokens": 52562,
          "session_cache_creation_tokens": 2009305,
          "session_cache_read_tokens": 44877792,
          "session_cost_usd": 34.48344600000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 180,
              "output": 52562,
              "cache_create": 2009305,
              "cache_read": 44877792
            }
          },
          "turn_count": 110,
          "tool_call_count": 62,
          "context_at_last_turn_tokens": 534837,
          "context_window_pct": 267.4185
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-13T14:46:34-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 41,
          "session_input_tokens": 186,
          "session_output_tokens": 60030,
          "session_cache_creation_tokens": 2018721,
          "session_cache_read_tokens": 48095899,
          "session_cost_usd": 35.40401800000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 186,
              "output": 60030,
              "cache_create": 2018721,
              "cache_read": 48095899
            }
          },
          "turn_count": 116,
          "tool_call_count": 65,
          "context_at_last_turn_tokens": 539787,
          "context_window_pct": 269.8935
        },
        {
          "step": 8,
          "field": "code_task",
          "captured_at": "2026-05-13T14:47:32-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 41,
          "session_input_tokens": 191,
          "session_output_tokens": 62256,
          "session_cache_creation_tokens": 2031643,
          "session_cache_read_tokens": 50799395,
          "session_cost_usd": 36.28932125000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 191,
              "output": 62256,
              "cache_create": 2031643,
              "cache_read": 50799395
            }
          },
          "turn_count": 121,
          "tool_call_count": 68,
          "context_at_last_turn_tokens": 546680,
          "context_window_pct": 273.34
        },
        {
          "step": 9,
          "field": "code_task",
          "captured_at": "2026-05-13T14:54:20-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 12,
          "seven_day_pct": 41,
          "session_input_tokens": 251,
          "session_output_tokens": 81825,
          "session_cache_creation_tokens": 2126640,
          "session_cache_read_tokens": 71752269,
          "session_cost_usd": 42.43023350000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 251,
              "output": 81825,
              "cache_create": 2126640,
              "cache_read": 71752269
            }
          },
          "turn_count": 158,
          "tool_call_count": 88,
          "context_at_last_turn_tokens": 585783,
          "context_window_pct": 292.8915
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-13T14:55:15-07:00",
        "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 12,
        "seven_day_pct": 41,
        "session_input_tokens": 291,
        "session_output_tokens": 86816,
        "session_cache_creation_tokens": 2165578,
        "session_cache_read_tokens": 81801753,
        "session_cost_usd": 45.23769875,
        "by_model": {
          "claude-opus-4-7": {
            "input": 291,
            "output": 86816,
            "cache_create": 2165578,
            "cache_read": 81801753
          }
        },
        "turn_count": 175,
        "tool_call_count": 97,
        "context_at_last_turn_tokens": 600898,
        "context_window_pct": 300.449
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-13T14:55:25-07:00",
      "completed_at": "2026-05-13T15:11:58-07:00",
      "session_started_at": null,
      "cumulative_seconds": 993,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-13T14:55:25-07:00",
        "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 12,
        "seven_day_pct": 41,
        "session_input_tokens": 298,
        "session_output_tokens": 87431,
        "session_cache_creation_tokens": 2181698,
        "session_cache_read_tokens": 83604624,
        "session_cost_usd": 45.94759075,
        "by_model": {
          "claude-opus-4-7": {
            "input": 298,
            "output": 87431,
            "cache_create": 2181698,
            "cache_read": 83604624
          }
        },
        "turn_count": 178,
        "tool_call_count": 99,
        "context_at_last_turn_tokens": 616842,
        "context_window_pct": 308.421
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-13T14:56:48-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 12,
          "seven_day_pct": 41,
          "session_input_tokens": 319,
          "session_output_tokens": 92332,
          "session_cache_creation_tokens": 2189660,
          "session_cache_read_tokens": 96598064,
          "session_cost_usd": 50.05851525,
          "by_model": {
            "claude-opus-4-7": {
              "input": 319,
              "output": 92332,
              "cache_create": 2189660,
              "cache_read": 96598064
            }
          },
          "turn_count": 199,
          "tool_call_count": 112,
          "context_at_last_turn_tokens": 621050,
          "context_window_pct": 310.525
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-13T15:02:21-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 42,
          "session_input_tokens": 4974,
          "session_output_tokens": 127617,
          "session_cache_creation_tokens": 2323294,
          "session_cache_read_tokens": 105461508,
          "session_cost_usd": 64.37431375,
          "by_model": {
            "claude-opus-4-7": {
              "input": 4974,
              "output": 127617,
              "cache_create": 2323294,
              "cache_read": 105461508
            }
          },
          "turn_count": 213,
          "tool_call_count": 122,
          "context_at_last_turn_tokens": 652236,
          "context_window_pct": 326.118
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-13T15:04:49-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 22,
          "seven_day_pct": 43,
          "session_input_tokens": 5002,
          "session_output_tokens": 152995,
          "session_cache_creation_tokens": 2380320,
          "session_cache_read_tokens": 114153638,
          "session_cost_usd": 68.47375125,
          "by_model": {
            "claude-opus-4-7": {
              "input": 5002,
              "output": 152995,
              "cache_create": 2380320,
              "cache_read": 114153638
            }
          },
          "turn_count": 226,
          "tool_call_count": 133,
          "context_at_last_turn_tokens": 678002,
          "context_window_pct": 339.001
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-13T15:11:48-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 26,
          "seven_day_pct": 43,
          "session_input_tokens": 5059,
          "session_output_tokens": 172238,
          "session_cache_creation_tokens": 2462222,
          "session_cache_read_tokens": 137975776,
          "session_cost_usd": 75.93615800000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 5059,
              "output": 172238,
              "cache_create": 2462222,
              "cache_read": 137975776
            }
          },
          "turn_count": 260,
          "tool_call_count": 153,
          "context_at_last_turn_tokens": 712309,
          "context_window_pct": 356.1545
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-13T15:02:01-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-13T15:02:06-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-13T15:02:11-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-13T15:02:16-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-13T15:11:58-07:00",
        "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 26,
        "seven_day_pct": 43,
        "session_input_tokens": 5078,
        "session_output_tokens": 172918,
        "session_cache_creation_tokens": 2509427,
        "session_cache_read_tokens": 140825953,
        "session_cost_usd": 76.75561475000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 5078,
            "output": 172918,
            "cache_create": 2509427,
            "cache_read": 140825953
          }
        },
        "turn_count": 264,
        "tool_call_count": 155,
        "context_at_last_turn_tokens": 728259,
        "context_window_pct": 364.1295
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-13T15:12:08-07:00",
      "completed_at": "2026-05-13T15:15:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 177,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-13T15:12:08-07:00",
        "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 26,
        "seven_day_pct": 43,
        "session_input_tokens": 5090,
        "session_output_tokens": 173742,
        "session_cache_creation_tokens": 2536779,
        "session_cache_read_tokens": 143739445,
        "session_cost_usd": 77.57979275000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 5090,
            "output": 173742,
            "cache_create": 2536779,
            "cache_read": 143739445
          }
        },
        "turn_count": 268,
        "tool_call_count": 157,
        "context_at_last_turn_tokens": 741934,
        "context_window_pct": 370.967
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-13T15:14:20-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-13T15:14:26-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 43,
          "session_input_tokens": 5103,
          "session_output_tokens": 179179,
          "session_cache_creation_tokens": 2553592,
          "session_cache_read_tokens": 153418136,
          "session_cost_usd": 81.26874675000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 5103,
              "output": 179179,
              "cache_create": 2553592,
              "cache_read": 153418136
            }
          },
          "turn_count": 281,
          "tool_call_count": 165,
          "context_at_last_turn_tokens": 751242,
          "context_window_pct": 375.621
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-13T15:14:33-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 43,
          "session_input_tokens": 5105,
          "session_output_tokens": 179483,
          "session_cache_creation_tokens": 2554052,
          "session_cache_read_tokens": 154920618,
          "session_cost_usd": 81.64960975000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 5105,
              "output": 179483,
              "cache_create": 2554052,
              "cache_read": 154920618
            }
          },
          "turn_count": 283,
          "tool_call_count": 166,
          "context_at_last_turn_tokens": 751472,
          "context_window_pct": 375.736
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-13T15:14:45-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 43,
          "session_input_tokens": 5108,
          "session_output_tokens": 179957,
          "session_cache_creation_tokens": 2554644,
          "session_cache_read_tokens": 157175223,
          "session_cost_usd": 82.41113675000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 5108,
              "output": 179957,
              "cache_create": 2554644,
              "cache_read": 157175223
            }
          },
          "turn_count": 286,
          "tool_call_count": 168,
          "context_at_last_turn_tokens": 751872,
          "context_window_pct": 375.936
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-13T15:14:51-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 43,
          "session_input_tokens": 5110,
          "session_output_tokens": 180275,
          "session_cache_creation_tokens": 2554968,
          "session_cache_read_tokens": 158678965,
          "session_cost_usd": 82.79206475000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 5110,
              "output": 180275,
              "cache_create": 2554968,
              "cache_read": 158678965
            }
          },
          "turn_count": 288,
          "tool_call_count": 169,
          "context_at_last_turn_tokens": 752034,
          "context_window_pct": 376.017
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-13T15:14:57-07:00",
          "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 43,
          "session_input_tokens": 5112,
          "session_output_tokens": 180589,
          "session_cache_creation_tokens": 2555366,
          "session_cache_read_tokens": 160183031,
          "session_cost_usd": 83.17325500000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 5112,
              "output": 180589,
              "cache_create": 2555366,
              "cache_read": 160183031
            }
          },
          "turn_count": 290,
          "tool_call_count": 170,
          "context_at_last_turn_tokens": 752233,
          "context_window_pct": 376.1165
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-13T15:15:05-07:00",
        "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 27,
        "seven_day_pct": 43,
        "session_input_tokens": 5114,
        "session_output_tokens": 181351,
        "session_cache_creation_tokens": 2556084,
        "session_cache_read_tokens": 161687495,
        "session_cost_usd": 83.56114475000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 5114,
            "output": 181351,
            "cache_create": 2556084,
            "cache_read": 161687495
          }
        },
        "turn_count": 292,
        "tool_call_count": 171,
        "context_at_last_turn_tokens": 752592,
        "context_window_pct": 376.296
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-13T15:15:26-07:00",
      "completed_at": "2026-05-13T15:15:53-07:00",
      "session_started_at": null,
      "cumulative_seconds": 27,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-13T15:15:26-07:00",
        "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 27,
        "seven_day_pct": 43,
        "session_input_tokens": 5133,
        "session_output_tokens": 183557,
        "session_cache_creation_tokens": 2595607,
        "session_cache_read_tokens": 166982964,
        "session_cost_usd": 84.80381875000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 5133,
            "output": 183557,
            "cache_create": 2595607,
            "cache_read": 166982964
          }
        },
        "turn_count": 299,
        "tool_call_count": 174,
        "context_at_last_turn_tokens": 766048,
        "context_window_pct": 383.024
      },
      "window_at_complete": {
        "captured_at": "2026-05-13T15:15:53-07:00",
        "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 27,
        "seven_day_pct": 43,
        "session_input_tokens": 5136,
        "session_output_tokens": 184086,
        "session_cache_creation_tokens": 2596744,
        "session_cache_read_tokens": 169281506,
        "session_cost_usd": 85.58412625000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 5136,
            "output": 184086,
            "cache_create": 2596744,
            "cache_read": 169281506
          }
        },
        "turn_count": 302,
        "tool_call_count": 176,
        "context_at_last_turn_tokens": 766784,
        "context_window_pct": 383.392
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-13T14:35:42-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-13T14:55:25-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-13T15:12:08-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-13T15:15:26-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-13T14:34:42-07:00",
    "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
    "model": "claude-opus-4-7",
    "five_hour_pct": 5,
    "seven_day_pct": 40,
    "session_input_tokens": 31,
    "session_output_tokens": 5374,
    "session_cache_creation_tokens": 437897,
    "session_cache_read_tokens": 937463,
    "session_cost_usd": 16.64431499999999,
    "by_model": {
      "claude-opus-4-7": {
        "input": 31,
        "output": 5374,
        "cache_create": 437897,
        "cache_read": 937463
      }
    },
    "turn_count": 6,
    "tool_call_count": 3,
    "context_at_last_turn_tokens": 232769,
    "context_window_pct": 116.3845
  },
  "code_tasks_total": 9,
  "code_task_name": "All tasks complete",
  "code_task": 9,
  "diff_stats": {
    "files_changed": 5,
    "insertions": 210,
    "deletions": 8,
    "captured_at": "2026-05-13T14:55:15-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThis conversation consists of a single user message requesting a detailed Learn-phase audit of a FLOW PR. The user has provided:\n\n1. A FRAMING section explaining the two-gate test for findings:\n   - (1) Forward-facing: Would a future session understand and apply this principle?\n   - (2) Value: Was the gap caught and remediated in this PR? If yes, drop.\n   - The rule: Return only findings that pass BOTH gates. No findings should be invented.\n\n2. References to four files that need to be read for analysis:\n   - `/Users/ben/code/flow/.flow-states/plugin-docs-and-setup-commands/full-diff.diff` — the PR diff\n   - `/Users/ben/code/flow/.flow-states/plugin-docs-and-setup-commands/plan.md` — the implementation plan\n   - `/Users/ben/code/flow/.worktrees/plugin-docs-and-setup-commands/CLAUDE.md` — project documentation\n   - `.claude/rules/` — rule files to be consulted as needed\n\n3. CONTEXT FOR AUDIT: A detailed technical summary of what the PR does:\n   - Fixes a user-blocking bug: incorrect Claude Code plugin cache path in docs\n   - README.md and docs/index.html documented `benkruger/flow/flow/bin/setup` instead of `flow-marketplace/flow/<version>/bin/setup`\n   - Three commits: Commit A (corrects literals + strengthens tests), Commit B (extends bump_version.rs with new helpers and wiring), Commit C (Review fix for absence-assertion gap)\n\n4. Three tenant questions for investigation:\n   - Tenant 1: Did the FLOW process work? (Plan-phase gaps vs expected friction)\n   - Tenant 2: Did Claude follow the rules? (mirror-pattern-rule-audit.md, Plan-phase enumerations, Code-phase Plan-deviation discipline)\n   - Tenant 3: Missing rules? (new pattern observations)\n\n5. Instruction to filter rigorously using the two-gate test and produce findings only where both gates pass.\n\nI read all the provided files (full-diff.diff, plan.md, CLAUDE.md limited excerpt) and the system reminders containing extensive rule files. The user is asking me to perform a Learn-phase audit that identifies real findings—not to invent them—and to apply the two-gate test strictly.\n\nThe three-tenant structure and the technical context provided indicate this is a code review audit task focused on process compliance and rule adherence during the FLOW lifecycle.\n\nThe user's intent is clear: perform a rigorous Learn-phase audit of the PR using the two-gate filter, identify real findings where they exist, and explicitly state \"No findings\" in any category where the gates eliminate candidates.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user is requesting a detailed Learn-phase audit of a FLOW PR that fixes a user-blocking bug in plugin cache path documentation. The audit must apply a strict two-gate test to every candidate finding:\n   - Gate 1 (Forward-facing): Would a future session understand and apply this principle?\n   - Gate 2 (Value): Was the gap caught and remediated in this PR? If yes, discard.\n   Only findings passing BOTH gates should be reported. The user explicitly instructs to return \"No findings\" markers when categories produce zero findings rather than inventing findings to fill sections.\n   \n   The audit must examine three tenant areas:\n   - Tenant 1: Process gaps (Plan-phase vs Code-phase friction)\n   - Tenant 2: Rule compliance (mirror patterns, enumerations, discipline)\n   - Tenant 3: Missing rule patterns (gaps in the rule framework itself)\n\n2. Key Technical Concepts:\n   - FLOW plugin development lifecycle (5 phases: Start, Code, Review, Learn, Complete)\n   - Plan-phase task enumeration and atomic commit grouping\n   - TDD (test-driven development) paired task execution\n   - Version bumping orchestration (bump_skill, new bump_install_path helpers)\n   - Mirror-pattern rule audit (when new code mirrors existing code, audit compliance with existing rules)\n   - Plan-deviation logging and discipline\n   - Adversarial probe lifecycle (temporary test files created during Review, disposed in Complete)\n   - Two-gate filtering for findings (forward-facing + value remediation)\n   - Error-propagation testing per callsite\n\n3. Files and Code Sections:\n   - `/Users/ben/code/flow/.flow-states/plugin-docs-and-setup-commands/full-diff.diff`\n     - Contains complete PR diff showing three commits\n     - Commit A: Corrects README.md line 145 and docs/index.html line 1161, strengthens install_docs_contain_setup_step test to assert literal path and reject stale versions via regex\n     - Commit B: Adds bump_install_path helper function (lines 35–56 in bump_version.rs), extends run_impl with two new call sites for README.md and docs/index.html\n     - Commit C: Review fix strengthening absence-assertion in test\n   \n   - `/Users/ben/code/flow/.flow-states/plugin-docs-and-setup-commands/plan.md`\n     - Documents the bug context, exploration, risks, approach\n     - Lists 9 tasks organized into two commits (Commit A: Tasks 1–3, Commit B: Tasks 5–8)\n     - Identifies verify-runtime-path.md Shape B requirement: every callsite must have a named test\n     - Plan Task 7 initially named 5 tests (README err-propagation only); Phase 2 session log shows Task 7 extended to 6 tests (added docs/index.html err-propagation) per Shape B requirement\n     - Documents the strengthened test must land atomically with rewrites per plan-commit-atomicity.md\n\n   - The diff shows code changes:\n     - bump_install_path function mirrors bump_skill exactly (same read→replace→write pattern)\n     - Tests added: 4 helper-level tests for bump_install_path (success, no-match, missing-file, write-failure)\n     - 6 run_impl integration tests (README success, docs success, README no-match, docs no-match, README err-propagation, docs err-propagation)\n     - Strengthened docs_sync test now reads marketplace.json to extract plugins[0].version and asserts literal presence + regex scan rejecting any stale version segment\n\n4. Errors and fixes:\n   No errors were encountered during the analysis phase. The user provided a well-structured context with the diff, plan, and comprehensive rule files, and explicitly instructed against calling any tools—only analyzing provided content.\n\n5. Problem Solving:\n   The primary solving challenge is applying the two-gate test rigorously to the three tenant questions:\n   - Tenant 1 candidates (Plan-phase gaps): \"was the Plan-phase docs_sync test strengthening sufficient?\" and \"was the adversarial finding a real gap or expected Review catch?\" Both fail the value gate—the gaps were caught and remediated in the PR itself, so they don't constitute open gaps.\n   - Tenant 2 candidates (Rule compliance): \"was mirror-pattern-rule-audit.md correctly applied?\" and \"were Plan-phase enumerations correct?\" The plan shows correct enumeration of Shape B callsites (the session log documents the Task 7 deviation when docs/index.html err-propagation was added). Mirror audit shows bump_install_path correctly mirrors bump_skill.\n   - Tenant 3 candidates (Missing rules): The context names two possible rule gaps—error-propagation site enumeration for file-target extensions, and adversarial probe lifecycle—but the second is already documented in rules, and the first is addressed by verify-runtime-path.md Shape B.\n\n6. All user messages:\n   - Initial message: Framing section explaining the two-gate test, followed by explicit instruction to read four files (full-diff.diff, plan.md, CLAUDE.md, .claude/rules/) and analyze a PR fixing a plugin cache path bug. User provides detailed CONTEXT FOR AUDIT explaining the three commits and lists three tenant questions. Explicitly instructs to apply two-gate test rigorously, filter findings, and return \"No findings\" markers explicitly where categories produce zero. User also provides comprehensive system-reminder rule files covering the entire FLOW development discipline.\n\n7. Pending Tasks:\n   None explicitly stated. The user requested a Learn-phase audit, which is a analysis/reporting task, not an implementation task.\n\n8. Current Work:\n   The current work is the Learn-phase audit itself. The user has provided all necessary context (full-diff.diff, plan.md, CLAUDE.md, rule files) and explicitly requested that the response be plain text analysis only—no tool calls. The task is to analyze the three-tenant framework against the PR and report findings that pass both gates (forward-facing + value remediation).\n\n9. Optional Next Step:\n   The user's immediate request is completion of the Learn-phase audit analysis and explicit reporting of findings per the two-gate test. The next step depends on the audit results:\n   - If real findings emerge that pass both gates, document them with citations to specific code sections and rule violations.\n   - If candidates fail the gates, explicitly state \"No findings\" per the user's framing instruction.\n   The user expects a response that follows the structure: \"Apply the two-gate test. Most candidates above will fail the value test (Review caught and PR remediated). Real findings only.\"\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/plugin-docs-and-setup-commands",
  "compact_count": 4,
  "findings": [
    {
      "finding": "Pre-mortem: Partial disk corruption on mid-bump write failure",
      "reason": "Mirror-inherited from sibling pattern (bump_skill, bump_json). Every prior run_impl file-target has the same non-transactional shape per .claude/rules/mirror-pattern-rule-audit.md. Cross-cutting refactor out of scope.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-13T15:03:45-07:00"
    },
    {
      "finding": "Pre-mortem: Silent no-op if flow-marketplace directory name ever changes",
      "reason": "The strengthened install_docs_contain_setup_step test from this PR catches the no-op scenario on next CI run. Future-event speculation; the PR's own gate covers it.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-13T15:03:51-07:00"
    },
    {
      "finding": "Pre-mortem: install_docs_contain_setup_step panics with misleading message on malformed marketplace.json",
      "reason": "New test uses descriptive .expect(...). Sibling test at tests/structural.rs:122 uses bare .unwrap() — new test is strictly better. Malformed marketplace.json fails multiple tests simultaneously.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-13T15:03:57-07:00"
    },
    {
      "finding": "Adversarial: run_impl leaves stale unrelated-version references in README/docs",
      "reason": "bump_install_path mirrors bump_skill/bump_json exact-old-only pattern by plan design. Cross-cutting sweep-all-versions is a different feature.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-13T15:04:02-07:00"
    },
    {
      "finding": "Adversarial: bump_install_path accepts empty old without validation",
      "reason": "Production caller (run_impl) validates upstream via validate_version. No other production consumer. Per external-input-validation.md Guaranteed-valid classification.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-13T15:04:09-07:00"
    },
    {
      "finding": "Adversarial: bump_install_path accepts slash-containing old",
      "reason": "validate_version rejects slash-containing input upstream in run_impl; no other production consumer. Same as empty-old finding.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-13T15:04:15-07:00"
    },
    {
      "finding": "Adversarial: run_impl does not warn when bumped file already contains new version",
      "reason": "Sibling-pattern inheritance (bump_skill, bump_json have same property). Recoverable via review.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-13T15:04:24-07:00"
    },
    {
      "finding": "Adversarial: run_impl silently skips non-semver version segments like dev",
      "reason": "Variant of stale-version finding; same mirror-inherited design. Out of scope per plan.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-13T15:04:29-07:00"
    },
    {
      "finding": "Documentation: Missing CLAUDE.md Key Files entry for src/bump_version.rs",
      "reason": "src/bump_version.rs is pre-existing (modified, not created). bump_install_path has clear doc comment naming boundary semantics. Bureaucracy-trap shape per review-scope.md Value-vs-Bureaucracy triage.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-13T15:04:40-07:00"
    },
    {
      "finding": "Adversarial: install_docs_contain_setup_step lacks old-version absence assertion",
      "reason": "Strengthened install_docs_contain_setup_step in tests/docs_sync.rs with a regex scan asserting every flow-marketplace/flow/<seg>/bin/setup occurrence in README.md and docs/index.html carries the current plugins[0].version. Stale prior-version references that bump_install_path's exact-old-match cannot scrub now fail CI.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-13T15:10:31-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-13T15:15:53-07:00",
    "session_id": "ccd57aa1-d0c0-42da-a72f-3ca331fc218b",
    "model": "claude-opus-4-7",
    "five_hour_pct": 27,
    "seven_day_pct": 43,
    "session_input_tokens": 5136,
    "session_output_tokens": 184086,
    "session_cache_creation_tokens": 2596744,
    "session_cache_read_tokens": 169281506,
    "session_cost_usd": 85.58412625000001,
    "by_model": {
      "claude-opus-4-7": {
        "input": 5136,
        "output": 184086,
        "cache_create": 2596744,
        "cache_read": 169281506
      }
    },
    "turn_count": 302,
    "tool_call_count": 176,
    "context_at_last_turn_tokens": 766784,
    "context_window_pct": 383.392
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>