### PR TITLE
Fix Bin Flow Issue   Body File

### DIFF
--- a/.claude/rules/filing-issues.md
+++ b/.claude/rules/filing-issues.md
@@ -39,27 +39,38 @@ issues are pre-planned by definition.
 
 ## The Pattern
 
-`bin/flow issue --body-file <path>` resolves `<path>` against
-`project_root()` (the main repo root), but the `validate-worktree-paths`
-hook blocks writing files directly to the main repo when the session
-is running inside a linked worktree. Using a relative path like
-`.flow-issue-body` creates a split: the Write tool writes it to the
-worktree (where the hook allows writes), but `bin/flow issue` then
-looks for it at `<main_repo>/.flow-issue-body` (where it does not
-exist). The fix is to always pass an absolute worktree path.
+`bin/flow issue --body-file <path>` resolves a relative `<path>`
+against the caller's current working directory (the Bash tool's
+cwd at invocation time); absolute paths are used as given. Inside
+an active FLOW worktree, flow-start anchors Bash cwd to the
+worktree root, so both the Write tool and `bin/flow issue` see
+the same directory and a relative `.flow-issue-body-<id>`
+resolves consistently between them. Outside a worktree, Bash cwd
+is the project root, so a relative path likewise resolves
+consistently. The `validate-worktree-paths` hook still blocks
+Write-tool calls targeting the main repo when invoked from
+inside a worktree, so paths written via the Write tool must land
+inside the worktree.
+
+Recommended absolute-path shape (unambiguous regardless of where
+Bash cwd ends up):
 
 1. Write the issue body to `<worktree>/.flow-issue-body` (or
    `<worktree>/.flow-issue-body-1`, etc., for parallel filing)
-   using the Write tool — the worktree path is allowed by the
-   `validate-worktree-paths` hook
+   using the Write tool — the absolute worktree path satisfies
+   the `validate-worktree-paths` hook
 2. Call `bin/flow issue --title "..." --body-file
    <worktree>/.flow-issue-body` using the absolute worktree path
-3. The script reads the file, deletes it, then creates the issue
+3. The script reads the file, deletes it on a best-effort basis
+   (per `read_body_file`'s doc comment — cleanup errors are
+   swallowed), then creates the issue
 
-When not in a worktree (no active FLOW phase), the project root
-IS the repo root — a relative path `.flow-issue-body` works because
-the Write tool and `bin/flow issue` both resolve to the same
-directory. Use the relative form in that case.
+Relative paths are accepted when the Bash cwd matches the Write
+target's parent directory. `bin/flow issue` rejects `..` traversal
+segments in relative paths, rejects empty `--body-file` arguments,
+and rejects non-regular-file targets (symlinks, directories,
+device nodes) via `fs::symlink_metadata` — see
+`.claude/rules/external-input-path-construction.md`.
 
 ## Editing Existing Issues
 
@@ -311,3 +322,5 @@ include an Implementation Plan section by design.
 - Proposed solutions or "open questions" about tradeoffs
 - Prescribed code changes or architectural suggestions
 - Diagnosis of why the bug happens — only what happens
+</content>
+</invoke>

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -15,12 +15,16 @@
 //! no inline `#[cfg(test)]` block in this file.
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 use clap::Parser;
 use regex::Regex;
 use serde_json::json;
+
+use crate::plan_from_issue::PLAN_BODY_BYTE_CAP;
 
 #[derive(Parser, Debug)]
 #[command(name = "issue", about = "Create a GitHub issue")]
@@ -170,33 +174,102 @@ struct IssueResult {
 /// Read body text from a file and delete the file.
 ///
 /// Relative paths resolve against the caller's current working
-/// directory via `std::env::current_dir()`; absolute paths are used as
-/// given. The body file is removed on both the success and failure
-/// arms so a read error does not orphan the temp file in the caller's
-/// directory.
+/// directory via `std::env::current_dir()`; absolute paths are used
+/// as given. The body file is removed on a best-effort basis on both
+/// success and failure — a read error does not orphan the temp file,
+/// but the function swallows `fs::remove_file` errors because no
+/// recovery path exists at this layer. Callers needing strict cleanup
+/// must handle deletion themselves.
+///
+/// Validation runs at the boundary per
+/// `.claude/rules/external-input-path-construction.md`:
+///
+/// - Empty path strings are rejected (would otherwise resolve to the
+///   cwd directory).
+/// - Relative paths containing `..` components are rejected (would
+///   escape the cwd subtree and expose `fs::remove_file` to
+///   arbitrary-file deletion).
+/// - Non-regular-file targets (symlinks, directories, device nodes,
+///   FIFOs) are rejected via `fs::symlink_metadata`. A hostile
+///   symlink at the path cannot redirect the read to an arbitrary
+///   file — the sibling `validate_issue_body::read_body` follows
+///   the same pattern.
+///
+/// The read is bounded by `PLAN_BODY_BYTE_CAP + 1` via
+/// `BufReader::new(file.take(...))` so an oversized or streaming
+/// body file cannot exhaust process memory; bodies exceeding the
+/// cap are rejected.
 pub fn read_body_file(path: &str) -> Result<String, String> {
+    if path.is_empty() {
+        return Err("Could not read body file: --body-file argument is empty".to_string());
+    }
+
     let resolved: PathBuf = if Path::new(path).is_absolute() {
         PathBuf::from(path)
     } else {
+        if Path::new(path)
+            .components()
+            .any(|c| matches!(c, Component::ParentDir))
+        {
+            return Err(format!(
+                "Could not read body file '{}': path contains forbidden `..` traversal segments",
+                path
+            ));
+        }
         let cwd = std::env::current_dir()
             .map_err(|e| format!("Could not determine current directory: {}", e))?;
         cwd.join(path)
     };
 
-    match fs::read_to_string(&resolved) {
-        Ok(body) => {
-            let _ = fs::remove_file(&resolved);
-            Ok(body)
-        }
+    let meta = match fs::symlink_metadata(&resolved) {
+        Ok(m) => m,
         Err(e) => {
-            let _ = fs::remove_file(&resolved);
-            Err(format!(
+            return Err(format!(
                 "Could not read body file '{}': {}",
                 resolved.display(),
                 e
-            ))
+            ));
         }
+    };
+    if !meta.file_type().is_file() {
+        return Err(format!(
+            "Could not read body file '{}': not a regular file",
+            resolved.display()
+        ));
     }
+
+    let read_cap = (PLAN_BODY_BYTE_CAP as u64) + 1;
+    let file = match File::open(&resolved) {
+        Ok(f) => f,
+        Err(e) => {
+            let _ = fs::remove_file(&resolved);
+            return Err(format!(
+                "Could not read body file '{}': {}",
+                resolved.display(),
+                e
+            ));
+        }
+    };
+    let mut reader = BufReader::new(file.take(read_cap));
+    let mut body = String::new();
+    if let Err(e) = reader.read_to_string(&mut body) {
+        let _ = fs::remove_file(&resolved);
+        return Err(format!(
+            "Could not read body file '{}': {}",
+            resolved.display(),
+            e
+        ));
+    }
+
+    let _ = fs::remove_file(&resolved);
+    if body.len() > PLAN_BODY_BYTE_CAP {
+        return Err(format!(
+            "Could not read body file '{}': body exceeds {} bytes",
+            resolved.display(),
+            PLAN_BODY_BYTE_CAP
+        ));
+    }
+    Ok(body)
 }
 
 /// Extract issue number from a GitHub issue URL.

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -168,21 +168,35 @@ struct IssueResult {
 }
 
 /// Read body text from a file and delete the file.
-/// Relative paths are resolved against `root`.
-pub fn read_body_file(path: &str, root: &Path) -> Result<String, String> {
+///
+/// Relative paths resolve against the caller's current working
+/// directory via `std::env::current_dir()`; absolute paths are used as
+/// given. The body file is removed on both the success and failure
+/// arms so a read error does not orphan the temp file in the caller's
+/// directory.
+pub fn read_body_file(path: &str) -> Result<String, String> {
     let resolved: PathBuf = if Path::new(path).is_absolute() {
         PathBuf::from(path)
     } else {
-        root.join(path)
+        let cwd = std::env::current_dir()
+            .map_err(|e| format!("Could not determine current directory: {}", e))?;
+        cwd.join(path)
     };
 
-    let body = fs::read_to_string(&resolved)
-        .map_err(|e| format!("Could not read body file '{}': {}", resolved.display(), e))?;
-
-    // Best-effort cleanup of the temp body file.
-    let _ = fs::remove_file(&resolved);
-
-    Ok(body)
+    match fs::read_to_string(&resolved) {
+        Ok(body) => {
+            let _ = fs::remove_file(&resolved);
+            Ok(body)
+        }
+        Err(e) => {
+            let _ = fs::remove_file(&resolved);
+            Err(format!(
+                "Could not read body file '{}': {}",
+                resolved.display(),
+                e
+            ))
+        }
+    }
 }
 
 /// Extract issue number from a GitHub issue URL.
@@ -342,10 +356,10 @@ pub fn extract_error(stderr: &str, stdout: &str) -> String {
 ///   (or `None` if no flow is active). Production binds it to
 ///   `resolve_branch + read_to_string`.
 /// - `repo_resolver` returns the repo from `git remote` (or `None`).
-///   Production binds it to `detect_repo(Some(root))`.
+///   Production binds it to `detect_repo(Some(&root))` where `root`
+///   is captured by the closure on the main-arm side.
 pub fn run_impl_main(
     args: Args,
-    root: &Path,
     state_reader: &dyn Fn() -> Option<String>,
     repo_resolver: &dyn Fn() -> Option<String>,
 ) -> (serde_json::Value, i32) {
@@ -381,7 +395,7 @@ pub fn run_impl_main(
     };
 
     let body = if let Some(ref bf) = args.body_file {
-        match read_body_file(bf, root) {
+        match read_body_file(bf) {
             Ok(b) => Some(b),
             Err(e) => return (json!({"status": "error", "message": e}), 1),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -671,7 +671,7 @@ fn main() {
             };
             let repo_resolver =
                 move || -> Option<String> { flow_rs::github::detect_repo(Some(&root_for_repo)) };
-            let (value, code) = issue::run_impl_main(args, &root, &state_reader, &repo_resolver);
+            let (value, code) = issue::run_impl_main(args, &state_reader, &repo_resolver);
             flow_rs::dispatch::dispatch_json(value, code);
         }
         Some(Commands::CloseIssue(args)) => {

--- a/tests/issue.rs
+++ b/tests/issue.rs
@@ -877,6 +877,98 @@ fn read_body_file_cleans_up_on_read_failure() {
     );
 }
 
+#[test]
+fn read_body_file_empty_path_rejected() {
+    let result = read_body_file("");
+    let err = result.expect_err("empty --body-file must reject");
+    assert!(
+        err.contains("empty"),
+        "empty-path error must name 'empty'; got: {}",
+        err
+    );
+}
+
+#[test]
+fn read_body_file_relative_dotdot_traversal_rejected() {
+    let result = read_body_file("../escape.md");
+    let err = result.expect_err("`..` traversal must reject");
+    assert!(
+        err.contains("forbidden") && err.contains("traversal"),
+        "dotdot rejection error must name 'forbidden' and 'traversal'; got: {}",
+        err
+    );
+}
+
+#[test]
+fn read_body_file_symlink_target_rejected_and_preserved() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("target.txt");
+    fs::write(&target, "preserve me").unwrap();
+    let link = dir.path().join("link.md");
+    symlink(&target, &link).unwrap();
+
+    let result = read_body_file(link.to_str().unwrap());
+
+    let err = result.expect_err("symlink must reject");
+    assert!(
+        err.contains("not a regular file"),
+        "symlink rejection error must name 'not a regular file'; got: {}",
+        err
+    );
+    assert!(
+        fs::read_to_string(&target).unwrap() == "preserve me",
+        "symlink target must survive — read_body_file must not follow the symlink"
+    );
+}
+
+#[test]
+fn read_body_file_body_exceeding_cap_rejected_and_cleaned_up() {
+    use flow_rs::plan_from_issue::PLAN_BODY_BYTE_CAP;
+
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("oversize.md");
+    let body = "x".repeat(PLAN_BODY_BYTE_CAP + 10);
+    fs::write(&file, &body).unwrap();
+
+    let result = read_body_file(file.to_str().unwrap());
+
+    let err = result.expect_err("oversize body must reject");
+    assert!(
+        err.contains("exceeds") && err.contains(&PLAN_BODY_BYTE_CAP.to_string()),
+        "oversize error must name 'exceeds' and the cap; got: {}",
+        err
+    );
+    assert!(
+        !file.exists(),
+        "oversize body file must still be cleaned up after rejection"
+    );
+}
+
+#[test]
+fn read_body_file_non_utf8_returns_error_and_cleans_up() {
+    // File::open succeeds (regular file with read permissions), but
+    // read_to_string fails because the bytes are not valid UTF-8.
+    // Covers the read_to_string Err arm in read_body_file.
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("non-utf8.md");
+    fs::write(&file, [0xFF, 0xFE, 0xFD, 0xFC]).unwrap();
+
+    let result = read_body_file(file.to_str().unwrap());
+
+    let err = result.expect_err("non-utf8 body must reject");
+    assert!(
+        err.contains("Could not read body file") && err.contains("UTF-8"),
+        "non-utf8 error must name read failure and 'UTF-8'; got: {}",
+        err
+    );
+    assert!(
+        !file.exists(),
+        "cleanup must run even when read_to_string fails on non-utf8 content"
+    );
+}
+
 /// Subprocess test for the cwd-relative resolution branch in
 /// `read_body_file`. Spawns the binary with `current_dir(<root>/subdir)`
 /// and passes a relative `--body-file` so the path-resolution path goes

--- a/tests/issue.rs
+++ b/tests/issue.rs
@@ -807,7 +807,7 @@ fn read_body_file_reads_and_deletes() {
     let file = dir.path().join(".flow-issue-body");
     fs::write(&file, "Issue body with | pipes and && ampersands").unwrap();
 
-    let result = read_body_file(file.to_str().unwrap(), dir.path());
+    let result = read_body_file(file.to_str().unwrap());
 
     assert_eq!(result.unwrap(), "Issue body with | pipes and && ampersands");
     assert!(!file.exists());
@@ -818,7 +818,7 @@ fn read_body_file_missing_returns_error() {
     let dir = tempfile::tempdir().unwrap();
     let file = dir.path().join("nonexistent.md");
 
-    let result = read_body_file(file.to_str().unwrap(), dir.path());
+    let result = read_body_file(file.to_str().unwrap());
 
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("Could not read body file"));
@@ -830,7 +830,7 @@ fn read_body_file_empty_returns_empty_string() {
     let file = dir.path().join(".flow-issue-body");
     fs::write(&file, "").unwrap();
 
-    let result = read_body_file(file.to_str().unwrap(), dir.path());
+    let result = read_body_file(file.to_str().unwrap());
 
     assert_eq!(result.unwrap(), "");
     assert!(!file.exists());
@@ -843,47 +843,192 @@ fn read_body_file_rich_markdown_preserved() {
     let content = "## Summary\n\n| Column | Value |\n|--------|-------|\n| A | B |\n";
     fs::write(&file, content).unwrap();
 
-    let result = read_body_file(file.to_str().unwrap(), dir.path());
+    let result = read_body_file(file.to_str().unwrap());
 
     assert_eq!(result.unwrap(), content);
 }
 
 #[test]
-fn read_body_file_relative_resolved_against_root() {
-    let dir = tempfile::tempdir().unwrap();
-    let project_dir = dir.path().join("project");
-    fs::create_dir_all(&project_dir).unwrap();
-    let file = project_dir.join(".flow-issue-body");
-    fs::write(&file, "Resolved body").unwrap();
-
-    let result = read_body_file(".flow-issue-body", &project_dir);
-
-    assert_eq!(result.unwrap(), "Resolved body");
-    assert!(!file.exists());
-}
-
-#[test]
-fn read_body_file_absolute_ignores_root() {
+fn read_body_file_absolute_path_unaffected_by_cwd() {
     let dir = tempfile::tempdir().unwrap();
     let file = dir.path().join(".flow-issue-body");
     fs::write(&file, "Absolute body").unwrap();
 
-    let other_root = dir.path().join("other");
-    fs::create_dir_all(&other_root).unwrap();
-
-    let result = read_body_file(file.to_str().unwrap(), &other_root);
+    let result = read_body_file(file.to_str().unwrap());
 
     assert_eq!(result.unwrap(), "Absolute body");
 }
 
 #[test]
-fn read_body_file_relative_missing_returns_error() {
-    let dir = tempfile::tempdir().unwrap();
+fn read_body_file_cleans_up_on_read_failure() {
+    use std::os::unix::fs::PermissionsExt;
 
-    let result = read_body_file("nonexistent.md", dir.path());
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("orphan.md");
+    fs::write(&file, "should be removed even though read fails").unwrap();
+    fs::set_permissions(&file, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let result = read_body_file(file.to_str().unwrap());
 
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("Could not read body file"));
+    assert!(
+        fs::metadata(&file).is_err(),
+        "read_body_file must delete the body file even when the read fails, leaving no orphan"
+    );
+}
+
+/// Subprocess test for the cwd-relative resolution branch in
+/// `read_body_file`. Spawns the binary with `current_dir(<root>/subdir)`
+/// and passes a relative `--body-file` so the path-resolution path goes
+/// through `std::env::current_dir()`. With the body file present at
+/// `<root>/subdir/.flow-issue-body-test`, the read step succeeds; the
+/// downstream `gh` call then fails on the invalid token but that error
+/// is distinct from "Could not read body file", which is the substring
+/// the test asserts is ABSENT.
+#[cfg(unix)]
+#[test]
+fn read_body_file_relative_resolves_against_caller_cwd() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().canonicalize().expect("canonicalize");
+    let subdir = root.join("subdir");
+    fs::create_dir_all(&subdir).expect("mkdir subdir");
+    let body_path = subdir.join(".flow-issue-body-test");
+    fs::write(&body_path, "Resolved body").expect("write body");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_flow-rs"));
+    cmd.args([
+        "issue",
+        "--title",
+        "test",
+        "--body-file",
+        ".flow-issue-body-test",
+        "--repo",
+        "fake/repo",
+    ]);
+    cmd.current_dir(&subdir);
+    cmd.env_remove("FLOW_CI_RUNNING");
+    cmd.env("GH_TOKEN", "invalid");
+    cmd.env("GITHUB_TOKEN", "invalid");
+    cmd.env("HOME", &root);
+    cmd.env("GIT_CEILING_DIRECTORIES", &root);
+
+    let output = cmd.output().expect("spawn flow-rs issue");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}\n{}", stdout, stderr);
+
+    assert!(
+        !combined.contains("Could not read body file"),
+        "expected body-file read to succeed via cwd resolution; combined output:\n{}",
+        combined
+    );
+}
+
+/// Subprocess test for the cwd-relative missing-file branch. Same
+/// fixture shape as the resolves-against-caller-cwd test above, but the
+/// body file is intentionally not written. The error path must surface
+/// `Could not read body file` AND name the cwd-resolved path
+/// (containing the `subdir/.flow-issue-body-test` suffix) so the user
+/// can see which absolute path the binary attempted to read.
+#[cfg(unix)]
+#[test]
+fn read_body_file_relative_missing_returns_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().canonicalize().expect("canonicalize");
+    let subdir = root.join("subdir");
+    fs::create_dir_all(&subdir).expect("mkdir subdir");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_flow-rs"));
+    cmd.args([
+        "issue",
+        "--title",
+        "test",
+        "--body-file",
+        ".flow-issue-body-test",
+        "--repo",
+        "fake/repo",
+    ]);
+    cmd.current_dir(&subdir);
+    cmd.env_remove("FLOW_CI_RUNNING");
+    cmd.env("GH_TOKEN", "invalid");
+    cmd.env("GITHUB_TOKEN", "invalid");
+    cmd.env("HOME", &root);
+    cmd.env("GIT_CEILING_DIRECTORIES", &root);
+
+    let output = cmd.output().expect("spawn flow-rs issue");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}\n{}", stdout, stderr);
+
+    assert!(
+        combined.contains("Could not read body file"),
+        "expected 'Could not read body file' error; combined output:\n{}",
+        combined
+    );
+    assert!(
+        combined.contains("subdir/.flow-issue-body-test"),
+        "expected error to name the cwd-resolved path; combined output:\n{}",
+        combined
+    );
+}
+
+/// Subprocess test for the `current_dir()` Err branch. The child is
+/// spawned with `current_dir(cwd)` set; a `pre_exec` closure then
+/// `rmdir`s that cwd after the kernel has chdir'd the child into it,
+/// leaving the child with an unlinked cwd inode — `getcwd(3)` then
+/// returns `ENOENT` and Rust's `env::current_dir()` reports Err. With a
+/// relative `--body-file`, the read path hits the Err arm and surfaces
+/// `Could not determine current directory`.
+#[cfg(unix)]
+#[test]
+fn read_body_file_current_dir_error_propagated() {
+    use std::os::unix::process::CommandExt;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().canonicalize().expect("canonicalize");
+    let cwd = root.join("doomed");
+    fs::create_dir(&cwd).expect("mkdir doomed");
+
+    let cwd_for_preexec = cwd.clone();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_flow-rs"));
+    cmd.args([
+        "issue",
+        "--title",
+        "test",
+        "--body-file",
+        ".flow-issue-body-test",
+        "--repo",
+        "fake/repo",
+    ]);
+    cmd.current_dir(&cwd);
+    cmd.env_remove("FLOW_CI_RUNNING");
+    cmd.env("GH_TOKEN", "invalid");
+    cmd.env("GITHUB_TOKEN", "invalid");
+    cmd.env("HOME", &root);
+    cmd.env("GIT_CEILING_DIRECTORIES", &root);
+
+    // SAFETY: `pre_exec` requires the closure to be async-signal-safe.
+    // `libc::rmdir` is listed as AS-safe by POSIX; we only call it and
+    // return Ok — no memory allocation, no panic surfaces.
+    let preexec_path = std::ffi::CString::new(cwd_for_preexec.to_str().expect("utf8").as_bytes())
+        .expect("CString from cwd path");
+    unsafe {
+        cmd.pre_exec(move || {
+            libc::rmdir(preexec_path.as_ptr());
+            Ok(())
+        });
+    }
+
+    let output = cmd.output().expect("spawn flow-rs issue");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}\n{}", stdout, stderr);
+
+    assert!(
+        combined.contains("Could not determine current directory"),
+        "expected current_dir Err propagation; combined output:\n{}",
+        combined
+    );
 }
 
 // --- parse_issue_number ---
@@ -987,10 +1132,9 @@ fn default_args() -> Args {
 
 #[test]
 fn gate_blocks_when_current_phase_is_review() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some(r#"{"current_phase":"flow-review"}"#.to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert_eq!(value["status"], "error");
     let msg = value["message"].as_str().unwrap();
@@ -1005,10 +1149,9 @@ fn gate_allows_in_learn_phase_with_stubbed_gh() {
     // spawns gh. With no gh on PATH the spawn fails, but what matters
     // here is the gate pass — the failure appears in the returned
     // error, not as a Review block.
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some(r#"{"current_phase":"flow-learn"}"#.to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, _code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, _code) = run_impl_main(default_args(), &state, &repo);
     // gate pass proven by absence of Review message.
     assert!(!value["message"]
         .as_str()
@@ -1018,10 +1161,9 @@ fn gate_allows_in_learn_phase_with_stubbed_gh() {
 
 #[test]
 fn gate_allows_when_no_state_file() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || None;
     let repo = || Some("owner/name".to_string());
-    let (value, _code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, _code) = run_impl_main(default_args(), &state, &repo);
     assert!(!value["message"]
         .as_str()
         .unwrap_or("")
@@ -1030,10 +1172,9 @@ fn gate_allows_when_no_state_file() {
 
 #[test]
 fn gate_fails_closed_when_state_malformed() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some("not json".to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"]
         .as_str()
@@ -1043,10 +1184,9 @@ fn gate_fails_closed_when_state_malformed() {
 
 #[test]
 fn gate_fails_closed_when_current_phase_missing() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some(r#"{"branch":"x"}"#.to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"]
         .as_str()
@@ -1056,10 +1196,9 @@ fn gate_fails_closed_when_current_phase_missing() {
 
 #[test]
 fn gate_fails_closed_when_current_phase_is_array() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some(r#"{"current_phase":["flow-review"]}"#.to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"]
         .as_str()
@@ -1069,20 +1208,18 @@ fn gate_fails_closed_when_current_phase_is_array() {
 
 #[test]
 fn gate_fails_closed_when_state_has_bom() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some("\u{feff}{\"current_phase\":\"flow-review\"}".to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"].as_str().unwrap().contains("Review"));
 }
 
 #[test]
 fn gate_fails_closed_when_state_has_bom_and_no_review() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some("\u{feff}{\"current_phase\":\"flow-learn\"}".to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"]
         .as_str()
@@ -1092,10 +1229,9 @@ fn gate_fails_closed_when_state_has_bom_and_no_review() {
 
 #[test]
 fn gate_allows_when_state_is_empty_string() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some(String::new());
     let repo = || Some("owner/name".to_string());
-    let (value, _code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, _code) = run_impl_main(default_args(), &state, &repo);
     assert!(!value["message"]
         .as_str()
         .unwrap_or("")
@@ -1104,10 +1240,9 @@ fn gate_allows_when_state_is_empty_string() {
 
 #[test]
 fn gate_allows_when_state_is_whitespace_only() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some("   \n  ".to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, _code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, _code) = run_impl_main(default_args(), &state, &repo);
     assert!(!value["message"]
         .as_str()
         .unwrap_or("")
@@ -1116,52 +1251,47 @@ fn gate_allows_when_state_is_whitespace_only() {
 
 #[test]
 fn gate_blocks_when_current_phase_is_whitespace_padded() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some(r#"{"current_phase":" flow-review "}"#.to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"].as_str().unwrap().contains("Review"));
 }
 
 #[test]
 fn gate_blocks_when_current_phase_is_uppercase() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some(r#"{"current_phase":"FLOW-REVIEW"}"#.to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"].as_str().unwrap().contains("Review"));
 }
 
 #[test]
 fn gate_blocks_when_current_phase_has_trailing_nul() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some("{\"current_phase\":\"flow-review\\u0000\"}".to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"].as_str().unwrap().contains("Review"));
 }
 
 #[test]
 fn gate_blocks_when_current_phase_duplicate_key_serde_last_wins() {
-    let dir = tempfile::tempdir().unwrap();
     let state =
         || Some(r#"{"current_phase":"flow-review","current_phase":"flow-learn"}"#.to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"].as_str().unwrap().contains("Review"));
 }
 
 #[test]
 fn gate_blocks_when_duplicate_key_in_reverse_order() {
-    let dir = tempfile::tempdir().unwrap();
     let state =
         || Some(r#"{"current_phase":"flow-learn","current_phase":"flow-review"}"#.to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"].as_str().unwrap().contains("Review"));
 }
@@ -1173,10 +1303,9 @@ fn gate_raw_scanner_advances_past_current_phase_without_colon() {
     // After trim_start, strip_prefix(':') returns None and the scanner
     // advances. The parser path then fails to parse and the gate
     // fails CLOSED.
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some(r#""current_phase" prefix no colon"#.to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"]
         .as_str()
@@ -1187,10 +1316,9 @@ fn gate_raw_scanner_advances_past_current_phase_without_colon() {
 #[test]
 fn gate_fails_closed_when_current_phase_value_has_no_closing_quote() {
     // Covers the raw scanner's `value_body.find('"')` None fallthrough.
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some(r#"{"current_phase":"flow-review"#.to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"]
         .as_str()
@@ -1202,12 +1330,11 @@ fn gate_fails_closed_when_current_phase_value_has_no_closing_quote() {
 
 #[test]
 fn run_impl_main_no_repo_returns_error_tuple() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || None;
     let repo = || None;
     let mut args = default_args();
     args.repo = None;
-    let (value, code) = run_impl_main(args, dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(args, &state, &repo);
     assert_eq!(value["status"], "error");
     assert_eq!(code, 1);
     assert!(value["message"]
@@ -1218,12 +1345,11 @@ fn run_impl_main_no_repo_returns_error_tuple() {
 
 #[test]
 fn run_impl_main_body_file_missing_returns_error_tuple() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || None;
     let repo = || Some("owner/name".to_string());
     let mut args = default_args();
     args.body_file = Some("nonexistent-body.md".to_string());
-    let (value, code) = run_impl_main(args, dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(args, &state, &repo);
     assert_eq!(value["status"], "error");
     assert_eq!(code, 1);
     assert!(value["message"]
@@ -1247,7 +1373,7 @@ fn run_impl_main_state_file_path_falls_back_to_resolver() {
     args.repo = None;
     args.state_file = Some(state_file.to_string_lossy().to_string());
     // Don't assert on code; just cover the branch.
-    let (_, _code) = run_impl_main(args, dir.path(), &state, &repo);
+    let (_, _code) = run_impl_main(args, &state, &repo);
 }
 
 #[test]
@@ -1260,18 +1386,17 @@ fn run_impl_main_state_file_resolves_repo() {
     let mut args = default_args();
     args.repo = None;
     args.state_file = Some(state_file.to_string_lossy().to_string());
-    let (_, _code) = run_impl_main(args, dir.path(), &state, &repo);
+    let (_, _code) = run_impl_main(args, &state, &repo);
 }
 
 #[test]
 fn run_impl_main_missing_state_file_falls_back_to_resolver() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || None;
     let repo = || Some("fallback/repo".to_string());
     let mut args = default_args();
     args.repo = None;
     args.state_file = Some("/nonexistent/state.json".to_string());
-    let (_, _code) = run_impl_main(args, dir.path(), &state, &repo);
+    let (_, _code) = run_impl_main(args, &state, &repo);
 }
 
 #[test]
@@ -1284,7 +1409,7 @@ fn run_impl_main_state_file_no_repo_no_resolver_errors() {
     let mut args = default_args();
     args.repo = None;
     args.state_file = Some(state_file.to_string_lossy().to_string());
-    let (value, code) = run_impl_main(args, dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(args, &state, &repo);
     assert_eq!(code, 1);
     assert!(value["message"]
         .as_str()
@@ -1294,10 +1419,9 @@ fn run_impl_main_state_file_no_repo_no_resolver_errors() {
 
 #[test]
 fn run_impl_main_blocked_by_review_returns_error_tuple() {
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some(r#"{"current_phase":"flow-review"}"#.to_string());
     let repo = || Some("owner/name".to_string());
-    let (value, code) = run_impl_main(default_args(), dir.path(), &state, &repo);
+    let (value, code) = run_impl_main(default_args(), &state, &repo);
     assert_eq!(value["status"], "error");
     assert_eq!(code, 1);
     assert!(value["message"].as_str().unwrap().contains("Review"));
@@ -1306,12 +1430,11 @@ fn run_impl_main_blocked_by_review_returns_error_tuple() {
 #[test]
 fn gate_override_bypasses_review_block() {
     // Covers the `if override_flag { return None; }` early return.
-    let dir = tempfile::tempdir().unwrap();
     let state = || Some(r#"{"current_phase":"flow-review"}"#.to_string());
     let repo = || Some("owner/name".to_string());
     let mut args = default_args();
     args.override_review_ban = true;
-    let (value, _code) = run_impl_main(args, dir.path(), &state, &repo);
+    let (value, _code) = run_impl_main(args, &state, &repo);
     // Gate passed — no Review message.
     assert!(!value["message"]
         .as_str()
@@ -1323,14 +1446,13 @@ fn gate_override_bypasses_review_block() {
 fn run_impl_main_resolver_only_path_uses_resolver_repo() {
     // Covers the outermost `else { match repo_resolver() Some(r) => r }`
     // branch: no --repo, no --state-file, resolver returns Some.
-    let dir = tempfile::tempdir().unwrap();
     let state = || None;
     let repo = || Some("resolver/repo".to_string());
     let mut args = default_args();
     args.repo = None;
     args.state_file = None;
     // Don't care about exit code; just covering the repo-resolution branch.
-    let (_, _code) = run_impl_main(args, dir.path(), &state, &repo);
+    let (_, _code) = run_impl_main(args, &state, &repo);
 }
 
 #[test]
@@ -1347,5 +1469,5 @@ fn run_impl_main_state_file_with_invalid_json_falls_back_to_resolver() {
     let mut args = default_args();
     args.repo = None;
     args.state_file = Some(state_file.to_string_lossy().to_string());
-    let (_, _code) = run_impl_main(args, dir.path(), &state, &repo);
+    let (_, _code) = run_impl_main(args, &state, &repo);
 }


### PR DESCRIPTION
## What

#1603.

Closes #1603

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/fix-bin-flow-issue---body-file/log` |
| State | `.flow-states/fix-bin-flow-issue---body-file/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/431cd65c-3be4-4187-96d1-99a88fc997f8.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 15m |
| Review | 22m |
| Learn | 4m |
| Complete | <1m |
| **Total** | **44m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 3.0M | $0.944 |
| Code | 69.9M | $23.011 |
| Review | 79.6M | $49.003 |
| Learn | 22.5M | $7.400 |
| Complete | 2.4M | $0.818 |
| **Total** | **177.4M** | **$81.176** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **Pre-mortem #2: cwd-relative resolution breaks skill callers**
  - Dismissed — Skills use relative body-file paths AND bash cwd is set to worktree root by flow-start's cd worktree_cwd at every phase-enter; the cwd-relative resolution resolves to the same worktree path the Write tool used. The change fixes the user's reported worktree filing bug rather than breaking skill callers.
- ✗ **Pre-mortem #4: pre_exec rmdir test introduces async-signal-unsafety risk**
  - Dismissed — Pre-mortem agent self-discarded this finding: the trace shows the test follows the documented pattern in .claude/rules/reachable-is-testable.md Fixture recipes and the libc::rmdir AS-safety is upheld. The risk is theoretical, not actual.
- ✗ **Documentation #2: read_body_file doc comment lacks test-strategy warning that relative-path branch requires subprocess testing**
  - Dismissed — Bureaucratic per .claude/rules/review-scope.md value test: the constraint is implicit but discoverable from the existing subprocess tests in tests/issue.rs. A future contributor will find the pattern by reading the existing tests. The fix duplicates information already encoded in the codebase.
- ✓ **Reviewer #1 / Documentation #1: filing-issues.md 'The Pattern' prose described old project_root() resolution**
  - Fixed — Updated the rule's 'The Pattern' subsection to describe cwd-relative resolution, name validation guards (empty/dotdot/non-regular-file), and document best-effort cleanup. Routed via bin/flow write-rule per .claude/rules/file-tool-preflights.md.
- ✓ **Pre-mortem #1 / Adversarial #1: read_body_file silently followed symlinks to external files**
  - Fixed — Added fs::symlink_metadata gate with file_type().is_file() check before File::open; non-regular-file targets (symlinks, directories, FIFOs) now reject with 'not a regular file'. Mirrors sibling validate_issue_body::read_body per .claude/rules/external-input-path-construction.md. New test read_body_file_symlink_target_rejected_and_preserved proves the symlink target is preserved.
- ✓ **Adversarial #2: read_body_file resolved relative '../foo' paths and read/deleted files outside cwd**
  - Fixed — Added Path::components iteration to reject any Component::ParentDir segment in relative paths before joining with cwd. The validator runs upfront so the resolved path is guaranteed to stay within cwd's subtree. New test read_body_file_relative_dotdot_traversal_rejected covers the branch.
- ✓ **Adversarial #3: cleanup-on-failure doc comment overstated 'removed on both arms' when fs::remove_file errors are silently swallowed**
  - Fixed — Doc comment updated to say best-effort cleanup with explicit note that fs::remove_file errors are swallowed and callers needing strict cleanup must handle deletion themselves. Adversarial probe's strict-cleanup assertion was the wrong contract for a CLI tool; the probe test was deleted per .claude/rules/adversarial-probe-lifecycle.md.
- ✓ **Adversarial #4: empty --body-file string resolved to caller cwd and attempted fs::remove_file on the cwd directory**
  - Fixed — Added upfront path.is_empty() check that rejects empty arguments before any path construction or filesystem call. The fs::remove_file-on-directory accidental defense (which previously rejected removing a directory) is no longer load-bearing. New test read_body_file_empty_path_rejected covers the branch.
- ✓ **Pre-mortem #3: read_body_file had no byte cap on fs::read_to_string enabling OOM / unbounded I/O**
  - Fixed — Added PLAN_BODY_BYTE_CAP-bounded read via BufReader::new(file.take(PLAN_BODY_BYTE_CAP as u64 + 1)) using the existing constant from plan_from_issue. Bodies exceeding the cap are rejected with 'body exceeds N bytes' AND still cleaned up. Mirrors sibling validate_issue_body::read_body pattern. New test read_body_file_body_exceeding_cap_rejected_and_cleaned_up covers the branch.

<!-- end:Review Findings -->

## Learn Findings

- ✗ **Tenant 3: Missing rule for cwd-dependent function testing**
  - Dismissed — Pattern is already documented across existing rules — .claude/rules/subprocess-test-hygiene.md covers env-var/cwd isolation for subprocess tests; .claude/rules/reachable-is-testable.md 'Fixture recipes' section names the canonical pre_exec rmdir pattern for current_dir() Err coverage. A new rule would duplicate existing guidance the Review system already drew on.
- ✗ **Tenant 3: Missing rule for best-effort cleanup on both success and error arms**
  - Dismissed — Caught by Review's adversarial agent (Finding Adv #3) and remediated in this PR — doc comment updated to describe best-effort semantics and the contract is now precise. The system already closed this gap via Review; codifying further would be backward-facing per .claude/rules/forward-facing-authoring.md.
- ✗ **Tenant 3: Extend rust-patterns.md 'Symlink-Safe Existence Checks Before Writes' to also cover reads**
  - Dismissed — Caught by Review's adversarial agent (Finding Adv #1) and Pre-mortem (#1) and remediated in this PR — read_body_file now uses fs::symlink_metadata + is_file() check before File::open. The broader rule .claude/rules/external-input-path-construction.md already requires validation before path-construction sinks and was the rule Review applied; extending the writes-only rule wording in rust-patterns.md is a narrow generalization where the existing external-input rule already gives sufficient guidance. Value test fails.

<!-- end:Learn Findings -->

## State File

<details>
<summary>.flow-states/fix-bin-flow-issue---body-file.json</summary>

````json
{
  "schema_version": 1,
  "branch": "fix-bin-flow-issue---body-file",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1605,
  "pr_url": "https://github.com/benkruger/flow/pull/1605",
  "started_at": "2026-05-15T17:02:44-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/fix-bin-flow-issue---body-file/log",
    "state": ".flow-states/fix-bin-flow-issue---body-file/state.json"
  },
  "session_tty": "/dev/ttys007",
  "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/431cd65c-3be4-4187-96d1-99a88fc997f8.jsonl",
  "notes": [],
  "prompt": "#1603",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-15T17:02:44-07:00",
      "completed_at": "2026-05-15T17:03:37-07:00",
      "session_started_at": null,
      "cumulative_seconds": 53,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T17:02:44-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 10,
        "seven_day_pct": 7,
        "session_input_tokens": 66,
        "session_output_tokens": 5918,
        "session_cache_creation_tokens": 918883,
        "session_cache_read_tokens": 2889264,
        "session_cost_usd": 12.336738549999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 66,
            "output": 5918,
            "cache_create": 918883,
            "cache_read": 2889264
          }
        },
        "turn_count": 16,
        "tool_call_count": 7,
        "context_at_last_turn_tokens": 245683,
        "context_window_pct": 122.8415
      },
      "window_at_complete": {
        "captured_at": "2026-05-15T17:03:37-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 10,
        "seven_day_pct": 7,
        "session_input_tokens": 78,
        "session_output_tokens": 11442,
        "session_cache_creation_tokens": 925710,
        "session_cache_read_tokens": 5853358,
        "session_cost_usd": 13.280652299999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 78,
            "output": 11442,
            "cache_create": 925710,
            "cache_read": 5853358
          }
        },
        "turn_count": 28,
        "tool_call_count": 14,
        "context_at_last_turn_tokens": 248869,
        "context_window_pct": 124.4345
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-15T17:03:57-07:00",
      "completed_at": "2026-05-15T17:19:46-07:00",
      "session_started_at": null,
      "cumulative_seconds": 949,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T17:03:57-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 10,
        "seven_day_pct": 7,
        "session_input_tokens": 91,
        "session_output_tokens": 15073,
        "session_cache_creation_tokens": 946008,
        "session_cache_read_tokens": 7098366,
        "session_cost_usd": 13.623704799999995,
        "by_model": {
          "claude-opus-4-7": {
            "input": 91,
            "output": 15073,
            "cache_create": 946008,
            "cache_read": 7098366
          }
        },
        "turn_count": 33,
        "tool_call_count": 16,
        "context_at_last_turn_tokens": 258855,
        "context_window_pct": 129.4275
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-15T17:16:15-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 12,
          "seven_day_pct": 7,
          "session_input_tokens": 187,
          "session_output_tokens": 77772,
          "session_cache_creation_tokens": 1683767,
          "session_cache_read_tokens": 53120376,
          "session_cost_usd": 29.316864800000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 187,
              "output": 77772,
              "cache_create": 1683767,
              "cache_read": 53120376
            }
          },
          "turn_count": 129,
          "tool_call_count": 71,
          "context_at_last_turn_tokens": 532227,
          "context_window_pct": 266.1135
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-15T17:16:15-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 12,
          "seven_day_pct": 7,
          "session_input_tokens": 187,
          "session_output_tokens": 77772,
          "session_cache_creation_tokens": 1683767,
          "session_cache_read_tokens": 53120376,
          "session_cost_usd": 29.316864800000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 187,
              "output": 77772,
              "cache_create": 1683767,
              "cache_read": 53120376
            }
          },
          "turn_count": 129,
          "tool_call_count": 71,
          "context_at_last_turn_tokens": 532227,
          "context_window_pct": 266.1135
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-15T17:16:15-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 12,
          "seven_day_pct": 7,
          "session_input_tokens": 187,
          "session_output_tokens": 77772,
          "session_cache_creation_tokens": 1683767,
          "session_cache_read_tokens": 53120376,
          "session_cost_usd": 29.316864800000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 187,
              "output": 77772,
              "cache_create": 1683767,
              "cache_read": 53120376
            }
          },
          "turn_count": 129,
          "tool_call_count": 71,
          "context_at_last_turn_tokens": 532227,
          "context_window_pct": 266.1135
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-15T17:16:15-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 12,
          "seven_day_pct": 7,
          "session_input_tokens": 187,
          "session_output_tokens": 77772,
          "session_cache_creation_tokens": 1683767,
          "session_cache_read_tokens": 53120376,
          "session_cost_usd": 29.316864800000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 187,
              "output": 77772,
              "cache_create": 1683767,
              "cache_read": 53120376
            }
          },
          "turn_count": 129,
          "tool_call_count": 71,
          "context_at_last_turn_tokens": 532227,
          "context_window_pct": 266.1135
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-15T17:16:15-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 12,
          "seven_day_pct": 7,
          "session_input_tokens": 187,
          "session_output_tokens": 77772,
          "session_cache_creation_tokens": 1683767,
          "session_cache_read_tokens": 53120376,
          "session_cost_usd": 29.316864800000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 187,
              "output": 77772,
              "cache_create": 1683767,
              "cache_read": 53120376
            }
          },
          "turn_count": 129,
          "tool_call_count": 71,
          "context_at_last_turn_tokens": 532227,
          "context_window_pct": 266.1135
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-15T17:18:56-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 13,
          "seven_day_pct": 7,
          "session_input_tokens": 243,
          "session_output_tokens": 98805,
          "session_cache_creation_tokens": 1737432,
          "session_cache_read_tokens": 68827810,
          "session_cost_usd": 34.2662733,
          "by_model": {
            "claude-opus-4-7": {
              "input": 243,
              "output": 98805,
              "cache_create": 1737432,
              "cache_read": 68827810
            }
          },
          "turn_count": 158,
          "tool_call_count": 88,
          "context_at_last_turn_tokens": 555733,
          "context_window_pct": 277.8665
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-15T17:19:46-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 13,
        "seven_day_pct": 7,
        "session_input_tokens": 279,
        "session_output_tokens": 102240,
        "session_cache_creation_tokens": 1774118,
        "session_cache_read_tokens": 76102739,
        "session_cost_usd": 36.63463055,
        "by_model": {
          "claude-opus-4-7": {
            "input": 279,
            "output": 102240,
            "cache_create": 1774118,
            "cache_read": 76102739
          }
        },
        "turn_count": 171,
        "tool_call_count": 96,
        "context_at_last_turn_tokens": 570116,
        "context_window_pct": 285.058
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-15T17:19:57-07:00",
      "completed_at": "2026-05-15T17:42:56-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1379,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T17:19:57-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 13,
        "seven_day_pct": 7,
        "session_input_tokens": 291,
        "session_output_tokens": 103004,
        "session_cache_creation_tokens": 1806586,
        "session_cache_read_tokens": 78383843,
        "session_cost_usd": 37.31594905,
        "by_model": {
          "claude-opus-4-7": {
            "input": 291,
            "output": 103004,
            "cache_create": 1806586,
            "cache_read": 78383843
          }
        },
        "turn_count": 175,
        "tool_call_count": 98,
        "context_at_last_turn_tokens": 586354,
        "context_window_pct": 293.177
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-15T17:21:07-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 13,
          "seven_day_pct": 7,
          "session_input_tokens": 308,
          "session_output_tokens": 106615,
          "session_cache_creation_tokens": 1810755,
          "session_cache_read_tokens": 88376534,
          "session_cost_usd": 40.919483800000016,
          "by_model": {
            "claude-opus-4-7": {
              "input": 308,
              "output": 106615,
              "cache_create": 1810755,
              "cache_read": 88376534
            }
          },
          "turn_count": 192,
          "tool_call_count": 110,
          "context_at_last_turn_tokens": 589515,
          "context_window_pct": 294.7575
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-15T17:27:16-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 18,
          "seven_day_pct": 8,
          "session_input_tokens": 367,
          "session_output_tokens": 129399,
          "session_cache_creation_tokens": 1968837,
          "session_cache_read_tokens": 96827690,
          "session_cost_usd": 64.75929280000003,
          "by_model": {
            "claude-opus-4-7": {
              "input": 367,
              "output": 129399,
              "cache_create": 1968837,
              "cache_read": 96827690
            }
          },
          "turn_count": 206,
          "tool_call_count": 120,
          "context_at_last_turn_tokens": 627276,
          "context_window_pct": 313.638
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-15T17:30:16-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 18,
          "seven_day_pct": 8,
          "session_input_tokens": 396,
          "session_output_tokens": 157750,
          "session_cache_creation_tokens": 2034841,
          "session_cache_read_tokens": 105858032,
          "session_cost_usd": 68.13811955000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 396,
              "output": 157750,
              "cache_create": 2034841,
              "cache_read": 105858032
            }
          },
          "turn_count": 220,
          "tool_call_count": 129,
          "context_at_last_turn_tokens": 656539,
          "context_window_pct": 328.2695
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-15T17:42:47-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 19,
          "seven_day_pct": 8,
          "session_input_tokens": 489,
          "session_output_tokens": 237257,
          "session_cache_creation_tokens": 2168417,
          "session_cache_read_tokens": 155239190,
          "session_cost_usd": 85.47778504999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 489,
              "output": 237257,
              "cache_create": 2168417,
              "cache_read": 155239190
            }
          },
          "turn_count": 290,
          "tool_call_count": 174,
          "context_at_last_turn_tokens": 733577,
          "context_window_pct": 366.7885
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-15T17:26:57-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-15T17:27:03-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-15T17:27:07-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-15T17:27:12-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-15T17:42:56-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 19,
        "seven_day_pct": 8,
        "session_input_tokens": 502,
        "session_output_tokens": 237669,
        "session_cache_creation_tokens": 2200365,
        "session_cache_read_tokens": 157440562,
        "session_cost_usd": 86.31877579999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 502,
            "output": 237669,
            "cache_create": 2200365,
            "cache_read": 157440562
          }
        },
        "turn_count": 293,
        "tool_call_count": 176,
        "context_at_last_turn_tokens": 749717,
        "context_window_pct": 374.8585
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-15T17:43:08-07:00",
      "completed_at": "2026-05-15T17:47:35-07:00",
      "session_started_at": null,
      "cumulative_seconds": 267,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T17:43:08-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 19,
        "seven_day_pct": 8,
        "session_input_tokens": 514,
        "session_output_tokens": 238435,
        "session_cache_creation_tokens": 2227409,
        "session_cache_read_tokens": 160439812,
        "session_cost_usd": 87.16270579999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 514,
            "output": 238435,
            "cache_create": 2227409,
            "cache_read": 160439812
          }
        },
        "turn_count": 297,
        "tool_call_count": 178,
        "context_at_last_turn_tokens": 763238,
        "context_window_pct": 381.619
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-15T17:45:34-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-15T17:46:04-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 8,
          "session_input_tokens": 525,
          "session_output_tokens": 248969,
          "session_cache_creation_tokens": 2242583,
          "session_cache_read_tokens": 168872085,
          "session_cost_usd": 90.100707,
          "by_model": {
            "claude-opus-4-7": {
              "input": 525,
              "output": 248969,
              "cache_create": 2242583,
              "cache_read": 168872085
            }
          },
          "turn_count": 308,
          "tool_call_count": 184,
          "context_at_last_turn_tokens": 771907,
          "context_window_pct": 385.9535
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-15T17:46:35-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 8,
          "session_input_tokens": 531,
          "session_output_tokens": 250770,
          "session_cache_creation_tokens": 2245836,
          "session_cache_read_tokens": 173512789,
          "session_cost_usd": 91.69305925,
          "by_model": {
            "claude-opus-4-7": {
              "input": 531,
              "output": 250770,
              "cache_create": 2245836,
              "cache_read": 173512789
            }
          },
          "turn_count": 314,
          "tool_call_count": 188,
          "context_at_last_turn_tokens": 774388,
          "context_window_pct": 387.194
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-15T17:46:40-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 8,
          "session_input_tokens": 532,
          "session_output_tokens": 250897,
          "session_cache_creation_tokens": 2246167,
          "session_cache_read_tokens": 174287176,
          "session_cost_usd": 92.0855015,
          "by_model": {
            "claude-opus-4-7": {
              "input": 532,
              "output": 250897,
              "cache_create": 2246167,
              "cache_read": 174287176
            }
          },
          "turn_count": 315,
          "tool_call_count": 189,
          "context_at_last_turn_tokens": 774719,
          "context_window_pct": 387.3595
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-15T17:46:52-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 8,
          "session_input_tokens": 534,
          "session_output_tokens": 251182,
          "session_cache_creation_tokens": 2246529,
          "session_cache_read_tokens": 175836779,
          "session_cost_usd": 92.8697005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 534,
              "output": 251182,
              "cache_create": 2246529,
              "cache_read": 175836779
            }
          },
          "turn_count": 317,
          "tool_call_count": 191,
          "context_at_last_turn_tokens": 775081,
          "context_window_pct": 387.5405
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-15T17:47:04-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 8,
          "session_input_tokens": 537,
          "session_output_tokens": 253234,
          "session_cache_creation_tokens": 2247015,
          "session_cache_read_tokens": 178162019,
          "session_cost_usd": 93.275358,
          "by_model": {
            "claude-opus-4-7": {
              "input": 537,
              "output": 253234,
              "cache_create": 2247015,
              "cache_read": 178162019
            }
          },
          "turn_count": 320,
          "tool_call_count": 192,
          "context_at_last_turn_tokens": 775243,
          "context_window_pct": 387.6215
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-15T17:47:20-07:00",
          "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 8,
          "session_input_tokens": 556,
          "session_output_tokens": 254113,
          "session_cache_creation_tokens": 2287399,
          "session_cache_read_tokens": 181265159,
          "session_cost_usd": 94.147122,
          "by_model": {
            "claude-opus-4-7": {
              "input": 556,
              "output": 254113,
              "cache_create": 2287399,
              "cache_read": 181265159
            }
          },
          "turn_count": 324,
          "tool_call_count": 194,
          "context_at_last_turn_tokens": 789192,
          "context_window_pct": 394.596
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-15T17:47:35-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 8,
        "session_input_tokens": 558,
        "session_output_tokens": 255597,
        "session_cache_creation_tokens": 2288295,
        "session_cache_read_tokens": 182843531,
        "session_cost_usd": 94.56307,
        "by_model": {
          "claude-opus-4-7": {
            "input": 558,
            "output": 255597,
            "cache_create": 2288295,
            "cache_read": 182843531
          }
        },
        "turn_count": 326,
        "tool_call_count": 195,
        "context_at_last_turn_tokens": 789635,
        "context_window_pct": 394.8175
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-15T17:48:05-07:00",
      "completed_at": "2026-05-15T17:48:26-07:00",
      "session_started_at": null,
      "cumulative_seconds": 21,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-15T17:48:05-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 9,
        "session_input_tokens": 574,
        "session_output_tokens": 258626,
        "session_cache_creation_tokens": 2317598,
        "session_cache_read_tokens": 189204605,
        "session_cost_usd": 96.27942525,
        "by_model": {
          "claude-opus-4-7": {
            "input": 574,
            "output": 258626,
            "cache_create": 2317598,
            "cache_read": 189204605
          }
        },
        "turn_count": 334,
        "tool_call_count": 199,
        "context_at_last_turn_tokens": 804070,
        "context_window_pct": 402.035
      },
      "window_at_complete": {
        "captured_at": "2026-05-15T17:48:26-07:00",
        "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 9,
        "session_input_tokens": 577,
        "session_output_tokens": 259135,
        "session_cache_creation_tokens": 2318681,
        "session_cache_read_tokens": 191617206,
        "session_cost_usd": 97.09748249999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 577,
            "output": 259135,
            "cache_create": 2318681,
            "cache_read": 191617206
          }
        },
        "turn_count": 337,
        "tool_call_count": 201,
        "context_at_last_turn_tokens": 804759,
        "context_window_pct": 402.3795
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-15T17:03:57-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-15T17:19:57-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-15T17:43:08-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-15T17:48:05-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-15T17:02:44-07:00",
    "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
    "model": "claude-opus-4-7",
    "five_hour_pct": 10,
    "seven_day_pct": 7,
    "session_input_tokens": 66,
    "session_output_tokens": 5918,
    "session_cache_creation_tokens": 918883,
    "session_cache_read_tokens": 2889264,
    "session_cost_usd": 12.336738549999998,
    "by_model": {
      "claude-opus-4-7": {
        "input": 66,
        "output": 5918,
        "cache_create": 918883,
        "cache_read": 2889264
      }
    },
    "turn_count": 16,
    "tool_call_count": 7,
    "context_at_last_turn_tokens": 245683,
    "context_window_pct": 122.8415
  },
  "code_tasks_total": 6,
  "code_task_name": "Verify bin/flow ci passes 100/100/100",
  "code_task": 6,
  "diff_stats": {
    "files_changed": 3,
    "insertions": 223,
    "deletions": 87,
    "captured_at": "2026-05-15T17:19:46-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThis conversation is a specialized analysis task where I am being invoked as the `learn-analyst` agent (per the instructions) to audit a completed FLOW feature PR. The context provided is substantial and pre-loaded, so I should NOT invoke tools to re-read these artifacts — they are already available in my context.\n\nLet me analyze what has happened:\n\n1. **Initial Setup**: The user provided a comprehensive prompt setting up the learn-analyst task with all required artifacts already inline:\n   - DIFF content (full git diff of the PR)\n   - STATE FILE DATA (phase timings, visit counts, notes)\n   - PLAN (implementation plan the developer followed)\n   - PROJECT CLAUDE.MD (project rules)\n   - RULES FILES (domain-specific rules)\n   - System reminders with extensive .claude/rules documentation\n\n2. **The Actual Task**: I was instructed to audit a PR on branch `fix-bin-flow-issue---body-file` against three tenants:\n   - Tenant 1: Did the FLOW process work? (gaps in plugin's workflow)\n   - Tenant 2: Did Claude follow the rules? (compliance audit)\n   - Tenant 3: What rules should exist but don't? (identify gaps)\n\n3. **What I Did**: I began executing the task by reading the provided artifacts (DIFF, STATE FILE, PLAN). I was collecting context to perform the analysis before writing findings.\n\n4. **The Critical Instruction**: At the very end, the user provided a CRITICAL instruction: \"Respond with TEXT ONLY. Do NOT call any tools\" and requested instead a detailed summary of the conversation for continuation purposes.\n\n5. **The Dilemma**: The user asked me to provide a summary before I had actually completed the learn-analyst task. This is a context-compaction scenario where the conversation needs to be summarized to preserve context before I can continue with the actual analysis.\n\nKey observations about the provided context:\n- The DIFF shows changes to `src/issue.rs` and `src/main.rs` to fix `read_body_file` function signature and path resolution\n- The plan describes changing relative path resolution from `project_root()` to `std::env::current_dir()`\n- The state file shows this PR completed all phases: Start (1 visit), Code (1 visit), Review (1 visit), Learn (in_progress, 1 visit)\n- Multiple findings were already recorded during Review phase indicating path validation and cleanup-on-failure issues were caught and fixed\n- The session used claude-opus-4-7 model across all phases\n\nThe user is now asking me to create a summary so that the context can be preserved for the continuation of the learn-analyst work.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user has invoked me as the `learn-analyst` sub-agent to perform a compliance and process audit of a completed FLOW feature PR on branch `fix-bin-flow-issue---body-file` (PR #1605). The audit is against three specific tenants:\n   - **Tenant 1 (Process Gap Analysis)**: Identify gaps in the FLOW plugin's workflow (tools, skills, hooks, phase gates) that caused friction or failure during this feature development. Look for patterns like dangling async operations, high visit counts (revisits), and missing automation.\n   - **Tenant 2 (Rule Compliance Audit)**: Determine whether Claude followed project rules (from PROJECT CLAUDE.MD and RULES FILES). For each violation, assess enforcement level (Unclear or Ignored) and recommend fixes.\n   - **Tenant 3 (Missing Rules)**: Identify patterns in the diff where something questionable happened but no existing rule covers it—these become new rule proposals.\n   \n   The analysis must follow a specific output format with structured findings blocks, each including Category (Process gap / Rule compliance / Missing rule), Enforcement level, Evidence, Location, and Recommendation. The output must end with the literal marker `## END-OF-FINDINGS`.\n\n2. Key Technical Concepts:\n   - **FLOW plugin architecture**: 5-phase development lifecycle (Start, Code, Review, Learn, Complete) with phase gates, state files, sub-agents, and orchestration via `bin/flow` Rust subcommands\n   - **State file system**: `.flow-states/<branch>/state.json` tracks phase status, visit counts, cumulative time per phase, agent returns, findings, and session metrics\n   - **Sub-agent isolation pattern**: Required agents (reviewer, pre-mortem, adversarial, documentation in Review; learn-analyst in Learn) invoked as foreground agents, transcript-verified returns via `bin/flow record-agent-return`\n   - **Path resolution models**: The PR changes `read_body_file` from `project_root()`-based resolution to `std::env::current_dir()`-based resolution for relative paths\n   - **Cleanup-on-failure pattern**: The PR adds cleanup (`fs::remove_file`) to both success and error arms of `read_body_file` to prevent orphaned temp files\n   - **Symlink and traversal safety**: The PR (per findings) adds `fs::symlink_metadata` checks and `.ParentDir` rejection to prevent following symlinks or reading outside the resolved directory\n   - **Byte cap enforcement**: The PR adds `PLAN_BODY_BYTE_CAP`-bounded reads via `BufReader::take()` to prevent unbounded I/O\n   - **Subprocess test hygiene**: Tests use `Command::current_dir()` for cwd control, `pre_exec` for edge cases (cwd deletion), and env neutralization (`GH_TOKEN=invalid`, `HOME=<tempdir>`, `env_remove(\"FLOW_CI_RUNNING\")`)\n\n3. Files and Code Sections:\n   - **`/Users/ben/code/flow/.flow-states/fix-bin-flow-issue---body-file/full-diff.diff`**\n     - The substantive diff showing all changes in the PR. Contains modifications to `src/issue.rs`, `src/main.rs`, and `tests/issue.rs` totaling 223 insertions and 87 deletions.\n     - Key change: `read_body_file(path: &str, root: &Path) -> Result<String, String>` → `read_body_file(path: &str) -> Result<String, String>` with internal `std::env::current_dir()` resolution for relative paths.\n     - Cleanup changed from success-only to both-arms: both `Ok` and `Err` branches now call `let _ = fs::remove_file(&resolved);`\n     - Test changes include renaming old tests, rewriting two tests as subprocess tests, and adding new coverage tests.\n\n   - **`/Users/ben/code/flow/.flow-states/fix-bin-flow-issue---body-file/state.json`**\n     - Complete state file showing:\n       - PR #1605, branch `fix-bin-flow-issue---body-file`\n       - All phases complete except Learn (in_progress)\n       - flow-start: 1 visit, 53 cumulative seconds\n       - flow-code: 1 visit, 949 cumulative seconds, 6 code tasks completed\n       - flow-review: 1 visit, 1379 cumulative seconds, 4 review steps completed, all 4 agents returned (reviewer, pre-mortem, adversarial, documentation)\n       - flow-learn: in_progress, 1 visit, session_started_at 2026-05-15T17:43:08-07:00\n       - 8 findings recorded with outcomes: 5 fixed, 3 dismissed\n       - Session used claude-opus-4-7 throughout\n\n   - **`/Users/ben/code/flow/.flow-states/fix-bin-flow-issue---body-file/plan.md`**\n     - Implementation plan showing the developer's approach to fixing the feature\n     - Context: Bug was that `bin/flow issue --body-file <relative-path>` in a linked worktree resolved relative paths against `project_root()` instead of the caller's cwd, causing the split problem described in `filing-issues.md`\n     - Approach: Change resolution to `std::env::current_dir()` and run cleanup on both success and failure\n     - Tests changed from 5 signature-only updates, 1 rename, 2 rewrites as subprocess tests\n     - Risks covered: cwd error branch (pre_exec rmdir), parallel test races (per-subprocess cwd), chmod 000 cleanup, atomicity with caller update, subprocess env hygiene\n     - Dependency graph shows 6 tasks with an atomic commit group (Tasks 1–5)\n\n   - **`.claude/rules/filing-issues.md` (\"The Pattern\" subsection)**\n     - Per the state file findings, this rule file was updated to reflect the PR's change from `project_root()`-based to `std::env::current_dir()`-based resolution\n     - The old prose described the \"split\" problem (Write tool writes to worktree but `bin/flow issue` looks at project root) which is now fixed\n     - Finding #4 (Reviewer #1 / Documentation #1) recorded: \"filing-issues.md 'The Pattern' prose described old project_root() resolution — Updated the rule's 'The Pattern' subsection to describe cwd-relative resolution, name validation guards (empty/dotdot/non-regular-file), and document best-effort cleanup. Routed via bin/flow write-rule.\"\n\n   - **`src/issue.rs`**\n     - Lines 170–186 (per plan): `read_body_file` function signature and implementation\n     - Old doc comment: \"Relative paths are resolved against `root`.\"\n     - New doc comment: \"Relative paths resolve against the caller's current working directory via `std::env::current_dir()`; absolute paths are used as given. The body file is removed on both the success and failure arms so a read error does not orphan the temp file in the caller's directory.\"\n     - Implementation changes:\n       ```rust\n       pub fn read_body_file(path: &str) -> Result<String, String> {\n           let resolved: PathBuf = if Path::new(path).is_absolute() {\n               PathBuf::from(path)\n           } else {\n               let cwd = std::env::current_dir()\n                   .map_err(|e| format!(\"Could not determine current directory: {}\", e))?;\n               cwd.join(path)\n           };\n           match fs::read_to_string(&resolved) {\n               Ok(body) => {\n                   let _ = fs::remove_file(&resolved);\n                   Ok(body)\n               }\n               Err(e) => {\n                   let _ = fs::remove_file(&resolved);\n                   Err(format!(\"Could not read body file '{}': {}\", resolved.display(), e))\n               }\n           }\n       }\n       ```\n     - Per Review findings, additional validation was added (not shown in original diff provided):\n       - `fs::symlink_metadata` check with `file_type().is_file()` to reject non-regular files (Finding #5)\n       - `Path::components` iteration to reject `..` (ParentDir) segments in relative paths (Finding #6)\n       - Empty-path check rejecting empty strings upfront (Finding #8)\n       - Byte cap enforcement via `BufReader::take(PLAN_BODY_BYTE_CAP as u64 + 1)` (Finding #9)\n\n   - **`src/main.rs` (line 659 area)**\n     - Call site in `Commands::Issue` arm:\n       - Old: `let (value, code) = issue::run_impl_main(args, &root, &state_reader, &repo_resolver);`\n       - New: `let (value, code) = issue::run_impl_main(args, &state_reader, &repo_resolver);`\n     - The `root` parameter was dropped from `run_impl_main` call (remaining in the function signature for unrelated repo resolution)\n\n   - **`tests/issue.rs` (lines 802–1469)**\n     - Section marker `// --- read_body_file ---` at L802\n     - Test changes:\n       - 5 tests with signature-only updates (dropped second argument): `read_body_file_reads_and_deletes`, `read_body_file_missing_returns_error`, `read_body_file_empty_returns_empty_string`, `read_body_file_rich_markdown_preserved`, and one more\n       - Renamed: `read_body_file_absolute_ignores_root` → `read_body_file_absolute_path_unaffected_by_cwd`\n       - Rewritten as subprocess tests: `read_body_file_relative_resolved_against_root` → `read_body_file_relative_resolves_against_caller_cwd` and `read_body_file_relative_missing_returns_error`\n       - New tests added: `read_body_file_cleans_up_on_read_failure` (chmod 000 test), `read_body_file_current_dir_error_propagated` (pre_exec rmdir test), and per Review findings: `read_body_file_symlink_target_rejected_and_preserved`, `read_body_file_relative_dotdot_traversal_rejected`, `read_body_file_empty_path_rejected`, `read_body_file_body_exceeding_cap_rejected_and_cleaned_up`\n       - All gate tests (`gate_blocks_when_current_phase_is_review`, etc.) had their `run_impl_main` calls updated to remove the `dir.path()` argument\n\n4. Errors and fixes:\n   - No errors were encountered during the conversation. The user did not report any execution failures or corrections needed to my approach. The only instruction given was the CRITICAL redirect to switch from tool-based analysis to text-only summary creation.\n\n5. Problem Solving:\n   - The primary problem being solved is the linked-worktree bug where `bin/flow issue --body-file <relative-path>` in a worktree resolved relative paths against the git project root rather than the caller's cwd, causing a mismatch with where the Write tool placed the file. This was fixed by switching from `project_root().join(path)` to `std::env::current_dir().join(path)` for relative paths.\n   - Secondary improvements (per Review findings): added symlink safety checks, parent-directory traversal prevention, empty-path validation, byte-cap enforcement, and cleanup-on-failure semantics. All were discovered and fixed during the Review phase (5 findings fixed, 3 dismissed).\n   - The PR successfully navigated all phases with no revisits (visit_count == 1 for each), indicating the approach was solid and Review caught edge-case safety issues that were remediated.\n\n6. All user messages:\n   - Initial system-reminder message establishing the learn-analyst role, providing all artifacts inline (DIFF, STATE FILE DATA, PLAN, PROJECT CLAUDE.MD, RULES FILES), and instructing to audit the three tenants, return findings in structured format, and end with `## END-OF-FINDINGS` marker.\n   - CRITICAL final instruction: \"Respond with TEXT ONLY. Do NOT call any tools... Your entire response must be plain text: an `<analysis>` block followed by a `<summary>` block.\" This redirected from tool-based investigation to context-preservation summary.\n   - Security-relevant instructions: The rules mention never using `cd <path> && git` (use `git -C <path>`), never running `cargo` directly (use `bin/flow ci`), and preserving certain restrictions. These remain in effect and must be continued.\n\n7. Pending Tasks:\n   - **Complete the learn-analyst audit** against the three tenants once context is restored. This requires:\n     - Analyzing whether the FLOW process worked (Tenant 1): check for process gaps in the workflow\n     - Auditing rule compliance (Tenant 2): verify Claude followed all project rules and classify violations\n     - Identifying missing rules (Tenant 3): find patterns the diff shows but rules don't cover\n   - **Write structured findings** in the format: `**Finding N: [Short title]** - Category: ... - Enforcement: ... - Evidence: ... - Where: ... - Recommendation: ...`\n   - **Emit the completion marker** `## END-OF-FINDINGS` at the end of all findings\n\n8. Current Work:\n   The work immediately before the summary request was the initialization of the learn-analyst audit. I had read the provided artifacts (DIFF, STATE FILE, PLAN) to gather context for analyzing whether the FLOW process worked (Tenant 1), whether Claude followed the rules (Tenant 2), and what rules should exist but don't (Tenant 3). The state file showed all Review findings already recorded, indicating the artifact data is complete and the learn-analyst simply needs to audit whether the process and rules were sound. The user then requested a context-preservation summary before I could write findings.\n\n9. Optional Next Step:\n   Upon context restoration, the next step is to **resume the learn-analyst audit and produce findings**. The task statement is: \"Audit Tenant 1 (process gaps), Tenant 2 (rule compliance), Tenant 3 (missing rules). Return findings via your declared Output Format, ending with the END-OF-FINDINGS marker.\"\n   \n   The analysis should focus on:\n   - Whether the FLOW phases and sub-agents worked as designed (all phases completed with 1 visit each = no friction signal)\n   - Whether Review's caught-and-fixed findings indicate the rule system is adequate or has gaps (8 findings total: 5 fixed, 3 dismissed)\n   - Whether any undiscovered patterns in the diff suggest new rules are needed (e.g., cwd-dependent function testing patterns, validation-before-construction patterns)\n   \n   Direct quote from initial instructions: \"Audit Tenant 1 (process gaps), Tenant 2 (rule compliance), Tenant 3 (missing rules). Return findings via your declared Output Format, ending with the END-OF-FINDINGS marker.\"\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/fix-bin-flow-issue---body-file",
  "compact_count": 2,
  "findings": [
    {
      "finding": "Pre-mortem #2: cwd-relative resolution breaks skill callers",
      "reason": "Skills use relative body-file paths AND bash cwd is set to worktree root by flow-start's cd worktree_cwd at every phase-enter; the cwd-relative resolution resolves to the same worktree path the Write tool used. The change fixes the user's reported worktree filing bug rather than breaking skill callers.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T17:29:47-07:00"
    },
    {
      "finding": "Pre-mortem #4: pre_exec rmdir test introduces async-signal-unsafety risk",
      "reason": "Pre-mortem agent self-discarded this finding: the trace shows the test follows the documented pattern in .claude/rules/reachable-is-testable.md Fixture recipes and the libc::rmdir AS-safety is upheld. The risk is theoretical, not actual.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T17:29:54-07:00"
    },
    {
      "finding": "Documentation #2: read_body_file doc comment lacks test-strategy warning that relative-path branch requires subprocess testing",
      "reason": "Bureaucratic per .claude/rules/review-scope.md value test: the constraint is implicit but discoverable from the existing subprocess tests in tests/issue.rs. A future contributor will find the pattern by reading the existing tests. The fix duplicates information already encoded in the codebase.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T17:30:01-07:00"
    },
    {
      "finding": "Reviewer #1 / Documentation #1: filing-issues.md 'The Pattern' prose described old project_root() resolution",
      "reason": "Updated the rule's 'The Pattern' subsection to describe cwd-relative resolution, name validation guards (empty/dotdot/non-regular-file), and document best-effort cleanup. Routed via bin/flow write-rule per .claude/rules/file-tool-preflights.md.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T17:40:24-07:00"
    },
    {
      "finding": "Pre-mortem #1 / Adversarial #1: read_body_file silently followed symlinks to external files",
      "reason": "Added fs::symlink_metadata gate with file_type().is_file() check before File::open; non-regular-file targets (symlinks, directories, FIFOs) now reject with 'not a regular file'. Mirrors sibling validate_issue_body::read_body per .claude/rules/external-input-path-construction.md. New test read_body_file_symlink_target_rejected_and_preserved proves the symlink target is preserved.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T17:40:31-07:00"
    },
    {
      "finding": "Adversarial #2: read_body_file resolved relative '../foo' paths and read/deleted files outside cwd",
      "reason": "Added Path::components iteration to reject any Component::ParentDir segment in relative paths before joining with cwd. The validator runs upfront so the resolved path is guaranteed to stay within cwd's subtree. New test read_body_file_relative_dotdot_traversal_rejected covers the branch.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T17:40:41-07:00"
    },
    {
      "finding": "Adversarial #3: cleanup-on-failure doc comment overstated 'removed on both arms' when fs::remove_file errors are silently swallowed",
      "reason": "Doc comment updated to say best-effort cleanup with explicit note that fs::remove_file errors are swallowed and callers needing strict cleanup must handle deletion themselves. Adversarial probe's strict-cleanup assertion was the wrong contract for a CLI tool; the probe test was deleted per .claude/rules/adversarial-probe-lifecycle.md.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T17:40:56-07:00"
    },
    {
      "finding": "Adversarial #4: empty --body-file string resolved to caller cwd and attempted fs::remove_file on the cwd directory",
      "reason": "Added upfront path.is_empty() check that rejects empty arguments before any path construction or filesystem call. The fs::remove_file-on-directory accidental defense (which previously rejected removing a directory) is no longer load-bearing. New test read_body_file_empty_path_rejected covers the branch.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T17:41:04-07:00"
    },
    {
      "finding": "Pre-mortem #3: read_body_file had no byte cap on fs::read_to_string enabling OOM / unbounded I/O",
      "reason": "Added PLAN_BODY_BYTE_CAP-bounded read via BufReader::new(file.take(PLAN_BODY_BYTE_CAP as u64 + 1)) using the existing constant from plan_from_issue. Bodies exceeding the cap are rejected with 'body exceeds N bytes' AND still cleaned up. Mirrors sibling validate_issue_body::read_body pattern. New test read_body_file_body_exceeding_cap_rejected_and_cleaned_up covers the branch.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-15T17:41:12-07:00"
    },
    {
      "finding": "Tenant 3: Missing rule for cwd-dependent function testing",
      "reason": "Pattern is already documented across existing rules — .claude/rules/subprocess-test-hygiene.md covers env-var/cwd isolation for subprocess tests; .claude/rules/reachable-is-testable.md 'Fixture recipes' section names the canonical pre_exec rmdir pattern for current_dir() Err coverage. A new rule would duplicate existing guidance the Review system already drew on.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-15T17:46:12-07:00"
    },
    {
      "finding": "Tenant 3: Missing rule for best-effort cleanup on both success and error arms",
      "reason": "Caught by Review's adversarial agent (Finding Adv #3) and remediated in this PR — doc comment updated to describe best-effort semantics and the contract is now precise. The system already closed this gap via Review; codifying further would be backward-facing per .claude/rules/forward-facing-authoring.md.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-15T17:46:20-07:00"
    },
    {
      "finding": "Tenant 3: Extend rust-patterns.md 'Symlink-Safe Existence Checks Before Writes' to also cover reads",
      "reason": "Caught by Review's adversarial agent (Finding Adv #1) and Pre-mortem (#1) and remediated in this PR — read_body_file now uses fs::symlink_metadata + is_file() check before File::open. The broader rule .claude/rules/external-input-path-construction.md already requires validation before path-construction sinks and was the rule Review applied; extending the writes-only rule wording in rust-patterns.md is a narrow generalization where the existing external-input rule already gives sufficient guidance. Value test fails.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-15T17:46:28-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-15T17:48:26-07:00",
    "session_id": "431cd65c-3be4-4187-96d1-99a88fc997f8",
    "model": "claude-opus-4-7",
    "five_hour_pct": 20,
    "seven_day_pct": 9,
    "session_input_tokens": 577,
    "session_output_tokens": 259135,
    "session_cache_creation_tokens": 2318681,
    "session_cache_read_tokens": 191617206,
    "session_cost_usd": 97.09748249999998,
    "by_model": {
      "claude-opus-4-7": {
        "input": 577,
        "output": 259135,
        "cache_create": 2318681,
        "cache_read": 191617206
      }
    },
    "turn_count": 337,
    "tool_call_count": 201,
    "context_at_last_turn_tokens": 804759,
    "context_window_pct": 402.3795
  },
  "_auto_continue": "/flow:flow-complete"
}
````

</details>