### PR TITLE
Flow Reset Rejects Non Main

### DIFF
--- a/docs/skills/flow-reset.md
+++ b/docs/skills/flow-reset.md
@@ -13,20 +13,21 @@ parent: Skills
 The nuclear option. Removes all FLOW artifacts from the current project in one
 sweep — worktrees, state files, local and remote branches, and open PRs.
 
-Must be run from the `main` branch. Inventories everything before acting and
-requires explicit confirmation.
+Must be run from the repository's integration branch (whatever
+`bin/flow base-branch` resolves to — `main`, `staging`, `develop`, etc.).
+Inventories everything before acting and requires explicit confirmation.
 
 ---
 
 ## What It Does
 
-1. Checks that the current branch is `main`
+1. Checks that the current branch matches `bin/flow base-branch`
 2. Runs `bin/flow cleanup . --all --dry-run` to print the inventory
    of artifacts that would be removed: every flow's per-branch
    directory under `.flow-states/<branch>/`, the orchestration queue
    singleton (`orchestrate.json`), the base-branch CI sentinel
-   directory (`.flow-states/main/`), and any residual start-lock
-   entries
+   directory at `.flow-states/<base-branch>/`, and any residual
+   start-lock entries
 3. Displays the JSON inventory and asks for confirmation
 4. Runs `bin/flow cleanup . --all` to perform the live cleanup. Each
    per-flow cleanup closes the PR, removes the worktree, deletes
@@ -34,7 +35,7 @@ requires explicit confirmation.
    sweeps the matching start-queue entry. The walk continues when
    individual per-flow steps fail.
 5. Verifies via `git worktree list` and `git branch --list` that
-   only `main` remains
+   only the integration branch remains
 
 ---
 
@@ -53,7 +54,7 @@ requires explicit confirmation.
 | **Scope** | Single feature | All features |
 | **When** | Abandon one feature | Clean everything |
 | **State file** | Required (warns if missing) | Not required |
-| **Prerequisite** | Active FLOW feature | Must be on `main` |
+| **Prerequisite** | Active FLOW feature | Must be on the integration branch |
 
 Use `/flow-abort` to walk away from one feature.
 Use `/flow-reset` to start completely fresh.
@@ -62,6 +63,6 @@ Use `/flow-reset` to start completely fresh.
 
 ## Gates
 
-- Must be on `main` branch
+- Must be on the integration branch (whatever `bin/flow base-branch` returns)
 - Requires explicit user confirmation before any destructive action
 - All operations are irreversible

--- a/skills/flow-reset/SKILL.md
+++ b/skills/flow-reset/SKILL.md
@@ -14,28 +14,40 @@ and PRs that the per-feature `/flow:flow-abort` cannot reach.
 The skill is a thin wrapper around `bin/flow cleanup --all`. The Rust primitive
 walks `.flow-states/` for every flow with a `state.json`, runs the per-branch
 cleanup against each, then runs the three machine-level tail steps
-(`orchestrate.json`, `.flow-states/main/`, `start-queue/` sweep). The directory
-shells (`.flow-states/`, `.flow-states/start-queue/`) survive so subsequent
+(`orchestrate.json`, the base-branch CI sentinel directory at
+`.flow-states/<base_branch>/`, `start-queue/` sweep). The directory shells
+(`.flow-states/`, `.flow-states/start-queue/`) survive so subsequent
 flow-starts do not need to recreate them.
 
 ## Guard
 
-Reset must run from the project root with `main` checked out. Running from a
-worktree would attempt to remove the worktree mid-execution.
+Reset must run from the project root with the repository's integration branch
+checked out. Running from a worktree would attempt to remove the worktree
+mid-execution. The integration branch is whatever `origin/HEAD` resolves to —
+`main` for most repos, but `staging`, `develop`, `master`, etc. for others —
+and `bin/flow base-branch` prints the resolved name.
+
+Run both commands and compare the outputs:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow base-branch
+```
 
 ```bash
 git branch --show-current
 ```
 
-If the current branch is NOT `main`, stop:
+If the current branch is NOT the resolved base branch, stop and substitute the
+resolved name into the rejection message:
 
-> "Must be on main branch to reset. Switch to main first."
+> "Must be on `<base_branch>` branch to reset. Switch to `<base_branch>` first."
 
 ## Step 1 — Inventory
 
 Print the inventory of what `--all` would remove without modifying disk. The
-JSON output's `flows[]`, `orchestrate_json`, `main_dir`, and `queue_sweep`
-fields describe every artifact that the live run would touch.
+JSON output's `flows[]`, `orchestrate_json`, `base_dir` (the base-branch CI
+sentinel directory result), `base_branch` (the resolved trunk name), and
+`queue_sweep` fields describe every artifact that the live run would touch.
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/bin/flow cleanup . --all --dry-run
@@ -44,7 +56,7 @@ ${CLAUDE_PLUGIN_ROOT}/bin/flow cleanup . --all --dry-run
 Render the JSON output inline inside a fenced code block so the user can
 review it before approving the destructive run.
 
-If `flows[]` is empty AND `orchestrate_json` is `"skipped"` AND `main_dir` is
+If `flows[]` is empty AND `orchestrate_json` is `"skipped"` AND `base_dir` is
 `"skipped"` AND `queue_sweep` is `"skipped"`, print:
 
 > "No FLOW artifacts found. Nothing to reset."
@@ -77,7 +89,7 @@ the tail-step results.
 
 ## Step 4 — Verify
 
-Confirm only `main` remains.
+Confirm only the integration branch remains.
 
 ```bash
 git worktree list
@@ -88,8 +100,8 @@ git branch --list
 ```
 
 If any worktree besides the main working tree appears, or any local branch
-besides `main`, list the survivors so the user can investigate. Otherwise
-print:
+besides the resolved base branch, list the survivors so the user can
+investigate. Otherwise print:
 
 ````markdown
 ```text
@@ -101,7 +113,7 @@ print:
 
 ## Rules
 
-- Available from `main` only — running from a worktree is unsafe
+- Available from the integration branch only — running from a worktree is unsafe
 - Never rebase, never force push — the cleanup primitive only invokes the
   destructive surfaces the per-feature `/flow:flow-abort` already uses
 - Every step after confirmation is best-effort — if one per-flow step fails,

--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -675,21 +675,36 @@ pub fn cleanup_all(project_root: &Path, dry_run: bool) -> Value {
     };
 
     // Tail step: base-branch CI sentinel directory removal at
-    // `.flow-states/<base_branch>/`.
-    let base_path = states_dir.join(&base_branch);
-    let base_dir = if dry_run {
-        if base_path.is_dir() {
-            "would_remove".to_string()
+    // `.flow-states/<base_branch>/`. The resolved `base_branch`
+    // comes from `git symbolic-ref --short refs/remotes/origin/HEAD`
+    // and is unvalidated state-derived input — git permits
+    // slash-containing branches as origin/HEAD targets (e.g.
+    // `feature/main`). Per `.claude/rules/branch-path-safety.md`,
+    // the value must pass `FlowPaths::is_valid_branch` before
+    // reaching `states_dir.join(...)` + `fs::remove_dir_all(...)` —
+    // otherwise an invalid branch traverses one directory deeper
+    // than the per-branch scope and the recursive deletion can
+    // strand adjacent flow state. When the validator rejects, the
+    // tail step skips entirely; the unsafe value still surfaces in
+    // the `base_branch` JSON field for diagnostic visibility.
+    let base_dir = if !FlowPaths::is_valid_branch(&base_branch) {
+        format!("skipped: invalid base_branch {:?}", base_branch)
+    } else {
+        let base_path = states_dir.join(&base_branch);
+        if dry_run {
+            if base_path.is_dir() {
+                "would_remove".to_string()
+            } else {
+                "skipped".to_string()
+            }
+        } else if base_path.is_dir() {
+            match fs::remove_dir_all(&base_path) {
+                Ok(()) => "removed".to_string(),
+                Err(e) => format!("failed: {}", e),
+            }
         } else {
             "skipped".to_string()
         }
-    } else if base_path.is_dir() {
-        match fs::remove_dir_all(&base_path) {
-            Ok(()) => "removed".to_string(),
-            Err(e) => format!("failed: {}", e),
-        }
-    } else {
-        "skipped".to_string()
     };
 
     // Tail step: residual start-queue/ entry sweep. The queue_dir

--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -9,10 +9,12 @@
 //! - **All-flows (`--all`)** — used by `/flow:flow-reset`. Walks every
 //!   subdirectory of `.flow-states/` that contains a `state.json` and
 //!   runs the per-branch cleanup against each flow. Then runs three
-//!   machine-level tail steps: remove `orchestrate.json`, remove
-//!   `.flow-states/main/`, and sweep any residual `start-queue/` entries
-//!   left behind by interrupted starts. `--dry-run` returns an inventory
-//!   of what would be removed without modifying disk.
+//!   machine-level tail steps: remove `orchestrate.json`, remove the
+//!   base-branch CI sentinel directory at `.flow-states/<base_branch>/`
+//!   (where `<base_branch>` is resolved per-repo via
+//!   `git::default_branch_in`), and sweep any residual `start-queue/`
+//!   entries left behind by interrupted starts. `--dry-run` returns
+//!   an inventory of what would be removed without modifying disk.
 //!
 //! Per-branch usage:
 //!   bin/flow cleanup <project_root> --branch <name> --worktree <path> [--pr <number>] [--pull]
@@ -27,7 +29,7 @@
 //!
 //! All-flows output (JSON to stdout):
 //!   {"status": "ok", "dry_run": <bool>, "flows": [...], "orchestrate_json": ...,
-//!    "main_dir": ..., "queue_sweep": ...}
+//!    "base_dir": ..., "base_branch": <resolved trunk name>, "queue_sweep": ...}
 //!
 //! Each step reports one of: "removed"/"deleted"/"closed"/"pulled", "skipped", or "failed: <reason>".
 //!
@@ -489,8 +491,12 @@ pub fn cleanup(
 ///
 /// - `orchestrate.json` removal — the machine-level orchestration
 ///   queue singleton.
-/// - `.flow-states/main/` removal — the base-branch CI sentinel
-///   directory written by `start-gate`.
+/// - base-branch CI sentinel directory removal — the
+///   `.flow-states/<base_branch>/` directory written by `start-gate`,
+///   where `<base_branch>` is the repository's integration branch
+///   resolved via `git::default_branch_in` (e.g. `main`, `staging`).
+///   The resolved trunk name is surfaced in the `base_branch` field
+///   of the JSON output and the removal result lives under `base_dir`.
 /// - residual `start-queue/` entry sweep — entries left after
 ///   per-flow cleanups, e.g. orphans from interrupted starts.
 ///
@@ -511,23 +517,28 @@ pub fn cleanup(
 /// `is_safe_worktree_rel`: per-flow `error` field, walk continues.
 ///
 /// **Concurrency.** This function is invoked exclusively from
-/// `/flow:flow-reset`, whose Guard gates entry on `git branch
-/// --show-current == main` (the user must be on the integration
-/// branch at the project root). The reset is destructive by
-/// design: it sweeps the start-lock queue, deletes
-/// `.flow-states/main/` (the base-branch CI sentinel directory),
-/// and removes orchestrate.json — none of which are coordinated
-/// with the start lock. Any concurrent `flow-start` running on
-/// the same machine during a `cleanup_all` invocation will be
-/// disrupted (the next start may re-run base-branch CI because
-/// the sentinel was removed; an in-flight start may have its
-/// queue entry deleted mid-acquire). The user invoking flow-reset
-/// has accepted that "reset every FLOW artifact" includes the
-/// start lock and the orchestration queue. The 30-minute stale
-/// timeout on queue entries protects against permanent block;
-/// recovery from sentinel-loss is automatic on the next CI run.
+/// `/flow:flow-reset`, whose Guard gates entry on the user being
+/// on the repository's integration branch at the project root.
+/// The reset is destructive by design: it sweeps the start-lock
+/// queue, deletes the base-branch CI sentinel directory at
+/// `.flow-states/<base_branch>/`, and removes orchestrate.json —
+/// none of which are coordinated with the start lock. Any
+/// concurrent `flow-start` running on the same machine during a
+/// `cleanup_all` invocation will be disrupted (the next start may
+/// re-run base-branch CI because the sentinel was removed; an
+/// in-flight start may have its queue entry deleted mid-acquire).
+/// The user invoking flow-reset has accepted that "reset every
+/// FLOW artifact" includes the start lock and the orchestration
+/// queue. The 30-minute stale timeout on queue entries protects
+/// against permanent block; recovery from sentinel-loss is
+/// automatic on the next CI run.
 pub fn cleanup_all(project_root: &Path, dry_run: bool) -> Value {
     let states_dir = FlowStatesDir::new(project_root).path().to_path_buf();
+    // Resolve the repository's integration branch so the base-branch
+    // CI sentinel directory tail step targets the correct trunk.
+    // `default_branch_in` falls back to `"main"` when origin/HEAD is
+    // unset, so legacy main-trunk repos behave unchanged.
+    let base_branch = crate::git::default_branch_in(project_root);
     let mut flows: Vec<Value> = Vec::new();
 
     if states_dir.is_dir() {
@@ -663,16 +674,17 @@ pub fn cleanup_all(project_root: &Path, dry_run: bool) -> Value {
         }
     };
 
-    // Tail step: `.flow-states/main/` directory removal.
-    let main_path = states_dir.join("main");
-    let main_dir = if dry_run {
-        if main_path.is_dir() {
+    // Tail step: base-branch CI sentinel directory removal at
+    // `.flow-states/<base_branch>/`.
+    let base_path = states_dir.join(&base_branch);
+    let base_dir = if dry_run {
+        if base_path.is_dir() {
             "would_remove".to_string()
         } else {
             "skipped".to_string()
         }
-    } else if main_path.is_dir() {
-        match fs::remove_dir_all(&main_path) {
+    } else if base_path.is_dir() {
+        match fs::remove_dir_all(&base_path) {
             Ok(()) => "removed".to_string(),
             Err(e) => format!("failed: {}", e),
         }
@@ -728,7 +740,8 @@ pub fn cleanup_all(project_root: &Path, dry_run: bool) -> Value {
         "dry_run": dry_run,
         "flows": flows,
         "orchestrate_json": orchestrate_json,
-        "main_dir": main_dir,
+        "base_dir": base_dir,
+        "base_branch": base_branch,
         "queue_sweep": queue_sweep,
     })
 }

--- a/src/complete_finalize.rs
+++ b/src/complete_finalize.rs
@@ -85,10 +85,15 @@ pub fn run_impl(args: &Args) -> Value {
     let branch = &args.branch;
 
     // Best-effort logging — `try_new` tolerates slash-containing
-    // branches per `.claude/rules/external-input-validation.md`.
+    // branches per `.claude/rules/external-input-validation.md`. The
+    // guard checks the branch directory rather than the parent
+    // `.flow-states/` directory so that the post-cleanup invocation
+    // skips when cleanup has just removed the branch directory:
+    // `append_log` calls `ensure_branch_dir()`, and a parent-scoped
+    // guard would resurrect the directory cleanup just removed.
     let log = |msg: &str| {
         if let Some(paths) = FlowPaths::try_new(&root, branch) {
-            if paths.flow_states_dir().is_dir() {
+            if paths.branch_dir().is_dir() {
                 let _ = append_log(&root, branch, msg);
             }
         }

--- a/src/complete_finalize.rs
+++ b/src/complete_finalize.rs
@@ -184,21 +184,36 @@ pub fn run_impl(args: &Args) -> Value {
     // write is best-effort — a filesystem error here must not fail
     // the merge that already succeeded upstream.
     if args.pull && cleanup_map.get("git_pull").and_then(|v| v.as_str()) == Some("pulled") {
-        let snapshot = crate::ci::tree_snapshot(&root, None);
-        let sentinel = crate::ci::sentinel_path(&root, &base_branch);
-        // `sentinel_path` always returns a multi-component path
-        // under `<root>/.flow-states/<branch>/`, so `.parent()` is
-        // never None. `.expect()` is the canonical pattern for an
-        // unreachable arm per
-        // `.claude/rules/testability-means-simplicity.md`. The parent
-        // dir may not exist when the sentinel branch is the base
-        // branch (no flow ever ran on main), so create it before
-        // writing.
-        let parent = sentinel
-            .parent()
-            .expect("sentinel_path always returns a multi-component path");
-        let _ = std::fs::create_dir_all(parent);
-        let _ = std::fs::write(&sentinel, &snapshot);
+        // `base_branch` comes from the state file's `base_branch`
+        // field OR the `default_branch_in` fallback. Both sources
+        // are unvalidated state-derived input — slash-containing
+        // origin/HEAD targets (e.g. `feature/main`) and corrupt
+        // state-file values can reach this branch. `sentinel_path`
+        // calls `FlowPaths::try_new(...).expect(...)` and panics on
+        // invalid branches; per
+        // `.claude/rules/branch-path-safety.md`, callers must
+        // pattern-match on `is_valid_branch` before reaching the
+        // panicking constructor. Sentinel writing is best-effort
+        // (per the surrounding rationale), so an invalid base_branch
+        // here simply skips the write — the next start-gate run will
+        // re-establish the sentinel.
+        if FlowPaths::is_valid_branch(&base_branch) {
+            let snapshot = crate::ci::tree_snapshot(&root, None);
+            let sentinel = crate::ci::sentinel_path(&root, &base_branch);
+            // `sentinel_path` always returns a multi-component path
+            // under `<root>/.flow-states/<branch>/`, so `.parent()` is
+            // never None. `.expect()` is the canonical pattern for an
+            // unreachable arm per
+            // `.claude/rules/testability-means-simplicity.md`. The parent
+            // dir may not exist when the sentinel branch is the base
+            // branch (no flow ever ran on it yet), so create it before
+            // writing.
+            let parent = sentinel
+                .parent()
+                .expect("sentinel_path always returns a multi-component path");
+            let _ = std::fs::create_dir_all(parent);
+            let _ = std::fs::write(&sentinel, &snapshot);
+        }
     }
 
     let mut result = json!({

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -1250,6 +1250,64 @@ fn cleanup_all_removes_base_branch_sentinel_on_non_main_repo() {
     assert!(!staging_dir.exists());
 }
 
+/// `cleanup_all` resolves `base_branch` via `default_branch_in`
+/// which returns the raw output of `git symbolic-ref --short
+/// refs/remotes/origin/HEAD` with the `origin/` prefix stripped.
+/// Git permits slash-containing branch names as `origin/HEAD`
+/// targets (e.g. `feature/foo`). Per
+/// `.claude/rules/branch-path-safety.md`, that value must pass
+/// `FlowPaths::is_valid_branch` before reaching
+/// `states_dir.join(...)` + `fs::remove_dir_all(...)` — otherwise
+/// the deletion traverses one directory deeper than the per-branch
+/// scope. This test seeds `origin/HEAD → origin/feature/foo` and
+/// asserts cleanup_all skips the tail step with a structured
+/// `base_dir` field rather than deleting `.flow-states/feature/foo`
+/// (or, worse, escaping the .flow-states/ scope entirely).
+#[test]
+fn cleanup_all_skips_base_dir_when_default_branch_is_slash_containing() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_git_repo(dir.path());
+    let _ = StdCommand::new("git")
+        .args(["remote", "add", "origin", dir.path().to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .expect("git remote add");
+    let _ = StdCommand::new("git")
+        .args(["update-ref", "refs/remotes/origin/feature/foo", "HEAD"])
+        .current_dir(dir.path())
+        .output()
+        .expect("git update-ref");
+    let _ = StdCommand::new("git")
+        .args([
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/feature/foo",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .expect("git symbolic-ref");
+
+    // Create a sibling directory the deletion MUST NOT touch.
+    let sibling = dir.path().join(".flow-states/feature/foo");
+    fs::create_dir_all(&sibling).unwrap();
+    fs::write(sibling.join("ci-passed"), "snapshot").unwrap();
+
+    let value = run_impl_main(&args_all(dir.path(), false)).0;
+
+    assert_eq!(value["base_branch"], "feature/foo");
+    let base_dir_str = value["base_dir"].as_str().unwrap();
+    assert!(
+        base_dir_str.starts_with("skipped: invalid base_branch"),
+        "expected skipped tail step for invalid base_branch, got: {}",
+        base_dir_str
+    );
+    assert!(
+        sibling.exists(),
+        "sibling directory must survive — cleanup_all must not traverse \
+         into a slash-containing base_branch path"
+    );
+}
+
 #[test]
 fn cleanup_all_states_dir_unreadable_skips_per_flow_walk() {
     // Covers the `if let Ok(entries) = fs::read_dir(&states_dir)`

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -792,7 +792,7 @@ fn cleanup_all_empty_states_dir_returns_empty_inventory() {
     assert_eq!(value["dry_run"], false);
     assert_eq!(value["flows"].as_array().unwrap().len(), 0);
     assert_eq!(value["orchestrate_json"], "skipped");
-    assert_eq!(value["main_dir"], "skipped");
+    assert_eq!(value["base_dir"], "skipped");
     assert_eq!(value["queue_sweep"], "skipped");
 }
 
@@ -926,28 +926,31 @@ fn cleanup_all_skips_missing_orchestrate_json() {
 }
 
 #[test]
-fn cleanup_all_removes_main_directory() {
+fn cleanup_all_removes_base_branch_directory() {
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(dir.path());
-    let main_dir = dir.path().join(".flow-states/main");
-    fs::create_dir_all(&main_dir).unwrap();
-    fs::write(main_dir.join("ci-passed"), "snapshot").unwrap();
+    // No origin/HEAD configured → default_branch_in falls back to
+    // "main", so the sentinel directory still lives at
+    // `.flow-states/main/` for this fixture.
+    let base_dir = dir.path().join(".flow-states/main");
+    fs::create_dir_all(&base_dir).unwrap();
+    fs::write(base_dir.join("ci-passed"), "snapshot").unwrap();
 
     let value = run_impl_main(&args_all(dir.path(), false)).0;
-    assert_eq!(value["main_dir"], "removed");
-    assert!(!main_dir.exists());
+    assert_eq!(value["base_dir"], "removed");
+    assert!(!base_dir.exists());
 }
 
 #[test]
-fn cleanup_all_skips_missing_main_directory() {
+fn cleanup_all_skips_missing_base_branch_directory() {
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(dir.path());
     let states_dir = dir.path().join(".flow-states");
     fs::create_dir_all(&states_dir).unwrap();
-    // No main/ subdir.
+    // No <base_branch>/ subdir.
 
     let value = run_impl_main(&args_all(dir.path(), false)).0;
-    assert_eq!(value["main_dir"], "skipped");
+    assert_eq!(value["base_dir"], "skipped");
 }
 
 #[test]
@@ -997,7 +1000,7 @@ fn cleanup_all_dry_run_returns_inventory_no_disk_mutation() {
 
     // Tail steps report the would-be values.
     assert_eq!(value["orchestrate_json"], "would_remove");
-    assert_eq!(value["main_dir"], "would_remove");
+    assert_eq!(value["base_dir"], "would_remove");
     assert_eq!(value["queue_sweep"], "would_sweep 1 entries");
 
     // Disk is unchanged.
@@ -1129,17 +1132,17 @@ fn cleanup_all_state_json_unreadable_reports_read_error() {
 #[test]
 fn cleanup_all_dry_run_reports_skipped_when_tail_artifacts_absent() {
     // Covers the dry_run==true + file/dir absent branches for
-    // orchestrate_json and main_dir tail steps.
+    // orchestrate_json and base_dir tail steps.
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(dir.path());
     let states_dir = dir.path().join(".flow-states");
     fs::create_dir_all(&states_dir).unwrap();
-    // No orchestrate.json, no main/ subdir, no start-queue/ entries.
+    // No orchestrate.json, no <base_branch>/ subdir, no start-queue/ entries.
 
     let value = run_impl_main(&args_all(dir.path(), true)).0;
     assert_eq!(value["dry_run"], true);
     assert_eq!(value["orchestrate_json"], "skipped");
-    assert_eq!(value["main_dir"], "skipped");
+    assert_eq!(value["base_dir"], "skipped");
     assert_eq!(value["queue_sweep"], "skipped");
 }
 
@@ -1170,30 +1173,81 @@ fn cleanup_all_orchestrate_json_remove_fails() {
 }
 
 #[test]
-fn cleanup_all_main_dir_remove_fails() {
-    // Covers the main_dir `Err(e) => format!("failed: ...")` arm.
-    // `.flow-states/main/` exists with an inner file, and
-    // `.flow-states/main/` is read-only so `remove_dir_all` cannot
-    // unlink the inner file.
+fn cleanup_all_base_dir_remove_fails() {
+    // Covers the base_dir `Err(e) => format!("failed: ...")` arm.
+    // The resolved base-branch sentinel directory exists with an
+    // inner file, and the directory is read-only so `remove_dir_all`
+    // cannot unlink the inner file. With no `origin/HEAD` configured,
+    // `default_branch_in` falls back to `"main"` so the fixture
+    // path is `.flow-states/main/`.
     use std::os::unix::fs::PermissionsExt;
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(dir.path());
-    let main_subdir = dir.path().join(".flow-states/main");
-    fs::create_dir_all(&main_subdir).unwrap();
-    fs::write(main_subdir.join("ci-passed"), "snapshot").unwrap();
-    fs::set_permissions(&main_subdir, fs::Permissions::from_mode(0o500)).unwrap();
+    let base_subdir = dir.path().join(".flow-states/main");
+    fs::create_dir_all(&base_subdir).unwrap();
+    fs::write(base_subdir.join("ci-passed"), "snapshot").unwrap();
+    fs::set_permissions(&base_subdir, fs::Permissions::from_mode(0o500)).unwrap();
 
     let value = run_impl_main(&args_all(dir.path(), false)).0;
 
     // Restore for TempDir cleanup.
-    fs::set_permissions(&main_subdir, fs::Permissions::from_mode(0o755)).unwrap();
+    fs::set_permissions(&base_subdir, fs::Permissions::from_mode(0o755)).unwrap();
 
-    let md = value["main_dir"].as_str().unwrap();
+    let bd = value["base_dir"].as_str().unwrap();
     assert!(
-        md.starts_with("failed:"),
-        "expected failed main_dir, got: {}",
-        md
+        bd.starts_with("failed:"),
+        "expected failed base_dir, got: {}",
+        bd
     );
+}
+
+/// Cleanup of the base-branch CI sentinel directory must follow the
+/// repository's actual integration branch — not a hardcoded "main"
+/// path. The sentinel lives at `.flow-states/<base_branch>/` and is
+/// written by `start-gate` after a successful base-branch CI run; on
+/// a repo whose trunk is `staging`, the sentinel lives at
+/// `.flow-states/staging/` and the hardcoded `.flow-states/main/`
+/// removal misses it entirely. This test seeds the fixture with
+/// `origin/HEAD` → `origin/staging` (following the inline pattern at
+/// `tests/hooks/validate_pretool.rs::t4_git_commit_on_staging_default_repo_blocks`)
+/// and a `.flow-states/staging/` directory, then asserts cleanup_all
+/// resolves the integration branch via `git::default_branch_in`,
+/// reports the resolved trunk in a new `base_branch` field, and
+/// removes the directory under the renamed `base_dir` field.
+#[test]
+fn cleanup_all_removes_base_branch_sentinel_on_non_main_repo() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_git_repo(dir.path());
+    // Configure origin/HEAD -> origin/staging so default_branch_in
+    // returns "staging".
+    let _ = StdCommand::new("git")
+        .args(["remote", "add", "origin", dir.path().to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .expect("git remote add");
+    let _ = StdCommand::new("git")
+        .args(["update-ref", "refs/remotes/origin/staging", "HEAD"])
+        .current_dir(dir.path())
+        .output()
+        .expect("git update-ref");
+    let _ = StdCommand::new("git")
+        .args([
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/staging",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .expect("git symbolic-ref");
+
+    let staging_dir = dir.path().join(".flow-states/staging");
+    fs::create_dir_all(&staging_dir).unwrap();
+    fs::write(staging_dir.join("ci-passed"), "snapshot").unwrap();
+
+    let value = run_impl_main(&args_all(dir.path(), false)).0;
+    assert_eq!(value["base_dir"], "removed");
+    assert_eq!(value["base_branch"], "staging");
+    assert!(!staging_dir.exists());
 }
 
 #[test]

--- a/tests/complete_finalize.rs
+++ b/tests/complete_finalize.rs
@@ -208,8 +208,28 @@ fn finalize_with_broken_flow_stubs_populates_post_merge_failures() {
     );
 }
 
+/// The log closure inside `complete_finalize::run_impl` fires twice:
+/// once before cleanup (the "starting" line) and once after cleanup
+/// (the "done" line). Cleanup deletes `.flow-states/<branch>/` via
+/// `try_remove_branch_dir`. If the post-cleanup log call's guard
+/// checks `flow_states_dir().is_dir()` (the parent directory, which
+/// survives cleanup because it holds sibling branches and the
+/// machine-level singletons), `append_log` then runs
+/// `ensure_branch_dir()` and recreates the just-deleted branch
+/// directory. The result is that `.flow-states/<branch>/` returns
+/// containing only the "done" line — silently undoing cleanup's
+/// removal step.
+///
+/// This test exercises the full subprocess path with a fixture that
+/// pre-creates the branch directory. After the call returns, the
+/// branch directory must NOT exist on disk: cleanup removed it and
+/// no subsequent code path may resurrect it. The pre-cleanup
+/// "starting" log line still fires while the branch directory
+/// exists; the cleanup-side audit trail (the
+/// `[Phase 5] cleanup — in progress` line) is covered by
+/// `tests/cleanup.rs` tests against the cleanup module directly.
 #[test]
-fn finalize_log_closure_writes_when_flow_states_dir_exists() {
+fn complete_finalize_does_not_recreate_branch_dir_after_cleanup() {
     let dir = tempfile::tempdir().unwrap();
     let parent = dir.path().canonicalize().unwrap();
     let repo = make_repo_fixture(&parent);
@@ -217,6 +237,13 @@ fn finalize_log_closure_writes_when_flow_states_dir_exists() {
     let flow_bin = parent.join("bin-flow-stub").join("flow");
     write_success_flow_stub(&flow_bin);
     let stubs = path_stub_dir(&parent);
+
+    let branch_dir = repo.join(".flow-states").join(BRANCH);
+    assert!(
+        branch_dir.exists(),
+        "fixture must pre-create the branch dir at {}",
+        branch_dir.display()
+    );
 
     let (code, _, _) = run_complete_finalize(
         &repo,
@@ -230,17 +257,10 @@ fn finalize_log_closure_writes_when_flow_states_dir_exists() {
     );
 
     assert_eq!(code, 0);
-    let log_path = repo.join(".flow-states").join(BRANCH).join("log");
     assert!(
-        log_path.exists(),
-        "log closure must write to {} when .flow-states/ exists",
-        log_path.display()
-    );
-    let log_content = fs::read_to_string(&log_path).unwrap_or_default();
-    assert!(
-        log_content.contains("complete-finalize"),
-        "log must contain complete-finalize entries; got: {}",
-        log_content
+        !branch_dir.exists(),
+        "branch directory must not exist after cleanup; found: {}",
+        branch_dir.display()
     );
 }
 

--- a/tests/complete_finalize.rs
+++ b/tests/complete_finalize.rs
@@ -208,26 +208,29 @@ fn finalize_with_broken_flow_stubs_populates_post_merge_failures() {
     );
 }
 
-/// The log closure inside `complete_finalize::run_impl` fires twice:
-/// once before cleanup (the "starting" line) and once after cleanup
-/// (the "done" line). Cleanup deletes `.flow-states/<branch>/` via
-/// `try_remove_branch_dir`. If the post-cleanup log call's guard
-/// checks `flow_states_dir().is_dir()` (the parent directory, which
-/// survives cleanup because it holds sibling branches and the
-/// machine-level singletons), `append_log` then runs
-/// `ensure_branch_dir()` and recreates the just-deleted branch
-/// directory. The result is that `.flow-states/<branch>/` returns
-/// containing only the "done" line — silently undoing cleanup's
-/// removal step.
+/// The log closure inside `complete_finalize::run_impl` writes the
+/// pre-cleanup "starting" line while the branch directory still
+/// exists, then attempts a post-cleanup "done" line. The closure's
+/// guard is scoped to `branch_dir().is_dir()` — narrower than the
+/// parent `.flow-states/` directory which survives cleanup —
+/// because a parent-scoped guard would let `append_log` call
+/// `ensure_branch_dir()` and recreate the directory cleanup just
+/// removed, silently undoing the removal step. On the happy path
+/// the post-cleanup call is therefore a no-op; the partial-failure
+/// path (cleanup leaves the branch directory intact) is the only
+/// case where the "done" line lands on disk.
 ///
 /// This test exercises the full subprocess path with a fixture that
 /// pre-creates the branch directory. After the call returns, the
 /// branch directory must NOT exist on disk: cleanup removed it and
 /// no subsequent code path may resurrect it. The pre-cleanup
 /// "starting" log line still fires while the branch directory
-/// exists; the cleanup-side audit trail (the
-/// `[Phase 5] cleanup — in progress` line) is covered by
-/// `tests/cleanup.rs` tests against the cleanup module directly.
+/// exists, but its file is removed alongside the branch directory.
+/// The cleanup-side audit trail (the `[Phase 5] cleanup — in progress`
+/// line) is covered by `tests/cleanup.rs` tests against the cleanup
+/// module directly, and the cleanup result is always available to
+/// callers via the JSON `cleanup` envelope `complete_finalize`
+/// returns.
 #[test]
 fn complete_finalize_does_not_recreate_branch_dir_after_cleanup() {
     let dir = tempfile::tempdir().unwrap();
@@ -659,6 +662,78 @@ fn complete_finalize_no_sentinel_when_pull_disabled() {
     assert!(
         !sentinel_path.exists(),
         "sentinel must NOT exist when --pull is unset"
+    );
+}
+
+/// `--pull` succeeds but the state file's `base_branch` field is a
+/// slash-containing value (`origin/HEAD` resolves to a branch like
+/// `feature/foo`). Without an `is_valid_branch` guard around the
+/// sentinel write, `sentinel_path` would call
+/// `FlowPaths::try_new(...).expect()` and panic — surfacing a Rust
+/// backtrace to the user mid-cleanup. Per
+/// `.claude/rules/branch-path-safety.md`, state-derived branches
+/// must pass `is_valid_branch` before reaching the panicking
+/// constructor. Sentinel writing is best-effort, so the
+/// invalid-branch path skips the write entirely; the next
+/// start-gate run re-establishes the sentinel.
+#[test]
+fn complete_finalize_skips_sentinel_when_base_branch_is_slash_containing() {
+    let dir = tempfile::tempdir().unwrap();
+    let parent = dir.path().canonicalize().unwrap();
+    let repo = make_repo_fixture(&parent);
+    // Push a feature/foo branch to the bare remote so the cleanup's
+    // git pull origin feature/foo succeeds — without that, git_pull
+    // returns "failed: ..." and the outer if-block never runs, so
+    // the inner is_valid_branch guard's false branch isn't exercised.
+    let _ = std::process::Command::new("git")
+        .args(["push", "origin", "HEAD:refs/heads/feature/foo"])
+        .current_dir(&repo)
+        .output()
+        .expect("push feature/foo");
+    let branch_dir = repo.join(".flow-states").join(BRANCH);
+    fs::create_dir_all(&branch_dir).unwrap();
+    let state_path = branch_dir.join("state.json");
+    let mut state = common::make_complete_state(BRANCH, "complete", None);
+    state["base_branch"] = json!("feature/foo");
+    fs::write(&state_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+    let flow_bin = parent.join("bin-flow-stub").join("flow");
+    write_success_flow_stub(&flow_bin);
+    let stubs = path_stub_dir(&parent);
+
+    let (code, stdout, stderr) = run_complete_finalize(
+        &repo,
+        "42",
+        state_path.to_string_lossy().as_ref(),
+        BRANCH,
+        ".worktrees/test-feature",
+        true, // --pull
+        Some(&flow_bin),
+        Some(&stubs),
+    );
+
+    assert_eq!(code, 0);
+    assert!(
+        !stderr.contains("panicked at"),
+        "complete-finalize must not panic on slash-containing base_branch; stderr={}",
+        stderr
+    );
+    let json = last_json_line(&stdout);
+    assert_eq!(
+        json["cleanup"]["git_pull"], "pulled",
+        "fixture must produce a clean pull so the sentinel branch is reachable: {}",
+        json
+    );
+    // No sentinel path is computable for a slash-containing branch
+    // (FlowPaths::try_new returns None), so we cannot assert against
+    // a canonical path. Instead assert no sentinel ever lands under
+    // .flow-states/feature/ — which would only exist if the guard
+    // failed and the write traversed into the slash-containing path.
+    let invalid_sentinel_root = repo.join(".flow-states").join("feature");
+    assert!(
+        !invalid_sentinel_root.exists(),
+        "guard must skip sentinel write entirely for slash-containing \
+         base_branch; found unexpected path: {}",
+        invalid_sentinel_root.display()
     );
 }
 

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -1531,12 +1531,45 @@ fn commit_no_docs_sync() {
 
 // --- Reset skill ---
 
+/// The flow-reset Guard must resolve the integration branch via
+/// `bin/flow base-branch` rather than hardcoding `main`. The resolved
+/// name flows into the rejection message via a `<base_branch>`
+/// placeholder so the user sees the actual trunk name on
+/// staging/develop/master repos.
 #[test]
-fn reset_guard_requires_main_branch() {
+fn reset_guard_requires_base_branch() {
     let c = common::read_skill("flow-reset");
     assert!(
-        c.contains("main") && c.contains("branch"),
-        "Reset must guard against running outside main branch"
+        c.contains("bin/flow base-branch"),
+        "flow-reset Guard must invoke `bin/flow base-branch` to resolve \
+         the integration branch dynamically"
+    );
+    assert!(
+        c.contains("<base_branch>"),
+        "flow-reset Guard rejection message must reference the resolved \
+         trunk via the `<base_branch>` placeholder so the message names \
+         the actual branch on non-main-trunk repos"
+    );
+}
+
+/// Tombstone-style guard against reintroducing a hardcoded `main`
+/// literal in user-visible flow-reset prose. Parallels
+/// `flow_start_prose_no_universal_main`. The bright-line forbidden
+/// phrasing is `Must be on main` — a future edit must paraphrase
+/// rather than name the integration branch by its `main` literal so
+/// staging/develop/master-trunked repos see the correct branch name.
+#[test]
+fn reset_no_universal_main() {
+    let c = common::read_skill("flow-reset");
+    assert!(
+        !c.contains("Must be on main"),
+        "flow-reset must not hardcode `Must be on main` — substitute the \
+         resolved `<base_branch>` placeholder into the rejection message"
+    );
+    assert!(
+        !c.contains("Available from `main` only"),
+        "flow-reset Rules must not name `main` as the only valid branch \
+         — use `the integration branch` instead"
     );
 }
 


### PR DESCRIPTION
## What

/flow:flow-start #1627.

Closes #1627

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/flow-reset-rejects-non-main/log` |
| State | `.flow-states/flow-reset-rejects-non-main/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/2a057ab3-fa7e-4c73-a5af-073cc14459c1.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 3m |
| Code | 21m |
| Review | 9h 52m |
| Learn | 2m |
| Complete | <1m |
| **Total** | **10h 20m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 3.0M | $0.864 |
| Code | 83.1M | $29.509 |
| Review | 80.9M | $61.945 |
| Learn | 14.1M | $4.204 |
| Complete | 2.4M | $0.819 |
| **Total** | **183.6M** | **$97.342** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **Permission prompt for bin/flow base-branch in flow-reset SKILL.md**
  - Dismissed — False positive — bin/flow base-branch is covered by the existing Bash(\*bin/flow \*) UNIVERSAL_ALLOW entry verified during Task 5. The empty-output concern is also incorrect: default_branch_in falls back to literal 'main' when origin/HEAD is unset, so the Guard comparison behaves correctly on repos without origin/HEAD configured.
- ✓ **docs/skills/flow-reset.md still hardcoded main after PR generalized to dynamic base-branch (6 references)**
  - Fixed — Generalized prose per docs-with-behavior.md Feature-Configurable Prose Generalization: replaced hardcoded 'main' references in the description, What It Does steps, comparison table, and Gates section with 'integration branch' / '&lt;base-branch&gt;' phrasing that matches the SKILL.md and Rust implementation.
- ✓ **cleanup_all interpolated unvalidated base_branch from default_branch_in into states_dir.join + fs::remove_dir_all**
  - Fixed — Per .claude/rules/branch-path-safety.md, branch names that flow into .flow-states/ paths must reach the filesystem through FlowPaths::try_new or FlowPaths::is_valid_branch pre-validation. default_branch_in returns unvalidated git output that may be slash-containing (origin/HEAD pointing to refs/remotes/origin/feature/foo). Added is_valid_branch check before path construction; invalid base_branch values now skip the tail step entirely and surface in the base_dir field as 'skipped: invalid base_branch &lt;value&gt;'.
- ✓ **complete_finalize sentinel_path call panicked on invalid base_branch via FlowPaths::try_new(...).expect()**
  - Fixed — Per .claude/rules/branch-path-safety.md and .claude/rules/external-input-validation.md CLI subcommand entry callsite discipline, state-derived branch values must pattern-match on FlowPaths::is_valid_branch before reaching the panicking constructor. Added is_valid_branch guard around the sentinel write block; invalid base_branch silently skips the best-effort write (the next start-gate run re-establishes the sentinel).
- ✓ **tests/complete_finalize.rs doc comment for complete_finalize_does_not_recreate_branch_dir_after_cleanup claimed log fires twice; implementation now fires once on happy path**
  - Fixed — Updated doc comment to accurately describe post-fix behavior: pre-cleanup 'starting' line writes (file removed with branch_dir during cleanup), post-cleanup 'done' line skipped on happy path; only the partial-failure cleanup path produces a persistent 'done' entry. The cleanup result remains available via the JSON envelope complete_finalize returns to callers.

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/flow-reset-rejects-non-main.json</summary>

```json
{
  "schema_version": 1,
  "branch": "flow-reset-rejects-non-main",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1628,
  "pr_url": "https://github.com/benkruger/flow/pull/1628",
  "started_at": "2026-05-16T19:44:49-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/flow-reset-rejects-non-main/log",
    "state": ".flow-states/flow-reset-rejects-non-main/state.json"
  },
  "session_tty": "/dev/ttys000",
  "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/2a057ab3-fa7e-4c73-a5af-073cc14459c1.jsonl",
  "notes": [],
  "prompt": "/flow:flow-start #1627",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-16T19:44:49-07:00",
      "completed_at": "2026-05-16T19:48:09-07:00",
      "session_started_at": null,
      "cumulative_seconds": 200,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-16T19:44:49-07:00",
        "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
        "model": "claude-opus-4-7",
        "five_hour_pct": 2,
        "seven_day_pct": 28,
        "session_input_tokens": 19,
        "session_output_tokens": 3812,
        "session_cache_creation_tokens": 647565,
        "session_cache_read_tokens": 280155,
        "session_cost_usd": 13.1161965,
        "by_model": {
          "claude-opus-4-7": {
            "input": 19,
            "output": 3812,
            "cache_create": 647565,
            "cache_read": 280155
          }
        },
        "turn_count": 4,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 232894,
        "context_window_pct": 116.447
      },
      "window_at_complete": {
        "captured_at": "2026-05-16T19:48:09-07:00",
        "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
        "model": "claude-opus-4-7",
        "five_hour_pct": 2,
        "seven_day_pct": 28,
        "session_input_tokens": 32,
        "session_output_tokens": 6177,
        "session_cache_creation_tokens": 652024,
        "session_cache_read_tokens": 3319375,
        "session_cost_usd": 13.980548999999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 32,
            "output": 6177,
            "cache_create": 652024,
            "cache_read": 3319375
          }
        },
        "turn_count": 17,
        "tool_call_count": 9,
        "context_at_last_turn_tokens": 235100,
        "context_window_pct": 117.55
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-16T19:48:19-07:00",
      "completed_at": "2026-05-16T20:09:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1284,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-16T19:48:19-07:00",
        "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
        "model": "claude-opus-4-7",
        "five_hour_pct": 2,
        "seven_day_pct": 28,
        "session_input_tokens": 49,
        "session_output_tokens": 7327,
        "session_cache_creation_tokens": 678786,
        "session_cache_read_tokens": 4495485,
        "session_cost_usd": 14.283536749999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 49,
            "output": 7327,
            "cache_create": 678786,
            "cache_read": 4495485
          }
        },
        "turn_count": 22,
        "tool_call_count": 11,
        "context_at_last_turn_tokens": 244093,
        "context_window_pct": 122.0465
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-16T19:52:06-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 4,
          "seven_day_pct": 28,
          "session_input_tokens": 86,
          "session_output_tokens": 36245,
          "session_cache_creation_tokens": 2330373,
          "session_cache_read_tokens": 14026543,
          "session_cost_usd": 21.243072749999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 86,
              "output": 36245,
              "cache_create": 2330373,
              "cache_read": 14026543
            }
          },
          "turn_count": 49,
          "tool_call_count": 24,
          "context_at_last_turn_tokens": 483237,
          "context_window_pct": 241.6185
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-16T19:53:23-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 4,
          "seven_day_pct": 28,
          "session_input_tokens": 98,
          "session_output_tokens": 44191,
          "session_cache_creation_tokens": 2341883,
          "session_cache_read_tokens": 19843952,
          "session_cost_usd": 23.055250999999995,
          "by_model": {
            "claude-opus-4-7": {
              "input": 98,
              "output": 44191,
              "cache_create": 2341883,
              "cache_read": 19843952
            }
          },
          "turn_count": 61,
          "tool_call_count": 31,
          "context_at_last_turn_tokens": 488690,
          "context_window_pct": 244.345
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-16T19:58:52-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 4,
          "seven_day_pct": 28,
          "session_input_tokens": 158,
          "session_output_tokens": 59288,
          "session_cache_creation_tokens": 2423453,
          "session_cache_read_tokens": 38640509,
          "session_cost_usd": 29.08477049999999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 158,
              "output": 59288,
              "cache_create": 2423453,
              "cache_read": 38640509
            }
          },
          "turn_count": 98,
          "tool_call_count": 53,
          "context_at_last_turn_tokens": 530866,
          "context_window_pct": 265.433
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-16T20:00:45-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 4,
          "seven_day_pct": 28,
          "session_input_tokens": 175,
          "session_output_tokens": 69068,
          "session_cache_creation_tokens": 2436827,
          "session_cache_read_tokens": 47724082,
          "session_cost_usd": 31.9350805,
          "by_model": {
            "claude-opus-4-7": {
              "input": 175,
              "output": 69068,
              "cache_create": 2436827,
              "cache_read": 47724082
            }
          },
          "turn_count": 115,
          "tool_call_count": 63,
          "context_at_last_turn_tokens": 538262,
          "context_window_pct": 269.131
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-16T20:01:57-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 4,
          "seven_day_pct": 28,
          "session_input_tokens": 187,
          "session_output_tokens": 78148,
          "session_cache_creation_tokens": 2447740,
          "session_cache_read_tokens": 54215785,
          "session_cost_usd": 33.69008875,
          "by_model": {
            "claude-opus-4-7": {
              "input": 187,
              "output": 78148,
              "cache_create": 2447740,
              "cache_read": 54215785
            }
          },
          "turn_count": 127,
          "tool_call_count": 69,
          "context_at_last_turn_tokens": 544389,
          "context_window_pct": 272.1945
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-16T20:03:44-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 4,
          "seven_day_pct": 28,
          "session_input_tokens": 202,
          "session_output_tokens": 84664,
          "session_cache_creation_tokens": 2457094,
          "session_cache_read_tokens": 62431959,
          "session_cost_usd": 36.86470625,
          "by_model": {
            "claude-opus-4-7": {
              "input": 202,
              "output": 84664,
              "cache_create": 2457094,
              "cache_read": 62431959
            }
          },
          "turn_count": 142,
          "tool_call_count": 80,
          "context_at_last_turn_tokens": 551021,
          "context_window_pct": 275.5105
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-16T20:04:47-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 4,
          "seven_day_pct": 28,
          "session_input_tokens": 212,
          "session_output_tokens": 92919,
          "session_cache_creation_tokens": 2467817,
          "session_cache_read_tokens": 67955342,
          "session_cost_usd": 38.348694999999985,
          "by_model": {
            "claude-opus-4-7": {
              "input": 212,
              "output": 92919,
              "cache_create": 2467817,
              "cache_read": 67955342
            }
          },
          "turn_count": 152,
          "tool_call_count": 85,
          "context_at_last_turn_tokens": 555478,
          "context_window_pct": 277.739
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-16T20:09:43-07:00",
        "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
        "model": "claude-opus-4-7",
        "five_hour_pct": 4,
        "seven_day_pct": 28,
        "session_input_tokens": 266,
        "session_output_tokens": 104217,
        "session_cache_creation_tokens": 2531982,
        "session_cache_read_tokens": 85596364,
        "session_cost_usd": 43.7922415,
        "by_model": {
          "claude-opus-4-7": {
            "input": 266,
            "output": 104217,
            "cache_create": 2531982,
            "cache_read": 85596364
          }
        },
        "turn_count": 183,
        "tool_call_count": 103,
        "context_at_last_turn_tokens": 585108,
        "context_window_pct": 292.554
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-16T20:09:57-07:00",
      "completed_at": "2026-05-17T06:02:08-07:00",
      "session_started_at": null,
      "cumulative_seconds": 35531,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-16T20:09:57-07:00",
        "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
        "model": "claude-opus-4-7",
        "five_hour_pct": 4,
        "seven_day_pct": 28,
        "session_input_tokens": 278,
        "session_output_tokens": 105075,
        "session_cache_creation_tokens": 2564680,
        "session_cache_read_tokens": 87937330,
        "session_cost_usd": 44.490419249999995,
        "by_model": {
          "claude-opus-4-7": {
            "input": 278,
            "output": 105075,
            "cache_create": 2564680,
            "cache_read": 87937330
          }
        },
        "turn_count": 187,
        "tool_call_count": 105,
        "context_at_last_turn_tokens": 601461,
        "context_window_pct": 300.7305
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-16T20:11:40-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 5,
          "seven_day_pct": 28,
          "session_input_tokens": 296,
          "session_output_tokens": 113172,
          "session_cache_creation_tokens": 2569491,
          "session_cache_read_tokens": 98792967,
          "session_cost_usd": 48.22089174999999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 296,
              "output": 113172,
              "cache_create": 2569491,
              "cache_read": 98792967
            }
          },
          "turn_count": 205,
          "tool_call_count": 117,
          "context_at_last_turn_tokens": 604789,
          "context_window_pct": 302.3945
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-17T05:44:55-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 3,
          "seven_day_pct": 31,
          "session_input_tokens": 4452,
          "session_output_tokens": 151614,
          "session_cache_creation_tokens": 4593383,
          "session_cache_read_tokens": 110669035,
          "session_cost_usd": 87.15738744999994,
          "by_model": {
            "claude-opus-4-7": {
              "input": 4452,
              "output": 151614,
              "cache_create": 4593383,
              "cache_read": 110669035
            }
          },
          "turn_count": 227,
          "tool_call_count": 131,
          "context_at_last_turn_tokens": 646058,
          "context_window_pct": 323.029
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-17T05:48:09-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 4,
          "seven_day_pct": 31,
          "session_input_tokens": 4472,
          "session_output_tokens": 191116,
          "session_cache_creation_tokens": 4654109,
          "session_cache_read_tokens": 113915777,
          "session_cost_usd": 88.64930544999993,
          "by_model": {
            "claude-opus-4-7": {
              "input": 4472,
              "output": 191116,
              "cache_create": 4654109,
              "cache_read": 113915777
            }
          },
          "turn_count": 232,
          "tool_call_count": 134,
          "context_at_last_turn_tokens": 675158,
          "context_window_pct": 337.579
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-17T06:01:50-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 6,
          "seven_day_pct": 32,
          "session_input_tokens": 4564,
          "session_output_tokens": 240571,
          "session_cache_creation_tokens": 4775876,
          "session_cache_read_tokens": 162748406,
          "session_cost_usd": 105.20714119999992,
          "by_model": {
            "claude-opus-4-7": {
              "input": 4564,
              "output": 240571,
              "cache_create": 4775876,
              "cache_read": 162748406
            }
          },
          "turn_count": 301,
          "tool_call_count": 178,
          "context_at_last_turn_tokens": 738039,
          "context_window_pct": 369.0195
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-16T20:17:32-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-16T20:17:38-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-17T05:44:39-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-17T05:44:48-07:00"
        }
      ],
      "agent_retry_counts": {
        "pre-mortem": 1,
        "adversarial": 1
      },
      "window_at_complete": {
        "captured_at": "2026-05-17T06:02:08-07:00",
        "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
        "model": "claude-opus-4-7",
        "five_hour_pct": 6,
        "seven_day_pct": 32,
        "session_input_tokens": 4584,
        "session_output_tokens": 241397,
        "session_cache_creation_tokens": 4823855,
        "session_cache_read_tokens": 166455677,
        "session_cost_usd": 106.43551794999992,
        "by_model": {
          "claude-opus-4-7": {
            "input": 4584,
            "output": 241397,
            "cache_create": 4823855,
            "cache_read": 166455677
          }
        },
        "turn_count": 306,
        "tool_call_count": 181,
        "context_at_last_turn_tokens": 754392,
        "context_window_pct": 377.196
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-17T06:02:24-07:00",
      "completed_at": "2026-05-17T06:05:18-07:00",
      "session_started_at": null,
      "cumulative_seconds": 174,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-17T06:02:24-07:00",
        "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
        "model": "claude-opus-4-7",
        "five_hour_pct": 6,
        "seven_day_pct": 32,
        "session_input_tokens": 4596,
        "session_output_tokens": 242271,
        "session_cache_creation_tokens": 4853287,
        "session_cache_read_tokens": 169473895,
        "session_cost_usd": 107.29300244999992,
        "by_model": {
          "claude-opus-4-7": {
            "input": 4596,
            "output": 242271,
            "cache_create": 4853287,
            "cache_read": 169473895
          }
        },
        "turn_count": 310,
        "tool_call_count": 183,
        "context_at_last_turn_tokens": 769112,
        "context_window_pct": 384.556
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-17T06:04:44-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-17T06:04:51-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 6,
          "seven_day_pct": 32,
          "session_input_tokens": 4624,
          "session_output_tokens": 247122,
          "session_cache_creation_tokens": 4917448,
          "session_cache_read_tokens": 179590489,
          "session_cost_usd": 110.67913694999991,
          "by_model": {
            "claude-opus-4-7": {
              "input": 4624,
              "output": 247122,
              "cache_create": 4917448,
              "cache_read": 179590489
            }
          },
          "turn_count": 323,
          "tool_call_count": 190,
          "context_at_last_turn_tokens": 791387,
          "context_window_pct": 395.6935
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-17T06:04:51-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 6,
          "seven_day_pct": 32,
          "session_input_tokens": 4624,
          "session_output_tokens": 247122,
          "session_cache_creation_tokens": 4917448,
          "session_cache_read_tokens": 179590489,
          "session_cost_usd": 110.67913694999991,
          "by_model": {
            "claude-opus-4-7": {
              "input": 4624,
              "output": 247122,
              "cache_create": 4917448,
              "cache_read": 179590489
            }
          },
          "turn_count": 323,
          "tool_call_count": 190,
          "context_at_last_turn_tokens": 791387,
          "context_window_pct": 395.6935
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-17T06:04:51-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 6,
          "seven_day_pct": 32,
          "session_input_tokens": 4624,
          "session_output_tokens": 247122,
          "session_cache_creation_tokens": 4917448,
          "session_cache_read_tokens": 179590489,
          "session_cost_usd": 110.67913694999991,
          "by_model": {
            "claude-opus-4-7": {
              "input": 4624,
              "output": 247122,
              "cache_create": 4917448,
              "cache_read": 179590489
            }
          },
          "turn_count": 323,
          "tool_call_count": 190,
          "context_at_last_turn_tokens": 791387,
          "context_window_pct": 395.6935
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-17T06:04:51-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 6,
          "seven_day_pct": 32,
          "session_input_tokens": 4624,
          "session_output_tokens": 247122,
          "session_cache_creation_tokens": 4917448,
          "session_cache_read_tokens": 179590489,
          "session_cost_usd": 110.67913694999991,
          "by_model": {
            "claude-opus-4-7": {
              "input": 4624,
              "output": 247122,
              "cache_create": 4917448,
              "cache_read": 179590489
            }
          },
          "turn_count": 323,
          "tool_call_count": 190,
          "context_at_last_turn_tokens": 791387,
          "context_window_pct": 395.6935
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-17T06:04:51-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 6,
          "seven_day_pct": 32,
          "session_input_tokens": 4624,
          "session_output_tokens": 247122,
          "session_cache_creation_tokens": 4917448,
          "session_cache_read_tokens": 179590489,
          "session_cost_usd": 110.67913694999991,
          "by_model": {
            "claude-opus-4-7": {
              "input": 4624,
              "output": 247122,
              "cache_create": 4917448,
              "cache_read": 179590489
            }
          },
          "turn_count": 323,
          "tool_call_count": 190,
          "context_at_last_turn_tokens": 791387,
          "context_window_pct": 395.6935
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-17T06:04:51-07:00",
          "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
          "model": "claude-opus-4-7",
          "five_hour_pct": 6,
          "seven_day_pct": 32,
          "session_input_tokens": 4624,
          "session_output_tokens": 247122,
          "session_cache_creation_tokens": 4917448,
          "session_cache_read_tokens": 179590489,
          "session_cost_usd": 110.67913694999991,
          "by_model": {
            "claude-opus-4-7": {
              "input": 4624,
              "output": 247122,
              "cache_create": 4917448,
              "cache_read": 179590489
            }
          },
          "turn_count": 323,
          "tool_call_count": 190,
          "context_at_last_turn_tokens": 791387,
          "context_window_pct": 395.6935
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-17T06:05:18-07:00",
        "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
        "model": "claude-opus-4-7",
        "five_hour_pct": 6,
        "seven_day_pct": 32,
        "session_input_tokens": 4629,
        "session_output_tokens": 249208,
        "session_cache_creation_tokens": 4918978,
        "session_cache_read_tokens": 183548047,
        "session_cost_usd": 111.49728994999994,
        "by_model": {
          "claude-opus-4-7": {
            "input": 4629,
            "output": 249208,
            "cache_create": 4918978,
            "cache_read": 183548047
          }
        },
        "turn_count": 328,
        "tool_call_count": 192,
        "context_at_last_turn_tokens": 791995,
        "context_window_pct": 395.9975
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-17T06:05:46-07:00",
      "completed_at": "2026-05-17T06:06:07-07:00",
      "session_started_at": null,
      "cumulative_seconds": 21,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-17T06:05:46-07:00",
        "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
        "model": "claude-opus-4-7",
        "five_hour_pct": 6,
        "seven_day_pct": 32,
        "session_input_tokens": 4644,
        "session_output_tokens": 251249,
        "session_cache_creation_tokens": 4947040,
        "session_cache_read_tokens": 189134319,
        "session_cost_usd": 112.80032094999994,
        "by_model": {
          "claude-opus-4-7": {
            "input": 4644,
            "output": 251249,
            "cache_create": 4947040,
            "cache_read": 189134319
          }
        },
        "turn_count": 335,
        "tool_call_count": 195,
        "context_at_last_turn_tokens": 805897,
        "context_window_pct": 402.9485
      },
      "window_at_complete": {
        "captured_at": "2026-05-17T06:06:07-07:00",
        "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
        "model": "claude-opus-4-7",
        "five_hour_pct": 6,
        "seven_day_pct": 32,
        "session_input_tokens": 4647,
        "session_output_tokens": 251747,
        "session_cache_creation_tokens": 4948169,
        "session_cache_read_tokens": 191552496,
        "session_cost_usd": 113.61969644999994,
        "by_model": {
          "claude-opus-4-7": {
            "input": 4647,
            "output": 251747,
            "cache_create": 4948169,
            "cache_read": 191552496
          }
        },
        "turn_count": 338,
        "tool_call_count": 197,
        "context_at_last_turn_tokens": 806537,
        "context_window_pct": 403.2685
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-16T19:48:19-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-16T20:09:57-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-17T06:02:24-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-17T06:05:46-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-16T19:44:49-07:00",
    "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
    "model": "claude-opus-4-7",
    "five_hour_pct": 2,
    "seven_day_pct": 28,
    "session_input_tokens": 19,
    "session_output_tokens": 3812,
    "session_cache_creation_tokens": 647565,
    "session_cache_read_tokens": 280155,
    "session_cost_usd": 13.1161965,
    "by_model": {
      "claude-opus-4-7": {
        "input": 19,
        "output": 3812,
        "cache_create": 647565,
        "cache_read": 280155
      }
    },
    "turn_count": 4,
    "tool_call_count": 2,
    "context_at_last_turn_tokens": 232894,
    "context_window_pct": 116.447
  },
  "code_tasks_total": 7,
  "code_task_name": "Rename and generalize reset_guard contract test; add tombstone-style assertion",
  "code_task": 7,
  "diff_stats": {
    "files_changed": 6,
    "insertions": 223,
    "deletions": 86,
    "captured_at": "2026-05-16T20:09:43-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThis conversation is a Learn-phase audit of PR #1628 on branch flow-reset-rejects-non-main. I was invoked as a cognitively isolated agent with specific instructions:\n\n1. **The Task**: Conduct a Learn-phase audit of a completed PR, analyzing three tenants:\n   - Tenant 1: Process gaps in FLOW plugin workflow\n   - Tenant 2: Rule compliance violations\n   - Tenant 3: Missing rules that should be codified\n\n2. **Key Constraints**:\n   - Apply a two-gate filter: (1) Forward-facing principle, (2) Value test (already fixed in PR = drop)\n   - Special note: agent_retry_counts reflect API rate-limiting, NOT a process gap\n   - Four findings from Review are already fixed — NOT Learn findings; drop them\n   - Return only findings that pass both gates\n   - Return \"No findings\" markers if appropriate\n   - End with ## END-OF-FINDINGS marker\n\n3. **Artifacts Provided**:\n   - Full diff at /Users/ben/code/flow/.flow-states/flow-reset-rejects-non-main/full-diff.diff\n   - State file data (visit counts, phase timings, findings from Review)\n   - Plan at /Users/ben/code/flow/.flow-states/flow-reset-rejects-non-main/plan.md\n   - Project CLAUDE.md and rules files\n\n4. **What I Did**:\n   - Read the full diff (1-813 lines) showing PR changes\n   - Read the plan.md (165 lines) describing the work\n   - Attempted to read CLAUDE.md but hit a PreToolUse hook error (protected .claude/ path)\n\n5. **What the Diff Shows**:\n   The PR generalizes `/flow:flow-reset` from hardcoded `main` to dynamic base-branch resolution:\n   - docs/skills/flow-reset.md: 6 references from \"main\" to \"<base_branch>\"\n   - skills/flow-reset/SKILL.md: Guard, Steps, Rules updated\n   - src/cleanup.rs: Resolved base_branch via git::default_branch_in(), replaced hardcoded \"main_path\" with base_path, added branch validation via FlowPaths::is_valid_branch, added \"base_branch\" JSON field\n   - src/complete_finalize.rs: Changed log closure guard from flow_states_dir() to branch_dir() to prevent directory resurrection post-cleanup\n   - tests/cleanup.rs: 16 references renamed main_dir→base_dir, 2 new tests for non-main trunk + slash-containing validation\n   - tests/complete_finalize.rs: Complete fixture test for directory non-existence post-cleanup\n   - tests/skill_contracts.rs: Renamed reset_guard_requires_main_branch test, added reset_no_universal_main tombstone test\n\n6. **State File Data Interpretation**:\n   - Phase timings: flow-start (200s, 1 visit), flow-code (1284s, 1 visit), flow-review (35531s, 1 visit, 4 agents returned with 2 retries)\n   - Review findings state: 4 findings fixed (docs sync, cleanup_all path validation, complete_finalize panic guard, test doc comment update), 1 finding dismissed (permission prompt for bin/flow base-branch)\n   - No correction notes from user\n\n7. **Key Insight from Plan**:\n   The plan correctly identified two independent bugs:\n   - Bug 1: Hardcoded \"main\" across cleanup.rs, SKILL.md, tests\n   - Bug 2: Post-cleanup log call resurrecting branch_dir via append_log→ensure_branch_dir\n   The plan established atomicity groups (Bug 2 as commit A, Bug 1 as commit B) and enumerated 7 tasks with dependencies.\n\n8. **Analysis Against Three Tenants**:\n   Looking at the diff and state data:\n   - Tenant 1 (Process gaps): No gaps evident. Review agents caught the issues (path validation, panic guard, doc accuracy). Agents were retried due to API rate-limiting (documented as expected per cognitive-isolation.md). The flow worked: risk identified in planning, caught in review, fixed.\n   - Tenant 2 (Rule compliance): The diff shows proper application of branch-path-safety.md (FlowPaths::is_valid_branch guard added), docs-with-behavior.md (prose updated atomically with code), test-placement.md (tests follow src/test mirror pattern), no-backwards-reasoning.md (prose is forward-facing).\n   - Tenant 3 (Missing rules): The slash-containing base_branch path traversal risk is addressed by the existing branch-path-safety.md rule (already in the codebase). The directory resurrection pattern is addressed by naming the principle in the closure guard's doc comment (per comment-quality.md). No new rules needed.\n\n9. **Two-Gate Filter Application**:\n   - Gate 1 (Forward-facing): Any finding must be generalizable to future sessions\n   - Gate 2 (Value): Was the gap caught and remediated in this PR? Yes — Review caught all 4 issues and they're fixed\n   - Result: All Review findings are already remediated, so they drop per the instructions. No unfixed gaps remain.\n\n10. **Completion Status**:\n    I have read the diff and plan. The task requires analysis of three tenants against known standards. The PR shows no gaps in FLOW process, no rule violations, and no new rules are needed. All findings from Review were fixed in the PR. Therefore, the analysis should report \"No findings\" across all three tenants with brief explanations.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   Conduct a cognitively isolated Learn-phase audit of PR #1628 (branch flow-reset-rejects-non-main) analyzing three tenants: (1) Process gaps in FLOW plugin workflow, (2) Rule compliance violations, (3) Missing rules. Apply two-gate filter: forward-facing principle test + value test (if already fixed in PR, drop). Report findings only if they pass both gates. Special instruction: agent API retries are expected behavior per cognitive-isolation.md, NOT process gaps. Four Review findings already fixed in the PR — drop them as they don't constitute Learn-phase findings. Return \"No findings\" markers if categories produce zero findings. End analysis with ## END-OF-FINDINGS marker.\n\n2. Key Technical Concepts:\n   - FLOW plugin 5-phase lifecycle (Start, Code, Review, Learn, Complete)\n   - Base-branch resolution via git::default_branch_in() with \"main\" fallback\n   - FlowPaths::is_valid_branch() guard for branch path safety\n   - Branch directory vs .flow-states directory scope (resource cleanup pattern)\n   - JSON state contract (main_dir → base_dir field rename)\n   - Cognitive isolation architecture (agents receive only persisted artifacts)\n   - Two-gate compliance filter: forward-facing + value test\n\n3. Files and Code Sections:\n   - docs/skills/flow-reset.md (6 lines generalized from \"main\" to \"<base_branch>\")\n   - skills/flow-reset/SKILL.md (Guard, Step 1, Step 4, Rules sections updated; bash invocation of bin/flow base-branch added to resolve trunk; rejection message uses <base_branch> placeholder)\n   - src/cleanup.rs (cleanup_all function: resolved base_branch via git::default_branch_in(), replaced \"main_path\" with base_path = states_dir.join(&base_branch); added FlowPaths::is_valid_branch(&base_branch) guard before fs::remove_dir_all; renamed main_dir JSON field to base_dir; added base_branch JSON field; updated module doc comment and cleanup_all doc comment to refer to integration branch by description not literal \"main\")\n   - src/complete_finalize.rs (log closure guard changed from paths.flow_states_dir().is_dir() to paths.branch_dir().is_dir() to prevent directory resurrection via append_log→ensure_branch_dir; added doc comment explaining scoped guard rationale)\n   - tests/cleanup.rs (16 references: main_dir → base_dir; renamed 3 test functions: cleanup_all_removes_main_directory → cleanup_all_removes_base_branch_directory, cleanup_all_skips_missing_main_directory → cleanup_all_skips_missing_base_branch_directory, cleanup_all_main_dir_remove_fails → cleanup_all_base_dir_remove_fails; added new test cleanup_all_removes_base_branch_sentinel_on_non_main_repo exercising origin/HEAD → staging with .flow-states/staging/ cleanup; added new test cleanup_all_skips_base_dir_when_default_branch_is_slash_containing exercising path safety guard with origin/HEAD → origin/feature/foo)\n   - tests/complete_finalize.rs (renamed test finalize_log_closure_writes_when_flow_states_dir_exists → complete_finalize_does_not_recreate_branch_dir_after_cleanup; updated doc comment to explain guard scoping and why post-cleanup log line does not fire; changed assertion from \"log file exists\" to \"branch directory does not exist\")\n   - tests/skill_contracts.rs (renamed reset_guard_requires_main_branch → reset_guard_requires_base_branch with updated assertion checking for bin/flow base-branch invocation and <base_branch> placeholder reference; added new test reset_no_universal_main asserting SKILL.md does not contain literal \"Must be on main\" or \"Available from `main` only\" phrases)\n\n4. Errors and fixes:\n   - PreToolUse:Read hook error when attempting to read CLAUDE.md: Protected .claude/ paths require use of bin/flow write-rule during active FLOW phases. This error did not block analysis because CLAUDE.md is not needed for Learn-phase audit (audit uses provided inline CLAUDE.md content and rules files).\n\n5. Problem Solving:\n   The PR solves two independent bugs: (1) hardcoded \"main\" literal preventing /flow:flow-reset from working on staging/develop/master-trunk repos, (2) post-cleanup log call resurrecting removed branch directory. Both bugs identified in planning phase, caught by Review agents (4 findings: doc sync, path validation, panic guard, test doc accuracy), and fixed in code. Review phase showed agent_retry_counts: {pre-mortem: 1, adversarial: 1} due to upstream API rate-limiting (expected per cognitive-isolation.md, not a process gap).\n\n6. All user messages:\n   - System message with task frame: Learn-phase audit of PR #1628 with three-tenant analysis (process gaps, rule compliance, missing rules) applying two-gate filter and dropping already-fixed Review findings.\n\n7. Pending Tasks:\n   None. The audit task is complete. Analysis of the diff and state data is finished.\n\n8. Current Work:\n   Just completed reading the full diff (813 lines) and plan (165 lines) for PR #1628. The diff shows generalization of /flow:flow-reset from hardcoded \"main\" to dynamic base-branch resolution via git::default_branch_in(), with proper path validation via FlowPaths::is_valid_branch(), and a fix to complete_finalize log closure guard (flow_states_dir() → branch_dir()) to prevent directory resurrection. The plan correctly decomposed two bugs into 7 tasks across two atomic commits. Review found 4 issues, all fixed in the code. Agent retries were due to API rate-limiting (expected per cognitive-isolation.md).\n\n9. Optional Next Step:\n   Complete the Learn-phase analysis by writing findings. Based on the two-gate filter applied to all three tenants: (1) Tenant 1 — no process gaps (Review caught all issues, FLOW workflow functioned correctly), (2) Tenant 2 — no rule violations (code follows branch-path-safety.md, docs-with-behavior.md, test-placement.md, no-backwards-reasoning.md), (3) Tenant 3 — no new rules needed (existing rules already cover the patterns in this PR). Output \"No findings\" for all three categories with brief explanations, then emit ## END-OF-FINDINGS completion marker.\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/flow-reset-rejects-non-main",
  "compact_count": 2,
  "findings": [
    {
      "finding": "Permission prompt for bin/flow base-branch in flow-reset SKILL.md",
      "reason": "False positive — bin/flow base-branch is covered by the existing Bash(*bin/flow *) UNIVERSAL_ALLOW entry verified during Task 5. The empty-output concern is also incorrect: default_branch_in falls back to literal 'main' when origin/HEAD is unset, so the Guard comparison behaves correctly on repos without origin/HEAD configured.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T05:47:55-07:00"
    },
    {
      "finding": "docs/skills/flow-reset.md still hardcoded main after PR generalized to dynamic base-branch (6 references)",
      "reason": "Generalized prose per docs-with-behavior.md Feature-Configurable Prose Generalization: replaced hardcoded 'main' references in the description, What It Does steps, comparison table, and Gates section with 'integration branch' / '<base-branch>' phrasing that matches the SKILL.md and Rust implementation.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T05:49:12-07:00"
    },
    {
      "finding": "cleanup_all interpolated unvalidated base_branch from default_branch_in into states_dir.join + fs::remove_dir_all",
      "reason": "Per .claude/rules/branch-path-safety.md, branch names that flow into .flow-states/ paths must reach the filesystem through FlowPaths::try_new or FlowPaths::is_valid_branch pre-validation. default_branch_in returns unvalidated git output that may be slash-containing (origin/HEAD pointing to refs/remotes/origin/feature/foo). Added is_valid_branch check before path construction; invalid base_branch values now skip the tail step entirely and surface in the base_dir field as 'skipped: invalid base_branch <value>'.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T05:49:45-07:00"
    },
    {
      "finding": "complete_finalize sentinel_path call panicked on invalid base_branch via FlowPaths::try_new(...).expect()",
      "reason": "Per .claude/rules/branch-path-safety.md and .claude/rules/external-input-validation.md CLI subcommand entry callsite discipline, state-derived branch values must pattern-match on FlowPaths::is_valid_branch before reaching the panicking constructor. Added is_valid_branch guard around the sentinel write block; invalid base_branch silently skips the best-effort write (the next start-gate run re-establishes the sentinel).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T05:50:18-07:00"
    },
    {
      "finding": "tests/complete_finalize.rs doc comment for complete_finalize_does_not_recreate_branch_dir_after_cleanup claimed log fires twice; implementation now fires once on happy path",
      "reason": "Updated doc comment to accurately describe post-fix behavior: pre-cleanup 'starting' line writes (file removed with branch_dir during cleanup), post-cleanup 'done' line skipped on happy path; only the partial-failure cleanup path produces a persistent 'done' entry. The cleanup result remains available via the JSON envelope complete_finalize returns to callers.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T05:50:48-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-17T06:06:07-07:00",
    "session_id": "2a057ab3-fa7e-4c73-a5af-073cc14459c1",
    "model": "claude-opus-4-7",
    "five_hour_pct": 6,
    "seven_day_pct": 32,
    "session_input_tokens": 4647,
    "session_output_tokens": 251747,
    "session_cache_creation_tokens": 4948169,
    "session_cache_read_tokens": 191552496,
    "session_cost_usd": 113.61969644999994,
    "by_model": {
      "claude-opus-4-7": {
        "input": 4647,
        "output": 251747,
        "cache_create": 4948169,
        "cache_read": 191552496
      }
    },
    "turn_count": 338,
    "tool_call_count": 197,
    "context_at_last_turn_tokens": 806537,
    "context_window_pct": 403.2685
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>