### PR TITLE
Bin Flow Issue Fails To Detect

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -21,8 +21,19 @@ pub fn parse_github_url(url: &str) -> Option<String> {
 
 /// Auto-detect GitHub repo from git remote origin URL.
 ///
-/// Returns `owner/repo` string or None if detection fails.
-/// Optional cwd parameter for running git in a specific directory.
+/// Returns `owner/repo` string or None if detection fails. Optional
+/// cwd parameter for running git in a specific directory.
+///
+/// Resolution order:
+/// 1. `git remote get-url origin` + `parse_github_url` regex — fast
+///    path for standard `github.com` URLs (HTTPS or SSH).
+/// 2. `gh repo view --json nameWithOwner -q .nameWithOwner` fallback
+///    — invoked when the regex returns None. Uses the `gh` CLI's
+///    authenticated session, so SSH host aliases (e.g.
+///    `git@github-pt:owner/repo.git`) resolve correctly via the user's
+///    GitHub auth rather than via the remote URL's literal text.
+///    Returns None if `gh` is missing, exits non-zero, or prints a
+///    string without `/`.
 pub fn detect_repo(cwd: Option<&Path>) -> Option<String> {
     let mut cmd = Command::new("git");
     cmd.args(["remote", "get-url", "origin"]);
@@ -30,15 +41,35 @@ pub fn detect_repo(cwd: Option<&Path>) -> Option<String> {
         cmd.current_dir(dir);
     }
 
-    let output = cmd.output().ok()?;
+    if let Ok(output) = cmd.output() {
+        if output.status.success() {
+            let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if let Some(owner_repo) = parse_github_url(&url) {
+                return Some(owner_repo);
+            }
+        }
+    }
+
+    let mut gh = Command::new("gh");
+    gh.args([
+        "repo",
+        "view",
+        "--json",
+        "nameWithOwner",
+        "-q",
+        ".nameWithOwner",
+    ]);
+    if let Some(dir) = cwd {
+        gh.current_dir(dir);
+    }
+    let output = gh.output().ok()?;
     if !output.status.success() {
         return None;
     }
-
-    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if url.is_empty() {
-        return None;
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if s.contains('/') {
+        Some(s)
+    } else {
+        None
     }
-
-    parse_github_url(&url)
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -19,6 +19,26 @@ pub fn parse_github_url(url: &str) -> Option<String> {
     re.captures(url).map(|cap| cap[1].to_string())
 }
 
+/// Validate that `gh repo view` stdout is a well-formed `owner/repo`
+/// slug before returning it from `detect_repo`'s gh fallback.
+///
+/// Accepts non-empty `<owner>/<repo>` strings where each segment
+/// matches `[A-Za-z0-9._-]+`. Rejects multi-line strings (newline
+/// injection), bare `/`, three-or-more-segment paths (`owner/repo/extra`),
+/// empty input, and any string containing whitespace or characters
+/// outside the allowed set. Run on the trimmed stdout of
+/// `gh repo view --json nameWithOwner -q .nameWithOwner` to ensure
+/// the returned identity is safe to interpolate into downstream
+/// `gh` args, state-file writes, and Markdown URLs.
+pub fn validate_gh_repo_output(s: &str) -> Option<String> {
+    let re = Regex::new(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$").unwrap();
+    if re.is_match(s) {
+        Some(s.to_string())
+    } else {
+        None
+    }
+}
+
 /// Auto-detect GitHub repo from git remote origin URL.
 ///
 /// Returns `owner/repo` string or None if detection fails. Optional
@@ -31,9 +51,11 @@ pub fn parse_github_url(url: &str) -> Option<String> {
 ///    — invoked when the regex returns None. Uses the `gh` CLI's
 ///    authenticated session, so SSH host aliases (e.g.
 ///    `git@github-pt:owner/repo.git`) resolve correctly via the user's
-///    GitHub auth rather than via the remote URL's literal text.
-///    Returns None if `gh` is missing, exits non-zero, or prints a
-///    string without `/`.
+///    GitHub auth rather than via the remote URL's literal text. The
+///    trimmed stdout is run through `validate_gh_repo_output` so only
+///    well-formed `owner/repo` slugs propagate to callers — multi-line
+///    output, bare `/`, three-component paths, and strings with
+///    whitespace or unsafe characters return None.
 pub fn detect_repo(cwd: Option<&Path>) -> Option<String> {
     let mut cmd = Command::new("git");
     cmd.args(["remote", "get-url", "origin"]);
@@ -67,9 +89,5 @@ pub fn detect_repo(cwd: Option<&Path>) -> Option<String> {
         return None;
     }
     let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if s.contains('/') {
-        Some(s)
-    } else {
-        None
-    }
+    validate_gh_repo_output(&s)
 }

--- a/src/tombstone_audit.rs
+++ b/src/tombstone_audit.rs
@@ -180,28 +180,6 @@ pub fn classify_tombstones(
     (stale, current)
 }
 
-/// Detect the repository from git remote.
-fn detect_repo() -> Option<String> {
-    let output = std::process::Command::new("gh")
-        .args([
-            "repo",
-            "view",
-            "--json",
-            "nameWithOwner",
-            "-q",
-            ".nameWithOwner",
-        ])
-        .output()
-        .ok()?;
-    if output.status.success() {
-        let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if s.contains('/') {
-            return Some(s);
-        }
-    }
-    None
-}
-
 /// Fetch the oldest open PR creation date as the staleness threshold.
 ///
 /// Returns `Ok(Some(date))` when open PRs exist, `Ok(None)` when no
@@ -303,7 +281,9 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
     // Detect repo
     let repo = match &args.repo {
         Some(r) => r.clone(),
-        None => detect_repo().ok_or("Could not detect repository from git remote")?,
+        None => {
+            crate::github::detect_repo(None).ok_or("Could not detect repository from git remote")?
+        }
     };
 
     // Fetch threshold (oldest open PR creation date)

--- a/tests/analyze_issues.rs
+++ b/tests/analyze_issues.rs
@@ -1626,10 +1626,11 @@ fn analyze_issues_milestone_cli_flag_still_forwarded_to_gh() {
     let log_path = repo.join("gh_args.log");
     // Append (`>>`) because `analyze_issues` invokes gh twice — once for
     // the issue list and once via `detect_repo`'s gh-repo-view fallback.
-    // Only the issue-list call carries `--milestone`, so a whole-log scan
-    // still uniquely locates the argument.
+    // The `---` separator keeps the per-call argv blocks distinguishable
+    // so a future change to either gh invocation doesn't silently
+    // overlap with the milestone-arg search.
     let stub_script = format!(
-        "#!/bin/bash\nprintf '%s\\n' \"$@\" >> {}\necho '[]'\nexit 0\n",
+        "#!/bin/bash\n{{ printf '%s\\n' \"$@\"; echo '---'; }} >> {}\necho '[]'\nexit 0\n",
         log_path.to_string_lossy(),
     );
     let stub_dir = create_gh_stub(&repo, &stub_script);

--- a/tests/analyze_issues.rs
+++ b/tests/analyze_issues.rs
@@ -430,8 +430,12 @@ fn analyze_issues_gh_json_field_list_includes_assignees() {
     let dir = tempfile::tempdir().unwrap();
     let repo = create_git_repo_with_remote(dir.path());
     let log_path = repo.join("gh_args.log");
+    // Append (`>>`) because `analyze_issues` invokes gh twice — once for
+    // the issue list and once via `detect_repo`'s gh-repo-view fallback.
+    // The stub separates calls with a `---` sentinel so the assertion
+    // can scan every invocation's argv.
     let stub_script = format!(
-        "#!/bin/bash\nprintf '%s\\n' \"$@\" > {}\necho '[]'\nexit 0\n",
+        "#!/bin/bash\n{{ printf '%s\\n' \"$@\"; echo '---'; }} >> {}\necho '[]'\nexit 0\n",
         log_path.to_string_lossy(),
     );
     let stub_dir = create_gh_stub(&repo, &stub_script);
@@ -446,17 +450,20 @@ fn analyze_issues_gh_json_field_list_includes_assignees() {
 
     let logged = fs::read_to_string(&log_path).expect("gh stub should have logged args");
     let lines: Vec<&str> = logged.lines().collect();
-    let json_idx = lines
+    let has_assignees = lines
         .iter()
-        .position(|l| *l == "--json")
-        .expect("gh args should include --json");
-    let field_list = lines
-        .get(json_idx + 1)
-        .expect("--json should be followed by a value");
+        .enumerate()
+        .filter(|(_, l)| **l == "--json")
+        .any(|(idx, _)| {
+            lines
+                .get(idx + 1)
+                .map(|fl| fl.split(',').any(|f| f == "assignees"))
+                .unwrap_or(false)
+        });
     assert!(
-        field_list.split(',').any(|f| f == "assignees"),
-        "expected --json field list to include `assignees`; got `{}`",
-        field_list,
+        has_assignees,
+        "expected at least one --json invocation to include `assignees`; got: {}",
+        logged,
     );
 }
 
@@ -1617,8 +1624,12 @@ fn analyze_issues_milestone_cli_flag_still_forwarded_to_gh() {
     let dir = tempfile::tempdir().unwrap();
     let repo = create_git_repo_with_remote(dir.path());
     let log_path = repo.join("gh_args.log");
+    // Append (`>>`) because `analyze_issues` invokes gh twice — once for
+    // the issue list and once via `detect_repo`'s gh-repo-view fallback.
+    // Only the issue-list call carries `--milestone`, so a whole-log scan
+    // still uniquely locates the argument.
     let stub_script = format!(
-        "#!/bin/bash\nprintf '%s\\n' \"$@\" > {}\necho '[]'\nexit 0\n",
+        "#!/bin/bash\nprintf '%s\\n' \"$@\" >> {}\necho '[]'\nexit 0\n",
         log_path.to_string_lossy(),
     );
     let stub_dir = create_gh_stub(&repo, &stub_script);

--- a/tests/github.rs
+++ b/tests/github.rs
@@ -67,6 +67,16 @@ fn extract_repo_http_not_https() {
     );
 }
 
+#[test]
+fn ssh_alias_url_does_not_match_regex() {
+    // The `parse_github_url` regex requires the literal `github.com`
+    // substring. SSH host aliases like `git@github-pt:owner/repo.git`
+    // do not match — the `detect_repo` gh fallback is the surface that
+    // resolves aliases. A future edit that loosens the regex to accept
+    // aliases must also delete or rewrite this test.
+    assert_eq!(parse_github_url("git@github-pt:owner/repo.git"), None);
+}
+
 // --- detect_repo (in-process) ---
 
 #[test]
@@ -151,6 +161,12 @@ fn detect_repo_returns_none_when_git_returns_empty_stdout() {
     let git_stub = stub_dir.join("git");
     fs::write(&git_stub, "#!/usr/bin/env bash\nexit 0\n").unwrap();
     fs::set_permissions(&git_stub, fs::Permissions::from_mode(0o755)).unwrap();
+    // Stub gh too so the fallback cannot reach the real gh CLI and pull
+    // in the user's authenticated session. Exit non-zero to drive the
+    // None branch of the fallback.
+    let gh_stub = stub_dir.join("gh");
+    fs::write(&gh_stub, "#!/usr/bin/env bash\nexit 1\n").unwrap();
+    fs::set_permissions(&gh_stub, fs::Permissions::from_mode(0o755)).unwrap();
 
     let path_env = format!(
         "{}:{}",
@@ -171,5 +187,143 @@ fn detect_repo_returns_none_when_git_returns_empty_stdout() {
         "session-context should succeed even when git returns empty. stdout: {}, stderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Helper: create a git repo whose `origin` remote URL is a custom
+/// string (SSH alias, non-GitHub URL, etc.). Returns the repo path.
+/// Unlike `common::create_git_repo_with_remote`, this does not push
+/// to a bare remote — the URL is a string, not a path to a real repo.
+fn create_repo_with_custom_remote(
+    parent: &std::path::Path,
+    remote_url: &str,
+) -> std::path::PathBuf {
+    let repo = parent.join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    for (key, val) in [
+        ("user.email", "test@test.com"),
+        ("user.name", "Test"),
+        ("commit.gpgsign", "false"),
+    ] {
+        Command::new("git")
+            .args(["config", key, val])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+    }
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["remote", "add", "origin", remote_url])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    repo
+}
+
+/// `detect_repo` falls back to `gh repo view` when `parse_github_url`
+/// returns None. SSH host aliases (`git@github-pt:owner/repo.git`)
+/// are the canonical case — the regex requires the literal `github.com`
+/// substring, but `gh` resolves the alias via its authenticated session.
+/// The stub touches a marker file when invoked; the marker's existence
+/// is what observably proves the fallback ran (session-context itself
+/// always exits 0 because it swallows detection failures).
+#[test]
+fn gh_fallback_resolves_ssh_alias() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_repo_with_custom_remote(dir.path(), "git@github-pt:owner/repo.git");
+    let stub_dir = dir.path().join("stub_bin");
+    fs::create_dir_all(&stub_dir).unwrap();
+    let gh_stub = stub_dir.join("gh");
+    let marker = stub_dir.join("gh-was-called");
+    fs::write(
+        &gh_stub,
+        format!(
+            "#!/usr/bin/env bash\ntouch '{}'\necho 'owner/repo'\nexit 0\n",
+            marker.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&gh_stub, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let path_env = format!(
+        "{}:{}",
+        stub_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let flow_rs = env!("CARGO_BIN_EXE_flow-rs");
+    let output = Command::new(flow_rs)
+        .args(["session-context"])
+        .current_dir(&repo)
+        .env("PATH", &path_env)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "session-context must succeed when gh fallback resolves the SSH alias. stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        marker.exists(),
+        "gh fallback must run when parse_github_url returns None for an SSH alias",
+    );
+}
+
+/// `detect_repo`'s gh fallback rejects malformed output that does not
+/// contain `/` — the `s.contains('/')` guard. Stub `gh` to print a
+/// no-slash string and verify the fallback ran AND that
+/// `session-context` still succeeds (detection failure is non-fatal).
+#[test]
+fn gh_fallback_rejects_malformed_output() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_repo_with_custom_remote(dir.path(), "git@github-pt:owner/repo.git");
+    let stub_dir = dir.path().join("stub_bin");
+    fs::create_dir_all(&stub_dir).unwrap();
+    let gh_stub = stub_dir.join("gh");
+    let marker = stub_dir.join("gh-was-called");
+    fs::write(
+        &gh_stub,
+        format!(
+            "#!/usr/bin/env bash\ntouch '{}'\necho 'no-slash-here'\nexit 0\n",
+            marker.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&gh_stub, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let path_env = format!(
+        "{}:{}",
+        stub_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let flow_rs = env!("CARGO_BIN_EXE_flow-rs");
+    let output = Command::new(flow_rs)
+        .args(["session-context"])
+        .current_dir(&repo)
+        .env("PATH", &path_env)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "session-context must tolerate malformed gh output. stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        marker.exists(),
+        "gh fallback must run even when the output is malformed",
     );
 }

--- a/tests/github.rs
+++ b/tests/github.rs
@@ -14,7 +14,7 @@ mod common;
 
 use std::process::Command;
 
-use flow_rs::github::{detect_repo, parse_github_url};
+use flow_rs::github::{detect_repo, parse_github_url, validate_gh_repo_output};
 
 // --- parse_github_url ---
 
@@ -75,6 +75,76 @@ fn ssh_alias_url_does_not_match_regex() {
     // resolves aliases. A future edit that loosens the regex to accept
     // aliases must also delete or rewrite this test.
     assert_eq!(parse_github_url("git@github-pt:owner/repo.git"), None);
+}
+
+// --- validate_gh_repo_output ---
+
+#[test]
+fn validate_gh_repo_output_accepts_canonical_owner_repo() {
+    assert_eq!(
+        validate_gh_repo_output("owner/repo"),
+        Some("owner/repo".to_string())
+    );
+}
+
+#[test]
+fn validate_gh_repo_output_accepts_dots_and_hyphens() {
+    // GitHub allows dots, underscores, and hyphens in segment names.
+    assert_eq!(
+        validate_gh_repo_output("acme-corp/my.project_v2"),
+        Some("acme-corp/my.project_v2".to_string())
+    );
+}
+
+#[test]
+fn validate_gh_repo_output_rejects_multiline_output() {
+    // Newline-injection bypass: `gh` stdout with an embedded newline
+    // passes the contains('/') check but corrupts every downstream
+    // consumer (gh args, state file, Markdown URLs).
+    assert_eq!(validate_gh_repo_output("owner/repo\nextra-garbage"), None);
+}
+
+#[test]
+fn validate_gh_repo_output_rejects_bare_slash() {
+    // Empty owner / empty repo segments: a bare `/` is not a valid
+    // GitHub repository slug.
+    assert_eq!(validate_gh_repo_output("/"), None);
+}
+
+#[test]
+fn validate_gh_repo_output_rejects_three_component_path() {
+    // `owner/repo/extra` looks repo-shaped but is not — `gh repo view`
+    // never produces three-segment paths.
+    assert_eq!(validate_gh_repo_output("owner/repo/extra"), None);
+}
+
+#[test]
+fn validate_gh_repo_output_rejects_empty_input() {
+    assert_eq!(validate_gh_repo_output(""), None);
+}
+
+#[test]
+fn validate_gh_repo_output_rejects_whitespace_inside_segment() {
+    assert_eq!(validate_gh_repo_output("owner /repo"), None);
+}
+
+#[test]
+fn validate_gh_repo_output_rejects_owner_only() {
+    assert_eq!(validate_gh_repo_output("owner/"), None);
+}
+
+#[test]
+fn validate_gh_repo_output_rejects_repo_only() {
+    assert_eq!(validate_gh_repo_output("/repo"), None);
+}
+
+#[test]
+fn validate_gh_repo_output_rejects_unsafe_characters() {
+    // Pipes, semicolons, quotes, and other shell metacharacters must
+    // not flow into downstream subprocess args.
+    assert_eq!(validate_gh_repo_output("owner|cat/etc"), None);
+    assert_eq!(validate_gh_repo_output("owner/repo;rm"), None);
+    assert_eq!(validate_gh_repo_output("owner/repo\"injection"), None);
 }
 
 // --- detect_repo (in-process) ---
@@ -231,11 +301,20 @@ fn create_repo_with_custom_remote(
 
 /// `detect_repo` falls back to `gh repo view` when `parse_github_url`
 /// returns None. SSH host aliases (`git@github-pt:owner/repo.git`)
-/// are the canonical case — the regex requires the literal `github.com`
-/// substring, but `gh` resolves the alias via its authenticated session.
-/// The stub touches a marker file when invoked; the marker's existence
-/// is what observably proves the fallback ran (session-context itself
-/// always exits 0 because it swallows detection failures).
+/// are the canonical case — the regex requires the literal
+/// `github.com` substring, but `gh` resolves the alias via its
+/// authenticated session.
+///
+/// Scope of this test: verify that the fallback *is invoked* when the
+/// regex misses an SSH alias. The marker file's existence is the
+/// observable signal — `session-context` is the shallowest entry
+/// point that exercises `detect_repo` and intentionally swallows the
+/// returned value (its `write_tab_sequences` call ignores failures).
+/// The behavior of the validator itself — what counts as a valid
+/// `owner/repo` slug — is covered by the in-process
+/// `validate_gh_repo_output_*` tests above, which do not need PATH
+/// manipulation. `HOME` is set to the tempdir so the child reads no
+/// user dotfiles per `.claude/rules/subprocess-test-hygiene.md`.
 #[test]
 fn gh_fallback_resolves_ssh_alias() {
     use std::fs;
@@ -266,6 +345,7 @@ fn gh_fallback_resolves_ssh_alias() {
         .args(["session-context"])
         .current_dir(&repo)
         .env("PATH", &path_env)
+        .env("HOME", dir.path())
         .output()
         .unwrap();
     assert!(
@@ -280,10 +360,18 @@ fn gh_fallback_resolves_ssh_alias() {
     );
 }
 
-/// `detect_repo`'s gh fallback rejects malformed output that does not
-/// contain `/` — the `s.contains('/')` guard. Stub `gh` to print a
-/// no-slash string and verify the fallback ran AND that
-/// `session-context` still succeeds (detection failure is non-fatal).
+/// `detect_repo`'s gh fallback rejects malformed output via
+/// `validate_gh_repo_output`. Stub `gh` to print a no-slash string
+/// and verify the fallback ran AND that `session-context` still
+/// succeeds (detection failure is non-fatal for `session-context`).
+///
+/// Scope of this test: verify the fallback is invoked and that
+/// malformed gh output does not cause `session-context` to fail. The
+/// rejection behavior itself — multi-line, bare slash, three-segment
+/// paths, etc. — is covered by the in-process
+/// `validate_gh_repo_output_*` tests, which test every rejection
+/// class without PATH manipulation. `HOME` is set to the tempdir per
+/// `.claude/rules/subprocess-test-hygiene.md`.
 #[test]
 fn gh_fallback_rejects_malformed_output() {
     use std::fs;
@@ -314,6 +402,7 @@ fn gh_fallback_rejects_malformed_output() {
         .args(["session-context"])
         .current_dir(&repo)
         .env("PATH", &path_env)
+        .env("HOME", dir.path())
         .output()
         .unwrap();
     assert!(

--- a/tests/start_workspace.rs
+++ b/tests/start_workspace.rs
@@ -19,12 +19,23 @@ use common::{
 
 // --- Test helpers ---
 
-/// Create a default gh stub (PR create returns fake URL).
+/// Create a default gh stub.
+///
+/// Dispatches by subcommand so the new `gh repo view` fallback in
+/// `github::detect_repo` (invoked by start-workspace's state backfill
+/// when the origin URL is a bare-path file rather than github.com)
+/// does not silently succeed and pollute the state file with a fake
+/// repo. `pr create` returns the test PR URL; `repo view` exits
+/// non-zero so `detect_repo` returns `None` and the `state["repo"]`
+/// None branch fires.
 fn create_default_gh_stub(repo: &Path) -> PathBuf {
     create_gh_stub(
         repo,
         "#!/bin/bash\n\
-         echo \"https://github.com/test/repo/pull/42\"\n",
+         case \"$1\" in\n  \
+           repo) exit 1 ;;\n  \
+           *) echo \"https://github.com/test/repo/pull/42\" ;;\n\
+         esac\n",
     )
 }
 


### PR DESCRIPTION
## What

/flow:flow-start #1602.

Closes #1602

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/bin-flow-issue-fails-to-detect/log` |
| State | `.flow-states/bin-flow-issue-fails-to-detect/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/431cd65c-3be4-4187-96d1-99a88fc997f8.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 1h 12m |
| Review | 18m |
| Learn | 2m |
| Complete | <1m |
| **Total** | **1h 35m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 3.8M | — |
| Code | 200.3M | $87.849 |
| Review | 0 | — |
| Learn | 0 | — |
| Complete | 0 | — |
| **Total** | **204.1M** | **$87.849**\* |

*Partial: some phases had no cost data.*

<!-- end:Token Cost -->

## Review Findings

- ✗ **Reviewer F2: url.is_empty() early-return removal**
  - Dismissed — Empty stdout from git remote get-url is unreachable in practice — git exits non-zero when no origin is configured. The deleted early-return guarded a dead branch.
- ✗ **Reviewer F4: Mirror-Pattern Rule Audit missing in plan**
  - Dismissed — Reviewer admits the gap is procedural rather than substantive — the current PR's mirror does not appear to inherit any rule violations from the sibling. This is a Plan-phase process gap routed to Learn, not a Code Review fix.
- ✗ **Pre-mortem F1: gh fallback corrupts state repo identity**
  - Dismissed — gh repo view without --repo resolves via the git remote URL through hosts.yml SSH-alias mapping — the same source the regex consumed. This is the designed behavior for SSH-alias use. The test fixture rewrite (create_default_gh_stub dispatching by subcommand) is test hygiene, not evidence of a production failure mode.
- ✗ **Pre-mortem F3: empty-stdout guard removal**
  - Dismissed — Same as reviewer F2 — git exits non-zero when no origin is configured, so empty-success-stdout is unreachable.
- ✗ **Pre-mortem F5: gh-auth exposure in sub-agents**
  - Dismissed — Pre-existing behavior — tombstone_audit's private detect_repo invoked gh repo view with identical shape before this PR. Sub-agent gh-auth inheritance is a property of the sub-agent execution model, not a behavior change introduced here.
- ✗ **Documentation F3: missing rationale for /-check in detect_repo**
  - Dismissed — Subsumed by Pre-mortem F2 / Adversarial findings — the /-check is being replaced with a positive shape validator. The rationale becomes self-evident from the new code.
- ✓ **Adversarial F1+F2+F3 / Pre-mortem F2: gh fallback validator too weak**
  - Fixed — Replaced s.contains('/') with validate_gh_repo_output helper that enforces ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$. Rejects multi-line strings, bare /, three-component paths, empty input, and unsafe characters. 10 named in-process unit tests cover every rejection class.
- ✓ **Reviewer F1 + Documentation F2: Tests assert fallback invocation but not return value**
  - Fixed — Extracted validate_gh_repo_output as a pure function and added validate_gh_repo_output_\* in-process unit tests covering canonical acceptance and every rejection class. Existing subprocess tests' doc comments now point at the in-process tests for return-value behavior.
- ✓ **Reviewer F3: subprocess tests do not neutralize HOME**
  - Fixed — Added .env('HOME', dir.path()) to gh_fallback_resolves_ssh_alias and gh_fallback_rejects_malformed_output per subprocess-test-hygiene.md.
- ✓ **Pre-mortem F4: milestone test stub lacks per-call separator**
  - Fixed — Added { ...; echo '---'; } separator to analyze_issues_milestone_cli_flag_still_forwarded_to_gh stub for parity with the assignees test's separator.
- ✓ **Documentation F1: session-context as test driver is unexplained**
  - Fixed — Expanded doc comments on gh_fallback_resolves_ssh_alias and gh_fallback_rejects_malformed_output to explain scope: subprocess tests verify fallback invocation; validator behavior is covered by in-process validate_gh_repo_output_\* tests.
- ✓ **Adversarial probe reconciliation**
  - Fixed — Probe assertions are addressed by validate_gh_repo_output and its 10 unit tests. Emptied the probe per .claude/rules/adversarial-probe-lifecycle.md default reconciliation; Phase 5 cleanup removes the file.

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/bin-flow-issue-fails-to-detect.json</summary>

```json
{
  "schema_version": 1,
  "branch": "bin-flow-issue-fails-to-detect",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1604,
  "pr_url": "https://github.com/benkruger/flow/pull/1604",
  "started_at": "2026-05-15T17:02:11-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/bin-flow-issue-fails-to-detect/log",
    "state": ".flow-states/bin-flow-issue-fails-to-detect/state.json"
  },
  "session_tty": "/dev/ttys006",
  "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/431cd65c-3be4-4187-96d1-99a88fc997f8.jsonl",
  "notes": [],
  "prompt": "/flow:flow-start #1602",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-15T17:02:11-07:00",
      "completed_at": "2026-05-15T17:02:51-07:00",
      "session_started_at": null,
      "cumulative_seconds": 40,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T17:02:11-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "five_hour_pct": 0,
        "seven_day_pct": 5,
        "session_cost_usd": 8.767918299999998
      },
      "window_at_complete": {
        "captured_at": "2026-05-15T17:02:51-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 10,
        "seven_day_pct": 7,
        "session_input_tokens": 66,
        "session_output_tokens": 5918,
        "session_cache_creation_tokens": 918883,
        "session_cache_read_tokens": 2889264,
        "session_cost_usd": 12.336738549999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 66,
            "output": 5918,
            "cache_create": 918883,
            "cache_read": 2889264
          }
        },
        "turn_count": 16,
        "tool_call_count": 7,
        "context_at_last_turn_tokens": 245683,
        "context_window_pct": 122.8415
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-15T17:03:09-07:00",
      "completed_at": "2026-05-15T18:16:00-07:00",
      "session_started_at": null,
      "cumulative_seconds": 4371,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T17:03:09-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 10,
        "seven_day_pct": 7,
        "session_input_tokens": 69,
        "session_output_tokens": 9083,
        "session_cache_creation_tokens": 920173,
        "session_cache_read_tokens": 3626295,
        "session_cost_usd": 12.488644549999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 69,
            "output": 9083,
            "cache_create": 920173,
            "cache_read": 3626295
          }
        },
        "turn_count": 19,
        "tool_call_count": 8,
        "context_at_last_turn_tokens": 246108,
        "context_window_pct": 123.054
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-15T18:06:15-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 9,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-15T18:06:15-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 9,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-15T18:06:15-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 9,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-15T18:06:15-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 9,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-15T18:13:06-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 9,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-15T18:16:00-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 9,
        "session_input_tokens": 610,
        "session_output_tokens": 281905,
        "session_cache_creation_tokens": 2358121,
        "session_cache_read_tokens": 202234970,
        "session_cost_usd": 100.33784999999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 610,
            "output": 281905,
            "cache_create": 2358121,
            "cache_read": 202234970
          }
        },
        "turn_count": 350,
        "tool_call_count": 206,
        "context_at_last_turn_tokens": 823975,
        "context_window_pct": 411.9875
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-15T18:16:14-07:00",
      "completed_at": "2026-05-15T18:34:47-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1113,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T18:16:14-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 9,
        "session_input_tokens": 610,
        "session_output_tokens": 281905,
        "session_cache_creation_tokens": 2358121,
        "session_cache_read_tokens": 202234970,
        "session_cost_usd": 100.33784999999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 610,
            "output": 281905,
            "cache_create": 2358121,
            "cache_read": 202234970
          }
        },
        "turn_count": 350,
        "tool_call_count": 206,
        "context_at_last_turn_tokens": 823975,
        "context_window_pct": 411.9875
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-15T18:17:27-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 21,
          "seven_day_pct": 9,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-15T18:23:25-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 26,
          "seven_day_pct": 10,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-15T18:25:58-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 26,
          "seven_day_pct": 10,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-15T18:34:36-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 10,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-15T18:23:05-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-15T18:23:11-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-15T18:23:16-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-15T18:23:21-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-15T18:34:47-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 27,
        "seven_day_pct": 10,
        "session_input_tokens": 610,
        "session_output_tokens": 281905,
        "session_cache_creation_tokens": 2358121,
        "session_cache_read_tokens": 202234970,
        "session_cost_usd": 100.33784999999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 610,
            "output": 281905,
            "cache_create": 2358121,
            "cache_read": 202234970
          }
        },
        "turn_count": 350,
        "tool_call_count": 206,
        "context_at_last_turn_tokens": 823975,
        "context_window_pct": 411.9875
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-15T18:34:58-07:00",
      "completed_at": "2026-05-15T18:37:56-07:00",
      "session_started_at": null,
      "cumulative_seconds": 178,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T18:34:58-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 27,
        "seven_day_pct": 10,
        "session_input_tokens": 610,
        "session_output_tokens": 281905,
        "session_cache_creation_tokens": 2358121,
        "session_cache_read_tokens": 202234970,
        "session_cost_usd": 100.33784999999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 610,
            "output": 281905,
            "cache_create": 2358121,
            "cache_read": 202234970
          }
        },
        "turn_count": 350,
        "tool_call_count": 206,
        "context_at_last_turn_tokens": 823975,
        "context_window_pct": 411.9875
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-15T18:37:09-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-15T18:37:17-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 10,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-15T18:37:24-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 10,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-15T18:37:35-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 10,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-15T18:37:41-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 10,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-15T18:37:47-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 10,
          "session_input_tokens": 610,
          "session_output_tokens": 281905,
          "session_cache_creation_tokens": 2358121,
          "session_cache_read_tokens": 202234970,
          "session_cost_usd": 100.33784999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 610,
              "output": 281905,
              "cache_create": 2358121,
              "cache_read": 202234970
            }
          },
          "turn_count": 350,
          "tool_call_count": 206,
          "context_at_last_turn_tokens": 823975,
          "context_window_pct": 411.9875
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-15T18:37:56-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 28,
        "seven_day_pct": 10,
        "session_input_tokens": 610,
        "session_output_tokens": 281905,
        "session_cache_creation_tokens": 2358121,
        "session_cache_read_tokens": 202234970,
        "session_cost_usd": 100.33784999999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 610,
            "output": 281905,
            "cache_create": 2358121,
            "cache_read": 202234970
          }
        },
        "turn_count": 350,
        "tool_call_count": 206,
        "context_at_last_turn_tokens": 823975,
        "context_window_pct": 411.9875
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-15T18:38:26-07:00",
      "completed_at": "2026-05-15T18:38:49-07:00",
      "session_started_at": null,
      "cumulative_seconds": 23,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T18:38:26-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 28,
        "seven_day_pct": 10,
        "session_input_tokens": 610,
        "session_output_tokens": 281905,
        "session_cache_creation_tokens": 2358121,
        "session_cache_read_tokens": 202234970,
        "session_cost_usd": 100.33784999999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 610,
            "output": 281905,
            "cache_create": 2358121,
            "cache_read": 202234970
          }
        },
        "turn_count": 350,
        "tool_call_count": 206,
        "context_at_last_turn_tokens": 823975,
        "context_window_pct": 411.9875
      },
      "window_at_complete": {
        "captured_at": "2026-05-15T18:38:49-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 28,
        "seven_day_pct": 10,
        "session_input_tokens": 610,
        "session_output_tokens": 281905,
        "session_cache_creation_tokens": 2358121,
        "session_cache_read_tokens": 202234970,
        "session_cost_usd": 100.33784999999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 610,
            "output": 281905,
            "cache_create": 2358121,
            "cache_read": 202234970
          }
        },
        "turn_count": 350,
        "tool_call_count": 206,
        "context_at_last_turn_tokens": 823975,
        "context_window_pct": 411.9875
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-15T17:03:09-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-15T18:16:14-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-15T18:34:58-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-15T18:38:26-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-15T17:02:11-07:00",
    "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
    "five_hour_pct": 0,
    "seven_day_pct": 5,
    "session_cost_usd": 8.767918299999998
  },
  "code_tasks_total": 5,
  "code_task_name": "Task 5: Dedupe — route tombstone_audit through public API",
  "code_task": 5,
  "diff_stats": {
    "files_changed": 5,
    "insertions": 232,
    "deletions": 45,
    "captured_at": "2026-05-15T18:16:00-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nLet me carefully analyze this conversation to understand what has happened:\n\n1. **User's Initial Request**: The user invoked a Learn phase task using the FRAMING from `.claude/rules/` files. The task is to apply a two-gate test to every candidate finding:\n   - Gate 1 (Forward-facing): Would a future session understand and apply the principle?\n   - Gate 2 (Value): Was the gap caught and remediated in this PR?\n   - If both gates pass, report the finding. Otherwise, drop it.\n   - \"No findings\" is the correct answer for many categories.\n\n2. **Artifacts Provided**: The user provided:\n   - STATE FILE DATA: Notes empty, phase timings showing flow-start/code/review completed, flow-learn in_progress. 6 dismissed findings, 6 fixed findings (no filed). Context window peaked at 412%.\n   - PLAN: Full implementation plan for PR #1592 (bin-flow-issue-fails-to-detect) - fixing regex failure for SSH alias URLs\n   - PROJECT CLAUDE.md: Comprehensive guide on FLOW plugin architecture\n   - RULES FILES: Extensive set of `.claude/rules/*.md` files covering everything from permissions to testing patterns\n\n3. **The PR Diff**: A complete diff showing:\n   - `src/github.rs`: Modified `detect_repo()` to add a `gh repo view` fallback when `parse_github_url` returns None\n   - `src/tombstone_audit.rs`: Removed private `detect_repo()` function, now calls `crate::github::detect_repo(None)`\n   - `tests/github.rs`: Added 3 new tests:\n     - `ssh_alias_url_does_not_match_regex()` - regression guard on regex\n     - `gh_fallback_resolves_ssh_alias()` - subprocess test for gh fallback success\n     - `gh_fallback_rejects_malformed_output()` - subprocess test for malformed gh output\n     - Helper function `create_repo_with_custom_remote()`\n   - `tests/analyze_issues.rs`: Updated 2 tests to handle multiple gh invocations (appending to log instead of overwriting)\n   - `tests/start_workspace.rs`: Updated gh stub to dispatch by subcommand (repo view exits 1, pr create returns URL)\n\n4. **What the Task Is Asking**: The user is asking me to perform a **Learn phase analysis** of this PR using the two-gate test framework. I need to:\n   - Read the provided artifacts\n   - Apply the two-gate test to potential findings\n   - Filter ruthlessly - only report findings that pass BOTH gates\n   - Explicitly state \"No findings\" in any category where nothing passes both gates\n   - Return output ending with `## END-OF-FINDINGS`\n\n5. **Key Rules Relevant to This Task**:\n   - From FRAMING: Two gates must BOTH pass for a finding to be reported\n   - Forward-facing: Can a future session use this without context?\n   - Value: Was the gap caught and remediated in THIS PR?\n   - The Learn phase reads 6 dismissed and 6 fixed findings already triaged in Review\n   - This is the Learn phase, not the Review phase - different scope\n\n6. **Critical Instruction**: The user explicitly states \"FRAMING\" at the top with specific instructions for the Learn phase - I must apply those two gates rigorously.\n\nThe actual task is to perform Learn-phase analysis and report findings using the two-gate test. However, I notice the user has NOT actually asked me to perform this analysis - they've set up the context and provided the framing, but there's no explicit \"now perform the Learn analysis\" instruction.\n\nWait, re-reading: The user said \"FRAMING:\" at the very top, then provided extensive context including the PLAN, CLAUDE.md, and rules files. The FINAL instruction is \"Apply the three Learn tenants. Return only findings that pass both gates. End your output with structured `**Finding N:**` blocks (or explicit \"No findings\" markers for each tenant) followed by `## END-OF-FINDINGS`.\"\n\nSo the user IS asking me to perform the Learn phase analysis. The three Learn tenants would be the standard three tenants defined in the project's Learn phase discipline. But I should be careful - I don't have an explicit list of what the three tenants are in this context. Looking at the CLAUDE.md and rules, I can infer they are likely:\n1. Process/Workflow gaps\n2. Documentation/Communication gaps  \n3. Architecture/Design gaps\n\nOr possibly the standard FLOW quality gates. The key is to apply the two-gate test to ANY potential findings.\n\n7. **What I Haven't Done Yet**: I have NOT actually performed the Learn phase analysis. I was simply asked to read the artifacts and set up the framing. The user is now asking me to summarize the conversation before proceeding.\n\nSo my task right now is to summarize what has been set up, not to complete the Learn analysis.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user is requesting a Learn phase analysis of PR #1592 (bin-flow-issue-fails-to-detect) using a rigorous two-gate filtering process. The user provided:\n   - Complete PR diff showing changes to implement a `gh repo view` fallback in `detect_repo()` for SSH alias URL detection\n   - Full FLOW project documentation and architecture guide (CLAUDE.md)\n   - Comprehensive set of `.claude/rules/*.md` files covering project discipline\n   - Implementation plan describing the fix, risks, and approach\n   - State file data indicating 6 dismissed and 6 fixed findings already triaged in Review phase\n   \n   The explicit task is to: \"Apply the three Learn tenants. Return only findings that pass both gates. End your output with structured `**Finding N:**` blocks (or explicit \"No findings\" markers for each tenant) followed by `## END-OF-FINDINGS`.\"\n\n2. Key Technical Concepts:\n   - Two-Gate Test Framework: Forward-facing (would future session understand/apply?) + Value (was gap caught and remediated in PR?)\n   - FLOW Plugin Architecture: Five-phase development lifecycle (Start, Code, Review, Learn, Complete)\n   - SSH Alias URL Resolution: Problem where regex requires literal \"github.com\" substring, SSH aliases like \"git@github-pt:owner/repo.git\" fail\n   - Subprocess Fallback Pattern: Using `gh repo view --json nameWithOwner` to leverage authenticated GitHub session when regex fails\n   - Test Fixtures and Stubs: Custom gh stub binaries that dispatch by subcommand to simulate various scenarios\n   - State File Management: `.flow-states/<branch>/state.json` with findings array tracking dismissed/fixed items\n\n3. Files and Code Sections:\n   - `src/github.rs` - `detect_repo()` function\n     - Original: Simple regex-only approach via `parse_github_url()` that fails on SSH aliases\n     - Modified: Added `gh repo view` fallback when regex returns None, with proper error handling and documentation\n     - Key change: Tries git remote URL first (fast path), then falls back to gh CLI which uses authenticated session\n   \n   - `src/tombstone_audit.rs` - Removed private `detect_repo()` duplicate\n     - Deleted: Lines 178-98 containing private `detect_repo()` function\n     - Modified: Line 307 now calls `crate::github::detect_repo(None)` instead of local function\n     - Rationale: Eliminates redundant code after public API now carries fallback\n   \n   - `tests/github.rs` - Added three new tests with helper function\n     - New: `ssh_alias_url_does_not_match_regex()` - Asserts `parse_github_url(\"git@github-pt:owner/repo.git\") == None`\n     - New: `gh_fallback_resolves_ssh_alias()` - Subprocess test verifying gh fallback runs and succeeds with custom remote\n     - New: `gh_fallback_rejects_malformed_output()` - Subprocess test verifying malformed gh output (no `/`) is rejected\n     - New: Helper `create_repo_with_custom_remote(parent, remote_url)` - Creates git repo with arbitrary remote URL string\n   \n   - `tests/analyze_issues.rs` - Updated two tests to handle multiple gh invocations\n     - Modified: `analyze_issues_gh_json_field_list_includes_assignees()` - Changed to append (`>>`) instead of overwrite, added sentinel separator `---` between calls\n     - Modified: `analyze_issues_milestone_cli_flag_still_forwarded_to_gh()` - Changed to append logs instead of overwrite\n     - Rationale: `analyze_issues` now invokes gh twice (once for issue list, once via detect_repo fallback)\n   \n   - `tests/start_workspace.rs` - Updated gh stub to dispatch by subcommand\n     - Modified: `create_default_gh_stub()` now uses case statement dispatching on `$1`\n     - Behavior: `repo` subcommand exits 1 (forcing detect_repo fallback to return None), other subcommands return test PR URL\n     - Rationale: Prevents state file pollution when start_workspace tests with bare-path file remotes\n\n4. Errors and fixes:\n   - No errors reported. The user is providing a complete, working PR that has already passed Code and Review phases.\n\n5. Problem Solving:\n   - Original Problem: SSH alias URLs like \"git@github-pt:owner/repo.git\" fail to be detected because the regex in `parse_github_url()` requires the literal string \"github.com\"\n   - Solution Implemented: Added subprocess fallback to `gh repo view --json nameWithOwner` which leverages the gh CLI's authenticated session to resolve aliases\n   - Risk Mitigation: \n     - Fallback only invoked when regex returns None (preserves fast path)\n     - Gh subprocess failures return None gracefully (caller handles as detection failure)\n     - Malformed output (missing `/`) is rejected explicitly\n     - 100% coverage on all branches via named subprocess tests\n   - Test Coverage: All three branches (gh-success, gh-failure, gh-malformed) exercised by distinct tests\n\n6. All user messages:\n   - First message: Provided FRAMING instruction with two-gate test discipline and explicit instruction to \"Apply the three Learn tenants. Return only findings that pass both gates. End your output with structured `**Finding N:**` blocks (or explicit \"No findings\" markers for each tenant) followed by `## END-OF-FINDINGS`.\"\n   - Context provided includes full plan.md, CLAUDE.md (project guide), complete set of .claude/rules/*.md files, state file data, and full PR diff\n   - No follow-up messages from user yet\n\n7. Pending Tasks:\n   - Perform Learn phase analysis using two-gate test\n   - Return findings (or \"No findings\" markers) for each of three Learn tenants\n   - End output with `## END-OF-FINDINGS` marker\n\n8. Current Work:\n   This is a summary request before beginning the Learn phase analysis. The user has provided all context and explicit instructions but is asking for a conversation summary first. I have not yet performed the actual Learn phase analysis.\n\n9. Optional Next Step:\n   After this summary is complete, perform the Learn phase analysis. The user's explicit instructions state: \"Apply the three Learn tenants. Return only findings that pass both gates. End your output with structured `**Finding N:**` blocks (or explicit \"No findings\" markers for each tenant) followed by `## END-OF-FINDINGS`.\" This requires reading the provided artifacts (already done via tool calls), identifying potential findings, applying the two-gate test to each, and returning only those that pass both gates, with explicit \"No findings\" markers for categories with no passing findings.\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/bin-flow-issue-fails-to-detect",
  "compact_count": 3,
  "findings": [
    {
      "finding": "Reviewer F2: url.is_empty() early-return removal",
      "reason": "Empty stdout from git remote get-url is unreachable in practice — git exits non-zero when no origin is configured. The deleted early-return guarded a dead branch.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:25:13-07:00"
    },
    {
      "finding": "Reviewer F4: Mirror-Pattern Rule Audit missing in plan",
      "reason": "Reviewer admits the gap is procedural rather than substantive — the current PR's mirror does not appear to inherit any rule violations from the sibling. This is a Plan-phase process gap routed to Learn, not a Code Review fix.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:25:23-07:00"
    },
    {
      "finding": "Pre-mortem F1: gh fallback corrupts state repo identity",
      "reason": "gh repo view without --repo resolves via the git remote URL through hosts.yml SSH-alias mapping — the same source the regex consumed. This is the designed behavior for SSH-alias use. The test fixture rewrite (create_default_gh_stub dispatching by subcommand) is test hygiene, not evidence of a production failure mode.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:25:29-07:00"
    },
    {
      "finding": "Pre-mortem F3: empty-stdout guard removal",
      "reason": "Same as reviewer F2 — git exits non-zero when no origin is configured, so empty-success-stdout is unreachable.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:25:40-07:00"
    },
    {
      "finding": "Pre-mortem F5: gh-auth exposure in sub-agents",
      "reason": "Pre-existing behavior — tombstone_audit's private detect_repo invoked gh repo view with identical shape before this PR. Sub-agent gh-auth inheritance is a property of the sub-agent execution model, not a behavior change introduced here.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:25:47-07:00"
    },
    {
      "finding": "Documentation F3: missing rationale for /-check in detect_repo",
      "reason": "Subsumed by Pre-mortem F2 / Adversarial findings — the /-check is being replaced with a positive shape validator. The rationale becomes self-evident from the new code.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:25:53-07:00"
    },
    {
      "finding": "Adversarial F1+F2+F3 / Pre-mortem F2: gh fallback validator too weak",
      "reason": "Replaced s.contains('/') with validate_gh_repo_output helper that enforces ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$. Rejects multi-line strings, bare /, three-component paths, empty input, and unsafe characters. 10 named in-process unit tests cover every rejection class.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:32:40-07:00"
    },
    {
      "finding": "Reviewer F1 + Documentation F2: Tests assert fallback invocation but not return value",
      "reason": "Extracted validate_gh_repo_output as a pure function and added validate_gh_repo_output_* in-process unit tests covering canonical acceptance and every rejection class. Existing subprocess tests' doc comments now point at the in-process tests for return-value behavior.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:32:45-07:00"
    },
    {
      "finding": "Reviewer F3: subprocess tests do not neutralize HOME",
      "reason": "Added .env('HOME', dir.path()) to gh_fallback_resolves_ssh_alias and gh_fallback_rejects_malformed_output per subprocess-test-hygiene.md.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:32:51-07:00"
    },
    {
      "finding": "Pre-mortem F4: milestone test stub lacks per-call separator",
      "reason": "Added { ...; echo '---'; } separator to analyze_issues_milestone_cli_flag_still_forwarded_to_gh stub for parity with the assignees test's separator.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:32:58-07:00"
    },
    {
      "finding": "Documentation F1: session-context as test driver is unexplained",
      "reason": "Expanded doc comments on gh_fallback_resolves_ssh_alias and gh_fallback_rejects_malformed_output to explain scope: subprocess tests verify fallback invocation; validator behavior is covered by in-process validate_gh_repo_output_* tests.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:33:04-07:00"
    },
    {
      "finding": "Adversarial probe reconciliation",
      "reason": "Probe assertions are addressed by validate_gh_repo_output and its 10 unit tests. Emptied the probe per .claude/rules/adversarial-probe-lifecycle.md default reconciliation; Phase 5 cleanup removes the file.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T18:33:10-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-15T18:38:49-07:00",
    "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
    "model": "claude-opus-4-7",
    "five_hour_pct": 28,
    "seven_day_pct": 10,
    "session_input_tokens": 610,
    "session_output_tokens": 281905,
    "session_cache_creation_tokens": 2358121,
    "session_cache_read_tokens": 202234970,
    "session_cost_usd": 100.33784999999996,
    "by_model": {
      "claude-opus-4-7": {
        "input": 610,
        "output": 281905,
        "cache_create": 2358121,
        "cache_read": 202234970
      }
    },
    "turn_count": 350,
    "tool_call_count": 206,
    "context_at_last_turn_tokens": 823975,
    "context_window_pct": 411.9875
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>