### PR TITLE
Mark High Priority Issues

### DIFF
--- a/docs/skills/flow-issues.md
+++ b/docs/skills/flow-issues.md
@@ -35,9 +35,9 @@ or closes issues.
 
 1. Runs `bin/flow analyze-issues` which calls `gh issue list`
    internally, parses the JSON, detects FLOW labels (`Decomposed`,
-   `Blocked`, `Vanilla`, `Flow In-Progress`, `Triage In-Progress`),
-   collects per-row `assignees`, and resolves native GitHub
-   `blocked_by` entries to `[{number, url}]` pairs.
+   `Blocked`, `Vanilla`, `Flow In-Progress`, `Triage In-Progress`,
+   `High Priority`), collects per-row `assignees`, and resolves
+   native GitHub `blocked_by` entries to `[{number, url}]` pairs.
 2. Walks the flat `issues` array and assigns each row to the first
    matching bucket: **Blocked** (`blocked == true`), then
    **Decomposed** (`decomposed == true`), then **Vanilla**
@@ -54,11 +54,18 @@ or closes issues.
    suppressed. Rows with `flow_in_progress == true` (🟡, Decomposed
    section) and `triage_in_progress == true` (🔍, Other section)
    carry a colored prefix on the bold Title cell and suppress the
-   Command cell — the row signals "someone else owns this".
+   Command cell — the row signals "someone else owns this". Rows
+   with `high_priority == true` (🔥, any bucket) carry an additive
+   prefix on the Title cell — 🔥 itself does not bold the Title or
+   suppress the Command (bucket-level Cell rules still decide
+   bolding and Command). When 🔥 stacks with 🟡 or 🔍 on the same
+   row, 🔥 leads: `🔥 🟡 **Title**` or `🔥 🔍 **Title**`.
 5. Sort within sections: Blocked and Vanilla by issue number
    descending; Other and Decomposed cluster colored rows first
    (🔍 / 🟡), then sort by issue number descending within each
-   cluster. Empty cells render as `—`.
+   cluster. `high_priority` does not participate in sort
+   clustering — 🔥 rows stay in their bucket's normal
+   number-descending order. Empty cells render as `—`.
 
 ---
 

--- a/skills/flow-issues/SKILL.md
+++ b/skills/flow-issues/SKILL.md
@@ -135,7 +135,8 @@ Parse the JSON output. The shape is:
       "assignees": ["alice"],
       "vanilla": false,
       "flow_in_progress": false,
-      "triage_in_progress": false
+      "triage_in_progress": false,
+      "high_priority": false
     }
   ]
 }
@@ -231,9 +232,12 @@ applies regardless of bucket:
 - `triage_in_progress == true` (Triage In-Progress label) → 🔍
   prefix on the bold Title cell, Command suppressed.
 - `high_priority == true` (High Priority label) → 🔥 prefix on the
-  Title cell. 🔥 does NOT bold the Title, does NOT suppress the
-  Command cell, and applies regardless of bucket — it is additive,
-  not exclusive with the other prefixes.
+  Title cell. 🔥 itself is not a Title-bolding signal and is not a
+  Command-suppressing signal — bucket-level Cell rules still
+  decide bolding and Command (a 🔥 row in the Blocked bucket
+  still renders Command as `—` per the Blocked bucket's rule).
+  The prefix applies regardless of bucket and is additive, not
+  exclusive with the other prefixes.
 
 The prefix follows the row into whichever bucket it lands; a
 Flow-In-Progress row in the Vanilla bucket still renders 🟡, a

--- a/skills/flow-issues/SKILL.md
+++ b/skills/flow-issues/SKILL.md
@@ -230,13 +230,23 @@ applies regardless of bucket:
   on the bold Title cell, Command suppressed.
 - `triage_in_progress == true` (Triage In-Progress label) → 🔍
   prefix on the bold Title cell, Command suppressed.
+- `high_priority == true` (High Priority label) → 🔥 prefix on the
+  Title cell. 🔥 does NOT bold the Title, does NOT suppress the
+  Command cell, and applies regardless of bucket — it is additive,
+  not exclusive with the other prefixes.
 
 The prefix follows the row into whichever bucket it lands; a
 Flow-In-Progress row in the Vanilla bucket still renders 🟡, a
-Triage-In-Progress row in the Blocked bucket still renders 🔍. The
+Triage-In-Progress row in the Blocked bucket still renders 🔍, and
+a High-Priority row in any bucket still renders 🔥. The
 cross-engineer WIP signal documented in `CLAUDE.md` "The 'Flow
 In-Progress' label on issues is the cross-engineer WIP detection
 mechanism" is honored from every section.
+
+When 🔥 stacks with 🟡 or 🔍 on the same row, 🔥 leads:
+`🔥 🟡 **Title**` or `🔥 🔍 **Title**`. The bolding and Command
+suppression still come from the in-progress signal; 🔥 is additive
+and does not change either behavior.
 
 ### Sort rules
 
@@ -245,6 +255,8 @@ mechanism" is honored from every section.
 - **Other** and **Decomposed** sections: sort colored rows first
   (Decomposed section: 🟡 rows; Other section: 🔍 rows), then by issue
   `number` descending within each cluster.
+- `high_priority` does not participate in sort clustering; 🔥 rows
+  stay in their bucket's normal number-descending order.
 
 ### Filter flag effect
 

--- a/src/analyze_issues.rs
+++ b/src/analyze_issues.rs
@@ -326,10 +326,11 @@ pub fn blocker_result_to_map(
 ///
 /// Every input issue flows into a single `issues` array on the output
 /// envelope. Per-row label flags (`decomposed`, `blocked`,
-/// `flow_in_progress`, `triage_in_progress`, `vanilla`) carry the
-/// signal the consumer dispatches on; no top-level `in_progress`
-/// partition. The `blocker_map` maps issue numbers to open blocker
-/// numbers; native_blocked rows fold into `blocked`.
+/// `flow_in_progress`, `triage_in_progress`, `vanilla`,
+/// `high_priority`) carry the signal the consumer dispatches on; no
+/// top-level `in_progress` partition. The `blocker_map` maps issue
+/// numbers to open blocker numbers; native_blocked rows fold into
+/// `blocked`.
 pub fn analyze_issues(issues: &[Value], blocker_map: &HashMap<i64, Vec<Value>>) -> Value {
     if issues.is_empty() {
         return serde_json::json!({

--- a/src/analyze_issues.rs
+++ b/src/analyze_issues.rs
@@ -392,6 +392,7 @@ pub fn analyze_issues(issues: &[Value], blocker_map: &HashMap<i64, Vec<Value>>) 
             "vanilla": label_flags.vanilla,
             "flow_in_progress": label_flags.flow_in_progress,
             "triage_in_progress": label_flags.triage_in_progress,
+            "high_priority": label_flags.high_priority,
         }));
     }
 

--- a/src/analyze_issues.rs
+++ b/src/analyze_issues.rs
@@ -2,10 +2,10 @@
 //!
 //! Produces a flat `issues` array enriched with per-row label flags
 //! (`decomposed`, `blocked`, `vanilla`, `flow_in_progress`,
-//! `triage_in_progress`), assignees, and resolved `blocked_by`
-//! entries that carry both `number` and a fully-constructed
-//! GitHub URL. The dashboard renderer reads one stream and
-//! dispatches by label.
+//! `triage_in_progress`, `high_priority`), assignees, and resolved
+//! `blocked_by` entries that carry both `number` and a
+//! fully-constructed GitHub URL. The dashboard renderer reads one
+//! stream and dispatches by label.
 //!
 //! Tests live at `tests/analyze_issues.rs` per
 //! `.claude/rules/test-placement.md` — no inline `#[cfg(test)]` in
@@ -20,16 +20,20 @@ use serde_json::Value;
 /// `decomposed` and `blocked` choose the section, `vanilla` marks
 /// the Vanilla bucket, and `flow_in_progress` / `triage_in_progress`
 /// flag rows that the renderer prefixes (🟡 / 🔍) with bold title
-/// and a suppressed Command cell.
+/// and a suppressed Command cell. `high_priority` flags rows that
+/// the renderer prefixes (🔥) regardless of bucket; the 🔥 prefix
+/// is additive — it does not bold the Title, does not suppress the
+/// Command cell, and does not participate in sort clustering.
 pub struct LabelFlags {
     pub decomposed: bool,
     pub blocked: bool,
     pub vanilla: bool,
     pub flow_in_progress: bool,
     pub triage_in_progress: bool,
+    pub high_priority: bool,
 }
 
-/// Check for canonical FLOW labels. All five labels match
+/// Check for canonical FLOW labels. All six labels match
 /// case-insensitively because GitHub's label registry is
 /// case-preserving and historic data may use mixed case. A repo
 /// that records `flow in-progress` as the label string still
@@ -56,6 +60,9 @@ pub fn detect_labels(labels: &[Value]) -> LabelFlags {
         triage_in_progress: label_names
             .iter()
             .any(|n| n.eq_ignore_ascii_case("Triage In-Progress")),
+        high_priority: label_names
+            .iter()
+            .any(|n| n.eq_ignore_ascii_case("High Priority")),
     }
 }
 

--- a/tests/analyze_issues.rs
+++ b/tests/analyze_issues.rs
@@ -582,6 +582,42 @@ fn no_blocked_label_lib() {
 }
 
 #[test]
+fn detects_high_priority_label_canonical_case_lib() {
+    let labels = vec![json!({"name": "High Priority"})];
+    assert!(detect_labels(&labels).high_priority);
+}
+
+#[test]
+fn detects_high_priority_label_lowercase_lib() {
+    let labels = vec![json!({"name": "high priority"})];
+    assert!(detect_labels(&labels).high_priority);
+}
+
+#[test]
+fn detects_high_priority_label_uppercase_lib() {
+    let labels = vec![json!({"name": "HIGH PRIORITY"})];
+    assert!(detect_labels(&labels).high_priority);
+}
+
+#[test]
+fn detects_high_priority_label_rejects_hyphenated_lib() {
+    let labels = vec![json!({"name": "high-priority"})];
+    assert!(!detect_labels(&labels).high_priority);
+}
+
+#[test]
+fn detects_high_priority_label_rejects_no_space_lib() {
+    let labels = vec![json!({"name": "highpriority"})];
+    assert!(!detect_labels(&labels).high_priority);
+}
+
+#[test]
+fn detects_no_high_priority_label_lib() {
+    let labels = vec![json!({"name": "Bug"})];
+    assert!(!detect_labels(&labels).high_priority);
+}
+
+#[test]
 fn no_special_labels_lib() {
     let labels = vec![json!({"name": "Bug"})];
     let result = detect_labels(&labels);

--- a/tests/analyze_issues.rs
+++ b/tests/analyze_issues.rs
@@ -635,6 +635,30 @@ fn empty_labels_lib() {
 }
 
 #[test]
+fn analyze_issues_emits_high_priority_field_lib() {
+    let issues = vec![
+        json!({
+            "number": 1,
+            "title": "Urgent bug",
+            "url": "https://example.com/1",
+            "labels": [{"name": "High Priority"}],
+        }),
+        json!({
+            "number": 2,
+            "title": "Routine bug",
+            "url": "https://example.com/2",
+            "labels": [{"name": "Bug"}],
+        }),
+    ];
+    let result = analyze_issues(&issues, &HashMap::new());
+    let issues_arr = result["issues"].as_array().unwrap();
+    let row1 = issues_arr.iter().find(|i| i["number"] == 1).unwrap();
+    assert_eq!(row1["high_priority"], true);
+    let row2 = issues_arr.iter().find(|i| i["number"] == 2).unwrap();
+    assert_eq!(row2["high_priority"], false);
+}
+
+#[test]
 fn build_blocker_query_single_issue_lib() {
     let query = build_blocker_query(&[10]);
     assert!(query.contains("issue_10: issue(number: 10)"));


### PR DESCRIPTION
## What

#1597.

Closes #1597

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/mark-high-priority-issues/log` |
| State | `.flow-states/mark-high-priority-issues/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/812f89d5-2608-49a9-b9cb-4b619952660b.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 13m |
| Review | 17m |
| Learn | 2m |
| Complete | <1m |
| **Total** | **35m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 2.4M | $0.868 |
| Code | 56.1M | $17.969 |
| Review | 61.4M | $46.470 |
| Learn | 17.0M | $5.317 |
| Complete | 2.2M | $0.738 |
| **Total** | **139.1M** | **$71.362** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **pre-mortem F4 label-name match silently misses hyphen/underscore/no-space label variants**
  - Dismissed — Plan explicitly defines eq_ignore_ascii_case('High Priority') as the canonical match and the test suite explicitly asserts rejection of high-priority and highpriority. Per .claude/rules/include-bias-in-issues.md 'Narrow Valid Exclusions' — user/plan explicitly rejected this scope. Broadening label matching across the 6 sibling label-detection branches (Flow In-Progress, Triage In-Progress, decomposed, blocked, vanilla, high_priority) is a behavioral sweep that requires a separate flow per scope-expansion.md (fixes not inert, each sibling has independent semantics).
- ✗ **adversarial 8 whitespace/Unicode probes (trailing/leading whitespace, tab, NBSP, Turkish dotted-I, multi-label, envelope trailing whitespace, multi-issue tab)**
  - Dismissed — All 8 probes test rejection variants of eq_ignore_ascii_case('High Priority'). The plan explicitly defines this as the canonical match string and asserts hyphen/no-space rejection. Per .claude/rules/mirror-pattern-rule-audit.md, the new code mirrors the existing label-detection pattern used by all 5 sibling labels — adversarial agent confirmed the same gap exists in every sibling branch. Broadening to add normalize-before-compare across all 6 branches is a behavioral sweep requiring a separate flow per scope-expansion.md. Per include-bias-in-issues.md, user/plan explicitly rejected this scope.
- ✗ **documentation F2 'renderer' terminology in src/analyze_issues.rs doc comments implies a Rust rendering module that does not exist**
  - Dismissed — Pre-existing terminology not introduced by this PR — the module-level doc comment used 'renderer' before this PR. The PR's new prose extends existing language. Per review-scope.md value-vs-bureaucracy triage (discoverability + forward-applicability): a reader can grep for skills/flow-issues/SKILL.md. A broader terminology rewrite of 'renderer' across the codebase is a separate flow.
- ✓ **pre-mortem F1 SKILL.md example JSON omits high_priority field**
  - Fixed — Added high_priority: false to the example payload in skills/flow-issues/SKILL.md so the renderer's documented schema matches the analyze_issues output contract.
- ✓ **pre-mortem F2 / documentation F1 docs/skills/flow-issues.md missing High Priority and the 🔥 prefix**
  - Fixed — Added High Priority to the label-detection list, documented the 🔥 prefix in step 4 with its additive (non-bolding/non-suppressing) semantics and stacking order, and noted that high_priority does not participate in sort clustering.
- ✓ **pre-mortem F3 analyze_issues fn doc-comment omits high_priority**
  - Fixed — Extended the analyze_issues function doc comment in src/analyze_issues.rs to list high_priority alongside the other per-row label flags.
- ✓ **pre-mortem F5 Color Treatment prose ambiguous about Command cell precedence in Blocked bucket**
  - Fixed — Rewrote the 🔥 bullet in skills/flow-issues/SKILL.md Color treatment section to make explicit that 🔥 itself is not a Title-bolding signal and not a Command-suppressing signal; bucket-level Cell rules still decide bolding and Command. Names the Blocked-bucket case explicitly.

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/mark-high-priority-issues.json</summary>

```json
{
  "schema_version": 1,
  "branch": "mark-high-priority-issues",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1598,
  "pr_url": "https://github.com/benkruger/flow/pull/1598",
  "started_at": "2026-05-15T13:35:20-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/mark-high-priority-issues/log",
    "state": ".flow-states/mark-high-priority-issues/state.json"
  },
  "session_tty": "/dev/ttys000",
  "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/812f89d5-2608-49a9-b9cb-4b619952660b.jsonl",
  "notes": [],
  "prompt": "#1597",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-15T13:35:20-07:00",
      "completed_at": "2026-05-15T13:36:00-07:00",
      "session_started_at": null,
      "cumulative_seconds": 40,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T13:35:20-07:00",
        "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 10,
        "seven_day_pct": 1,
        "session_input_tokens": 19,
        "session_output_tokens": 3576,
        "session_cache_creation_tokens": 655086,
        "session_cache_read_tokens": 282686,
        "session_cost_usd": 1.5272085,
        "by_model": {
          "claude-opus-4-7": {
            "input": 19,
            "output": 3576,
            "cache_create": 655086,
            "cache_read": 282686
          }
        },
        "turn_count": 4,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 235353,
        "context_window_pct": 117.6765
      },
      "window_at_complete": {
        "captured_at": "2026-05-15T13:36:00-07:00",
        "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 10,
        "seven_day_pct": 1,
        "session_input_tokens": 29,
        "session_output_tokens": 5518,
        "session_cache_creation_tokens": 657689,
        "session_cache_read_tokens": 2643457,
        "session_cost_usd": 2.39487825,
        "by_model": {
          "claude-opus-4-7": {
            "input": 29,
            "output": 5518,
            "cache_create": 657689,
            "cache_read": 2643457
          }
        },
        "turn_count": 14,
        "tool_call_count": 9,
        "context_at_last_turn_tokens": 237196,
        "context_window_pct": 118.598
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-15T13:36:13-07:00",
      "completed_at": "2026-05-15T13:49:39-07:00",
      "session_started_at": null,
      "cumulative_seconds": 806,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T13:36:13-07:00",
        "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 10,
        "seven_day_pct": 1,
        "session_input_tokens": 41,
        "session_output_tokens": 6340,
        "session_cache_creation_tokens": 675885,
        "session_cache_read_tokens": 3592847,
        "session_cost_usd": 2.6993932500000004,
        "by_model": {
          "claude-opus-4-7": {
            "input": 41,
            "output": 6340,
            "cache_create": 675885,
            "cache_read": 3592847
          }
        },
        "turn_count": 18,
        "tool_call_count": 11,
        "context_at_last_turn_tokens": 246298,
        "context_window_pct": 123.149
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-15T13:37:45-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 11,
          "seven_day_pct": 1,
          "session_input_tokens": 65,
          "session_output_tokens": 14874,
          "session_cache_creation_tokens": 1347872,
          "session_cache_read_tokens": 12387524,
          "session_cost_usd": 6.456901500000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 65,
              "output": 14874,
              "cache_create": 1347872,
              "cache_read": 12387524
            }
          },
          "turn_count": 42,
          "tool_call_count": 23,
          "context_at_last_turn_tokens": 472687,
          "context_window_pct": 236.3435
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-15T13:41:53-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 12,
          "seven_day_pct": 2,
          "session_input_tokens": 85,
          "session_output_tokens": 23648,
          "session_cache_creation_tokens": 1394017,
          "session_cache_read_tokens": 21996290,
          "session_cost_usd": 9.353464,
          "by_model": {
            "claude-opus-4-7": {
              "input": 85,
              "output": 23648,
              "cache_create": 1394017,
              "cache_read": 21996290
            }
          },
          "turn_count": 62,
          "tool_call_count": 34,
          "context_at_last_turn_tokens": 493321,
          "context_window_pct": 246.6605
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-15T13:44:31-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 13,
          "seven_day_pct": 2,
          "session_input_tokens": 144,
          "session_output_tokens": 36851,
          "session_cache_creation_tokens": 1451946,
          "session_cache_read_tokens": 40178156,
          "session_cost_usd": 14.719123500000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 144,
              "output": 36851,
              "cache_create": 1451946,
              "cache_read": 40178156
            }
          },
          "turn_count": 98,
          "tool_call_count": 54,
          "context_at_last_turn_tokens": 519553,
          "context_window_pct": 259.7765
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-15T13:48:06-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 14,
          "seven_day_pct": 2,
          "session_input_tokens": 159,
          "session_output_tokens": 43053,
          "session_cache_creation_tokens": 1476207,
          "session_cache_read_tokens": 48053697,
          "session_cost_usd": 16.984660000000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 159,
              "output": 43053,
              "cache_create": 1476207,
              "cache_read": 48053697
            }
          },
          "turn_count": 113,
          "tool_call_count": 62,
          "context_at_last_turn_tokens": 531961,
          "context_window_pct": 265.9805
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-15T13:49:39-07:00",
        "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 14,
        "seven_day_pct": 2,
        "session_input_tokens": 198,
        "session_output_tokens": 49316,
        "session_cache_creation_tokens": 1514279,
        "session_cache_read_tokens": 58828729,
        "session_cost_usd": 20.668471,
        "by_model": {
          "claude-opus-4-7": {
            "input": 198,
            "output": 49316,
            "cache_create": 1514279,
            "cache_read": 58828729
          }
        },
        "turn_count": 133,
        "tool_call_count": 75,
        "context_at_last_turn_tokens": 549437,
        "context_window_pct": 274.7185
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-15T13:49:52-07:00",
      "completed_at": "2026-05-15T14:07:48-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1076,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T13:49:52-07:00",
        "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 14,
        "seven_day_pct": 2,
        "session_input_tokens": 210,
        "session_output_tokens": 50126,
        "session_cache_creation_tokens": 1547375,
        "session_cache_read_tokens": 61027679,
        "session_cost_usd": 21.3317885,
        "by_model": {
          "claude-opus-4-7": {
            "input": 210,
            "output": 50126,
            "cache_create": 1547375,
            "cache_read": 61027679
          }
        },
        "turn_count": 137,
        "tool_call_count": 77,
        "context_at_last_turn_tokens": 565989,
        "context_window_pct": 282.9945
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-15T13:51:20-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 15,
          "seven_day_pct": 2,
          "session_input_tokens": 232,
          "session_output_tokens": 55874,
          "session_cache_creation_tokens": 1556164,
          "session_cache_read_tokens": 73532041,
          "session_cost_usd": 25.13399275,
          "by_model": {
            "claude-opus-4-7": {
              "input": 232,
              "output": 55874,
              "cache_create": 1556164,
              "cache_read": 73532041
            }
          },
          "turn_count": 159,
          "tool_call_count": 90,
          "context_at_last_turn_tokens": 571132,
          "context_window_pct": 285.566
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-15T13:59:46-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 4,
          "session_input_tokens": 300,
          "session_output_tokens": 115532,
          "session_cache_creation_tokens": 1728677,
          "session_cache_read_tokens": 87124561,
          "session_cost_usd": 56.00889505000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 300,
              "output": 115532,
              "cache_create": 1728677,
              "cache_read": 87124561
            }
          },
          "turn_count": 182,
          "tool_call_count": 104,
          "context_at_last_turn_tokens": 614727,
          "context_window_pct": 307.3635
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-15T14:02:05-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 28,
          "seven_day_pct": 4,
          "session_input_tokens": 323,
          "session_output_tokens": 141465,
          "session_cache_creation_tokens": 1785748,
          "session_cache_read_tokens": 92132749,
          "session_cost_usd": 57.9668253,
          "by_model": {
            "claude-opus-4-7": {
              "input": 323,
              "output": 141465,
              "cache_create": 1785748,
              "cache_read": 92132749
            }
          },
          "turn_count": 190,
          "tool_call_count": 109,
          "context_at_last_turn_tokens": 639826,
          "context_window_pct": 319.913
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-15T14:07:38-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 28,
          "seven_day_pct": 4,
          "session_input_tokens": 387,
          "session_output_tokens": 156276,
          "session_cache_creation_tokens": 1866515,
          "session_cache_read_tokens": 119264305,
          "session_cost_usd": 67.0183843,
          "by_model": {
            "claude-opus-4-7": {
              "input": 387,
              "output": 156276,
              "cache_create": 1866515,
              "cache_read": 119264305
            }
          },
          "turn_count": 231,
          "tool_call_count": 135,
          "context_at_last_turn_tokens": 674988,
          "context_window_pct": 337.494
        }
      ],
      "agents_returned": [
        {
          "agent": "documentation",
          "timestamp": "2026-05-15T13:54:31-07:00"
        },
        {
          "agent": "reviewer",
          "timestamp": "2026-05-15T13:59:31-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-15T13:59:36-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-15T13:59:41-07:00"
        }
      ],
      "agent_retry_counts": {
        "reviewer": 1,
        "pre-mortem": 1,
        "adversarial": 1
      },
      "window_at_complete": {
        "captured_at": "2026-05-15T14:07:48-07:00",
        "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 28,
        "seven_day_pct": 4,
        "session_input_tokens": 406,
        "session_output_tokens": 156953,
        "session_cache_creation_tokens": 1914293,
        "session_cache_read_tokens": 121965270,
        "session_cost_usd": 67.8018008,
        "by_model": {
          "claude-opus-4-7": {
            "input": 406,
            "output": 156953,
            "cache_create": 1914293,
            "cache_read": 121965270
          }
        },
        "turn_count": 235,
        "tool_call_count": 137,
        "context_at_last_turn_tokens": 691145,
        "context_window_pct": 345.5725
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-15T14:08:24-07:00",
      "completed_at": "2026-05-15T14:11:10-07:00",
      "session_started_at": null,
      "cumulative_seconds": 166,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T14:08:24-07:00",
        "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 28,
        "seven_day_pct": 4,
        "session_input_tokens": 418,
        "session_output_tokens": 157787,
        "session_cache_creation_tokens": 1941763,
        "session_cache_read_tokens": 124730590,
        "session_cost_usd": 68.58942954999999,
        "by_model": {
          "claude-opus-4-7": {
            "input": 418,
            "output": 157787,
            "cache_create": 1941763,
            "cache_read": 124730590
          }
        },
        "turn_count": 239,
        "tool_call_count": 139,
        "context_at_last_turn_tokens": 704879,
        "context_window_pct": 352.4395
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-15T14:10:18-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-15T14:10:24-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 28,
          "seven_day_pct": 4,
          "session_input_tokens": 446,
          "session_output_tokens": 163651,
          "session_cache_creation_tokens": 1952468,
          "session_cache_read_tokens": 133913728,
          "session_cost_usd": 71.73392415,
          "by_model": {
            "claude-opus-4-7": {
              "input": 446,
              "output": 163651,
              "cache_create": 1952468,
              "cache_read": 133913728
            }
          },
          "turn_count": 252,
          "tool_call_count": 146,
          "context_at_last_turn_tokens": 709415,
          "context_window_pct": 354.7075
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-15T14:10:30-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 28,
          "seven_day_pct": 4,
          "session_input_tokens": 448,
          "session_output_tokens": 163975,
          "session_cache_creation_tokens": 1952984,
          "session_cache_read_tokens": 135332556,
          "session_cost_usd": 72.09429865000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 448,
              "output": 163975,
              "cache_create": 1952984,
              "cache_read": 135332556
            }
          },
          "turn_count": 254,
          "tool_call_count": 147,
          "context_at_last_turn_tokens": 709673,
          "context_window_pct": 354.8365
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-15T14:10:46-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 28,
          "seven_day_pct": 4,
          "session_input_tokens": 451,
          "session_output_tokens": 164442,
          "session_cache_creation_tokens": 1953592,
          "session_cache_read_tokens": 137461774,
          "session_cost_usd": 72.81399415000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 451,
              "output": 164442,
              "cache_create": 1953592,
              "cache_read": 137461774
            }
          },
          "turn_count": 257,
          "tool_call_count": 149,
          "context_at_last_turn_tokens": 710079,
          "context_window_pct": 355.0395
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-15T14:10:52-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 28,
          "seven_day_pct": 4,
          "session_input_tokens": 453,
          "session_output_tokens": 164782,
          "session_cache_creation_tokens": 1953918,
          "session_cache_read_tokens": 138881930,
          "session_cost_usd": 73.17430690000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 453,
              "output": 164782,
              "cache_create": 1953918,
              "cache_read": 138881930
            }
          },
          "turn_count": 259,
          "tool_call_count": 150,
          "context_at_last_turn_tokens": 710242,
          "context_window_pct": 355.121
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-15T14:10:57-07:00",
          "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 28,
          "seven_day_pct": 4,
          "session_input_tokens": 455,
          "session_output_tokens": 165098,
          "session_cache_creation_tokens": 1954624,
          "session_cache_read_tokens": 140302412,
          "session_cost_usd": 73.53558865000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 455,
              "output": 165098,
              "cache_create": 1954624,
              "cache_read": 140302412
            }
          },
          "turn_count": 261,
          "tool_call_count": 151,
          "context_at_last_turn_tokens": 710595,
          "context_window_pct": 355.2975
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-15T14:11:10-07:00",
        "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 28,
        "seven_day_pct": 4,
        "session_input_tokens": 457,
        "session_output_tokens": 166244,
        "session_cache_creation_tokens": 1955020,
        "session_cache_read_tokens": 141723600,
        "session_cost_usd": 73.90645315000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 457,
            "output": 166244,
            "cache_create": 1955020,
            "cache_read": 141723600
          }
        },
        "turn_count": 263,
        "tool_call_count": 152,
        "context_at_last_turn_tokens": 710793,
        "context_window_pct": 355.3965
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-15T14:11:39-07:00",
      "completed_at": "2026-05-15T14:11:58-07:00",
      "session_started_at": null,
      "cumulative_seconds": 19,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T14:11:39-07:00",
        "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 28,
        "seven_day_pct": 4,
        "session_input_tokens": 475,
        "session_output_tokens": 169612,
        "session_cache_creation_tokens": 1984756,
        "session_cache_read_tokens": 148888070,
        "session_cost_usd": 75.46042715000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 475,
            "output": 169612,
            "cache_create": 1984756,
            "cache_read": 148888070
          }
        },
        "turn_count": 273,
        "tool_call_count": 156,
        "context_at_last_turn_tokens": 725047,
        "context_window_pct": 362.5235
      },
      "window_at_complete": {
        "captured_at": "2026-05-15T14:11:58-07:00",
        "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 28,
        "seven_day_pct": 4,
        "session_input_tokens": 478,
        "session_output_tokens": 170101,
        "session_cache_creation_tokens": 1985912,
        "session_cache_read_tokens": 151063711,
        "session_cost_usd": 76.19884090000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 478,
            "output": 170101,
            "cache_create": 1985912,
            "cache_read": 151063711
          }
        },
        "turn_count": 276,
        "tool_call_count": 158,
        "context_at_last_turn_tokens": 725700,
        "context_window_pct": 362.85
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-15T13:36:13-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-15T13:49:52-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-15T14:08:24-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-15T14:11:39-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-15T13:35:20-07:00",
    "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
    "model": "claude-opus-4-7",
    "five_hour_pct": 10,
    "seven_day_pct": 1,
    "session_input_tokens": 19,
    "session_output_tokens": 3576,
    "session_cache_creation_tokens": 655086,
    "session_cache_read_tokens": 282686,
    "session_cost_usd": 1.5272085,
    "by_model": {
      "claude-opus-4-7": {
        "input": 19,
        "output": 3576,
        "cache_create": 655086,
        "cache_read": 282686
      }
    },
    "turn_count": 4,
    "tool_call_count": 2,
    "context_at_last_turn_tokens": 235353,
    "context_window_pct": 117.6765
  },
  "code_tasks_total": 4,
  "code_task_name": "Implement analyze_issues JSON field + SKILL.md render docs",
  "code_task": 4,
  "diff_stats": {
    "files_changed": 3,
    "insertions": 87,
    "deletions": 7,
    "captured_at": "2026-05-15T13:49:39-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThis conversation is about a Learn phase audit for a FLOW feature development. The user provided:\n\n1. A detailed framing about Learn phase findings requiring a two-gate filter:\n   - Gate 1 (Forward-facing): Would a future session understand and apply the principle?\n   - Gate 2 (Value): Was the gap caught and remediated in this PR?\n   - Result: Report only findings passing both gates; use \"No findings\" markers if appropriate\n\n2. Multiple artifact paths:\n   - DIFF_FILE: `/Users/ben/code/flow/.flow-states/mark-high-priority-issues/full-diff.diff`\n   - STATE FILE DATA: showing visit counts and agent information\n   - PLAN_FILE: `/Users/ben/code/flow/.flow-states/mark-high-priority-issues/plan.md`\n   - CLAUDE_MD: `/Users/ben/code/flow/.worktrees/mark-high-priority-issues/CLAUDE.md`\n   - RULES_DIR: `/Users/ben/code/flow/.worktrees/mark-high-priority-issues/.claude/rules/`\n\n3. Three-tenant audit framework:\n   - Tenant 1 (process gaps): Did the FLOW process work end-to-end?\n   - Tenant 2 (rule compliance): Did the plan follow documented rules?\n   - Tenant 3 (missing rules): Are there new patterns not covered by existing rules?\n\n4. Specific findings to audit:\n   - The Plan's \"Risks\" section claimed code mirrored sibling `flow_in_progress` cleanly but did NOT enumerate affected docs/skills/flow-issues.md per `.claude/rules/docs-with-behavior.md`\n   - Plan did NOT enumerate the analyze_issues function-level doc comment per rules about \"Changed type signatures or module architecture\"\n   - Review caught 4 documentation findings that Code phase missed (all fixed in Step 4)\n   - Review-caught-and-fixed is the system working, not a gap\n\nThe user then asked me to read three files to understand the full context:\n- full-diff.diff (the changes made)\n- plan.md (the implementation plan)\n- CLAUDE.md (project context)\n\nI read all three files and received extensive rule documentation that provides the framework for evaluating findings.\n\nThe task is to apply the two-gate filter and emit findings against the three tenants, using the END-OF-FINDINGS marker when complete.\n\nI have all the necessary context:\n- The diff showing what code changed\n- The plan showing what was intended\n- The rules showing what should have been followed\n- The state showing what happened during execution\n\nNow I need to analyze:\n1. Did the FLOW process work? (Tenant 1)\n2. Did the plan follow the rules? (Tenant 2)\n3. Are there new rule-worthy patterns? (Tenant 3)\n\nFor each finding candidate, I must apply:\n- Gate 1: Is it forward-facing (future-session understandable)?\n- Gate 2: Was it caught and remediated in this PR?\n\nFrom the user's framing, I already know:\n- Tenant 1: Three rate-limited opus agents retried successfully (system working, not a gap). Review surfaced 4 documentation findings, all fixed in Step 4 (system working, not a gap per the Value Test).\n- Tenant 2: Review caught two rule violations. The question is whether these were \"rule clear-but-ignored\" gaps or \"rule unclear\" gaps.\n- Tenant 3: No new patterns observed.\n\nThe user is asking me to filter these through the two-gate framework and report results. They are NOT asking me to read the diff, plan, or rules files again—they've already provided those to me.\n\nMy task: Apply the two-gate filter and emit findings.\n</analysis>\n\n<summary>\n\n## 1. Primary Request and Intent\n\nThe user requests a Learn phase analysis of a completed FLOW feature development (`mark-high-priority-issues`). The analysis must:\n- Apply a two-gate filter to every candidate finding:\n  1. Forward-facing: Would a future session understand and apply the principle?\n  2. Value: Was the gap caught and remediated in this PR?\n- Report only findings passing both gates\n- Use explicit \"No findings\" markers for empty categories\n- Audit three tenants: (1) process gaps, (2) rule compliance, (3) missing rules\n- Not invent findings to fill sections\n\n## 2. Key Technical Concepts\n\n- FLOW: A 5-phase development lifecycle plugin (Start, Code, Review, Learn, Complete)\n- Two-gate Learn filter: Forward-facing test + Value test (both must pass)\n- Three-tenant framework: Process gaps, rule compliance, missing rule patterns\n- Cognitive isolation: Review agents provide debiased analysis separate from Code phase\n- Rule compliance zones: `.claude/rules/docs-with-behavior.md` governs documentation updates alongside code changes\n- Recovery from rate limits: Three agents (reviewer, pre-mortem, adversarial) with retry-3-then-skip protocol\n- Documentation atomicity: Behavior changes and documentation must land in same commit\n\n## 3. Files and Code Sections\n\n**full-diff.diff** (`/Users/ben/code/flow/.flow-states/mark-high-priority-issues/full-diff.diff`)\n- Shows changes to implement High Priority label detection in issue analyzer\n- Modified files: `docs/skills/flow-issues.md`, `skills/flow-issues/SKILL.md`, `src/analyze_issues.rs`, `tests/analyze_issues.rs`\n- Key changes: Added `high_priority` field to `LabelFlags` struct, extended `detect_labels()` function, updated documentation to describe 🔥 prefix behavior\n\n**plan.md** (`/Users/ben/code/flow/.flow-states/mark-high-priority-issues/plan.md`)\n- Implementation Plan for adding High Priority label support\n- Context: Add third color-treatment prefix (🔥) to flow-issues renderer\n- Four tasks: (1) detect_labels tests, (2) LabelFlags + detect_labels branch + doc comment, (3) analyze_issues output test, (4) analyze_issues JSON field + SKILL.md render docs\n- Risks section claimed \"Mirror-pattern audit clean\" for `flow_in_progress` sibling\n- **Critical gap**: Plan did NOT enumerate the affected doc files per `.claude/rules/docs-with-behavior.md` \"Changed skill behavior → docs/skills/<name>.md\"\n- **Critical gap**: Plan did NOT enumerate the analyze_issues function-level doc comment per the rule \"Changed type signatures or module architecture → module-level doc comment AND every affected item's doc comment\"\n\n## 4. Errors and fixes\n\nNo errors encountered during this analysis. The user framed the audit task clearly with explicit guidance on what to report and what constitutes a valid finding under the two-gate framework.\n\n## 5. Problem Solving\n\nThe primary analytical challenge is correctly applying the Value Test (Gate 2) to distinguish between:\n- Review-caught-and-fixed violations (system working, not a gap)\n- Genuine process gaps (system failed to catch and fix within normal flow)\n\nThe user's framing resolves this: \"Review-caught-and-fixed is the system working, not a gap.\" This is per `.claude/rules/filing-issues.md` \"Value Test Before Filing\": gaps caught by another phase gate and remediated in this PR are not process gaps—they are the system working as designed.\n\n## 6. All user messages\n\n- Initial framing message: Detailed explanation of Learn phase gate structure, identifying the three tenants to audit, and explicitly stating \"No findings in any category is the most common correct answer. Return only findings that pass both gates.\"\n- Artifact paths and state data provided for context\n- Request to read DIFF_FILE, PLAN_FILE, CLAUDE_MD, and rules directory\n- User instruction at task initiation: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools. [Tool calls will be REJECTED and will waste your only turn — you will fail the task.]\"\n\n## 7. Pending Tasks\n\nNone. The user's explicit request is to emit Learn-phase findings filtered through the two-gate test, with END-OF-FINDINGS marker.\n\n## 8. Current Work\n\nApplying the two-gate Learn filter to the `mark-high-priority-issues` feature PR to determine which findings are reportable as genuine process or rule-compliance gaps:\n\n**Tenant 1 (Process gaps):**\n- Three rate-limited opus agents retried successfully (no gap—this is the retry-3-then-skip protocol working as designed)\n- Review surfaced 4 documentation findings missed by Code phase; all fixed in Step 4 (no gap—Review is part of the process, review-caught-and-fixed is the system working per Gate 2 / Value Test)\n\n**Tenant 2 (Rule compliance):**\n- Plan claimed \"Mirror-pattern audit clean\" but did NOT enumerate affected docs per `.claude/rules/docs-with-behavior.md`\n  - Gate 1 (forward-facing): Yes, a rule about documenting affected files when behavior changes is forward-facing and generalizable\n  - Gate 2 (value): The docs WERE updated and correct in the PR, so the gap was caught and remediated in Code/Review (failing Gate 2)\n- Plan did NOT enumerate function-level doc comment per \"Changed type signatures\" rule\n  - Gate 1 (forward-facing): Yes, the rule is clear and forward-facing\n  - Gate 2 (value): The function doc comment WAS updated in the PR (in src/analyze_issues.rs lines 95-106 per diff), so the gap was caught and remediated (failing Gate 2)\n\n**Tenant 3 (Missing rules):**\n- No new pattern observed that isn't already covered by existing rules\n\n## 9. Optional Next Step\n\nUpon reviewing this summary, emit the Learn-phase findings report with END-OF-FINDINGS marker. Based on the analysis above, all candidate findings fail Gate 2 (Value Test) because both the rule violations were caught and remediated within the PR itself. The correct output should be explicit \"No findings\" markers for all three tenants per the user's framing: \"No findings in any category is the most common correct answer.\"\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/mark-high-priority-issues",
  "compact_count": 2,
  "findings": [
    {
      "finding": "pre-mortem F4 label-name match silently misses hyphen/underscore/no-space label variants",
      "reason": "Plan explicitly defines eq_ignore_ascii_case('High Priority') as the canonical match and the test suite explicitly asserts rejection of high-priority and highpriority. Per .claude/rules/include-bias-in-issues.md 'Narrow Valid Exclusions' — user/plan explicitly rejected this scope. Broadening label matching across the 6 sibling label-detection branches (Flow In-Progress, Triage In-Progress, decomposed, blocked, vanilla, high_priority) is a behavioral sweep that requires a separate flow per scope-expansion.md (fixes not inert, each sibling has independent semantics).",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T14:01:42-07:00"
    },
    {
      "finding": "adversarial 8 whitespace/Unicode probes (trailing/leading whitespace, tab, NBSP, Turkish dotted-I, multi-label, envelope trailing whitespace, multi-issue tab)",
      "reason": "All 8 probes test rejection variants of eq_ignore_ascii_case('High Priority'). The plan explicitly defines this as the canonical match string and asserts hyphen/no-space rejection. Per .claude/rules/mirror-pattern-rule-audit.md, the new code mirrors the existing label-detection pattern used by all 5 sibling labels — adversarial agent confirmed the same gap exists in every sibling branch. Broadening to add normalize-before-compare across all 6 branches is a behavioral sweep requiring a separate flow per scope-expansion.md. Per include-bias-in-issues.md, user/plan explicitly rejected this scope.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T14:01:50-07:00"
    },
    {
      "finding": "documentation F2 'renderer' terminology in src/analyze_issues.rs doc comments implies a Rust rendering module that does not exist",
      "reason": "Pre-existing terminology not introduced by this PR — the module-level doc comment used 'renderer' before this PR. The PR's new prose extends existing language. Per review-scope.md value-vs-bureaucracy triage (discoverability + forward-applicability): a reader can grep for skills/flow-issues/SKILL.md. A broader terminology rewrite of 'renderer' across the codebase is a separate flow.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T14:01:57-07:00"
    },
    {
      "finding": "pre-mortem F1 SKILL.md example JSON omits high_priority field",
      "reason": "Added high_priority: false to the example payload in skills/flow-issues/SKILL.md so the renderer's documented schema matches the analyze_issues output contract.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T14:03:38-07:00"
    },
    {
      "finding": "pre-mortem F2 / documentation F1 docs/skills/flow-issues.md missing High Priority and the 🔥 prefix",
      "reason": "Added High Priority to the label-detection list, documented the 🔥 prefix in step 4 with its additive (non-bolding/non-suppressing) semantics and stacking order, and noted that high_priority does not participate in sort clustering.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T14:03:51-07:00"
    },
    {
      "finding": "pre-mortem F3 analyze_issues fn doc-comment omits high_priority",
      "reason": "Extended the analyze_issues function doc comment in src/analyze_issues.rs to list high_priority alongside the other per-row label flags.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T14:03:56-07:00"
    },
    {
      "finding": "pre-mortem F5 Color Treatment prose ambiguous about Command cell precedence in Blocked bucket",
      "reason": "Rewrote the 🔥 bullet in skills/flow-issues/SKILL.md Color treatment section to make explicit that 🔥 itself is not a Title-bolding signal and not a Command-suppressing signal; bucket-level Cell rules still decide bolding and Command. Names the Blocked-bucket case explicitly.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T14:04:03-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-15T14:11:58-07:00",
    "session_id": "812f89d5-2608-49a9-b9cb-4b619952660b",
    "model": "claude-opus-4-7",
    "five_hour_pct": 28,
    "seven_day_pct": 4,
    "session_input_tokens": 478,
    "session_output_tokens": 170101,
    "session_cache_creation_tokens": 1985912,
    "session_cache_read_tokens": 151063711,
    "session_cost_usd": 76.19884090000001,
    "by_model": {
      "claude-opus-4-7": {
        "input": 478,
        "output": 170101,
        "cache_create": 1985912,
        "cache_read": 151063711
      }
    },
    "turn_count": 276,
    "tool_call_count": 158,
    "context_at_last_turn_tokens": 725700,
    "context_window_pct": 362.85
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>