### PR TITLE
Fix Agent Retry Counter That

### DIFF
--- a/src/commands/set_timestamp.rs
+++ b/src/commands/set_timestamp.rs
@@ -32,7 +32,11 @@ pub fn is_step_counter_field(field: &str) -> bool {
 ///
 /// Numeric path segments are treated as array indexes (0-based).
 /// Missing intermediate object keys are auto-vivified as empty
-/// objects, so a dot-path can create the nesting it needs.
+/// objects, so a dot-path can create the nesting it needs. This
+/// serves the per-agent retry counter at
+/// `phases.<phase>.agent_retry_counts.<agent>`, whose
+/// `agent_retry_counts` segment is absent from the state file
+/// until its first write.
 /// Present-but-wrong-type intermediates (a string, number, bool, or
 /// null where an object or array is expected) and out-of-range array
 /// indices still error.

--- a/src/commands/set_timestamp.rs
+++ b/src/commands/set_timestamp.rs
@@ -31,6 +31,11 @@ pub fn is_step_counter_field(field: &str) -> bool {
 /// Navigate a nested JSON Value by dot-path parts and set the final value.
 ///
 /// Numeric path segments are treated as array indexes (0-based).
+/// Missing intermediate object keys are auto-vivified as empty
+/// objects, so a dot-path can create the nesting it needs.
+/// Present-but-wrong-type intermediates (a string, number, bool, or
+/// null where an object or array is expected) and out-of-range array
+/// indices still error.
 pub fn set_nested(obj: &mut Value, path_parts: &[&str], value: Value) -> Result<(), String> {
     if path_parts.is_empty() {
         return Err("Empty path".to_string());
@@ -57,9 +62,7 @@ pub fn set_nested(obj: &mut Value, path_parts: &[&str], value: Value) -> Result<
                 }
                 &mut arr[index]
             }
-            Value::Object(map) => map
-                .get_mut(*part)
-                .ok_or_else(|| format!("Key '{}' not found", part))?,
+            Value::Object(map) => map.entry(part.to_string()).or_insert_with(|| json!({})),
             Value::Null => {
                 return Err(format!("Cannot navigate into NoneType with key '{}'", part))
             }

--- a/tests/commands/set_timestamp.rs
+++ b/tests/commands/set_timestamp.rs
@@ -123,11 +123,18 @@ fn test_set_nested_list_intermediate_out_of_range() {
 }
 
 #[test]
-fn test_set_nested_dict_key_not_found() {
+fn test_set_nested_vivifies_missing_intermediate() {
     let mut obj = json!({"a": {"b": 1}});
-    let result = set_nested(&mut obj, &["a", "missing", "x"], json!("val"));
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("not found"));
+    set_nested(&mut obj, &["a", "missing", "x"], json!("val")).unwrap();
+    assert_eq!(obj["a"]["missing"]["x"], "val");
+    assert_eq!(obj["a"]["b"], 1);
+}
+
+#[test]
+fn test_set_nested_vivifies_consecutive_missing_intermediates() {
+    let mut obj = json!({});
+    set_nested(&mut obj, &["a", "b", "c", "d"], json!(7)).unwrap();
+    assert_eq!(obj["a"]["b"]["c"]["d"], 7);
 }
 
 #[test]
@@ -807,16 +814,26 @@ fn test_cli_error_no_state_file() {
         .contains("No state file"));
 }
 
+/// A path that navigates *through* a wrong-type intermediate (a
+/// string value where an object is expected) still errors at the CLI
+/// layer with exit 1 + a structured message. Missing intermediate
+/// keys are auto-vivified, but present-but-wrong-type intermediates
+/// are not — `set_nested` cannot navigate into a string.
 #[test]
 fn test_cli_error_invalid_path() {
     let dir = tempfile::tempdir().unwrap();
     let state = make_cli_state();
     setup_cli_state(dir.path(), "test-feature", &state);
 
-    let (code, output) = run_cli(dir.path(), &["--set", "nonexistent.field=NOW"]);
+    // `current_phase` is the string "flow-code" in make_cli_state();
+    // navigating through it to reach `.deep.sub` is unrepresentable.
+    let (code, output) = run_cli(dir.path(), &["--set", "current_phase.deep.sub=NOW"]);
     assert_eq!(code, 1);
     assert_eq!(output["status"], "error");
-    assert!(output["message"].as_str().unwrap().contains("not found"));
+    assert!(output["message"]
+        .as_str()
+        .unwrap()
+        .contains("Cannot navigate into"));
 }
 
 #[test]
@@ -960,4 +977,48 @@ fn run_impl_main_with_slash_branch_returns_structured_error_no_panic() {
         .as_str()
         .unwrap_or("")
         .contains("Invalid branch name"));
+}
+
+/// Auto-vivification end-to-end: a `set-timestamp` invocation whose
+/// dot-path includes a missing intermediate object key
+/// (`phases.flow-review.agent_retry_counts`) succeeds and creates the
+/// nesting. Guards the per-agent retry counter increment that
+/// otherwise fails on first use because `agent_retry_counts` is absent
+/// until first write.
+#[test]
+fn test_cli_set_nested_vivifies_missing_intermediate() {
+    let parent = tempfile::tempdir().unwrap();
+    let repo = crate::common::create_git_repo_with_remote(parent.path());
+    let root = repo.canonicalize().unwrap();
+
+    let branch_dir = flow_states_dir(&root).join("main");
+    fs::create_dir_all(&branch_dir).unwrap();
+    let state_path = branch_dir.join("state.json");
+    fs::write(
+        &state_path,
+        r#"{"branch":"main","phases":{"flow-review":{"status":"in_progress"}}}"#,
+    )
+    .unwrap();
+
+    let mut cmd = flow_rs();
+    cmd.arg("set-timestamp")
+        .arg("--set")
+        .arg("phases.flow-review.agent_retry_counts.reviewer=1")
+        .env_remove("FLOW_CI_RUNNING")
+        .env_remove("FLOW_SIMULATE_BRANCH")
+        .env("HOME", &root)
+        .current_dir(&root);
+
+    let output = cmd.output().unwrap();
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let parsed: Value = serde_json::from_str(&stdout).unwrap_or(json!({"raw": stdout}));
+    assert_eq!(exit_code, 0, "stdout={}", stdout);
+    assert_eq!(parsed["status"], "ok");
+
+    let on_disk: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    assert_eq!(
+        on_disk["phases"]["flow-review"]["agent_retry_counts"]["reviewer"],
+        1
+    );
 }


### PR DESCRIPTION
## What

#1586.

Closes #1586

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/fix-agent-retry-counter-that/log` |
| State | `.flow-states/fix-agent-retry-counter-that/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/9fcd53c9-848f-45c9-8246-1d8a2697350a.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 14m |
| Review | 19m |
| Learn | 10m |
| Complete | <1m |
| **Total** | **44m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 3.6M | $0.894 |
| Code | 40.3M | $11.531 |
| Review | 54.3M | $27.264 |
| Learn | 40.2M | $9.394 |
| Complete | 3.4M | $0.880 |
| **Total** | **141.9M** | **$49.964** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **set_nested auto-vivification lets a typo'd intermediate dot-path segment silently create a junk nested key instead of erroring**
  - Dismissed — Plan Risks section explicitly enumerated and accepted 'Typo'd paths no longer fail fast'. set-timestamp callers are FLOW skills with fixed, contract-tested literal paths; a skill-literal typo is caught by tests/permissions.rs skill-contract scanning. No production consumer reads the junk key. The context-rich reviewer agent independently found no findings.
- ✗ **set_nested auto-vivification could recreate a missing phases.&lt;phase&gt; object as empty instead of surfacing state-file corruption**
  - Dismissed — .claude/rules/state-files.md Corruption Resilience explicitly sanctions auto-vivification on write paths ('acceptable for writes'); set_nested is a write path. phases.&lt;phase&gt; is created by src/commands/init_state.rs at flow-start and present in every valid state file. The context-rich reviewer agent independently refuted this on the same rule grounds.
- ✗ **a nested dot-path such as nonexistent.code_task=99 auto-vivifies the parent and bypasses validate_code_task**
  - Dismissed — validate_code_task only ever gated the top-level code_task path (apply_updates checks path_parts == ['code_task']); a nested x.code_task was never validated even before this change. No consumer reads a nested code_task — the resume check and Learn audit read top-level code_task. The junk key is dead weight, the same accepted class as the typo'd-path risk.
- ✗ **an empty path segment from an 'a..b' typo is silently vivified as an empty-string key instead of erroring**
  - Dismissed — Same class as the plan's explicitly-accepted 'Typo'd paths no longer fail fast' risk. No FLOW skill prescribes a path containing a double-dot; a skill-literal double-dot is caught by tests/permissions.rs skill-contract scanning. set-timestamp is a FLOW-internal state mutator invoked with prescribed paths, not arbitrary user input.
- ✗ **apply_updates leaves partial vivification mutations in state when a later --set arg fails**
  - Dismissed — apply_updates never had an atomicity contract — its doc comment describes in-place application, and even pre-change a successful first arg followed by a failing later arg left the first arg mutated. The sole production caller run_impl_main snapshots state and restores on apply_updates error, verified by run_impl_main_invalid_set_arg_returns_error_and_preserves_state. The probe exercises apply_updates in isolation, a non-production path with no consumer.
- ✗ **a fully-missing dot-path with a numeric final segment such as plan.tasks.0 silently creates a string-keyed object instead of an array**
  - Dismissed — Plan Risks section explicitly enumerated 'Object-vs-array vivification' and accepted it — every path the skills prescribe is object-keyed and auto-creating array slots has no caller. Issue 1586's prescribed path phases.&lt;phase&gt;.agent_retry_counts.&lt;agent&gt; is fully object-keyed. No FLOW skill issues set-timestamp against a missing array-shaped path.
- ✗ **a numeric intermediate segment through a vivified object such as a.0.x produces a string-keyed object instead of an array**
  - Dismissed — Same as the numeric-final-segment finding — within the plan's explicitly-accepted 'Object-vs-array vivification' risk. No FLOW skill prescribes a numeric segment through a missing intermediate; issue 1586's prescribed paths are fully object-keyed.
- ✓ **set_nested doc comment described what auto-vivification does but not why — the agent_retry_counts use case was not discoverable from set_nested itself**
  - Fixed — Added a forward-facing sentence to the set_nested doc comment naming the concrete permanent use case: the per-agent retry counter at phases.&lt;phase&gt;.agent_retry_counts.&lt;agent&gt;, whose agent_retry_counts segment is absent from the state file until its first write.

<!-- end:Review Findings -->

## Learn Findings

- ✗ **learn-analyst suggested a new rule requiring plans to enumerate all entry-point test families (unit/CLI/subprocess) when naming a contract-changing test**
  - Dismissed — Fails the value gate. The gap — plan Exploration named test_set_nested_dict_key_not_found but missed its CLI sibling test_cli_error_invalid_path — was caught by the Code-phase CI gate and remediated in this PR: the CLI test was retargeted and the deviation logged per .claude/rules/plan-commit-atomicity.md. Per .claude/rules/filing-issues.md Value Test Before Filing, a gap caught by a phase gate and remediated in-PR is the system working, not an open gap. Single-flow occurrence, not a recurring-across-flows pattern; existing rules (plan-commit-atomicity.md deviation logging, verify-runtime-path.md callsite enumeration, test-placement.md) already cover the surface.

<!-- end:Learn Findings -->

## State File

<details>
<summary>.flow-states/fix-agent-retry-counter-that.json</summary>

```json
{
  "schema_version": 1,
  "branch": "fix-agent-retry-counter-that",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1588,
  "pr_url": "https://github.com/benkruger/flow/pull/1588",
  "started_at": "2026-05-14T15:40:14-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/fix-agent-retry-counter-that/log",
    "state": ".flow-states/fix-agent-retry-counter-that/state.json"
  },
  "session_tty": "/dev/ttys001",
  "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/9fcd53c9-848f-45c9-8246-1d8a2697350a.jsonl",
  "notes": [],
  "prompt": "#1586",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-14T15:40:14-07:00",
      "completed_at": "2026-05-14T15:40:57-07:00",
      "session_started_at": null,
      "cumulative_seconds": 43,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-14T15:40:14-07:00",
        "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
        "model": "claude-opus-4-7",
        "five_hour_pct": 56,
        "seven_day_pct": 27,
        "session_input_tokens": 20,
        "session_output_tokens": 8896,
        "session_cache_creation_tokens": 451687,
        "session_cache_read_tokens": 2159519,
        "session_cost_usd": 108.77638515,
        "by_model": {
          "claude-opus-4-7": {
            "input": 20,
            "output": 8896,
            "cache_create": 451687,
            "cache_read": 2159519
          }
        },
        "turn_count": 11,
        "tool_call_count": 4,
        "context_at_last_turn_tokens": 241881,
        "context_window_pct": 120.9405
      },
      "window_at_complete": {
        "captured_at": "2026-05-14T15:40:57-07:00",
        "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
        "model": "claude-opus-4-7",
        "five_hour_pct": 56,
        "seven_day_pct": 27,
        "session_input_tokens": 50,
        "session_output_tokens": 11723,
        "session_cache_creation_tokens": 456288,
        "session_cache_read_tokens": 5801075,
        "session_cost_usd": 109.67049915,
        "by_model": {
          "claude-opus-4-7": {
            "input": 50,
            "output": 11723,
            "cache_create": 456288,
            "cache_read": 5801075
          }
        },
        "turn_count": 26,
        "tool_call_count": 11,
        "context_at_last_turn_tokens": 243909,
        "context_window_pct": 121.9545
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-14T15:41:06-07:00",
      "completed_at": "2026-05-14T15:55:09-07:00",
      "session_started_at": null,
      "cumulative_seconds": 843,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-14T15:41:06-07:00",
        "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
        "model": "claude-opus-4-7",
        "five_hour_pct": 56,
        "seven_day_pct": 27,
        "session_input_tokens": 56,
        "session_output_tokens": 12539,
        "session_cache_creation_tokens": 474476,
        "session_cache_read_tokens": 6777357,
        "session_cost_usd": 109.98162215000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 56,
            "output": 12539,
            "cache_create": 474476,
            "cache_read": 6777357
          }
        },
        "turn_count": 30,
        "tool_call_count": 13,
        "context_at_last_turn_tokens": 253002,
        "context_window_pct": 126.501
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-14T15:51:08-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 57,
          "seven_day_pct": 27,
          "session_input_tokens": 152,
          "session_output_tokens": 94737,
          "session_cache_creation_tokens": 1057714,
          "session_cache_read_tokens": 28703203,
          "session_cost_usd": 117.24624215000004,
          "by_model": {
            "claude-opus-4-7": {
              "input": 152,
              "output": 94737,
              "cache_create": 1057714,
              "cache_read": 28703203
            }
          },
          "turn_count": 78,
          "tool_call_count": 34,
          "context_at_last_turn_tokens": 531375,
          "context_window_pct": 265.6875
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-14T15:51:08-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 57,
          "seven_day_pct": 27,
          "session_input_tokens": 152,
          "session_output_tokens": 94737,
          "session_cache_creation_tokens": 1057714,
          "session_cache_read_tokens": 28703203,
          "session_cost_usd": 117.24624215000004,
          "by_model": {
            "claude-opus-4-7": {
              "input": 152,
              "output": 94737,
              "cache_create": 1057714,
              "cache_read": 28703203
            }
          },
          "turn_count": 78,
          "tool_call_count": 34,
          "context_at_last_turn_tokens": 531375,
          "context_window_pct": 265.6875
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-14T15:51:08-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 57,
          "seven_day_pct": 27,
          "session_input_tokens": 152,
          "session_output_tokens": 94737,
          "session_cache_creation_tokens": 1057714,
          "session_cache_read_tokens": 28703203,
          "session_cost_usd": 117.24624215000004,
          "by_model": {
            "claude-opus-4-7": {
              "input": 152,
              "output": 94737,
              "cache_create": 1057714,
              "cache_read": 28703203
            }
          },
          "turn_count": 78,
          "tool_call_count": 34,
          "context_at_last_turn_tokens": 531375,
          "context_window_pct": 265.6875
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-14T15:51:08-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 57,
          "seven_day_pct": 27,
          "session_input_tokens": 152,
          "session_output_tokens": 94737,
          "session_cache_creation_tokens": 1057714,
          "session_cache_read_tokens": 28703203,
          "session_cost_usd": 117.24624215000004,
          "by_model": {
            "claude-opus-4-7": {
              "input": 152,
              "output": 94737,
              "cache_create": 1057714,
              "cache_read": 28703203
            }
          },
          "turn_count": 78,
          "tool_call_count": 34,
          "context_at_last_turn_tokens": 531375,
          "context_window_pct": 265.6875
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-14T15:55:09-07:00",
        "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
        "model": "claude-opus-4-7",
        "five_hour_pct": 57,
        "seven_day_pct": 27,
        "session_input_tokens": 214,
        "session_output_tokens": 120588,
        "session_cache_creation_tokens": 1133396,
        "session_cache_read_tokens": 46277905,
        "session_cost_usd": 121.51308540000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 214,
            "output": 120588,
            "cache_create": 1133396,
            "cache_read": 46277905
          }
        },
        "turn_count": 110,
        "tool_call_count": 49,
        "context_at_last_turn_tokens": 563504,
        "context_window_pct": 281.752
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-14T15:55:28-07:00",
      "completed_at": "2026-05-14T16:14:58-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1170,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-14T15:55:28-07:00",
        "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
        "model": "claude-opus-4-7",
        "five_hour_pct": 57,
        "seven_day_pct": 27,
        "session_input_tokens": 221,
        "session_output_tokens": 121678,
        "session_cache_creation_tokens": 1183814,
        "session_cache_read_tokens": 49097755,
        "session_cost_usd": 122.1947299,
        "by_model": {
          "claude-opus-4-7": {
            "input": 221,
            "output": 121678,
            "cache_create": 1183814,
            "cache_read": 49097755
          }
        },
        "turn_count": 115,
        "tool_call_count": 51,
        "context_at_last_turn_tokens": 580569,
        "context_window_pct": 290.2845
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-14T15:57:29-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 59,
          "seven_day_pct": 27,
          "session_input_tokens": 257,
          "session_output_tokens": 154971,
          "session_cache_creation_tokens": 1232482,
          "session_cache_read_tokens": 59594256,
          "session_cost_usd": 123.90882290000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 257,
              "output": 154971,
              "cache_create": 1232482,
              "cache_read": 59594256
            }
          },
          "turn_count": 133,
          "tool_call_count": 61,
          "context_at_last_turn_tokens": 591172,
          "context_window_pct": 295.586
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-14T16:02:18-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 64,
          "seven_day_pct": 28,
          "session_input_tokens": 287,
          "session_output_tokens": 216813,
          "session_cache_creation_tokens": 1474171,
          "session_cache_read_tokens": 68662314,
          "session_cost_usd": 140.84013485000008,
          "by_model": {
            "claude-opus-4-7": {
              "input": 287,
              "output": 216813,
              "cache_create": 1474171,
              "cache_read": 68662314
            }
          },
          "turn_count": 148,
          "tool_call_count": 71,
          "context_at_last_turn_tokens": 634302,
          "context_window_pct": 317.151
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-14T16:09:05-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 64,
          "seven_day_pct": 28,
          "session_input_tokens": 313,
          "session_output_tokens": 483883,
          "session_cache_creation_tokens": 1707361,
          "session_cache_read_tokens": 76958128,
          "session_cost_usd": 142.8510748500001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 313,
              "output": 483883,
              "cache_create": 1707361,
              "cache_read": 76958128
            }
          },
          "turn_count": 161,
          "tool_call_count": 80,
          "context_at_last_turn_tokens": 680134,
          "context_window_pct": 340.067
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-14T16:14:42-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 65,
          "seven_day_pct": 28,
          "session_input_tokens": 375,
          "session_output_tokens": 513792,
          "session_cache_creation_tokens": 1797497,
          "session_cache_read_tokens": 99498058,
          "session_cost_usd": 148.62577735000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 375,
              "output": 513792,
              "cache_create": 1797497,
              "cache_read": 99498058
            }
          },
          "turn_count": 193,
          "tool_call_count": 96,
          "context_at_last_turn_tokens": 715922,
          "context_window_pct": 357.961
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-14T16:02:11-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-14T16:02:11-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-14T16:02:12-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-14T16:02:13-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-14T16:14:58-07:00",
        "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
        "model": "claude-opus-4-7",
        "five_hour_pct": 65,
        "seven_day_pct": 28,
        "session_input_tokens": 383,
        "session_output_tokens": 515128,
        "session_cache_creation_tokens": 1846141,
        "session_cache_read_tokens": 102363652,
        "session_cost_usd": 149.45853635000006,
        "by_model": {
          "claude-opus-4-7": {
            "input": 383,
            "output": 515128,
            "cache_create": 1846141,
            "cache_read": 102363652
          }
        },
        "turn_count": 197,
        "tool_call_count": 98,
        "context_at_last_turn_tokens": 732562,
        "context_window_pct": 366.281
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-14T16:15:11-07:00",
      "completed_at": "2026-05-14T16:25:22-07:00",
      "session_started_at": null,
      "cumulative_seconds": 611,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-14T16:15:11-07:00",
        "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
        "model": "claude-opus-4-7",
        "five_hour_pct": 65,
        "seven_day_pct": 28,
        "session_input_tokens": 390,
        "session_output_tokens": 516234,
        "session_cache_creation_tokens": 1887110,
        "session_cache_read_tokens": 106028240,
        "session_cost_usd": 150.28922810000006,
        "by_model": {
          "claude-opus-4-7": {
            "input": 390,
            "output": 516234,
            "cache_create": 1887110,
            "cache_read": 106028240
          }
        },
        "turn_count": 202,
        "tool_call_count": 100,
        "context_at_last_turn_tokens": 746416,
        "context_window_pct": 373.208
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-14T16:22:59-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-14T16:23:39-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 66,
          "seven_day_pct": 28,
          "session_input_tokens": 456,
          "session_output_tokens": 616630,
          "session_cache_creation_tokens": 2061455,
          "session_cache_read_tokens": 131404128,
          "session_cost_usd": 156.17292040000007,
          "by_model": {
            "claude-opus-4-7": {
              "input": 456,
              "output": 616630,
              "cache_create": 2061455,
              "cache_read": 131404128
            }
          },
          "turn_count": 235,
          "tool_call_count": 115,
          "context_at_last_turn_tokens": 799895,
          "context_window_pct": 399.9475
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-14T16:24:22-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 66,
          "seven_day_pct": 28,
          "session_input_tokens": 468,
          "session_output_tokens": 625669,
          "session_cache_creation_tokens": 2072906,
          "session_cache_read_tokens": 136212399,
          "session_cost_usd": 157.07350015000006,
          "by_model": {
            "claude-opus-4-7": {
              "input": 468,
              "output": 625669,
              "cache_create": 2072906,
              "cache_read": 136212399
            }
          },
          "turn_count": 241,
          "tool_call_count": 117,
          "context_at_last_turn_tokens": 803712,
          "context_window_pct": 401.856
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-14T16:24:22-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 66,
          "seven_day_pct": 28,
          "session_input_tokens": 468,
          "session_output_tokens": 625669,
          "session_cache_creation_tokens": 2072906,
          "session_cache_read_tokens": 136212399,
          "session_cost_usd": 157.07350015000006,
          "by_model": {
            "claude-opus-4-7": {
              "input": 468,
              "output": 625669,
              "cache_create": 2072906,
              "cache_read": 136212399
            }
          },
          "turn_count": 241,
          "tool_call_count": 117,
          "context_at_last_turn_tokens": 803712,
          "context_window_pct": 401.856
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-14T16:24:33-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 66,
          "seven_day_pct": 28,
          "session_input_tokens": 474,
          "session_output_tokens": 626112,
          "session_cache_creation_tokens": 2075632,
          "session_cache_read_tokens": 138628285,
          "session_cost_usd": 157.90176915000006,
          "by_model": {
            "claude-opus-4-7": {
              "input": 474,
              "output": 626112,
              "cache_create": 2075632,
              "cache_read": 138628285
            }
          },
          "turn_count": 244,
          "tool_call_count": 119,
          "context_at_last_turn_tokens": 806264,
          "context_window_pct": 403.132
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-14T16:24:43-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 66,
          "seven_day_pct": 28,
          "session_input_tokens": 480,
          "session_output_tokens": 627243,
          "session_cache_creation_tokens": 2076172,
          "session_cache_read_tokens": 141047071,
          "session_cost_usd": 158.31546015000006,
          "by_model": {
            "claude-opus-4-7": {
              "input": 480,
              "output": 627243,
              "cache_create": 2076172,
              "cache_read": 141047071
            }
          },
          "turn_count": 247,
          "tool_call_count": 120,
          "context_at_last_turn_tokens": 806444,
          "context_window_pct": 403.222
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-14T16:25:11-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 66,
          "seven_day_pct": 28,
          "session_input_tokens": 488,
          "session_output_tokens": 631958,
          "session_cache_creation_tokens": 2115936,
          "session_cache_read_tokens": 144274069,
          "session_cost_usd": 159.24735215000007,
          "by_model": {
            "claude-opus-4-7": {
              "input": 488,
              "output": 631958,
              "cache_create": 2115936,
              "cache_read": 144274069
            }
          },
          "turn_count": 251,
          "tool_call_count": 122,
          "context_at_last_turn_tokens": 819972,
          "context_window_pct": 409.986
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-14T16:25:11-07:00",
          "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
          "model": "claude-opus-4-7",
          "five_hour_pct": 66,
          "seven_day_pct": 28,
          "session_input_tokens": 488,
          "session_output_tokens": 631958,
          "session_cache_creation_tokens": 2115936,
          "session_cache_read_tokens": 144274069,
          "session_cost_usd": 159.24735215000007,
          "by_model": {
            "claude-opus-4-7": {
              "input": 488,
              "output": 631958,
              "cache_create": 2115936,
              "cache_read": 144274069
            }
          },
          "turn_count": 251,
          "tool_call_count": 122,
          "context_at_last_turn_tokens": 819972,
          "context_window_pct": 409.986
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-14T16:25:22-07:00",
        "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
        "model": "claude-opus-4-7",
        "five_hour_pct": 66,
        "seven_day_pct": 28,
        "session_input_tokens": 492,
        "session_output_tokens": 633264,
        "session_cache_creation_tokens": 2119118,
        "session_cache_read_tokens": 145914009,
        "session_cost_usd": 159.68361590000006,
        "by_model": {
          "claude-opus-4-7": {
            "input": 492,
            "output": 633264,
            "cache_create": 2119118,
            "cache_read": 145914009
          }
        },
        "turn_count": 253,
        "tool_call_count": 123,
        "context_at_last_turn_tokens": 821563,
        "context_window_pct": 410.7815
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-14T16:26:04-07:00",
      "completed_at": "2026-05-14T16:26:31-07:00",
      "session_started_at": null,
      "cumulative_seconds": 27,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-14T16:26:04-07:00",
        "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
        "model": "claude-opus-4-7",
        "five_hour_pct": 66,
        "seven_day_pct": 28,
        "session_input_tokens": 507,
        "session_output_tokens": 643481,
        "session_cache_creation_tokens": 2244167,
        "session_cache_read_tokens": 154173752,
        "session_cost_usd": 161.19447140000003,
        "by_model": {
          "claude-opus-4-7": {
            "input": 507,
            "output": 643481,
            "cache_create": 2244167,
            "cache_read": 154173752
          }
        },
        "turn_count": 263,
        "tool_call_count": 128,
        "context_at_last_turn_tokens": 854889,
        "context_window_pct": 427.4445
      },
      "window_at_complete": {
        "captured_at": "2026-05-14T16:26:31-07:00",
        "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
        "model": "claude-opus-4-7",
        "five_hour_pct": 67,
        "seven_day_pct": 28,
        "session_input_tokens": 515,
        "session_output_tokens": 644943,
        "session_cache_creation_tokens": 2247348,
        "session_cache_read_tokens": 157594219,
        "session_cost_usd": 162.07433165000006,
        "by_model": {
          "claude-opus-4-7": {
            "input": 515,
            "output": 644943,
            "cache_create": 2247348,
            "cache_read": 157594219
          }
        },
        "turn_count": 267,
        "tool_call_count": 130,
        "context_at_last_turn_tokens": 856232,
        "context_window_pct": 428.116
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-14T15:41:06-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-14T15:55:28-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-14T16:15:11-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-14T16:26:04-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-14T15:40:14-07:00",
    "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
    "model": "claude-opus-4-7",
    "five_hour_pct": 56,
    "seven_day_pct": 27,
    "session_input_tokens": 20,
    "session_output_tokens": 8896,
    "session_cache_creation_tokens": 451687,
    "session_cache_read_tokens": 2159519,
    "session_cost_usd": 108.77638515,
    "by_model": {
      "claude-opus-4-7": {
        "input": 20,
        "output": 8896,
        "cache_create": 451687,
        "cache_read": 2159519
      }
    },
    "turn_count": 11,
    "tool_call_count": 4,
    "context_at_last_turn_tokens": 241881,
    "context_window_pct": 120.9405
  },
  "code_tasks_total": 4,
  "code_task_name": "Auto-vivify missing intermediate keys in set_nested",
  "code_task": 4,
  "diff_stats": {
    "files_changed": 2,
    "insertions": 73,
    "deletions": 9,
    "captured_at": "2026-05-14T15:55:09-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nLet me analyze this conversation thoroughly to understand what's being asked and what work was done.\n\nThe user's initial request was to perform a three-tenant audit on a FLOW plugin's flow-learn phase as a learn-analyst. The user provided:\n1. A diff showing changes to `src/commands/set_timestamp.rs` and `tests/commands/set_timestamp.rs`\n2. State file data showing visit counts and review findings\n3. A session log showing deviations that occurred\n4. An implementation plan that was executed\n\nThe user explicitly stated the three-tenant audit criteria:\n1. Did the FLOW process work?\n2. Did Claude follow the rules?\n3. What rules should exist but don't?\n\nThe user also provided a critical instruction: \"Apply the two-gate test to every candidate finding before reporting it: (1) Forward-facing — would a future session who has never read this PR understand and apply the principle? If no, drop. (2) Value — was the gap caught and remediated in this PR? If yes, drop (the system already closed it).\"\n\nThe user emphasized: \"No findings\" in any category is the most common correct answer. Return only findings that pass both gates. If all categories produce zero, say so explicitly with \"No findings\" markers — do NOT invent findings to fill sections.\n\nLooking at the artifacts provided:\n- The diff shows changes to auto-vivify missing intermediate object keys in `set_nested` function\n- Tests were updated: `test_set_nested_dict_key_not_found` was renamed to `test_set_nested_vivifies_missing_intermediate`\n- A new test `test_set_nested_vivifies_consecutive_missing_intermediates` was added\n- CLI test `test_cli_error_invalid_path` was retargeted to test wrong-type intermediates\n- A new end-to-end test `test_cli_set_nested_vivifies_missing_intermediate` was added\n- The state file shows 7 dismissed findings and 1 fixed finding\n- The session log shows a plan deviation: the plan missed the CLI-layer sibling test `test_cli_error_invalid_path`\n- Another log entry shows mechanical recovery: git diff via Bash returned empty due to RTK proxy issue, rerouted to `bin/flow capture-diff`\n\nThe user is asking me to analyze this audit, not to execute it. I need to determine:\n1. Did the FLOW process work? (Did the Code phase successfully implement the plan?)\n2. Did Claude follow the rules? (Were rules violated in the implementation?)\n3. What rules should exist but don't?\n\nHowever, looking more carefully at the user's request, they are asking me to act as the \"learn-analyst for the FLOW plugin's flow-learn phase\" and perform \"the three-tenant audit.\" This means I need to analyze the provided artifacts and determine if there are any findings that should be reported according to the two-gate test criteria.\n\nLet me evaluate the evidence:\n\n**Tenant 1 (Process worked):**\n- The plan proposed auto-vivification of missing intermediate keys in `set_nested`\n- The Code phase implemented it\n- Tests were added and modified\n- CI passed (finalize-commit shows \"ci (ok)\")\n- Review phase completed (reviewer findings: 7 dismissed, 1 fixed)\n- The one fixed finding was about documentation (the \"why\" of auto-vivification was added to doc comment)\n\nThe process appears to have worked. The plan deviation logged about missing the CLI-layer sibling test was caught and remediated in the same PR by retargeting the existing test.\n\n**Tenant 2 (Claude followed rules):**\n- Looking at the diff and rules corpus provided, I need to check:\n  - Did doc comments get updated? Yes, the `set_nested` doc comment was expanded with explanation of why auto-vivification serves the per-agent retry counter.\n  - Were tests added properly? Yes, tests were added and placed in the correct location (`tests/commands/set_timestamp.rs`)\n  - Was the plan deviation logged? Yes, it was logged in the session log\n  - Were all affected code paths tested? The new end-to-end test covers the real use case\n\nThe deviation about missing the CLI-layer test was caught during Code phase and remediated. This is the system working correctly per `.claude/rules/test-placement.md` and related rules.\n\n**Tenant 3 (Rules that should exist but don't):**\nThis requires identifying gaps in the rule corpus that this PR discovered.\n\nLooking at the artifacts and the two-gate test:\n1. Forward-facing: Would a future session understand the principle without reading this specific PR?\n2. Value: Was the gap caught and remediated in this PR?\n\nThe plan deviation about missing the CLI-layer sibling test is interesting. The session log shows it was caught and fixed, so it passes the Value gate (already remediated). For the Forward-facing gate, this is specific to contract-changing tests and their sibling CLI layers, which is already covered by `.claude/rules/test-placement.md` and test-related rules.\n\nActually, I need to reconsider. The user is asking me to perform the audit. They haven't asked me to execute any tools - they've provided me with all the artifacts needed to perform the analysis. The diff, plan, state file data, and logs are all provided.\n\nSo I should analyze these artifacts and report my findings according to the three-tenant audit criteria and the two-gate test.\n</analysis>\n\n<summary>\n\n1. Primary Request and Intent:\n   The user requested that I act as the learn-analyst for the FLOW plugin's flow-learn phase and perform a three-tenant audit on the provided pull request. The three tenants to audit are: (1) Did the FLOW process work? (2) Did Claude follow the rules? (3) What rules should exist but don't? The user explicitly emphasized applying a two-gate test to every candidate finding: (1) Forward-facing — would a future session who has never read this PR understand and apply the principle? (2) Value — was the gap caught and remediated in this PR? If yes, drop (the system already closed it). The user emphasized that \"No findings\" in any category is the most common correct answer and to return only findings that pass both gates. If all categories produce zero, say so explicitly with \"No findings\" markers — do NOT invent findings to fill sections.\n\n2. Key Technical Concepts:\n   - FLOW plugin architecture and five-phase development lifecycle (Start, Code, Review, Learn, Complete)\n   - `set_nested` function that navigates nested JSON by dot-path and sets final values\n   - Auto-vivification pattern for creating missing intermediate object keys on demand\n   - Per-agent retry counter mechanism that uses `phases.<phase>.agent_retry_counts.<agent>` path\n   - Contract-changing tests and their relationship to CLI-layer sibling tests\n   - Two-gate test filtering for learn-analyst findings\n   - State file mutations and JSON value handling in Rust\n   - Test placement discipline and mirror pattern between src and tests directories\n   - Plan deviation logging and mechanical recovery documentation\n\n3. Files and Code Sections:\n   - `src/commands/set_timestamp.rs`\n      - The `set_nested` function was modified to auto-vivify missing intermediate object keys\n      - Changed from: `map.get_mut(*part).ok_or_else(|| format!(\"Key '{}' not found\", part))?`\n      - Changed to: `map.entry(part.to_string()).or_insert_with(|| json!({}))`\n      - Doc comment expanded with explanation: \"Missing intermediate object keys are auto-vivified as empty objects, so a dot-path can create the nesting it needs. This serves the per-agent retry counter at `phases.<phase>.agent_retry_counts.<agent>`, whose `agent_retry_counts` segment is absent from the state file until its first write. Present-but-wrong-type intermediates (a string, number, bool, or null where an object or array is expected) and out-of-range array indices still error.\"\n      - Significance: This change enables the per-agent retry counter functionality that was previously blocked\n\n   - `tests/commands/set_timestamp.rs`\n      - Test `test_set_nested_dict_key_not_found` was renamed to `test_set_nested_vivifies_missing_intermediate` and changed to assert vivification instead of error\n      - New test `test_set_nested_vivifies_consecutive_missing_intermediates` added to test multiple missing intermediate levels\n      - Existing test `test_cli_error_invalid_path` was retargeted from testing missing keys to testing wrong-type intermediates (current_phase.deep.sub)\n      - New end-to-end test `test_cli_set_nested_vivifies_missing_intermediate` added that exercises the real use case with a state file lacking `agent_retry_counts`\n      - Significance: Contract-changing tests were properly updated and extended\n\n4. Errors and fixes:\n   - Plan deviation discovered during Code phase: The plan's Exploration named `test_set_nested_dict_key_not_found` as the contract-changing test but missed its CLI-layer sibling test `test_cli_error_invalid_path`. This was caught and remediated in the same PR by retargeting the CLI test to test wrong-type intermediates (which still error after auto-vivification) and adding a separate end-to-end vivification test. The deviation was logged per plan-commit-atomicity rules.\n   - Mechanical recovery issue: `git diff origin/main...HEAD` via Bash returned empty output because RTK proxy mangles git diff invocations with ref arguments. This was verified as a proxy artifact (not a real state issue) via `git log` commands. The issue was rerouted to `bin/flow capture-diff` which spawns git directly and bypasses RTK.\n\n5. Problem Solving:\n   - The per-agent retry counter feature was blocked because `set_nested` required all intermediate keys to exist. The solution was to auto-vivify missing intermediate object keys while maintaining strict validation for present-but-wrong-type intermediates.\n   - The plan deviation about missing a CLI-layer sibling test was solved by retargeting the existing test and adding a new end-to-end test to cover the vivification case.\n   - The git diff tool issue was solved by routing through the capture-diff subcommand which bypasses RTK proxy issues.\n\n6. All user messages:\n   - Initial message: \"You are the learn-analyst for the FLOW plugin's flow-learn phase. You have no knowledge of the conversation that produced these changes — analyze only the persisted artifacts below. Your job is the three-tenant audit: (1) Did the FLOW process work? (2) Did Claude follow the rules? (3) What rules should exist but don't?\" followed by detailed framing instructions including the two-gate test criteria and emphasis on applying filters strictly.\n\n7. Pending Tasks:\n   - None explicitly stated; the user has requested the analysis but has not issued a separate task request\n\n8. Current Work:\n   The user has provided all artifacts for the three-tenant audit and requested analysis. The artifacts are complete and include: the diff showing implementation changes, state file data showing visit counts and findings disposition, a session log showing deviations and mechanical recovery actions, and an implementation plan. The task is to analyze these artifacts according to the three-tenant audit criteria with the two-gate test filtering applied strictly.\n\n9. Optional Next Step:\n   Upon completion of the analysis, provide the three-tenant audit findings according to the structure specified: (1) Did the FLOW process work? (2) Did Claude follow the rules? (3) What rules should exist but don't? — with explicit \"No findings\" markers for any categories with zero findings that pass both gates, rather than inventing findings to fill sections.\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/fix-agent-retry-counter-that",
  "compact_count": 2,
  "findings": [
    {
      "finding": "set_nested auto-vivification lets a typo'd intermediate dot-path segment silently create a junk nested key instead of erroring",
      "reason": "Plan Risks section explicitly enumerated and accepted 'Typo'd paths no longer fail fast'. set-timestamp callers are FLOW skills with fixed, contract-tested literal paths; a skill-literal typo is caught by tests/permissions.rs skill-contract scanning. No production consumer reads the junk key. The context-rich reviewer agent independently found no findings.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-14T16:08:42-07:00"
    },
    {
      "finding": "set_nested auto-vivification could recreate a missing phases.<phase> object as empty instead of surfacing state-file corruption",
      "reason": ".claude/rules/state-files.md Corruption Resilience explicitly sanctions auto-vivification on write paths ('acceptable for writes'); set_nested is a write path. phases.<phase> is created by src/commands/init_state.rs at flow-start and present in every valid state file. The context-rich reviewer agent independently refuted this on the same rule grounds.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-14T16:08:43-07:00"
    },
    {
      "finding": "a nested dot-path such as nonexistent.code_task=99 auto-vivifies the parent and bypasses validate_code_task",
      "reason": "validate_code_task only ever gated the top-level code_task path (apply_updates checks path_parts == ['code_task']); a nested x.code_task was never validated even before this change. No consumer reads a nested code_task — the resume check and Learn audit read top-level code_task. The junk key is dead weight, the same accepted class as the typo'd-path risk.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-14T16:08:44-07:00"
    },
    {
      "finding": "an empty path segment from an 'a..b' typo is silently vivified as an empty-string key instead of erroring",
      "reason": "Same class as the plan's explicitly-accepted 'Typo'd paths no longer fail fast' risk. No FLOW skill prescribes a path containing a double-dot; a skill-literal double-dot is caught by tests/permissions.rs skill-contract scanning. set-timestamp is a FLOW-internal state mutator invoked with prescribed paths, not arbitrary user input.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-14T16:08:45-07:00"
    },
    {
      "finding": "apply_updates leaves partial vivification mutations in state when a later --set arg fails",
      "reason": "apply_updates never had an atomicity contract — its doc comment describes in-place application, and even pre-change a successful first arg followed by a failing later arg left the first arg mutated. The sole production caller run_impl_main snapshots state and restores on apply_updates error, verified by run_impl_main_invalid_set_arg_returns_error_and_preserves_state. The probe exercises apply_updates in isolation, a non-production path with no consumer.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-14T16:08:46-07:00"
    },
    {
      "finding": "a fully-missing dot-path with a numeric final segment such as plan.tasks.0 silently creates a string-keyed object instead of an array",
      "reason": "Plan Risks section explicitly enumerated 'Object-vs-array vivification' and accepted it — every path the skills prescribe is object-keyed and auto-creating array slots has no caller. Issue 1586's prescribed path phases.<phase>.agent_retry_counts.<agent> is fully object-keyed. No FLOW skill issues set-timestamp against a missing array-shaped path.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-14T16:08:46-07:00"
    },
    {
      "finding": "a numeric intermediate segment through a vivified object such as a.0.x produces a string-keyed object instead of an array",
      "reason": "Same as the numeric-final-segment finding — within the plan's explicitly-accepted 'Object-vs-array vivification' risk. No FLOW skill prescribes a numeric segment through a missing intermediate; issue 1586's prescribed paths are fully object-keyed.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-14T16:08:47-07:00"
    },
    {
      "finding": "set_nested doc comment described what auto-vivification does but not why — the agent_retry_counts use case was not discoverable from set_nested itself",
      "reason": "Added a forward-facing sentence to the set_nested doc comment naming the concrete permanent use case: the per-agent retry counter at phases.<phase>.agent_retry_counts.<agent>, whose agent_retry_counts segment is absent from the state file until its first write.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-14T16:10:57-07:00"
    },
    {
      "finding": "learn-analyst suggested a new rule requiring plans to enumerate all entry-point test families (unit/CLI/subprocess) when naming a contract-changing test",
      "reason": "Fails the value gate. The gap — plan Exploration named test_set_nested_dict_key_not_found but missed its CLI sibling test_cli_error_invalid_path — was caught by the Code-phase CI gate and remediated in this PR: the CLI test was retargeted and the deviation logged per .claude/rules/plan-commit-atomicity.md. Per .claude/rules/filing-issues.md Value Test Before Filing, a gap caught by a phase gate and remediated in-PR is the system working, not an open gap. Single-flow occurrence, not a recurring-across-flows pattern; existing rules (plan-commit-atomicity.md deviation logging, verify-runtime-path.md callsite enumeration, test-placement.md) already cover the surface.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-14T16:23:51-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-14T16:26:31-07:00",
    "session_id": "9fcd53c9-848f-45c9-8246-1d8a2697350a",
    "model": "claude-opus-4-7",
    "five_hour_pct": 67,
    "seven_day_pct": 28,
    "session_input_tokens": 515,
    "session_output_tokens": 644943,
    "session_cache_creation_tokens": 2247348,
    "session_cache_read_tokens": 157594219,
    "session_cost_usd": 162.07433165000006,
    "by_model": {
      "claude-opus-4-7": {
        "input": 515,
        "output": 644943,
        "cache_create": 2247348,
        "cache_read": 157594219
      }
    },
    "turn_count": 267,
    "tool_call_count": 130,
    "context_at_last_turn_tokens": 856232,
    "context_window_pct": 428.116
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>