### PR TITLE
Flow Release Leaves Stale Target

### DIFF
--- a/.claude/skills/flow-release/SKILL.md
+++ b/.claude/skills/flow-release/SKILL.md
@@ -152,13 +152,22 @@ a fresh install needs no build step. It must be regenerated from source
 at every release so its bytes match the tagged source generation; a
 stale binary would run an older FLOW than the release claims.
 
-`bin/setup --stage-binary` builds the release binary and copies it to
-the committed path in one step. The compiler and the copy both run
-inside that script, which keeps them off the FLOW Bash allow-list
-surface — invoking the Rust toolchain or `cp` directly is
-permission-denied. Use a 10-minute Bash tool timeout
-(`timeout: 600000`) — a cold release build can take several minutes
-and the default 2-minute timeout would background the process.
+`bin/setup --stage-binary` builds the release binary and moves it to
+the committed path in one step. The move (rather than a copy) leaves
+no source artifact at `target/release/flow-rs` after staging — a
+leftover would sit at higher dispatcher precedence than the committed
+binary at `bin/flow-rs-darwin-arm64` and shadow source changes during
+`--plugin-dir` QA on a session that runs without rebuilding (see
+`bin/flow` lines 27-33: the dispatcher prefers `target/release` over
+the committed binary by existence priority, not mtime). The compiler
+and the move both run inside that script, which keeps them off the
+FLOW Bash allow-list surface — invoking the Rust toolchain or `mv`
+directly is permission-denied. The staging is idempotent: invoking
+`--stage-binary` after a prior successful staging (no fresh build
+output) leaves the committed binary in place rather than failing.
+Use a 10-minute Bash tool timeout (`timeout: 600000`) — a cold
+release build can take several minutes and the default 2-minute
+timeout would background the process.
 
 ```bash
 bin/setup --stage-binary

--- a/bin/setup
+++ b/bin/setup
@@ -18,10 +18,15 @@ cargo build --release --manifest-path "$REPO_ROOT/Cargo.toml"
 
 # --stage-binary additionally refreshes the committed prebuilt binary
 # from the fresh release build, so bin/flow-rs-darwin-arm64 never lags
-# the source it ships alongside. The copy runs inside this script,
-# keeping it off the FLOW Bash allow-list surface.
+# the source it ships alongside. The move runs inside this script,
+# keeping it off the FLOW Bash allow-list surface AND ensuring the
+# source artifact at target/release/flow-rs does not survive staging
+# (a leftover artifact would shadow source changes during
+# --plugin-dir QA via the dispatcher's mtime preference). chmod stays
+# in place as defensive coverage for environments where mv ever fails
+# to preserve mode bits.
 if [ "${1:-}" = "--stage-binary" ]; then
-  cp "$REPO_ROOT/target/release/flow-rs" "$REPO_ROOT/bin/flow-rs-darwin-arm64"
+  mv "$REPO_ROOT/target/release/flow-rs" "$REPO_ROOT/bin/flow-rs-darwin-arm64"
   chmod 755 "$REPO_ROOT/bin/flow-rs-darwin-arm64"
 fi
 

--- a/bin/setup
+++ b/bin/setup
@@ -16,18 +16,46 @@ fi
 
 cargo build --release --manifest-path "$REPO_ROOT/Cargo.toml"
 
-# --stage-binary additionally refreshes the committed prebuilt binary
-# from the fresh release build, so bin/flow-rs-darwin-arm64 never lags
-# the source it ships alongside. The move runs inside this script,
-# keeping it off the FLOW Bash allow-list surface AND ensuring the
-# source artifact at target/release/flow-rs does not survive staging
-# (a leftover artifact would shadow source changes during
-# --plugin-dir QA via the dispatcher's mtime preference). chmod stays
-# in place as defensive coverage for environments where mv ever fails
-# to preserve mode bits.
+# --stage-binary refreshes the committed prebuilt binary from the
+# fresh release build so bin/flow-rs-darwin-arm64 never lags the
+# source it ships alongside. The move (rather than a copy) leaves
+# no source artifact at target/release/flow-rs after staging — the
+# dispatcher in bin/flow prefers target/release over the committed
+# binary by existence priority (bin/flow lines 27-33, first-match-
+# wins, not mtime), so a leftover artifact would silently shadow
+# source changes during --plugin-dir QA on the next session that
+# runs without rebuilding.
+#
+# The staging is idempotent: a re-invocation after a prior
+# successful staging finds no fresh build output (cargo's
+# incremental cache may skip the link step when nothing changed),
+# so the script preserves the already-staged committed binary
+# rather than failing with a raw "mv: rename ... No such file or
+# directory" error. The guard distinguishes three cases:
+#
+#   (1) Source exists  → mv it onto the committed path.
+#   (2) Source absent, committed binary already in place → no-op
+#       (the prior run already staged successfully).
+#   (3) Source absent AND committed binary absent → fail with a
+#       diagnostic naming the cargo-build expectation rather than
+#       leaking mv's kernel-level error.
+#
+# chmod stays in place as defensive coverage for environments
+# where mv ever fails to preserve mode bits.
 if [ "${1:-}" = "--stage-binary" ]; then
-  mv "$REPO_ROOT/target/release/flow-rs" "$REPO_ROOT/bin/flow-rs-darwin-arm64"
-  chmod 755 "$REPO_ROOT/bin/flow-rs-darwin-arm64"
+  SRC="$REPO_ROOT/target/release/flow-rs"
+  DST="$REPO_ROOT/bin/flow-rs-darwin-arm64"
+  if [ -f "$SRC" ]; then
+    mv "$SRC" "$DST"
+  elif [ ! -f "$DST" ]; then
+    echo "bin/setup: --stage-binary cannot proceed: no artifact at $SRC" >&2
+    echo "  and no prior staging left $DST in place. cargo build --release" >&2
+    echo "  succeeded but produced no binary at the expected path. Check" >&2
+    echo "  Cargo.toml [[bin]] config, CARGO_TARGET_DIR env, and workspace" >&2
+    echo "  layout, then re-run." >&2
+    exit 1
+  fi
+  chmod 755 "$DST"
 fi
 
 echo "Setup complete — run /flow:flow-prime in your project to initialize."

--- a/tests/bin_setup.rs
+++ b/tests/bin_setup.rs
@@ -3,20 +3,25 @@
 //! The script is invoked by users from their plain terminal after
 //! `/plugin install` and before `/flow:flow-prime`. It checks for
 //! `cargo` and `cc` prereqs and runs `cargo build --release` when
-//! both are present. Passed `--stage-binary`, it additionally copies
+//! both are present. Passed `--stage-binary`, it additionally moves
 //! the fresh release binary to `bin/flow-rs-darwin-arm64` so the
-//! committed prebuilt binary never lags the source.
-//! The first three tests assert structural
-//! contracts (existence, executable bit, bash syntax, content
-//! snippets, shebang, strict-mode preamble, active success echo)
-//! so an accidental edit that drops a prereq check, the build
-//! invocation, the success message, the executable bit, the
-//! bash-specific shebang, or the strict-mode preamble fails CI
-//! immediately. The last two tests exercise the script's runtime
-//! behavior against mocked PATHs so a regression that breaks the
-//! prereq-missing exit code or stderr routing is caught — the
-//! script's full build path (`cargo build --release`) is not
-//! exercised here because it would take minutes.
+//! committed prebuilt binary never lags the source AND the source
+//! artifact at `target/release/flow-rs` does not survive staging
+//! (a leftover would shadow the committed binary on the next
+//! `--plugin-dir` QA session because the dispatcher in `bin/flow`
+//! prefers `target/release` over the committed path).
+//!
+//! The structural tests assert presence-contracts (existence,
+//! executable bit, bash syntax, content snippets, shebang,
+//! strict-mode preamble, active success echo) so an accidental edit
+//! that drops a prereq check, the build invocation, the success
+//! message, the executable bit, the bash-specific shebang, or the
+//! strict-mode preamble fails CI immediately. The runtime tests
+//! exercise the script's behavior against mocked PATHs so
+//! regressions in the prereq-missing exit code, stderr routing, or
+//! `--stage-binary` move semantics are caught — the script's full
+//! cargo-driven build path is not exercised here because it would
+//! take minutes.
 
 mod common;
 
@@ -233,6 +238,18 @@ exit 0
     (tmp, path_value, staged_setup, PLACEHOLDER)
 }
 
+/// Reset the mock cargo so a subsequent `--stage-binary` invocation
+/// finds NO source artifact at `target/release/flow-rs` — simulates
+/// cargo's incremental cache skipping the link step on a re-run.
+fn replace_cargo_with_noop(root: &std::path::Path) {
+    let no_op_body = "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n";
+    let cargo = root.join("mock_bin").join("cargo");
+    fs::write(&cargo, no_op_body).expect("rewrite mock cargo");
+    let mut perms = fs::metadata(&cargo).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&cargo, perms).expect("chmod no-op cargo");
+}
+
 /// `bin/setup --stage-binary` must MOVE the freshly-built binary from
 /// `target/release/flow-rs` to `bin/flow-rs-darwin-arm64`, not copy
 /// it. A leftover `target/release/flow-rs` shadows source changes
@@ -288,6 +305,122 @@ fn stage_binary_removes_target_release_artifact() {
         placeholder,
         "committed binary bytes must equal the mock cargo's output; \
          the move must transfer content, not just delete the source"
+    );
+}
+
+/// `bin/setup --stage-binary` must be idempotent across re-runs.
+/// After the first staging consumes `target/release/flow-rs` via
+/// the move, a second invocation whose cargo cache hits and skips
+/// the link step (no new artifact at `target/release/flow-rs`)
+/// must leave the already-staged committed binary in place rather
+/// than failing with a raw `mv: rename ... No such file or
+/// directory` error. The flow-release skill at
+/// `.claude/skills/flow-release/SKILL.md` line 253 declares the
+/// release skill idempotent — Step 6's `bin/setup --stage-binary`
+/// must honor that contract on `/loop`-driven retries.
+#[test]
+fn stage_binary_is_idempotent_when_source_artifact_already_consumed() {
+    let (tmp, path_value, staged_setup, placeholder) = stage_setup_fixture();
+    let root = tmp.path();
+
+    let first = Command::new("/bin/bash")
+        .arg(&staged_setup)
+        .arg("--stage-binary")
+        .env("PATH", &path_value)
+        .output()
+        .expect("spawn staged bin/setup (first run)");
+    assert!(
+        first.status.success(),
+        "first --stage-binary must succeed; stderr: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    replace_cargo_with_noop(root);
+
+    let second = Command::new("/bin/bash")
+        .arg(&staged_setup)
+        .arg("--stage-binary")
+        .env("PATH", &path_value)
+        .output()
+        .expect("spawn staged bin/setup (second run, no fresh artifact)");
+    assert!(
+        second.status.success(),
+        "second --stage-binary with no fresh artifact must succeed (idempotent); \
+         got status {:?}\nstdout: {}\nstderr: {}",
+        second.status,
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr),
+    );
+    let stderr2 = String::from_utf8_lossy(&second.stderr);
+    assert!(
+        !stderr2.contains("mv: rename"),
+        "second --stage-binary must not leak a raw mv error; got stderr: {}",
+        stderr2
+    );
+
+    let committed = root.join("bin/flow-rs-darwin-arm64");
+    let committed_bytes = fs::read(&committed).expect("read committed binary");
+    assert_eq!(
+        committed_bytes.as_slice(),
+        placeholder,
+        "second run must preserve the bytes the first run staged"
+    );
+}
+
+/// When `bin/setup --stage-binary` runs with no source artifact at
+/// `target/release/flow-rs` AND no prior staged binary at
+/// `bin/flow-rs-darwin-arm64`, the script must fail with a
+/// diagnostic naming the cargo-build expectation rather than
+/// leaking a raw `mv: rename ... No such file or directory`
+/// kernel-level error. This catches the genuinely-broken case
+/// (cargo build succeeded without producing the expected
+/// artifact: workspace-target-dir misconfiguration, [[bin]]
+/// rename, CARGO_TARGET_DIR env divergence) without obscuring the
+/// operator's recovery path.
+#[test]
+fn stage_binary_emits_useful_error_when_source_and_destination_both_missing() {
+    let (tmp, path_value, staged_setup, _) = stage_setup_fixture();
+    let root = tmp.path();
+
+    replace_cargo_with_noop(root);
+
+    let output = Command::new("/bin/bash")
+        .arg(&staged_setup)
+        .arg("--stage-binary")
+        .env("PATH", &path_value)
+        .output()
+        .expect("spawn staged bin/setup");
+
+    assert!(
+        !output.status.success(),
+        "bin/setup --stage-binary must fail when neither source nor destination exists; \
+         got status {:?}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("mv: rename"),
+        "stderr must not leak a raw mv error; got: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("--stage-binary cannot proceed"),
+        "stderr must name the staging-failure diagnostic; got: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("cargo build --release"),
+        "stderr must point the operator at the cargo-build expectation; got: {}",
+        stderr
+    );
+
+    let committed = root.join("bin/flow-rs-darwin-arm64");
+    assert!(
+        !committed.exists(),
+        "destination must remain absent when neither source nor prior staging is present"
     );
 }
 

--- a/tests/bin_setup.rs
+++ b/tests/bin_setup.rs
@@ -173,6 +173,124 @@ fn script_missing_cargo_exits_nonzero_with_stderr_hint() {
     );
 }
 
+/// Stage a mock-cargo / mock-cc environment that lets bin/setup run
+/// without invoking the real Rust toolchain. The mock cargo parses
+/// `--manifest-path`, creates `target/release/` next to it, and
+/// writes a small placeholder file to `target/release/flow-rs` with
+/// mode 0755. Returns (tempdir, path_value, setup_script_path,
+/// placeholder_contents) so the test can drive the script and
+/// inspect the resulting tree.
+fn stage_setup_fixture() -> (tempfile::TempDir, String, std::path::PathBuf, &'static [u8]) {
+    const PLACEHOLDER: &[u8] = b"mock-flow-rs-binary-contents";
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    let mock_bin = root.join("mock_bin");
+    fs::create_dir_all(&mock_bin).expect("create mock_bin");
+
+    let mock_cargo_body = r#"#!/usr/bin/env bash
+set -euo pipefail
+manifest=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --manifest-path)
+      manifest="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+repo_root="$(dirname "$manifest")"
+mkdir -p "$repo_root/target/release"
+printf 'mock-flow-rs-binary-contents' > "$repo_root/target/release/flow-rs"
+chmod 0755 "$repo_root/target/release/flow-rs"
+exit 0
+"#;
+    let mock_cargo = mock_bin.join("cargo");
+    fs::write(&mock_cargo, mock_cargo_body).expect("write mock cargo");
+    let mut perms = fs::metadata(&mock_cargo).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&mock_cargo, perms).expect("chmod mock cargo");
+
+    let mock_cc = mock_bin.join("cc");
+    fs::write(&mock_cc, "#!/bin/sh\nexit 0\n").expect("write mock cc");
+    let mut perms = fs::metadata(&mock_cc).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&mock_cc, perms).expect("chmod mock cc");
+
+    let staged_bin = root.join("bin");
+    fs::create_dir_all(&staged_bin).expect("create staged bin");
+    let staged_setup = staged_bin.join("setup");
+    let setup_source = fs::read(script_path()).expect("read source bin/setup");
+    fs::write(&staged_setup, &setup_source).expect("write staged setup");
+    let mut perms = fs::metadata(&staged_setup).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&staged_setup, perms).expect("chmod staged setup");
+
+    let path_value = format!("{}:/usr/bin:/bin", mock_bin.to_string_lossy());
+    (tmp, path_value, staged_setup, PLACEHOLDER)
+}
+
+/// `bin/setup --stage-binary` must MOVE the freshly-built binary from
+/// `target/release/flow-rs` to `bin/flow-rs-darwin-arm64`, not copy
+/// it. A leftover `target/release/flow-rs` shadows source changes
+/// during `--plugin-dir` QA because the dispatcher prefers the
+/// release artifact when its mtime is newer than the committed
+/// binary's mtime — so the second-run gate must assert the source
+/// artifact is gone after staging.
+#[test]
+fn stage_binary_removes_target_release_artifact() {
+    let (tmp, path_value, staged_setup, placeholder) = stage_setup_fixture();
+    let root = tmp.path();
+
+    let output = Command::new("/bin/bash")
+        .arg(&staged_setup)
+        .arg("--stage-binary")
+        .env("PATH", &path_value)
+        .output()
+        .expect("spawn staged bin/setup");
+
+    assert!(
+        output.status.success(),
+        "bin/setup --stage-binary must exit 0; got status {:?}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let source_artifact = root.join("target/release/flow-rs");
+    assert!(
+        !source_artifact.exists(),
+        "bin/setup --stage-binary must remove the source artifact at \
+         target/release/flow-rs after staging; found it still on disk at {}",
+        source_artifact.display()
+    );
+
+    let committed = root.join("bin/flow-rs-darwin-arm64");
+    assert!(
+        committed.exists(),
+        "bin/setup --stage-binary must place the binary at \
+         bin/flow-rs-darwin-arm64; missing at {}",
+        committed.display()
+    );
+    let committed_meta = fs::metadata(&committed).expect("metadata committed");
+    assert!(
+        committed_meta.permissions().mode() & 0o111 != 0,
+        "bin/setup --stage-binary must leave the committed binary executable; mode was {:o}",
+        committed_meta.permissions().mode()
+    );
+
+    let committed_bytes = fs::read(&committed).expect("read committed binary");
+    assert_eq!(
+        committed_bytes.as_slice(),
+        placeholder,
+        "committed binary bytes must equal the mock cargo's output; \
+         the move must transfer content, not just delete the source"
+    );
+}
+
 /// When `cargo` is present but `cc` is absent the script must exit
 /// non-zero AND emit the `xcode-select --install` hint to stderr.
 /// Tests that only assert "bin/setup contains 'xcode-select


### PR DESCRIPTION
## What

#1637.

Closes #1637

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/flow-release-leaves-stale-target/log` |
| State | `.flow-states/flow-release-leaves-stale-target/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/b327c9d0-dc94-4a57-b00b-979331c0d708.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 4m |
| Code | 12m |
| Review | 24m |
| Learn | 3m |
| Complete | <1m |
| **Total** | **44m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 2.9M | $0.875 |
| Code | 31.4M | $10.319 |
| Review | 64.2M | $44.392 |
| Learn | 17.2M | $5.488 |
| Complete | 2.1M | $0.720 |
| **Total** | **117.7M** | **$61.794** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **Plan deviation: bin/setup comment block extended beyond lines 19-22 (the plan said 'unchanged')**
  - Dismissed — Implementation-detail carve-out per .claude/rules/plan-commit-atomicity.md 'What Is NOT a deviation' — the comment-block change adds rationale prose without altering function signatures, type shapes, task counts, or file names. The comment update aligns with .claude/rules/docs-with-behavior.md (changed behavior requires updated docs in the same commit). Reviewer agent self-classified as borderline. The deviation-log requirement applies to interface prototype changes, not comment-prose extensions.
- ✗ **Subprocess test hygiene gap: stage_binary_removes_target_release_artifact spawns /bin/bash without env_remove(FLOW_CI_RUNNING) or env(HOME=tempdir)**
  - Dismissed — The test spawns bin/setup, which does not read HOME, FLOW_CI_RUNNING, or any GH/Slack/cloud credential. .claude/rules/subprocess-test-hygiene.md scopes the neutralizer requirement to subjects that 'reach external services' — bin/setup invokes only cargo and cc, both already controlled via PATH override. Adding env_remove would be bureaucracy without behavior change per .claude/rules/review-scope.md value test (no runtime behavior change, no bug class prevented). Pre-mortem itself classified the severity as Low.
- ✓ **Adversarial probe tests/test_adversarial_flow.rs left on disk with assertions that fail against the current implementation**
  - Fixed — Reconciled per .claude/rules/adversarial-probe-lifecycle.md 'How to Apply' — emptied the probe file (default disposition: delete; sanctioned via overwrite-with-empty-contents per the rule). The probe's three findings (SKILL.md cp drift, opaque mv error on missing source, non-idempotent re-stage) are addressed by the in-place fixes below.
- ✓ **flow-release SKILL.md Step 6 prose still described cp/copy/copies semantics after the bin/setup cp→mv switch**
  - Fixed — Updated lines 155-161 to describe the move, name the post-staging absence of target/release/flow-rs, point at the dispatcher precedence rule (existence priority, NOT mtime) in bin/flow:27-33, and document the new idempotency guarantee. Also paired the mv permission-denied note with mv (not cp). Per .claude/rules/docs-with-behavior.md — changed skill behavior requires docs/skill prose update in the same commit.
- ✓ **tests/bin_setup.rs module doc: 'copies' verb stale after cp→mv, AND test-count prose ('first three structural ... last two runtime') stale**
  - Fixed — Rewrote the file-level doc comment to describe the move semantics and the dispatcher-shadowing motivation. Replaced count-based prose with category-based prose ('structural tests' vs 'runtime tests') so future test additions do not re-drift the count — per .claude/rules/forward-facing-authoring.md, the prose describes what IS, not what WAS.
- ✓ **bin/setup --stage-binary lost idempotency under the cp→mv switch: a second invocation whose cargo cache hit and skipped the link step would fail with a raw 'mv: rename ... No such file or directory' error**
  - Fixed — Added a source-existence guard (lines 30-43) that distinguishes three cases: (1) source exists → mv onto destination; (2) source absent, prior staging present → no-op (idempotent); (3) source absent AND no prior staging → fail with a diagnostic naming the cargo-build expectation rather than leaking mv's kernel-level error. Restores the .claude/skills/flow-release/SKILL.md line 253 idempotency contract. Two new regression tests in tests/bin_setup.rs: stage_binary_is_idempotent_when_source_artifact_already_consumed and stage_binary_emits_useful_error_when_source_and_destination_both_missing.
- ✓ **bin/setup comment claimed 'shadow source changes during --plugin-dir QA via the dispatcher's mtime preference' but bin/flow:27-33 uses unconditional existence priority, not mtime**
  - Fixed — Rewrote the bin/setup comment block to describe the dispatcher's actual selection mechanism (existence priority, first-match-wins) and cite the specific bin/flow line range so a future reader can verify the claim. Per .claude/rules/read-before-asserting.md — claims about how code works must match what the code does.

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/flow-release-leaves-stale-target.json</summary>

```json
{
  "schema_version": 1,
  "branch": "flow-release-leaves-stale-target",
  "base_branch": "main",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1638,
  "pr_url": "https://github.com/benkruger/flow/pull/1638",
  "started_at": "2026-05-17T15:21:12-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/flow-release-leaves-stale-target/log",
    "state": ".flow-states/flow-release-leaves-stale-target/state.json"
  },
  "session_tty": "/dev/ttys005",
  "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/b327c9d0-dc94-4a57-b00b-979331c0d708.jsonl",
  "notes": [],
  "prompt": "#1637",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-17T15:21:12-07:00",
      "completed_at": "2026-05-17T15:25:22-07:00",
      "session_started_at": null,
      "cumulative_seconds": 250,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-17T15:21:12-07:00",
        "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
        "model": "claude-opus-4-7",
        "five_hour_pct": 7,
        "seven_day_pct": 41,
        "session_input_tokens": 19,
        "session_output_tokens": 2327,
        "session_cache_creation_tokens": 659859,
        "session_cache_read_tokens": 284418,
        "session_cost_usd": 144.16316630000006,
        "by_model": {
          "claude-opus-4-7": {
            "input": 19,
            "output": 2327,
            "cache_create": 659859,
            "cache_read": 284418
          }
        },
        "turn_count": 4,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 236662,
        "context_window_pct": 118.331
      },
      "window_at_complete": {
        "captured_at": "2026-05-17T15:25:22-07:00",
        "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
        "model": "claude-opus-4-7",
        "five_hour_pct": 7,
        "seven_day_pct": 41,
        "session_input_tokens": 31,
        "session_output_tokens": 4469,
        "session_cache_creation_tokens": 663706,
        "session_cache_read_tokens": 3135008,
        "session_cost_usd": 145.03798755000005,
        "by_model": {
          "claude-opus-4-7": {
            "input": 31,
            "output": 4469,
            "cache_create": 663706,
            "cache_read": 3135008
          }
        },
        "turn_count": 16,
        "tool_call_count": 9,
        "context_at_last_turn_tokens": 238787,
        "context_window_pct": 119.3935
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-17T15:25:34-07:00",
      "completed_at": "2026-05-17T15:37:38-07:00",
      "session_started_at": null,
      "cumulative_seconds": 724,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-17T15:25:34-07:00",
        "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
        "model": "claude-opus-4-7",
        "five_hour_pct": 7,
        "seven_day_pct": 41,
        "session_input_tokens": 43,
        "session_output_tokens": 5263,
        "session_cache_creation_tokens": 681678,
        "session_cache_read_tokens": 4090556,
        "session_cost_usd": 145.34299205000005,
        "by_model": {
          "claude-opus-4-7": {
            "input": 43,
            "output": 5263,
            "cache_create": 681678,
            "cache_read": 4090556
          }
        },
        "turn_count": 20,
        "tool_call_count": 11,
        "context_at_last_turn_tokens": 247777,
        "context_window_pct": 123.8885
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-17T15:28:33-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 41,
          "session_input_tokens": 63,
          "session_output_tokens": 20902,
          "session_cache_creation_tokens": 1120215,
          "session_cache_read_tokens": 11168487,
          "session_cost_usd": 148.37276830000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 63,
              "output": 20902,
              "cache_create": 1120215,
              "cache_read": 11168487
            }
          },
          "turn_count": 40,
          "tool_call_count": 20,
          "context_at_last_turn_tokens": 463764,
          "context_window_pct": 231.882
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-17T15:32:15-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 41,
          "session_input_tokens": 77,
          "session_output_tokens": 27327,
          "session_cache_creation_tokens": 1150555,
          "session_cache_read_tokens": 17697928,
          "session_cost_usd": 150.14718755000004,
          "by_model": {
            "claude-opus-4-7": {
              "input": 77,
              "output": 27327,
              "cache_create": 1150555,
              "cache_read": 17697928
            }
          },
          "turn_count": 54,
          "tool_call_count": 27,
          "context_at_last_turn_tokens": 475935,
          "context_window_pct": 237.9675
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-17T15:36:35-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 41,
          "session_input_tokens": 127,
          "session_output_tokens": 34523,
          "session_cache_creation_tokens": 1202108,
          "session_cache_read_tokens": 28868496,
          "session_cost_usd": 153.77327680000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 127,
              "output": 34523,
              "cache_create": 1202108,
              "cache_read": 28868496
            }
          },
          "turn_count": 77,
          "tool_call_count": 41,
          "context_at_last_turn_tokens": 497628,
          "context_window_pct": 248.814
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-17T15:37:38-07:00",
        "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 41,
        "session_input_tokens": 162,
        "session_output_tokens": 37659,
        "session_cache_creation_tokens": 1238727,
        "session_cache_read_tokens": 34907398,
        "session_cost_usd": 155.66165255000004,
        "by_model": {
          "claude-opus-4-7": {
            "input": 162,
            "output": 37659,
            "cache_create": 1238727,
            "cache_read": 34907398
          }
        },
        "turn_count": 89,
        "tool_call_count": 48,
        "context_at_last_turn_tokens": 511857,
        "context_window_pct": 255.9285
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-17T15:38:25-07:00",
      "completed_at": "2026-05-17T16:02:48-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1463,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-17T15:38:25-07:00",
        "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 41,
        "session_input_tokens": 174,
        "session_output_tokens": 38451,
        "session_cache_creation_tokens": 1270945,
        "session_cache_read_tokens": 36955178,
        "session_cost_usd": 156.28420880000004,
        "by_model": {
          "claude-opus-4-7": {
            "input": 174,
            "output": 38451,
            "cache_create": 1270945,
            "cache_read": 36955178
          }
        },
        "turn_count": 93,
        "tool_call_count": 50,
        "context_at_last_turn_tokens": 527970,
        "context_window_pct": 263.985
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-17T15:40:28-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 41,
          "session_input_tokens": 196,
          "session_output_tokens": 42906,
          "session_cache_creation_tokens": 1276889,
          "session_cache_read_tokens": 48609263,
          "session_cost_usd": 160.07420930000004,
          "by_model": {
            "claude-opus-4-7": {
              "input": 196,
              "output": 42906,
              "cache_create": 1276889,
              "cache_read": 48609263
            }
          },
          "turn_count": 115,
          "tool_call_count": 64,
          "context_at_last_turn_tokens": 531546,
          "context_window_pct": 265.773
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-17T15:50:29-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 18,
          "seven_day_pct": 43,
          "session_input_tokens": 245,
          "session_output_tokens": 104232,
          "session_cache_creation_tokens": 1423110,
          "session_cache_read_tokens": 59146966,
          "session_cost_usd": 187.04201535,
          "by_model": {
            "claude-opus-4-7": {
              "input": 245,
              "output": 104232,
              "cache_create": 1423110,
              "cache_read": 59146966
            }
          },
          "turn_count": 134,
          "tool_call_count": 76,
          "context_at_last_turn_tokens": 584233,
          "context_window_pct": 292.1165
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-17T15:53:55-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 18,
          "seven_day_pct": 43,
          "session_input_tokens": 269,
          "session_output_tokens": 123401,
          "session_cache_creation_tokens": 1440954,
          "session_cache_read_tokens": 73248836,
          "session_cost_usd": 191.41864085,
          "by_model": {
            "claude-opus-4-7": {
              "input": 269,
              "output": 123401,
              "cache_create": 1440954,
              "cache_read": 73248836
            }
          },
          "turn_count": 158,
          "tool_call_count": 90,
          "context_at_last_turn_tokens": 595131,
          "context_window_pct": 297.5655
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-17T16:02:33-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 19,
          "seven_day_pct": 43,
          "session_input_tokens": 333,
          "session_output_tokens": 150748,
          "session_cache_creation_tokens": 1541325,
          "session_cache_read_tokens": 98807891,
          "session_cost_usd": 199.9260636,
          "by_model": {
            "claude-opus-4-7": {
              "input": 333,
              "output": 150748,
              "cache_create": 1541325,
              "cache_read": 98807891
            }
          },
          "turn_count": 199,
          "tool_call_count": 115,
          "context_at_last_turn_tokens": 642952,
          "context_window_pct": 321.476
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-17T15:50:00-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-17T15:50:07-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-17T15:50:16-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-17T15:50:23-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-17T16:02:48-07:00",
        "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
        "model": "claude-opus-4-7",
        "five_hour_pct": 19,
        "seven_day_pct": 43,
        "session_input_tokens": 346,
        "session_output_tokens": 151158,
        "session_cache_creation_tokens": 1573265,
        "session_cache_read_tokens": 100737372,
        "session_cost_usd": 200.67635035000004,
        "by_model": {
          "claude-opus-4-7": {
            "input": 346,
            "output": 151158,
            "cache_create": 1573265,
            "cache_read": 100737372
          }
        },
        "turn_count": 202,
        "tool_call_count": 117,
        "context_at_last_turn_tokens": 659084,
        "context_window_pct": 329.542
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-17T16:03:05-07:00",
      "completed_at": "2026-05-17T16:06:58-07:00",
      "session_started_at": null,
      "cumulative_seconds": 233,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-17T16:03:05-07:00",
        "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
        "model": "claude-opus-4-7",
        "five_hour_pct": 19,
        "seven_day_pct": 43,
        "session_input_tokens": 358,
        "session_output_tokens": 151958,
        "session_cache_creation_tokens": 1602429,
        "session_cache_read_tokens": 103374088,
        "session_cost_usd": 201.43669685000003,
        "by_model": {
          "claude-opus-4-7": {
            "input": 358,
            "output": 151958,
            "cache_create": 1602429,
            "cache_read": 103374088
          }
        },
        "turn_count": 206,
        "tool_call_count": 119,
        "context_at_last_turn_tokens": 673665,
        "context_window_pct": 336.8325
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-17T16:05:41-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-17T16:05:51-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 43,
          "session_input_tokens": 371,
          "session_output_tokens": 159665,
          "session_cache_creation_tokens": 1640797,
          "session_cache_read_tokens": 112209690,
          "session_cost_usd": 204.4603608500001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 371,
              "output": 159665,
              "cache_create": 1640797,
              "cache_read": 112209690
            }
          },
          "turn_count": 219,
          "tool_call_count": 126,
          "context_at_last_turn_tokens": 689555,
          "context_window_pct": 344.7775
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-17T16:05:59-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 43,
          "session_input_tokens": 372,
          "session_output_tokens": 159796,
          "session_cache_creation_tokens": 1641149,
          "session_cache_read_tokens": 112899244,
          "session_cost_usd": 204.81061785000009,
          "by_model": {
            "claude-opus-4-7": {
              "input": 372,
              "output": 159796,
              "cache_create": 1641149,
              "cache_read": 112899244
            }
          },
          "turn_count": 220,
          "tool_call_count": 127,
          "context_at_last_turn_tokens": 689907,
          "context_window_pct": 344.9535
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-17T16:06:08-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 43,
          "session_input_tokens": 374,
          "session_output_tokens": 160096,
          "session_cache_creation_tokens": 1641491,
          "session_cache_read_tokens": 114279056,
          "session_cost_usd": 205.16039460000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 374,
              "output": 160096,
              "cache_create": 1641491,
              "cache_read": 114279056
            }
          },
          "turn_count": 222,
          "tool_call_count": 128,
          "context_at_last_turn_tokens": 690078,
          "context_window_pct": 345.039
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-17T16:06:24-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 43,
          "session_input_tokens": 377,
          "session_output_tokens": 160517,
          "session_cache_creation_tokens": 1642067,
          "session_cache_read_tokens": 116349667,
          "session_cost_usd": 205.86024535000004,
          "by_model": {
            "claude-opus-4-7": {
              "input": 377,
              "output": 160517,
              "cache_create": 1642067,
              "cache_read": 116349667
            }
          },
          "turn_count": 225,
          "tool_call_count": 130,
          "context_at_last_turn_tokens": 690461,
          "context_window_pct": 345.2305
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-17T16:06:32-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 43,
          "session_input_tokens": 379,
          "session_output_tokens": 160823,
          "session_cache_creation_tokens": 1642407,
          "session_cache_read_tokens": 117730587,
          "session_cost_usd": 206.21036785000004,
          "by_model": {
            "claude-opus-4-7": {
              "input": 379,
              "output": 160823,
              "cache_create": 1642407,
              "cache_read": 117730587
            }
          },
          "turn_count": 227,
          "tool_call_count": 131,
          "context_at_last_turn_tokens": 690631,
          "context_window_pct": 345.3155
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-17T16:06:42-07:00",
          "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 43,
          "session_input_tokens": 381,
          "session_output_tokens": 161121,
          "session_cache_creation_tokens": 1642793,
          "session_cache_read_tokens": 119111847,
          "session_cost_usd": 206.56061910000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 381,
              "output": 161121,
              "cache_create": 1642793,
              "cache_read": 119111847
            }
          },
          "turn_count": 229,
          "tool_call_count": 132,
          "context_at_last_turn_tokens": 690824,
          "context_window_pct": 345.412
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-17T16:06:58-07:00",
        "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 43,
        "session_input_tokens": 383,
        "session_output_tokens": 162477,
        "session_cache_creation_tokens": 1643457,
        "session_cache_read_tokens": 120493493,
        "session_cost_usd": 206.92506060000005,
        "by_model": {
          "claude-opus-4-7": {
            "input": 383,
            "output": 162477,
            "cache_create": 1643457,
            "cache_read": 120493493
          }
        },
        "turn_count": 231,
        "tool_call_count": 133,
        "context_at_last_turn_tokens": 691156,
        "context_window_pct": 345.578
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-17T16:07:38-07:00",
      "completed_at": "2026-05-17T16:08:03-07:00",
      "session_started_at": null,
      "cumulative_seconds": 25,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-17T16:07:38-07:00",
        "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 43,
        "session_input_tokens": 398,
        "session_output_tokens": 164099,
        "session_cache_creation_tokens": 1671131,
        "session_cache_read_tokens": 125374133,
        "session_cost_usd": 208.4306676,
        "by_model": {
          "claude-opus-4-7": {
            "input": 398,
            "output": 164099,
            "cache_create": 1671131,
            "cache_read": 125374133
          }
        },
        "turn_count": 238,
        "tool_call_count": 137,
        "context_at_last_turn_tokens": 705130,
        "context_window_pct": 352.565
      },
      "window_at_complete": {
        "captured_at": "2026-05-17T16:08:03-07:00",
        "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 43,
        "session_input_tokens": 401,
        "session_output_tokens": 164605,
        "session_cache_creation_tokens": 1672350,
        "session_cache_read_tokens": 127489983,
        "session_cost_usd": 209.15021310000003,
        "by_model": {
          "claude-opus-4-7": {
            "input": 401,
            "output": 164605,
            "cache_create": 1672350,
            "cache_read": 127489983
          }
        },
        "turn_count": 241,
        "tool_call_count": 139,
        "context_at_last_turn_tokens": 705886,
        "context_window_pct": 352.943
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-17T15:25:34-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-17T15:38:25-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-17T16:03:05-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-17T16:07:38-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-17T15:21:12-07:00",
    "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
    "model": "claude-opus-4-7",
    "five_hour_pct": 7,
    "seven_day_pct": 41,
    "session_input_tokens": 19,
    "session_output_tokens": 2327,
    "session_cache_creation_tokens": 659859,
    "session_cache_read_tokens": 284418,
    "session_cost_usd": 144.16316630000006,
    "by_model": {
      "claude-opus-4-7": {
        "input": 19,
        "output": 2327,
        "cache_create": 659859,
        "cache_read": 284418
      }
    },
    "turn_count": 4,
    "tool_call_count": 2,
    "context_at_last_turn_tokens": 236662,
    "context_window_pct": 118.331
  },
  "code_tasks_total": 3,
  "code_task_name": "Full CI verification",
  "code_task": 3,
  "diff_stats": {
    "files_changed": 2,
    "insertions": 126,
    "deletions": 3,
    "captured_at": "2026-05-17T15:37:38-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThis is a Learn phase (Phase 4) agent invocation for PR #1638 on branch `flow-release-leaves-stale-target`. I am the learn-analyst agent, tasked with auditing the PR for process gaps (Tenant 1), rule compliance violations (Tenant 2), and missing rules (Tenant 3) by analyzing the diff, state file, plan, and project rules.\n\nThe task requires me to apply TWO gates to every candidate finding:\n1. Forward-facing: Would a future session understand and apply the principle?\n2. Value test: Was the gap caught and remediated in this PR? If yes, drop it (the system already closed it).\n\nLet me reconstruct what I've read:\n\n**State file (`state.json`):**\n- Phase timing shows Start (250s), Code (724s), Review (1463s), all single-visit phases\n- Review phase produced 6 findings: 2 dismissed, 4 fixed\n- Found findings: (1) Plan deviation on comment extension, (2) Subprocess test hygiene gap, (3) Adversarial probe left on disk, (4) SKILL.md cp drift, (5) tests/bin_setup.rs module doc drift, (6) bin/setup idempotency regression\n- All 4 real findings were fixed in Review Step 4\n- Current phase is flow-learn, Step 0\n\n**Plan (`plan.md`):**\n- Context: Release process leaves stale `target/release/flow-rs` that shadows source changes during `--plugin-dir` QA\n- Narrow fix: Switch from `cp` to `mv` in bin/setup\n- Exploration: Lists 5 files (bin/setup, tests/bin_setup.rs, .claude/skills/flow-release/SKILL.md, tests/binary_artifact.rs, bin/flow dispatcher)\n- Risks: Cross-filesystem mv, mv permission preservation, mock fidelity\n- Approach: Replace cp with mv, keep chmod 755 defensive, TDD order\n- Tasks: (1) Add failing test, (2) Change cp to mv, (3) Full CI verification\n\n**Diff (`full-diff.diff`):**\n- Two files changed: bin/setup and tests/bin_setup.rs\n- bin/setup: Lines 9-21 — comment block extended (5 lines added explaining the WHY of mv, dispatcher precedence, mtime behavior), line 19 changed cp→mv, line 21 chmod retained\n- tests/bin_setup.rs: Lines 32-148 added:\n  - `stage_setup_fixture()` helper with 58 lines (creates tempdir with mock_bin/cargo, mock_bin/cc, staged bin/setup, returns (TempDir, PATH_value, setup_path, placeholder_bytes))\n  - `stage_binary_removes_target_release_artifact()` test with 48 lines (spawns script with --stage-binary, asserts source artifact gone, committed binary exists and executable, bytes match)\n\n**Review findings (from state.json findings array):**\n1. Plan deviation: Comment block extended beyond lines 19-22 (dismissed as implementation-detail carve-out per plan-commit-atomicity.md; comment extensions aligning with docs-with-behavior.md are not interface prototypes)\n2. Subprocess test hygiene gap: No env_remove(FLOW_CI_RUNNING) or env(HOME) (dismissed as out of scope; bin/setup doesn't reach external services, only cargo/cc controlled via PATH)\n3. Adversarial probe left on disk (fixed: emptied per adversarial-probe-lifecycle.md)\n4. SKILL.md cp drift at lines 155-161 (fixed: updated to describe move, removed cp reference, added dispatcher precedence cite, noted idempotency guarantee)\n5. tests/bin_setup.rs module doc drift (fixed: rewrote line 7 \"copies\" → \"moves\", replaced count-based prose with category-based to avoid future drift)\n6. bin/setup idempotency regression under cp→mv (fixed: added three-case source-existence guard at lines 30-43, two new regression tests)\n\n**Key context from compact_summary:**\n- Code phase was straightforward: implemented the narrow plan without deviations\n- Review surfaced multiple gaps the plan did not anticipate\n- Pre-mortem and adversarial agents found the idempotency regression independently\n- All 4 real findings were fixed in the same PR\n\nNow I apply my three-tenant audit plus two-gate filter:\n\n**TENANT 1 (Process gaps):**\nCandidates:\n- Visit count of 1 for all phases (no friction, no revisits) ✓\n- Code phase shipped exactly per plan (no mid-course discovery pivots requiring logging) ✓\n- Review discovered gaps plan did not anticipate (idempotency, prose drift) — but ALL were caught and fixed in-PR\n- Pre-mortem and adversarial agents both found the same idempotency regression independently, proving the cognitive isolation design caught it\n\nNo process gaps survive the value test. The Review agents did their job; the gaps were fixed in-PR.\n\n**TENANT 2 (Rule compliance):**\nChecking against `.claude/rules/`:\n- `.claude/rules/docs-with-behavior.md` \"Changed behavior requires updated docs in same commit\" — PASSED: comment in bin/setup updated, SKILL.md updated, tests/bin_setup.rs module doc updated, all in one commit\n- `.claude/rules/adversarial-probe-lifecycle.md` \"Probe must be reconciled in Step 4\" — PASSED: probe was emptied\n- `.claude/rules/plan-commit-atomicity.md` \"Comment extensions for implementation details are not deviations\" — PASSED: comment extension was dismissed correctly\n- `.claude/rules/test-placement.rs` \"Test fixture helpers must have doc comments\" — the `stage_setup_fixture()` at line 32-38 has a doc comment explaining return value and behavior ✓\n- `.claude/rules/no-waivers.md` \"100% coverage gate\" — tests added cover the new code paths ✓\n- `.claude/rules/substring-test-hygiene.md` — subprocess test `stage_binary_removes_target_release_artifact` does not set env_remove, but this is dismissed as out of scope (bin/setup doesn't reach external services)\n\nNo rule violations detected after all fixes were applied.\n\n**TENANT 3 (Missing rules):**\nCandidates:\n- Should there be a rule about testing `mv` idempotency when switching from `cp`? The issue arose because `cp` is inherently idempotent (second run just overwrites) but `mv` is not (second run fails if source is gone). This is a general pattern when refactoring operations. However, this is already covered by existing rules: TDD discipline, the pre-mortem review (which caught it), and adversarial probe testing. No new rule needed.\n- Should there be a rule about dispatcher shadowing artifacts? This is a very specific pattern (stale artifact with newer mtime shadowing source changes). The fix is to remove the artifact, which is what was done. This is not a forward-facing principle applicable to future work; it's a one-time fix for this specific artifact artifact. Discard.\n\nNo missing rules detected.\n\n**Two-gate application:**\n\nForward-facing test: Would a future session understand and apply what principle?\n- All findings were already fixed in-PR, so there's nothing left to forward-face\n\nValue test: Was the gap caught and remediated in this PR?\n- All 4 real findings: Yes, fixed in Review Step 4\n- Both dismissed findings: Correctly classified\n\nResult: **No findings to report.** All real findings were caught by Review agents (cognitive isolation working) and fixed in the same PR (system already closed the gaps).\n\nThe only artifacts for Learn phase are the 6 findings already recorded in state.json. My job is to audit whether they represent process gaps or rule violations. They don't — they were all legitimate findings that were appropriately triaged and fixed.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   I am the learn-analyst agent invoked for Phase 4 (Learn) of PR #1638 on branch `flow-release-leaves-stale-target`. My task is to audit the completed feature for three categories of findings: (Tenant 1) process gaps in the FLOW workflow, (Tenant 2) rule compliance violations, and (Tenant 3) missing rules. I must apply two gates to every candidate: (a) forward-facing—would a future session understand and apply this principle?—and (b) value—was the gap caught and remediated in this PR? If yes to (b), the finding is discarded because the system already closed it.\n\n2. Key Technical Concepts:\n   - `bin/setup` script: The one-time install-flow build script that users run after `/plugin install` and before `/flow:flow-prime`. It checks for `cargo` and `cc` prerequisites and runs `cargo build --release` when both are present.\n   - `--stage-binary` flag: An optional argument to bin/setup that stages the freshly-built release binary to the committed prebuilt path (`bin/flow-rs-darwin-arm64`).\n   - cp vs. mv semantics: The PR changes from `cp` (copy, preserving source) to `mv` (move, removing source). This matters because the dispatcher uses existence priority (first-match-wins), not mtime, and a leftover `target/release/flow-rs` would shadow source changes during `--plugin-dir` QA.\n   - Dispatcher precedence: bin/flow lines 23-33 resolve the binary using existence priority, not mtime. The initial diff comment incorrectly claimed \"mtime preference\" but this was fixed in Review Step 4.\n   - Idempotency regression: Switching from `cp` (inherently idempotent—second run just overwrites) to `mv` (not idempotent—second run fails if source is gone) introduced a regression when cargo cache hits and the build step is skipped.\n   - Adversarial probe lifecycle: Tests in `tests/test_adversarial_flow.rs` that the adversarial agent writes to prove findings by failing against the current implementation. These must be reconciled in Review Step 4.\n   - Cognitive isolation: The Review phase uses four cognitively isolated agents (reviewer, pre-mortem, adversarial, documentation), each receiving only persisted artifacts (diff, plan, rules) to catch biases the session's emotional arc would mask.\n\n3. Files and Code Sections:\n   - `bin/setup`:\n     - Lines 9-21 (comment block): Extended from 3 lines to 8 lines explaining why `mv` is used (removes source artifact to prevent dispatcher shadowing), describing the dispatcher's actual mechanism (existence priority, not mtime), and noting chmod as defensive coverage. This change was flagged as a \"plan deviation\" in Review (dismissed as implementation-detail carve-out per plan-commit-atomicity.md because comment extensions aligning with docs-with-behavior.md are not interface prototypes).\n     - Line 19: Changed from `cp \"$REPO_ROOT/target/release/flow-rs\" \"$REPO_ROOT/bin/flow-rs-darwin-arm64\"` to `mv \"$REPO_ROOT/target/release/flow-rs\" \"$REPO_ROOT/bin/flow-rs-darwin-arm64\"`\n     - Line 21: Retained `chmod 755 \"$REPO_ROOT/bin/flow-rs-darwin-arm64\"` as defensive coverage in case mv fails to preserve mode bits\n   - `tests/bin_setup.rs`:\n     - Lines 32-90: New `stage_setup_fixture()` helper function (58 lines). Creates a tempdir with mock_bin/cargo, mock_bin/cc, and a staged copy of bin/setup. The mock cargo parses `--manifest-path`, creates `target/release/` directory, and writes a placeholder file with mode 0755. Returns (TempDir, PATH_value_with_mocks, staged_setup_path, placeholder_bytes). This allows tests to drive the script against mocked toolchain without invoking real cargo/cc.\n     - Lines 92-148: New `stage_binary_removes_target_release_artifact()` test (48 lines). Spawns staged bin/setup with --stage-binary, asserts exit code 0, asserts source artifact at `target/release/flow-rs` does NOT exist, asserts committed binary at `bin/flow-rs-darwin-arm64` DOES exist and is executable, asserts bytes match (proving move transferred content, not just deleted source).\n     - Module doc comment at lines 1-19: Was incorrectly worded with \"the script...copies\" and count-based prose (\"first three tests...last two tests\"). Fixed in Review Step 4 to say \"moves\" and use category-based prose (\"structural tests...runtime tests\") to avoid future drift when tests are added.\n   - `.claude/skills/flow-release/SKILL.md` (not in diff but fixed in Review Step 4):\n     - Lines 155-161: Originally said \"copies it to\", \"the copy both run\", \"`cp` directly is permission-denied\". Updated to describe move semantics, removed cp references, added cite to bin/flow:27-33 for dispatcher precedence rule, documented idempotency guarantee.\n   - Review findings (from state.json, all recorded and triaged):\n     - Adversarial probe at `tests/test_adversarial_flow.rs`: Left on disk with failing assertions. Reconciled by emptying the file per adversarial-probe-lifecycle.md (default disposition: delete).\n\n4. Errors and fixes:\n   - Initial bin/setup comment claimed dispatcher uses \"mtime preference\" but bin/flow lines 27-33 actually use unconditional existence priority (first-match-wins). Fixed in Review Step 4 by rewriting comment to cite the exact dispatcher mechanism.\n   - bin/setup lost idempotency under cp→mv switch. When cargo cache hit and build step skipped, second invocation of --stage-binary would fail with raw \"mv: rename ... No such file or directory\" error. Fixed in Review Step 4 by adding three-case source-existence guard (lines 30-43): (1) source exists → mv; (2) source absent, prior staging present → no-op (idempotent); (3) source absent AND no prior staging → fail with diagnostic error naming cargo-build expectation. Two new regression tests added: `stage_binary_is_idempotent_when_source_artifact_already_consumed` and `stage_binary_emits_useful_error_when_source_and_destination_both_missing`.\n   - SKILL.md and tests/bin_setup.rs module doc still described \"copies\" after the switch to \"moves\". Fixed in Review Step 4 by updating prose in both files.\n   - Subprocess test hygiene: Test `stage_binary_removes_target_release_artifact` does not set env_remove(FLOW_CI_RUNNING) or env(HOME=tempdir). Reviewed and dismissed as out of scope because bin/setup only invokes cargo and cc (both controlled via PATH override), does not reach GitHub/Slack/cloud services. Per subprocess-test-hygiene.md, neutralizers are scoped to subjects that reach external services.\n\n5. Problem Solving:\n   - Code phase executed straightforwardly, shipping exactly per plan with no mid-course deviations.\n   - Review phase discovered 6 findings: 2 dismissed as low-risk (plan deviation on comment extension, subprocess hygiene out of scope), 4 fixed (adversarial probe reconciliation, SKILL.md prose drift, tests/bin_setup.rs module doc drift, idempotency regression). All 4 real findings were remediated in Review Step 4, committed atomically.\n   - Idempotency regression was found independently by both pre-mortem agent (predicted failure mode of second invocation) and adversarial agent (wrote failing test). This dual detection confirms cognitive isolation design is working—gaps caught by multiple agents prove they're not self-reporting bias.\n   - All Review findings were Real (not false positives) and were fixed in the same PR per review-scope.md rule (\"every real finding fixed during Step 4\").\n\n6. All user messages:\n   - Initial prompt (system instructions at top of this conversation): \"FRAMING: Most Learn phases produce zero findings. Your job is to filter, not to find things to say. Apply the two-gate test to every candidate finding before reporting it: (1) Forward-facing—would a future session who has never read this PR understand and apply the principle? If no, drop. (2) Value—was the gap caught and remediated in this PR? If yes, drop (the system already closed it). 'No findings' in any category is the most common correct answer. Return only findings that pass both gates. If all categories produce zero, say so explicitly with 'No findings' markers — do NOT invent findings to fill sections.\"\n   - Instructions to read DIFF_FILE, PLAN_FILE, STATE_FILE, CLAUDE_MD_PATH, and RULES_DIR before analyzing.\n   - Request to apply three-tenant audit (process gap / rule compliance / missing rule) AND two-gate filter.\n   - Request to pay special attention to: (a) whether Plan phase anticipated idempotency regression (is this a Plan-phase enumeration gap warranting a rule?), (b) whether plan-commit-atomicity \"implementation-detail\" carve-out is clear about when comment extensions need deviation logging, (c) whether adversarial probe lifecycle ran as designed and existing rules fully cover it.\n   - Final system instruction (TEXT ONLY, NO TOOLS): Create a detailed summary of the conversation so far in <analysis> and <summary> blocks.\n\n7. Pending Tasks:\n   - None. I have completed the Learn-phase analysis. All artifacts (diff, plan, state file, findings) have been read. The three tenants have been audited against the rules. The two gates have been applied. All findings were either dismissed or already fixed in-PR.\n\n8. Current Work:\n   I am analyzing PR #1638 for Learn phase. I have read:\n   - state.json: Full state file showing all 6 Review findings (2 dismissed, 4 fixed)\n   - plan.md: Full implementation plan with 3 tasks (add test, change cp→mv, full CI verification)\n   - full-diff.diff: Complete diff showing bin/setup (comment + cp→mv + chmod retained) and tests/bin_setup.rs (stage_setup_fixture helper + stage_binary_removes_target_release_artifact test)\n   \n   I am currently in the analysis phase, applying the two-gate filter to determine whether any findings warrant reporting. So far:\n   - Tenant 1 (process gaps): No findings pass both gates. All real findings were caught by Review agents and fixed in-PR. The system worked.\n   - Tenant 2 (rule compliance): All rules followed. docs-with-behavior.md complied (docs updated in same commit). adversarial-probe-lifecycle.md complied (probe reconciled). plan-commit-atomicity.md correctly dismissed comment extension as non-deviation. No violations.\n   - Tenant 3 (missing rules): No new rules needed. Idempotency testing is already covered by TDD discipline and pre-mortem/adversarial review. Dispatcher shadowing is a one-time fix, not a forward-facing principle.\n\n9. Optional Next Step:\n   Emit structured findings report. The only possible output is: \"No [Tenant] findings.\" for each of Tenants 1, 2, and 3, followed by the `## END-OF-FINDINGS` completion marker, because all candidate findings fail the value gate (\"was the gap caught and remediated in this PR? Yes—all four real findings were fixed in Review Step 4\").\n\n</summary>\n\nBased on my analysis of the artifacts provided (state file, plan, diff, rules), I find:\n\n**No Tenant 1 findings.** All review findings were appropriately triaged and all real findings (4 of 6) were fixed in Review Step 4. Code phase executed per plan without mid-course deviations. Visit counts of 1 for all phases indicate no friction or rework. Pre-mortem and adversarial agents both caught the idempotency regression independently, demonstrating that cognitive isolation is working as designed. The value gate (\"was this gap caught and remediated in the PR?\") is \"yes\" for all real findings, so they do not surface as process gaps.\n\n**No Tenant 2 findings.** All applicable rules were followed: (a) docs-with-behavior.md—bin/setup comment, SKILL.md prose, and tests/bin_setup.rs module doc were all updated in the same commits as code changes; (b) adversarial-probe-lifecycle.md—the probe was reconciled in Review Step 4 by emptying the file; (c) plan-commit-atomicity.md—the comment extension was correctly dismissed as an implementation-detail carve-out, not a signature deviation; (d) test-placement.md—the stage_setup_fixture helper carries a doc comment explaining its return type and behavior; (e) no-waivers.md—new test assertions cover the refactored code paths.\n\n**No Tenant 3 findings.** No new rules are needed. Idempotency testing when switching from copy to move is already covered by TDD discipline and the existing pre-mortem/adversarial review process (both agents independently identified the regression). The dispatcher shadowing issue is a one-time artifact-cleanup fix for this specific release binary, not a forward-facing principle applicable to future work.\n\n## END-OF-FINDINGS",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/flow-release-leaves-stale-target",
  "compact_count": 4,
  "findings": [
    {
      "finding": "Plan deviation: bin/setup comment block extended beyond lines 19-22 (the plan said 'unchanged')",
      "reason": "Implementation-detail carve-out per .claude/rules/plan-commit-atomicity.md 'What Is NOT a deviation' — the comment-block change adds rationale prose without altering function signatures, type shapes, task counts, or file names. The comment update aligns with .claude/rules/docs-with-behavior.md (changed behavior requires updated docs in the same commit). Reviewer agent self-classified as borderline. The deviation-log requirement applies to interface prototype changes, not comment-prose extensions.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T15:53:23-07:00"
    },
    {
      "finding": "Subprocess test hygiene gap: stage_binary_removes_target_release_artifact spawns /bin/bash without env_remove(FLOW_CI_RUNNING) or env(HOME=tempdir)",
      "reason": "The test spawns bin/setup, which does not read HOME, FLOW_CI_RUNNING, or any GH/Slack/cloud credential. .claude/rules/subprocess-test-hygiene.md scopes the neutralizer requirement to subjects that 'reach external services' — bin/setup invokes only cargo and cc, both already controlled via PATH override. Adding env_remove would be bureaucracy without behavior change per .claude/rules/review-scope.md value test (no runtime behavior change, no bug class prevented). Pre-mortem itself classified the severity as Low.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T15:53:34-07:00"
    },
    {
      "finding": "Adversarial probe tests/test_adversarial_flow.rs left on disk with assertions that fail against the current implementation",
      "reason": "Reconciled per .claude/rules/adversarial-probe-lifecycle.md 'How to Apply' — emptied the probe file (default disposition: delete; sanctioned via overwrite-with-empty-contents per the rule). The probe's three findings (SKILL.md cp drift, opaque mv error on missing source, non-idempotent re-stage) are addressed by the in-place fixes below.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T15:59:55-07:00"
    },
    {
      "finding": "flow-release SKILL.md Step 6 prose still described cp/copy/copies semantics after the bin/setup cp→mv switch",
      "reason": "Updated lines 155-161 to describe the move, name the post-staging absence of target/release/flow-rs, point at the dispatcher precedence rule (existence priority, NOT mtime) in bin/flow:27-33, and document the new idempotency guarantee. Also paired the mv permission-denied note with mv (not cp). Per .claude/rules/docs-with-behavior.md — changed skill behavior requires docs/skill prose update in the same commit.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T16:00:09-07:00"
    },
    {
      "finding": "tests/bin_setup.rs module doc: 'copies' verb stale after cp→mv, AND test-count prose ('first three structural ... last two runtime') stale",
      "reason": "Rewrote the file-level doc comment to describe the move semantics and the dispatcher-shadowing motivation. Replaced count-based prose with category-based prose ('structural tests' vs 'runtime tests') so future test additions do not re-drift the count — per .claude/rules/forward-facing-authoring.md, the prose describes what IS, not what WAS.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T16:00:21-07:00"
    },
    {
      "finding": "bin/setup --stage-binary lost idempotency under the cp→mv switch: a second invocation whose cargo cache hit and skipped the link step would fail with a raw 'mv: rename ... No such file or directory' error",
      "reason": "Added a source-existence guard (lines 30-43) that distinguishes three cases: (1) source exists → mv onto destination; (2) source absent, prior staging present → no-op (idempotent); (3) source absent AND no prior staging → fail with a diagnostic naming the cargo-build expectation rather than leaking mv's kernel-level error. Restores the .claude/skills/flow-release/SKILL.md line 253 idempotency contract. Two new regression tests in tests/bin_setup.rs: stage_binary_is_idempotent_when_source_artifact_already_consumed and stage_binary_emits_useful_error_when_source_and_destination_both_missing.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T16:00:35-07:00"
    },
    {
      "finding": "bin/setup comment claimed 'shadow source changes during --plugin-dir QA via the dispatcher's mtime preference' but bin/flow:27-33 uses unconditional existence priority, not mtime",
      "reason": "Rewrote the bin/setup comment block to describe the dispatcher's actual selection mechanism (existence priority, first-match-wins) and cite the specific bin/flow line range so a future reader can verify the claim. Per .claude/rules/read-before-asserting.md — claims about how code works must match what the code does.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-17T16:00:45-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-17T16:08:03-07:00",
    "session_id": "b327c9d0-dc94-4a57-b00b-979331c0d708",
    "model": "claude-opus-4-7",
    "five_hour_pct": 20,
    "seven_day_pct": 43,
    "session_input_tokens": 401,
    "session_output_tokens": 164605,
    "session_cache_creation_tokens": 1672350,
    "session_cache_read_tokens": 127489983,
    "session_cost_usd": 209.15021310000003,
    "by_model": {
      "claude-opus-4-7": {
        "input": 401,
        "output": 164605,
        "cache_create": 1672350,
        "cache_read": 127489983
      }
    },
    "turn_count": 241,
    "tool_call_count": 139,
    "context_at_last_turn_tokens": 705886,
    "context_window_pct": 352.943
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>