### PR TITLE
Shared Config Edits Stay Blocked

### DIFF
--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -364,19 +364,29 @@ Layer 2 for the full design.
 ## Shared-Config Carve-Out
 
 The autonomous-phase block above protects against
-model-initiated prompts. The shared-config block from
+model-initiated prompts. The shared-config gate from
 `validate_worktree_paths` (see `.claude/rules/permissions.md`
-"Shared Config Files — Express User Permission Required") is the
-opposite shape: another hook explicitly instructs the model to
-call `AskUserQuestion` to confirm a shared-config edit. Without a
-carve-out, the autonomous-phase block refuses the very prompt the
-prior hook demanded — the flow deadlocks while two hooks
-contradict each other.
+"Shared Config Files — Express User Permission Required") has a
+two-half recovery: the block message instructs the **user** to
+reply with the exact line `approve shared-config: <path>`, and
+the model then runs `bin/flow approve-shared-config --path
+<path>` (which self-gates on that user-typed phrase and writes a
+single-use approval marker the gate consults+consumes). The model
+never fires an `AskUserQuestion` for a shared-config edit — so
+there is no model-initiated prompt to reconcile with the
+autonomous-phase block, and `bin/flow approve-shared-config` is
+not a user-only skill, so the model may run it once the user has
+replied.
 
-The trigger is system-initiated, not model-initiated: the
-shared-config BLOCKED message itself directs the next action.
-Letting the prompt fire completes the confirmation flow the
-system asked for.
+The `validate-ask-user` shared-config carve-out nonetheless
+remains as a system-initiated-prompt safety net. If a
+system-initiated confirmation prompt is raised during an
+in-progress autonomous phase in response to a recent
+shared-config block, the autonomous-phase block in
+`validate-ask-user` would otherwise refuse it; the carve-out lets
+it fire so a system-initiated confirmation flow completes rather
+than deadlocking. The trigger is system-initiated, not
+model-initiated.
 
 `validate-ask-user`'s `run_impl_main` calls
 `crate::hooks::transcript_walker::recent_edit_blocked_on_shared_config`

--- a/.claude/rules/hook-vs-instruction.md
+++ b/.claude/rules/hook-vs-instruction.md
@@ -161,10 +161,17 @@ insufficient:
       shared-config edit-block tool_result (a `tool_result`
       with `is_error: true` whose content contains the
       literal substring `"is a shared configuration file"`),
-      the block is suppressed so the system-initiated
-      AskUserQuestion the BLOCKED message demanded fires
-      instead of deadlocking. The user-only carve-out is
-      checked first. See
+      the block is suppressed so a system-initiated
+      confirmation prompt raised in response to that
+      shared-config block can fire instead of deadlocking
+      against the autonomous-phase block. The BLOCKED message
+      itself instructs the user to reply with `approve
+      shared-config: <path>` and the model to run `bin/flow
+      approve-shared-config` — the model never fires an
+      `AskUserQuestion` for a shared-config edit, so the
+      carve-out is the system-initiated-prompt safety net,
+      not a model-`AskUserQuestion` release. The user-only
+      carve-out is checked first. See
       `.claude/rules/autonomous-phase-discipline.md`
       "Shared-Config Carve-Out".
 - **Autonomous Stop refusal** — `stop_continue::run` composes

--- a/.claude/rules/permissions.md
+++ b/.claude/rules/permissions.md
@@ -398,6 +398,43 @@ Prefer approaches that keep the diff scoped to task-relevant
 code. Ask before expanding scope into shared territory. If the
 user approves the edit, proceed. If not, find a different path.
 
+### When the gate blocks an unapproved edit
+
+When an Edit/Write on a shared-config file is attempted inside a
+worktree without prior approval, `validate_shared_config` blocks
+it. The block is a confirm-and-proceed gate with a two-half
+recovery the model cannot self-authorize:
+
+1. The block message instructs the **user** to reply with the
+   exact line `approve shared-config: <path>`. The model does NOT
+   ask via `AskUserQuestion` and does NOT run anything until that
+   exact user reply lands — the user-typed phrase is the
+   authorization anchor (the same unforgeable trust model as
+   `clear-halt`: a real user-typed turn the model cannot
+   synthesize).
+2. After the user has replied, the model runs `bin/flow
+   approve-shared-config --path <path>`. That subcommand
+   self-gates on the persisted transcript via
+   `transcript_walker::user_approved_shared_config_edit` — it
+   requires the most recent real user turn to carry the fixed
+   phrase for that exact path AND a genuine system-emitted
+   shared-config block for that full path in the same exchange.
+   Only then does it write a single-use approval marker
+   (`src/shared_config_approval.rs`,
+   `.flow-states/<branch>/shared-config-approvals/<sha256(path)>`).
+3. `validate_shared_config` consults and consumes (deletes) the
+   marker immediately before its block return, allowing exactly
+   one Edit/Write of exactly that file. A second edit re-blocks
+   (single-use). Any unreadable, oversized, unparseable, or
+   target-mismatched marker yields no approval and the gate keeps
+   blocking — fail-closed, a corrupt marker is never an escape
+   hatch (the deliberate asymmetry vs. Layer 11's fail-open).
+
+A `not_user_approved` result from `bin/flow approve-shared-config`
+means the user has not yet replied with the exact line: keep
+waiting for the user — do not retry the edit or re-run the
+subcommand in a loop.
+
 ## Enforcement
 
 Shared-config protection is a workflow discipline, not a universal
@@ -425,21 +462,32 @@ The `validate_shared_config` function gates on tool name: only
 the CWD is inside a `.worktrees/` directory and the target path
 is inside the worktree.
 
-The block message directs the model to confirm with the user via
-`AskUserQuestion` before proceeding, and points to this section
-for context.
+The block message names the recovery path: the user must reply
+with the exact line `approve shared-config: <path>` and the model
+then runs `bin/flow approve-shared-config --path <path>`.
+Immediately before the block return, `validate_shared_config`
+calls `shared_config_approval::check_and_consume_approval` keyed
+on `(project_root, branch, file_path)` — a valid unconsumed
+single-use marker allows the edit exactly once (the marker is
+deleted on the allow path); any marker IO/parse/validation error
+keeps blocking (fail-closed). The block message also points to
+this section for context.
 
 ### Autonomous-phase carve-out for the confirmation prompt
 
-The block message instructs the model to call
-`AskUserQuestion` to confirm the shared-config edit. During an
-in-progress autonomous phase, the autonomous-phase block in
-`validate-ask-user` would refuse that prompt — two hooks
-contradicting each other and deadlocking the flow. To resolve
-the contradiction, `validate-ask-user::run_impl_main` carves out
-the AskUserQuestion when the persisted transcript carries a
-recent shared-config block: the carve-out lets the prompt fire
-so the system-initiated confirmation flow completes.
+The model never fires an `AskUserQuestion` for a shared-config
+edit — the recovery is the user-typed `approve shared-config:
+<path>` phrase plus `bin/flow approve-shared-config`, neither of
+which is a model-initiated prompt. The `validate-ask-user`
+shared-config carve-out
+(`recent_edit_blocked_on_shared_config`) nonetheless remains as a
+system-initiated-prompt safety net: the block message still
+contains the load-bearing substring `is a shared configuration
+file that affects every engineer`, so if a system-initiated
+confirmation prompt is raised during an in-progress autonomous
+phase in response to a recent shared-config block, the carve-out
+lets it fire rather than deadlocking against the autonomous-phase
+block in `validate-ask-user`.
 
 The carve-out is system-initiated, not model-initiated, so it
 does not violate the autonomous-mode discipline against

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,14 +91,14 @@ The full step sequence and JSON status handling live in `skills/flow-start/SKILL
 
 - State file schema reference: `docs/reference/flow-state-schema.md`
 - Test fixtures: `tests/common/mod.rs` helpers
-- **Claude never computes timestamps, time differences, or counter increments.** All standard state mutations go through `bin/flow` commands (`phase-enter`, `phase-finalize`, `phase-transition`, `set-timestamp`, `add-finding`, `add-skipped-agent`, `record-agent-return`, `clear-halt`).
+- **Claude never computes timestamps, time differences, or counter increments.** All standard state mutations go through `bin/flow` commands (`phase-enter`, `phase-finalize`, `phase-transition`, `set-timestamp`, `add-finding`, `add-skipped-agent`, `record-agent-return`, `clear-halt`, `approve-shared-config`).
 - Plan handoff: `bin/flow plan-from-issue --issue <N> --branch <name>` extracts content between `<!-- FLOW-PLAN-BEGIN -->` and `<!-- FLOW-PLAN-END -->` sentinels in the issue body and writes it to `.flow-states/<branch>/plan.md`. Issue-filing skills wrap their output in these sentinels automatically.
 
 ## Architecture References
 
 Behavior I obey lives in the rule files below. Reading the rule when relevant beats pre-loading the architecture description.
 
-- **Permissions, commit gates, concurrency** — see `.claude/rules/permissions.md` and `.claude/rules/concurrency-model.md`.
+- **Permissions, commit gates, concurrency** — see `.claude/rules/permissions.md` and `.claude/rules/concurrency-model.md`. The shared-config edit gate's "proceed" half — the user-typed `approve shared-config: <path>` phrase, the `bin/flow approve-shared-config` subcommand, and the single-use marker store (`src/shared_config_approval.rs`) — is documented in `.claude/rules/permissions.md` "Shared Config Files".
 - **User-only skills** (model must never invoke `/flow:flow-abort`, `/flow:flow-reset`, `/flow-release`, `/flow-qa`, `/flow:flow-prime`, `/flow:flow-continue`) — see `.claude/rules/user-only-skills.md`.
 - **Autonomous phase discipline** (Stop-hook two-exit halt model, AskUserQuestion gate) — see `.claude/rules/autonomous-phase-discipline.md`.
 - **Tombstone tests** — see `.claude/rules/tombstone-tests.md`.

--- a/docs/reference/flow-state-schema.md
+++ b/docs/reference/flow-state-schema.md
@@ -19,7 +19,7 @@ State files live under `.flow-states/<branch>/` at the project root, one subdire
 .flow-states/user-profile-redesign/ci-passed
 ```
 
-Each feature has up to four files inside its subdirectory: the state file (`state.json`), the log file (`log`), a frozen copy of `flow-phases.json` (`phases.json`), and a CI sentinel (`ci-passed`). The CI sentinel caches the last passing `bin/flow ci` snapshot so subsequent runs skip automatically when nothing changed (use `--force` to bypass). The sentinel is also automatically refreshed after `finalize-commit` when `git pull` does not introduce new content, preserving the optimization across commits. Multiple features can run simultaneously with no conflicts. The `.flow-states/` directory is added to `.git/info/exclude` by `/flow-start` (per-repo, not committed). Created by `/flow-start`, deleted by `/flow-complete` in a single `remove_dir_all(branch_dir)` call.
+Each feature has up to four files inside its subdirectory: the state file (`state.json`), the log file (`log`), a frozen copy of `flow-phases.json` (`phases.json`), and a CI sentinel (`ci-passed`). A feature may also hold a `shared-config-approvals/` subdirectory of single-use approval markers — see [Shared-Config Approval Markers](#shared-config-approval-markers). The CI sentinel caches the last passing `bin/flow ci` snapshot so subsequent runs skip automatically when nothing changed (use `--force` to bypass). The sentinel is also automatically refreshed after `finalize-commit` when `git pull` does not introduce new content, preserving the optimization across commits. Multiple features can run simultaneously with no conflicts. The `.flow-states/` directory is added to `.git/info/exclude` by `/flow-start` (per-repo, not committed). Created by `/flow-start`, deleted by `/flow-complete` in a single `remove_dir_all(branch_dir)` call.
 
 **State files are local to each machine.** In a multi-engineer team, each engineer's `.flow-states/` directory only contains their own features. GitHub (issues, PRs, labels) is the shared coordination layer visible to all engineers. The "Flow In-Progress" label on issues is the mechanism for cross-engineer WIP detection — see `/flow-issues`.
 
@@ -572,6 +572,47 @@ Appended to a phase's `step_snapshots[]` on every step-counter increment that na
 | `step` | integer | Counter value at capture time |
 | `field` | string | Counter name (one of `code_task`, `review_step`, `learn_step`, `complete_step`) |
 | _flattened snapshot fields_ | various | Every [Window Snapshot](#window-snapshot) field, inlined at the same level |
+
+---
+
+## Shared-Config Approval Markers
+
+The shared-config gate (`validate_worktree_paths::validate_shared_config`)
+blocks Edit/Write on `.gitignore`/`Cargo.toml`/`.github/`/etc. inside a
+worktree. The "proceed" half is a branch-scoped, per-file, single-use
+approval marker store at:
+
+```text
+.flow-states/<branch>/shared-config-approvals/<sha256(target_path)>
+```
+
+One marker file per approved target path. The on-disk filename is the
+SHA-256 hex of the full target path string (collision-safe,
+filesystem-safe — no separators or traversal segments). The marker body is:
+
+```json
+{"approved": true, "target": "/abs/path/to/Cargo.toml"}
+```
+
+Lifecycle:
+
+- **Created** by `bin/flow approve-shared-config --path <file>` after the
+  user replies with the exact line `approve shared-config: <path>`. The
+  subcommand self-gates on the persisted transcript (the user-typed
+  phrase is the unforgeable anchor — same trust model as `clear-halt`)
+  before `shared_config_approval::write_approval` writes the marker.
+- **Consumed** (read, validated, then deleted — single-use) by
+  `validate_shared_config` immediately before its block return, allowing
+  exactly one Edit/Write of exactly that file. Any unreadable, oversized
+  (> 64 KB read cap), unparseable, wrong-root-type, `approved != true`,
+  or target-mismatched marker yields no approval and the gate keeps
+  blocking (fail-closed — a corrupt marker is never an escape hatch).
+- **Bulk-cleared** by `shared_config_approval::clear_all` on phase
+  advance (`phase_enter`), best-effort, so a stale approval cannot
+  bleed into a later phase.
+
+The directory is removed with the rest of `.flow-states/<branch>/` by
+`/flow-complete` / `/flow-abort` cleanup.
 
 ---
 

--- a/src/approve_shared_config.rs
+++ b/src/approve_shared_config.rs
@@ -101,9 +101,23 @@ fn path_shape_ok(path: &str) -> bool {
 /// git worktree root for `cwd` (`git rev-parse --show-toplevel`),
 /// matching `cwd_scope`'s notion of the worktree. `None` when `cwd`
 /// is not git-managed (non-zero exit) — the caller fails closed
-/// (`path_outside_worktree`). git is a hard dependency (same
-/// `.expect` precedent as `cwd_scope::enforce`), so the spawn is
-/// treated as infallible; only git-managed-vs-not branches.
+/// (`path_outside_worktree`).
+///
+/// Unreachability proof for the `.output().expect(...)` (per
+/// `.claude/rules/external-input-path-construction.md` "No
+/// `.expect()` on Filesystem Reads in Hooks or CLI Subcommands" —
+/// the carve-out requires a proof the arm cannot be reached from
+/// any production path): `Command::output()` only `Err`s when the
+/// `git` binary cannot be spawned. `run_impl_main` calls
+/// `cwd_scope::enforce(cwd, root)` BEFORE `worktree_root(cwd)`, and
+/// `cwd_scope::enforce` itself runs `git rev-parse` with an
+/// identical `.expect` — so in any environment where `git` cannot
+/// spawn, that earlier call panics first and this arm is never
+/// reached. The `.expect` here is documentation of that invariant,
+/// not a reachable panic vector. A future refactor that moves this
+/// call ahead of `cwd_scope::enforce` (or removes the cwd guard)
+/// must convert this to a non-panicking `.ok()?` (the function
+/// already returns `Option`, so `None` → `path_outside_worktree`).
 fn worktree_root(cwd: &Path) -> Option<PathBuf> {
     let out = Command::new("git")
         .args(["rev-parse", "--show-toplevel"])

--- a/src/approve_shared_config.rs
+++ b/src/approve_shared_config.rs
@@ -1,0 +1,246 @@
+//! `bin/flow approve-shared-config --path <file>` — the user-driven
+//! "proceed" half of the shared-config gate.
+//!
+//! The shared-config gate (`validate_worktree_paths::validate_shared_config`)
+//! blocks Edit/Write on `.gitignore`/`Cargo.toml`/etc. inside a
+//! worktree and instructs the user to grant the edit by typing the
+//! fixed phrase `approve shared-config: <path>`. This subcommand,
+//! invoked after that phrase, writes a single-use approval marker
+//! (`shared_config_approval::write_approval`) that the gate then
+//! consults+consumes on the next edit.
+//!
+//! Forgery model — identical anchor to `clear-halt`: the marker
+//! itself is forgeable (any Bash call can invoke this subcommand),
+//! so the subcommand SELF-GATES on the persisted transcript via
+//! `transcript_walker::user_approved_shared_config_edit`. That
+//! walker requires the most recent real user turn (a turn Claude
+//! Code marks so the model cannot synthesize it) to carry the fixed
+//! `approve shared-config: <path>` phrase AND a system-emitted
+//! shared-config BLOCK naming the target in the same exchange.
+//! Neither signal is model-forgeable, so the subcommand cannot be
+//! used to self-authorize an edit the user never granted.
+//!
+//! Output shape (callers parse `status`/`reason`; exit 0 ok, exit 1
+//! on any rejection so a non-grant never silently writes a marker):
+//! - `{"status":"ok"}` — marker written for `(branch, path)`.
+//! - `{"status":"error","reason":"cwd_drift",...}` — the
+//!   state-mutator cwd guard (`cwd_scope::enforce`) rejected.
+//! - `{"status":"error","reason":"invalid_branch"}` — branch
+//!   undetectable or fails `FlowPaths::is_valid_branch`.
+//! - `{"status":"error","reason":"invalid_path"}` — `--path` is
+//!   empty, NUL-bearing, relative, or contains a `..` component.
+//! - `{"status":"error","reason":"path_outside_worktree"}` —
+//!   `--path` does not resolve under the flow's git worktree.
+//! - `{"status":"error","reason":"no_state_file"}` — no active
+//!   flow for the branch.
+//! - `{"status":"error","reason":"no_transcript_path"}` — state
+//!   lacks a usable `session_id`/`transcript_path`.
+//! - `{"status":"error","reason":"not_user_approved"}` — the
+//!   transcript does not show a genuine per-file user grant.
+//! - `{"status":"error","reason":"write_failed"}` — the marker
+//!   write failed (filesystem error).
+//!
+//! Tests live at `tests/approve_shared_config.rs` per
+//! `.claude/rules/test-placement.md`.
+
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use clap::Parser;
+use serde_json::{json, Value};
+
+use crate::flow_paths::FlowPaths;
+use crate::git::resolve_branch_in;
+use crate::hooks::transcript_walker::user_approved_shared_config_edit;
+use crate::per_flow_capture::derive_transcript_path;
+use crate::session_metrics::{is_safe_session_id, is_safe_transcript_path};
+use crate::shared_config_approval::write_approval;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "approve-shared-config",
+    about = "Record a single-use user grant to edit a shared-config file"
+)]
+pub struct Args {
+    /// Absolute path of the shared-config file the user granted.
+    /// Must be the exact path the Edit/Write tool targets — the
+    /// marker is keyed on this string and the gate consults the
+    /// same string.
+    #[arg(long)]
+    pub path: String,
+
+    /// Branch whose `.flow-states/<branch>/` holds the marker.
+    /// Optional; resolved from the worktree cwd when absent.
+    #[arg(long)]
+    pub branch: Option<String>,
+}
+
+fn err(reason: &str, message: impl Into<String>) -> (Value, i32) {
+    (
+        json!({"status": "error", "reason": reason, "message": message.into()}),
+        1,
+    )
+}
+
+/// Reject `--path` shapes that are unsafe before any filesystem or
+/// containment work: empty, NUL-bearing, relative, or carrying a
+/// `..` (ParentDir) component. Per
+/// `.claude/rules/external-input-path-construction.md` the
+/// validator runs at the boundary before path construction.
+fn path_shape_ok(path: &str) -> bool {
+    if path.is_empty() || path.contains('\0') {
+        return false;
+    }
+    let p = Path::new(path);
+    if !p.is_absolute() {
+        return false;
+    }
+    !p.components().any(|c| matches!(c, Component::ParentDir))
+}
+
+/// git worktree root for `cwd` (`git rev-parse --show-toplevel`),
+/// matching `cwd_scope`'s notion of the worktree. `None` when `cwd`
+/// is not git-managed (non-zero exit) — the caller fails closed
+/// (`path_outside_worktree`). git is a hard dependency (same
+/// `.expect` precedent as `cwd_scope::enforce`), so the spawn is
+/// treated as infallible; only git-managed-vs-not branches.
+fn worktree_root(cwd: &Path) -> Option<PathBuf> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(cwd)
+        .output()
+        .expect("git is a hard dependency (cwd_scope precedent)");
+    if !out.status.success() {
+        return None;
+    }
+    // `--show-toplevel` on success always prints an existing path.
+    Some(PathBuf::from(
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+    ))
+}
+
+/// True when `path` (already shape-validated: absolute, no `..`)
+/// resolves inside `worktree`. The parent directory is
+/// canonicalized so a `/var` vs `/private/var` symlink (macOS
+/// tempdirs) cannot produce a spurious mismatch. Fails closed: a
+/// rootless path or an unresolvable parent returns `false`.
+fn path_inside_worktree(path: &str, worktree: &Path) -> bool {
+    let parent = match Path::new(path).parent() {
+        Some(p) => p,
+        None => return false,
+    };
+    match (parent.canonicalize(), worktree.canonicalize()) {
+        (Ok(p), Ok(w)) => p.starts_with(&w),
+        _ => false,
+    }
+}
+
+/// Resolve a validated transcript path from state's `session_id` /
+/// `transcript_path`. Mirrors the `clear-halt` resolver: both
+/// reuse the shared `is_safe_session_id` / `is_safe_transcript_path`
+/// validators and `derive_transcript_path`. Returns `None` when
+/// neither field yields a path under `<home>/.claude/projects/`.
+fn resolve_transcript_path(state: &Value, home: &Path, project_root: &Path) -> Option<PathBuf> {
+    let session_id = state
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| is_safe_session_id(s))
+        .map(|s| s.to_string());
+    state
+        .get("transcript_path")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)
+        .filter(|p| is_safe_transcript_path(p, home))
+        .or_else(|| {
+            session_id
+                .as_ref()
+                .map(|sid| derive_transcript_path(home, project_root, sid))
+                .filter(|p| is_safe_transcript_path(p, home))
+        })
+}
+
+/// Main-arm dispatcher that accepts `cwd` as a `Result` so the
+/// `current_dir()`-failure fallback (deleted-cwd / chroot) lives in
+/// the module where a unit test can drive it — keeping the
+/// `src/main.rs` arm a closure-free one-liner. Mirrors
+/// `add_finding::run_impl_main_with_cwd_result`.
+pub fn run_impl_main_with_cwd_result(
+    args: &Args,
+    root: &Path,
+    cwd_result: std::io::Result<PathBuf>,
+    home: &Path,
+) -> (Value, i32) {
+    let cwd = cwd_result.unwrap_or(PathBuf::from("."));
+    run_impl_main(args, root, &cwd, home)
+}
+
+/// Main-arm dispatcher. `cwd` is the subcommand's working directory
+/// (inside the flow worktree); `home` is the user's home for
+/// transcript resolution. Exit code is `1` on every rejection so a
+/// non-grant can never silently produce an approval marker.
+pub fn run_impl_main(args: &Args, root: &Path, cwd: &Path, home: &Path) -> (Value, i32) {
+    // State-mutator cwd guard (rust-patterns "Guard Universality
+    // Across CLI Entry Points"): this subcommand writes a marker, so
+    // it must enforce the same drift guard as other state mutators.
+    if let Err(message) = crate::cwd_scope::enforce(cwd, root) {
+        return err("cwd_drift", message);
+    }
+
+    let branch = match resolve_branch_in(args.branch.as_deref(), cwd, root) {
+        Some(b) => b,
+        None => return err("invalid_branch", "could not determine branch"),
+    };
+    let paths = match FlowPaths::try_new(root, &branch) {
+        Some(p) => p,
+        None => return err("invalid_branch", format!("invalid branch: {branch:?}")),
+    };
+
+    if !path_shape_ok(&args.path) {
+        return err(
+            "invalid_path",
+            "--path must be a non-empty absolute path with no NUL byte and no `..` segment",
+        );
+    }
+    match worktree_root(cwd) {
+        Some(wt) if path_inside_worktree(&args.path, &wt) => {}
+        _ => {
+            return err(
+                "path_outside_worktree",
+                "--path must resolve inside the flow's git worktree",
+            )
+        }
+    }
+
+    let state_path = paths.state_file();
+    if !state_path.exists() {
+        return err("no_state_file", "no active flow for this branch");
+    }
+    let state: Value = match std::fs::read_to_string(&state_path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+    {
+        Some(v) => v,
+        None => return err("no_state_file", "state file unreadable or unparseable"),
+    };
+    let transcript_path = match resolve_transcript_path(&state, home, root) {
+        Some(p) => p,
+        None => return err("no_transcript_path", "state has no usable transcript path"),
+    };
+
+    // Forgery self-gate: the marker is model-writable, so authority
+    // comes from the unforgeable transcript signal, not the call.
+    if !user_approved_shared_config_edit(&transcript_path, home, &args.path) {
+        return err(
+            "not_user_approved",
+            "transcript does not show a per-file user grant for this path in the current exchange",
+        );
+    }
+
+    // Gate-action atomicity: the walker and the marker key on the
+    // same `args.path` (shape-validated, never transformed), which
+    // is the exact string the gate later consults.
+    match write_approval(root, &branch, &args.path) {
+        Ok(()) => (json!({"status": "ok"}), 0),
+        Err(e) => err("write_failed", format!("failed to write approval: {e}")),
+    }
+}

--- a/src/hooks/transcript_walker.rs
+++ b/src/hooks/transcript_walker.rs
@@ -1500,17 +1500,22 @@ fn user_turn_carries_shared_config_block(turn: &Value) -> bool {
 ///    tool_result) is NOT the approval channel and yields `false`.
 /// 2. A system-emitted shared-config BLOCKED tool_result (the
 ///    literal `is a shared configuration file that affects every
-///    engineer` substring, `is_error` truthy, naming the
-///    `target_path` basename) must appear earlier in the window but
-///    not past the next-older real user turn — so the grant responds
-///    to a genuine block in the current exchange, not a stale or
-///    cross-file one. Only
+///    engineer` substring, `is_error` truthy, containing the FULL
+///    `target_path`) must appear earlier in the window but not past
+///    the next-older real user turn — so the grant responds to a
+///    genuine block in the current exchange, not a stale or
+///    cross-file one. The production block message interpolates the
+///    full file path, so matching the full path (not the basename)
+///    is what makes "not a cross-file one" true: a block for a
+///    same-basename sibling (`/a/Cargo.toml` vs `/a/sub/Cargo.toml`,
+///    a nested `.gitignore`, a monorepo `package.json`) cannot
+///    cross-corroborate a grant for a different file. Only
 ///    `validate_worktree_paths::validate_shared_config` emits that
 ///    substring, so the model cannot forge it.
 ///
 /// Fail-closed: any I/O, parse, or validation failure, a
 /// non-approval most-recent user turn, a missing/cross-file block,
-/// or an empty target basename returns `false` so the gate keeps
+/// or a target with no file name returns `false` so the gate keeps
 /// blocking. `transcript_path` is validated through
 /// `is_safe_transcript_path` per
 /// `.claude/rules/external-input-path-construction.md`; synthetic
@@ -1526,12 +1531,17 @@ pub fn user_approved_shared_config_edit(
         return false;
     }
     // `Path::file_name()` yields `None` for `/`, `""`, and
-    // `..`-terminal paths and never an empty component otherwise, so
-    // a `Some` is always a non-empty basename — no empty guard.
-    let basename = match Path::new(target_path).file_name().and_then(|n| n.to_str()) {
-        Some(b) => b.to_string(),
-        None => return false,
-    };
+    // `..`-terminal paths — reject those as not a real file target.
+    // Block-corroboration below matches the FULL `target_path` (not
+    // the basename) so a system block for a same-basename sibling
+    // cannot cross-corroborate a grant for a different file.
+    if Path::new(target_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_none()
+    {
+        return false;
+    }
     let lines = match read_recent_turns(transcript_path) {
         Some(s) => s,
         None => return false,
@@ -1593,7 +1603,7 @@ pub fn user_approved_shared_config_edit(
         if approval_seen
             && any_error_tool_result_text(&turn, |t| {
                 t.contains("is a shared configuration file that affects every engineer")
-                    && t.contains(&basename)
+                    && t.contains(target_path)
             })
         {
             return true;

--- a/src/hooks/transcript_walker.rs
+++ b/src/hooks/transcript_walker.rs
@@ -1405,20 +1405,26 @@ pub fn recent_edit_blocked_on_shared_config(transcript_path: &Path, home: &Path)
     false
 }
 
-/// Returns `true` when the user-role turn carries a tool_result
-/// block whose `is_error` is truthy AND whose `content` contains
-/// the shared-config substring. Returns `false` for string-content
-/// user turns (the user typed a message), missing or non-array
-/// content, and array content where no block matches.
-fn user_turn_carries_shared_config_block(turn: &Value) -> bool {
+/// Scan every `tool_result` block in `turn` whose `is_error` is
+/// truthy and return `true` as soon as `pred` accepts that block's
+/// text. Returns `false` for string-content user turns (the user
+/// typed a message — not a tool_result wrapper), missing or
+/// non-array content, and array content where no error block's
+/// text satisfies `pred`.
+///
+/// `tool_result.content` is either a plain string or an array of
+/// content blocks (each typically a `text` block); both wire
+/// formats are flattened per block so `pred` sees the same text
+/// either way. Per-block short-circuit (no cross-block
+/// accumulation) keeps the branch surface minimal. Shared by
+/// `user_turn_carries_shared_config_block` and the
+/// `user_approved_shared_config_edit` block-corroboration check so
+/// the extraction logic lives in one place.
+fn any_error_tool_result_text<F: FnMut(&str) -> bool>(turn: &Value, mut pred: F) -> bool {
     let content = match turn.get("message").and_then(|m| m.get("content")) {
         Some(c) => c,
         None => return false,
     };
-    // String content is a real user-typed message — not a
-    // tool_result wrapper. The carve-out only fires when the
-    // most recent user-role event is a tool_result-wrapped turn
-    // carrying the shared-config block.
     if content.as_str().is_some() {
         return false;
     }
@@ -1437,10 +1443,6 @@ fn user_turn_carries_shared_config_block(turn: &Value) -> bool {
             Some(c) => c,
             None => continue,
         };
-        // tool_result.content is either a plain string or an
-        // array of content blocks (each typically a `text`
-        // block). Concatenate text fields for the array shape
-        // so a substring match catches both wire formats.
         let text = if let Some(s) = block_content.as_str() {
             s.to_string()
         } else if let Some(items) = block_content.as_array() {
@@ -1457,7 +1459,143 @@ fn user_turn_carries_shared_config_block(turn: &Value) -> bool {
         } else {
             continue;
         };
-        if text.contains("is a shared configuration file that affects every engineer") {
+        if pred(&text) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns `true` when the user-role turn carries a tool_result
+/// block whose `is_error` is truthy AND whose `content` contains
+/// the shared-config substring. Returns `false` for string-content
+/// user turns (the user typed a message), missing or non-array
+/// content, and array content where no block matches.
+fn user_turn_carries_shared_config_block(turn: &Value) -> bool {
+    any_error_tool_result_text(turn, |t| {
+        t.contains("is a shared configuration file that affects every engineer")
+    })
+}
+
+/// Returns `true` iff the persisted transcript shows the user
+/// granted a per-file shared-config edit for `target_path` in the
+/// current exchange. The forgery-resistant "proceed" predicate
+/// behind `bin/flow approve-shared-config` — the same trust model
+/// as `clear-halt`: a real user-typed turn the model cannot
+/// synthesize is the authorization anchor.
+///
+/// Scanning `read_recent_turns(transcript_path)` backward (4 MB
+/// tail; a block buried before the cap is a documented acceptable
+/// false-negative — the user re-triggers the block and re-approves):
+///
+/// 1. The most recent non-hook-feedback user-role turn MUST be a
+///    real user turn (`is_real_user_turn`: string `message.content`,
+///    no `isMeta:true`) whose `normalize_gate_input`-normalized
+///    content contains the fixed phrase
+///    `approve shared-config: <normalized target_path>`. Claude Code
+///    marks every model/synthetic turn with array content or
+///    `isMeta:true`, so the model cannot forge this turn. The full
+///    path in the phrase makes the grant per-file and
+///    replay-resistant. An AskUserQuestion answer (a model-mediated
+///    tool_result) is NOT the approval channel and yields `false`.
+/// 2. A system-emitted shared-config BLOCKED tool_result (the
+///    literal `is a shared configuration file that affects every
+///    engineer` substring, `is_error` truthy, naming the
+///    `target_path` basename) must appear earlier in the window but
+///    not past the next-older real user turn — so the grant responds
+///    to a genuine block in the current exchange, not a stale or
+///    cross-file one. Only
+///    `validate_worktree_paths::validate_shared_config` emits that
+///    substring, so the model cannot forge it.
+///
+/// Fail-closed: any I/O, parse, or validation failure, a
+/// non-approval most-recent user turn, a missing/cross-file block,
+/// or an empty target basename returns `false` so the gate keeps
+/// blocking. `transcript_path` is validated through
+/// `is_safe_transcript_path` per
+/// `.claude/rules/external-input-path-construction.md`; synthetic
+/// hook-feedback turns are skipped with the targeted
+/// string-content + `isMeta` skip per
+/// `.claude/rules/transcript-shape.md`.
+pub fn user_approved_shared_config_edit(
+    transcript_path: &Path,
+    home: &Path,
+    target_path: &str,
+) -> bool {
+    if !is_safe_transcript_path(transcript_path, home) {
+        return false;
+    }
+    // `Path::file_name()` yields `None` for `/`, `""`, and
+    // `..`-terminal paths and never an empty component otherwise, so
+    // a `Some` is always a non-empty basename — no empty guard.
+    let basename = match Path::new(target_path).file_name().and_then(|n| n.to_str()) {
+        Some(b) => b.to_string(),
+        None => return false,
+    };
+    let lines = match read_recent_turns(transcript_path) {
+        Some(s) => s,
+        None => return false,
+    };
+    let approve_phrase = format!(
+        "approve shared-config: {}",
+        normalize_gate_input(target_path)
+    );
+    let mut approval_seen = false;
+    for line in lines.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let turn: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let turn_type =
+            normalize_gate_input(turn.get("type").and_then(|v| v.as_str()).unwrap_or(""));
+        if turn_type != "user" {
+            continue;
+        }
+        // Targeted hook-feedback skip: string content + an isMeta
+        // marker is a Stop-hook refusal, never a real user turn or
+        // a tool_result wrapper. Per
+        // `.claude/rules/transcript-shape.md`.
+        let is_string_content = turn
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_str())
+            .is_some();
+        if is_string_content && is_meta_marker_present(turn.get("isMeta")) {
+            continue;
+        }
+        if is_real_user_turn(&turn) {
+            if approval_seen {
+                // Reached the next-older real user turn — the
+                // conversation boundary — without finding the system
+                // block. The grant does not respond to a block in
+                // this exchange.
+                return false;
+            }
+            // The most recent real user turn MUST be the approval.
+            let content = turn
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_str())
+                .unwrap_or("");
+            if normalize_gate_input(content).contains(&approve_phrase) {
+                approval_seen = true;
+                continue;
+            }
+            return false;
+        }
+        // Non-real user-role turn = tool_result wrapper. The system
+        // block only corroborates the grant once the approval (more
+        // recent) has been seen, and must name the target basename.
+        if approval_seen
+            && any_error_tool_result_text(&turn, |t| {
+                t.contains("is a shared configuration file that affects every engineer")
+                    && t.contains(&basename)
+            })
+        {
             return true;
         }
     }

--- a/src/hooks/validate_worktree_paths.rs
+++ b/src/hooks/validate_worktree_paths.rs
@@ -77,11 +77,27 @@ pub fn is_shared_config(file_path: &str) -> bool {
 
 /// Check if an Edit/Write on a shared config file should be blocked.
 ///
-/// Returns `(allowed, message)`. Only blocks when all of:
-/// - `tool_name` is "Edit" or "Write" (reads are fine)
+/// Returns `(allowed, message)`. The edit would block when all of:
+/// - `tool_name` is "Edit" or "Write" (reads are fine and never
+///   consult or consume a marker)
 /// - CWD is inside a `.worktrees/` directory
 /// - `file_path` is inside the worktree (not targeting main repo or external paths)
 /// - the file matches the shared-config list
+///
+/// The "proceed" half: immediately before the block return, the gate
+/// consults+consumes a single-use approval marker via
+/// `shared_config_approval::check_and_consume_approval` keyed on
+/// `(project_root, branch, file_path)` — `project_root`/branch derived
+/// from `cwd` via `compute_worktree_paths` (branch = the worktree
+/// directory name). A valid unconsumed marker allows the edit exactly
+/// once (the marker is deleted). Any absence, corruption, IO error,
+/// per-file mismatch, or unresolvable worktree keeps blocking
+/// (fail-closed — a corrupt marker can never become an escape hatch,
+/// the deliberate asymmetry vs. Layer 11). The block message names
+/// the `bin/flow approve-shared-config` recovery path and the exact
+/// `approve shared-config: <path>` phrase the user must type so the
+/// transcript self-gate (`user_approved_shared_config_edit`) can
+/// authorize the subcommand.
 pub fn validate_shared_config(file_path: &str, cwd: &str, tool_name: &str) -> (bool, String) {
     if file_path.is_empty() {
         return (true, String::new());
@@ -109,6 +125,33 @@ pub fn validate_shared_config(file_path: &str, cwd: &str, tool_name: &str) -> (b
         return (true, String::new());
     }
 
+    // Proceed half: a valid unconsumed single-use approval marker
+    // for this exact file allows the edit once. project_root/branch
+    // come from the same `compute_worktree_paths` the worktree gate
+    // uses (branch = the worktree directory name, structurally
+    // `/`-free). Any unresolvable worktree, invalid branch, or
+    // marker IO/parse failure falls through to the block
+    // (fail-closed) because `check_and_consume_approval` returns
+    // false on every error class.
+    if let Some((project_root, worktree_root)) = compute_worktree_paths(cwd) {
+        // `compute_worktree_paths` only returns `Some` for a path of
+        // the form `<root>/.worktrees/<branch>` with a non-empty,
+        // trailing-slash-stripped branch segment, so `file_name` is
+        // structurally `Some`. The `.expect` documents that
+        // invariant; it is unreachable, not a panic vector.
+        let branch = Path::new(worktree_root)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("compute_worktree_paths yields a path ending in the branch segment");
+        if crate::shared_config_approval::check_and_consume_approval(
+            Path::new(project_root),
+            branch,
+            file_path,
+        ) {
+            return (true, String::new());
+        }
+    }
+
     // For .github/ directory matches, surface `.github/` as the protected
     // boundary rather than the leaf filename (e.g. "ci.yml" is not inherently
     // shared config — the `.github/` directory is).
@@ -127,9 +170,12 @@ pub fn validate_shared_config(file_path: &str, cwd: &str, tool_name: &str) -> (b
         format!(
             "BLOCKED: {} is a shared configuration file that affects every engineer \
              in the repository. Modifying it during a FLOW phase requires explicit \
-             user permission. Use AskUserQuestion to confirm with the user before \
-             proceeding. See .claude/rules/permissions.md \"Shared Config Files\" section.",
-            display_name
+             user permission. To authorize this single edit, the USER must reply \
+             with the exact line `approve shared-config: {}`, then run \
+             `bin/flow approve-shared-config --path {}` and retry the edit. The \
+             grant is single-use and scoped to this file. See \
+             .claude/rules/permissions.md \"Shared Config Files\" section.",
+            display_name, file_path, file_path
         ),
     )
 }

--- a/src/hooks/validate_worktree_paths.rs
+++ b/src/hooks/validate_worktree_paths.rs
@@ -171,9 +171,13 @@ pub fn validate_shared_config(file_path: &str, cwd: &str, tool_name: &str) -> (b
             "BLOCKED: {} is a shared configuration file that affects every engineer \
              in the repository. Modifying it during a FLOW phase requires explicit \
              user permission. To authorize this single edit, the USER must reply \
-             with the exact line `approve shared-config: {}`, then run \
-             `bin/flow approve-shared-config --path {}` and retry the edit. The \
-             grant is single-use and scoped to this file. See \
+             with the exact line `approve shared-config: {}`. Do NOT run \
+             `bin/flow approve-shared-config` until the user has sent that exact \
+             reply — wait for it. Once the user has replied, run \
+             `bin/flow approve-shared-config --path {}` and retry the edit. A \
+             `not_user_approved` result means the user has not yet replied: keep \
+             waiting, do not retry the edit or re-run the subcommand in a loop. \
+             The grant is single-use and scoped to this file. See \
              .claude/rules/permissions.md \"Shared Config Files\" section.",
             display_name, file_path, file_path
         ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod add_notification;
 pub mod add_skipped_agent;
 pub mod analyze_issues;
 pub mod append_note;
+pub mod approve_shared_config;
 pub mod auto_close_parent;
 pub mod base_branch_cmd;
 pub mod bump_version;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod reset;
 pub mod resolve_skill_mode;
 pub mod session_cost;
 pub mod session_metrics;
+pub mod shared_config_approval;
 pub mod start_finalize;
 pub mod start_gate;
 pub mod start_init;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use flow_rs::add_notification;
 use flow_rs::add_skipped_agent;
 use flow_rs::analyze_issues;
 use flow_rs::append_note;
+use flow_rs::approve_shared_config;
 use flow_rs::auto_close_parent;
 use flow_rs::base_branch_cmd;
 use flow_rs::bump_version;
@@ -168,6 +169,12 @@ enum Commands {
     /// without the user typing `/flow:flow-continue`.
     #[command(name = "clear-halt")]
     ClearHalt(clear_halt::Args),
+    /// Record a single-use user grant to edit a shared-config file.
+    /// The "proceed" half of the shared-config gate; self-gates via
+    /// the transcript walker so a Bash bypass cannot self-authorize
+    /// without a genuine per-file user grant.
+    #[command(name = "approve-shared-config")]
+    ApproveSharedConfig(approve_shared_config::Args),
 
     /// FLOW cleanup orchestrator (worktree, branches, state files).
     Cleanup(cleanup::Args),
@@ -657,6 +664,17 @@ fn main() {
             let root = project_root();
             let home = flow_rs::session_metrics::home_dir_or_empty();
             let (value, code) = clear_halt::run_impl_main(&args, &root, &home);
+            flow_rs::dispatch::dispatch_json(value, code);
+        }
+        Some(Commands::ApproveSharedConfig(args)) => {
+            let root = project_root();
+            let home = flow_rs::session_metrics::home_dir_or_empty();
+            let (value, code) = approve_shared_config::run_impl_main_with_cwd_result(
+                &args,
+                &root,
+                std::env::current_dir(),
+                &home,
+            );
             flow_rs::dispatch::dispatch_json(value, code);
         }
         Some(Commands::Issue(args)) => {

--- a/src/phase_enter.rs
+++ b/src/phase_enter.rs
@@ -255,6 +255,14 @@ pub fn run_impl(args: &Args) -> Result<Value, String> {
         }
     }
 
+    // Defense-in-depth: clear any stale shared-config approval
+    // markers for this branch on phase advance so a grant issued in
+    // an earlier phase cannot bleed forward (the primary guarantee
+    // is single-use consumption on the gate-allow path). Best-effort
+    // — `clear_all` swallows every IO error and never panics, so a
+    // marker-dir anomaly cannot block phase entry.
+    crate::shared_config_approval::clear_all(&root, &branch);
+
     let enter_result = enter_result_holder.into_inner();
     let _ = append_log(
         &root,

--- a/src/shared_config_approval.rs
+++ b/src/shared_config_approval.rs
@@ -3,11 +3,15 @@
 //!
 //! The shared-config gate (`validate_worktree_paths::validate_shared_config`)
 //! blocks Edit/Write on `.gitignore`/`Cargo.toml`/etc. inside a
-//! worktree and instructs the model to confirm with the user via
-//! `AskUserQuestion`. This module is the "proceed" half: once the
-//! user approves, `bin/flow approve-shared-config` writes a marker
-//! here, and the gate consults+consumes it immediately before its
-//! block return — allowing exactly one edit of exactly that file.
+//! worktree and instructs the user to reply with the exact line
+//! `approve shared-config: <path>`. This module is the "proceed"
+//! half: after that reply, `bin/flow approve-shared-config`
+//! self-gates on the transcript (the user-typed phrase is the
+//! unforgeable anchor — same trust model as `clear-halt`) and
+//! writes a marker here; the gate then consults+consumes it
+//! immediately before its block return — allowing exactly one edit
+//! of exactly that file. The model never fires an `AskUserQuestion`
+//! for shared-config; the user-typed phrase is the authorization.
 //!
 //! Three invariants the store enforces:
 //!

--- a/src/shared_config_approval.rs
+++ b/src/shared_config_approval.rs
@@ -1,0 +1,183 @@
+//! Branch-scoped, per-file, single-use approval marker store for the
+//! shared-config gate.
+//!
+//! The shared-config gate (`validate_worktree_paths::validate_shared_config`)
+//! blocks Edit/Write on `.gitignore`/`Cargo.toml`/etc. inside a
+//! worktree and instructs the model to confirm with the user via
+//! `AskUserQuestion`. This module is the "proceed" half: once the
+//! user approves, `bin/flow approve-shared-config` writes a marker
+//! here, and the gate consults+consumes it immediately before its
+//! block return — allowing exactly one edit of exactly that file.
+//!
+//! Three invariants the store enforces:
+//!
+//! - **Single-use.** Consumption deletes the marker. A second edit of
+//!   the same file finds no marker and re-blocks. There is no
+//!   "consumed" flag — file presence IS the unconsumed state.
+//! - **Per-file scope (defense-in-depth).** The marker's on-disk
+//!   filename is the SHA-256 hex of the full target path, so an
+//!   approval for path A is stored at a different filename than an
+//!   approval for path B. The marker body ALSO carries the target
+//!   path and `check_and_consume_approval` re-verifies it, so a
+//!   hand-moved marker file cannot satisfy a check for a different
+//!   path.
+//! - **Fail-closed corruption resilience.** Any unreadable,
+//!   oversized, unparseable, wrong-root-type, `approved != true`, or
+//!   target-mismatched marker yields no approval. The gate then
+//!   still blocks — a corrupt marker can never become an escape
+//!   hatch. This is the deliberate asymmetry vs. Layer 11
+//!   (friction-prevention, fail-open): this gate is protective.
+//!
+//! Markers live at
+//! `<project_root>/.flow-states/<branch>/shared-config-approvals/<sha256(target)>`
+//! — branch-scoped under `.flow-states/` (project root, never the
+//! worktree) so concurrent flows never collide and
+//! `flow-abort`/`flow-complete` cleanup removes them with the
+//! branch subdirectory. `clear_all` additionally clears them on
+//! phase advance so a stale approval cannot bleed into a later phase.
+//!
+//! The branch reaches filesystem path construction only through
+//! `FlowPaths::try_new`, which rejects empty / `.` / `..` /
+//! `/`-bearing / NUL-bearing branches per
+//! `.claude/rules/branch-path-safety.md`. The target path never
+//! reaches path construction directly — it is hashed to a fixed
+//! `[0-9a-f]{64}` filename, so a traversal-shaped target cannot
+//! escape the approvals directory.
+//!
+//! Tests live at `tests/shared_config_approval.rs` per
+//! `.claude/rules/test-placement.md`.
+
+use std::fs::{self, File};
+use std::io::{self, BufReader, Read};
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::flow_paths::FlowPaths;
+
+/// Maximum bytes read from a marker file. Markers this module writes
+/// are a few dozen bytes of JSON; the cap bounds I/O when the marker
+/// path holds a corrupted or hostile oversized file (a hand-edit, an
+/// interrupted unrelated write, a symlink to a large file). Per
+/// `.claude/rules/external-input-path-construction.md` every external
+/// read enforces a documented byte cap.
+const MARKER_BYTE_CAP: u64 = 64 * 1024;
+
+/// Directory (under the branch dir) that holds one marker file per
+/// approved target path.
+const APPROVALS_SUBDIR: &str = "shared-config-approvals";
+
+/// The on-disk marker filename for `target_path`: the SHA-256 hex of
+/// the full path string. Collision-safe (cryptographic digest) and
+/// filesystem-safe (`[0-9a-f]{64}`, no separators or traversal
+/// segments), so distinct target paths never share a marker and a
+/// traversal-shaped target cannot escape the approvals directory.
+fn target_key(target_path: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(target_path.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// The marker file path for `(branch, target_path)`, or `None` when
+/// `branch` fails `FlowPaths::is_valid_branch` (empty / `.` / `..` /
+/// `/`-bearing / NUL-bearing). Callers treat `None` as "no approval
+/// possible" — the gate keeps blocking, the subcommand returns a
+/// structured error.
+pub fn marker_path(root: &Path, branch: &str, target_path: &str) -> Option<PathBuf> {
+    let paths = FlowPaths::try_new(root, branch)?;
+    Some(
+        paths
+            .branch_dir()
+            .join(APPROVALS_SUBDIR)
+            .join(target_key(target_path)),
+    )
+}
+
+/// Write an approval marker authorizing exactly one subsequent edit
+/// of `target_path` under `branch`. Creates the branch-scoped
+/// approvals directory if absent. Returns `Err` when `branch` is
+/// invalid (no path can be constructed) or on any filesystem failure
+/// — the caller surfaces a structured error rather than silently
+/// approving.
+pub fn write_approval(root: &Path, branch: &str, target_path: &str) -> io::Result<()> {
+    let path = marker_path(root, branch, target_path).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid branch name: {branch:?}"),
+        )
+    })?;
+    // `marker_path` always yields `<branch_dir>/shared-config-approvals/<hash>`
+    // — a path at least three components deep — so `.parent()` is
+    // structurally `Some`. The `.expect` documents the invariant; it
+    // is unreachable, not a panic vector.
+    let parent = path
+        .parent()
+        .expect("marker_path yields a path with a parent directory");
+    fs::create_dir_all(parent)?;
+    let body = json!({ "approved": true, "target": target_path });
+    fs::write(&path, body.to_string())
+}
+
+/// Consult and consume the approval for `(branch, target_path)`.
+///
+/// Returns `true` iff a valid, unconsumed marker existed AND was
+/// successfully deleted (single-use consume-on-allow). Every other
+/// outcome returns `false` so the gate keeps blocking:
+///
+/// - invalid branch (no marker path constructible)
+/// - missing / unreadable marker
+/// - marker larger than `MARKER_BYTE_CAP`
+/// - non-JSON or wrong-root-type content
+/// - `approved` not boolean `true`
+/// - `target` field absent or not equal to `target_path`
+/// - the marker existed and validated but `fs::remove_file` failed
+///   (fail-closed: if it cannot be consumed it must not authorize,
+///   so a subsequent edit cannot reuse the same marker)
+pub fn check_and_consume_approval(root: &Path, branch: &str, target_path: &str) -> bool {
+    let path = match marker_path(root, branch, target_path) {
+        Some(p) => p,
+        None => return false,
+    };
+    let file = match File::open(&path) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+    let mut buf = String::new();
+    if BufReader::new(file.take(MARKER_BYTE_CAP))
+        .read_to_string(&mut buf)
+        .is_err()
+    {
+        return false;
+    }
+    let parsed: Value = match serde_json::from_str(&buf) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let obj = match parsed.as_object() {
+        Some(o) => o,
+        None => return false,
+    };
+    if obj.get("approved").and_then(Value::as_bool) != Some(true) {
+        return false;
+    }
+    if obj.get("target").and_then(Value::as_str) != Some(target_path) {
+        return false;
+    }
+    // Valid + unconsumed: deleting the marker IS the consume. Only
+    // report approval when the delete succeeds, so a failed remove
+    // cannot leave a reusable marker behind.
+    fs::remove_file(&path).is_ok()
+}
+
+/// Remove every approval marker for `branch` (best-effort). Called on
+/// phase advance so an approval written in one phase cannot bleed
+/// into the next. No-op when `branch` is invalid or the approvals
+/// directory does not exist; filesystem errors are swallowed because
+/// a failed clear must never block phase advance.
+pub fn clear_all(root: &Path, branch: &str) {
+    if let Some(paths) = FlowPaths::try_new(root, branch) {
+        let dir = paths.branch_dir().join(APPROVALS_SUBDIR);
+        let _ = fs::remove_dir_all(dir);
+    }
+}

--- a/tests/approve_shared_config.rs
+++ b/tests/approve_shared_config.rs
@@ -1,0 +1,490 @@
+//! Tests for `bin/flow approve-shared-config` — the user-driven
+//! "proceed" subcommand that writes a single-use shared-config
+//! approval marker after self-gating on the persisted transcript.
+//!
+//! Forgery model (same anchor as `clear-halt`): the marker is
+//! forgeable (any Bash call can invoke this subcommand), so the
+//! subcommand self-gates via
+//! `transcript_walker::user_approved_shared_config_edit` — it
+//! refuses unless the most recent real user turn typed the fixed
+//! `approve shared-config: <path>` phrase AND a genuine
+//! system-emitted shared-config block named the target in the same
+//! exchange. Neither signal is model-forgeable.
+
+mod common;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use common::{create_git_repo_with_remote, parse_output};
+use flow_rs::approve_shared_config::{run_impl_main, Args};
+use serde_json::{json, Value};
+
+fn flow_rs_no_recursion() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_flow-rs"));
+    cmd.env_remove("FLOW_CI_RUNNING");
+    cmd
+}
+
+fn encode_project_root(root: &Path) -> String {
+    root.to_string_lossy()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn write_transcript_for_session(
+    home: &Path,
+    project_root: &Path,
+    session_id: &str,
+    jsonl: &str,
+) -> PathBuf {
+    let encoded = encode_project_root(project_root);
+    let dir = home.join(".claude").join("projects").join(&encoded);
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{}.jsonl", session_id));
+    fs::write(&path, jsonl).unwrap();
+    path
+}
+
+fn write_state(repo: &Path, branch: &str, state: &Value) -> PathBuf {
+    let branch_dir = repo.join(".flow-states").join(branch);
+    fs::create_dir_all(&branch_dir).unwrap();
+    let path = branch_dir.join("state.json");
+    fs::write(&path, serde_json::to_string_pretty(state).unwrap()).unwrap();
+    path
+}
+
+/// An approving exchange: a real user request, an Edit, the
+/// system shared-config BLOCK for `<basename>`, then the user's
+/// fixed approval phrase for `<target>` as the most recent real
+/// user turn.
+fn approving_jsonl(basename: &str, target: &str) -> String {
+    format!(
+        "{{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":\"edit the manifest\"}}}}\n\
+{{\"type\":\"assistant\",\"message\":{{\"role\":\"assistant\",\"content\":[{{\"type\":\"tool_use\",\"name\":\"Edit\",\"id\":\"e1\",\"input\":{{\"file_path\":\"{target}\"}}}}]}}}}\n\
+{{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":[{{\"type\":\"tool_result\",\"tool_use_id\":\"e1\",\"content\":\"BLOCKED: {basename} is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}}]}}}}\n\
+{{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":\"approve shared-config: {target}\"}}}}\n"
+    )
+}
+
+fn run_subcmd(repo: &Path, home: &Path, args: &[&str]) -> Output {
+    flow_rs_no_recursion()
+        .arg("approve-shared-config")
+        .args(args)
+        .current_dir(repo)
+        .env("HOME", home)
+        .env("GH_TOKEN", "invalid")
+        .env("CLAUDE_PLUGIN_ROOT", env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .unwrap()
+}
+
+// --- happy path (subprocess) ---
+
+#[test]
+fn approves_and_writes_marker_when_user_granted() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical_repo = repo.canonicalize().unwrap();
+    let target = format!("{}/Cargo.toml", canonical_repo.display());
+    let session_id = "asc-happy-001";
+    write_transcript_for_session(
+        dir.path(),
+        &canonical_repo,
+        session_id,
+        &approving_jsonl("Cargo.toml", &target),
+    );
+    write_state(
+        &repo,
+        "b",
+        &json!({ "branch": "b", "session_id": session_id, "current_phase": "flow-code" }),
+    );
+
+    let output = run_subcmd(&repo, dir.path(), &["--path", &target, "--branch", "b"]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    assert_eq!(data["status"], "ok");
+    // Marker consumable exactly once afterward.
+    assert!(flow_rs::shared_config_approval::check_and_consume_approval(
+        &repo, "b", &target
+    ));
+}
+
+// --- forgery defense: no approving transcript ---
+
+#[test]
+fn rejects_when_transcript_lacks_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical_repo = repo.canonicalize().unwrap();
+    let target = format!("{}/Cargo.toml", canonical_repo.display());
+    let session_id = "asc-forge-001";
+    // BLOCK present but no user approval phrase.
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"edit it\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"e1\",\"content\":\"BLOCKED: Cargo.toml is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}]}}\n";
+    write_transcript_for_session(dir.path(), &canonical_repo, session_id, jsonl);
+    write_state(
+        &repo,
+        "b",
+        &json!({ "branch": "b", "session_id": session_id, "current_phase": "flow-code" }),
+    );
+
+    let output = run_subcmd(&repo, dir.path(), &["--path", &target, "--branch", "b"]);
+    assert_eq!(output.status.code(), Some(1));
+    let data = parse_output(&output);
+    assert_eq!(data["status"], "error");
+    assert_eq!(data["reason"], "not_user_approved");
+    assert!(!flow_rs::shared_config_approval::check_and_consume_approval(&repo, "b", &target));
+}
+
+// --- --path validation (library, exhaustive) ---
+
+fn lib_args(path: &str) -> Args {
+    Args {
+        path: path.to_string(),
+        branch: Some("b".to_string()),
+    }
+}
+
+#[test]
+fn rejects_empty_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let home = dir.path();
+    let (v, code) = run_impl_main(&lib_args(""), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["status"], "error");
+    assert_eq!(v["reason"], "invalid_path");
+}
+
+#[test]
+fn rejects_relative_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let home = dir.path();
+    let (v, code) = run_impl_main(&lib_args("Cargo.toml"), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "invalid_path");
+}
+
+#[test]
+fn rejects_traversal_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let p = format!("{}/../escape/Cargo.toml", canonical.display());
+    let (v, code) = run_impl_main(&lib_args(&p), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "invalid_path");
+}
+
+#[test]
+fn rejects_nul_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let p = format!("{}/Cargo\0.toml", canonical.display());
+    let (v, code) = run_impl_main(&lib_args(&p), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "invalid_path");
+}
+
+#[test]
+fn rejects_path_outside_worktree() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let home = dir.path();
+    // Absolute, well-formed, but outside the git worktree.
+    let outside = dir.path().join("elsewhere").join("Cargo.toml");
+    fs::create_dir_all(outside.parent().unwrap()).unwrap();
+    let (v, code) = run_impl_main(&lib_args(outside.to_str().unwrap()), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "path_outside_worktree");
+}
+
+// --- invalid branch ---
+
+#[test]
+fn rejects_invalid_branch() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let target = format!("{}/Cargo.toml", canonical.display());
+    let args = Args {
+        path: target,
+        branch: Some("a/b".to_string()),
+    };
+    let (v, code) = run_impl_main(&args, &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "invalid_branch");
+}
+
+// --- no state file ---
+
+#[test]
+fn rejects_when_no_state_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let target = format!("{}/Cargo.toml", canonical.display());
+    let (v, code) = run_impl_main(&lib_args(&target), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "no_state_file");
+}
+
+// --- no transcript path ---
+
+#[test]
+fn rejects_when_state_has_no_transcript() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let target = format!("{}/Cargo.toml", canonical.display());
+    write_state(&repo, "b", &json!({ "branch": "b" }));
+    let (v, code) = run_impl_main(&lib_args(&target), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "no_transcript_path");
+}
+
+// --- cwd-scope drift (state-mutator guard) ---
+
+#[test]
+fn rejects_on_cwd_drift() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let target = format!("{}/Cargo.toml", canonical.display());
+    // cwd_scope::enforce resolves the branch from git (the fixture
+    // clone is on `main`), so the drift state must live under the
+    // git branch. relative_cwd="api" with cwd at the repo root is a
+    // drift the guard rejects before any branch override is read.
+    write_state(
+        &repo,
+        "main",
+        &json!({ "branch": "main", "relative_cwd": "api", "session_id": "s" }),
+    );
+    let (v, code) = run_impl_main(&lib_args(&target), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "cwd_drift");
+}
+
+// --- cwd-result wrapper (main-arm fallback) ---
+
+#[test]
+fn cwd_result_ok_delegates_to_run_impl_main() {
+    use flow_rs::approve_shared_config::run_impl_main_with_cwd_result;
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let target = format!("{}/Cargo.toml", canonical.display());
+    let (v, code) =
+        run_impl_main_with_cwd_result(&lib_args(&target), &repo, Ok(repo.clone()), home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "no_state_file");
+}
+
+#[test]
+fn cwd_result_err_falls_back_to_dot() {
+    use flow_rs::approve_shared_config::run_impl_main_with_cwd_result;
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let target = format!("{}/Cargo.toml", canonical.display());
+    // current_dir() failure → cwd = ".". The git toplevel of "."
+    // (the test process worktree) is not the fixture repo, so the
+    // fixture target resolves outside it: deterministic rejection.
+    let (v, code) = run_impl_main_with_cwd_result(
+        &lib_args(&target),
+        &repo,
+        Err(std::io::Error::other("simulated current_dir failure")),
+        home,
+    );
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "path_outside_worktree");
+}
+
+// --- branch / path / transcript edge coverage ---
+
+#[test]
+fn rejects_when_branch_undetectable() {
+    // Non-git cwd and no --branch override: resolve_branch_in
+    // returns None.
+    let dir = tempfile::tempdir().unwrap();
+    let nongit = dir.path().join("plain");
+    fs::create_dir_all(&nongit).unwrap();
+    let home = dir.path();
+    let args = Args {
+        path: "/etc/hosts".to_string(),
+        branch: None,
+    };
+    let (v, code) = run_impl_main(&args, dir.path(), &nongit, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "invalid_branch");
+}
+
+#[test]
+fn rejects_when_cwd_not_git_managed() {
+    // worktree_root returns None (git rev-parse fails in a non-git
+    // cwd) → path_outside_worktree at the callsite.
+    let dir = tempfile::tempdir().unwrap();
+    let nongit = dir.path().join("plain");
+    fs::create_dir_all(&nongit).unwrap();
+    let home = dir.path();
+    let p = nongit.join("Cargo.toml");
+    let args = Args {
+        path: p.to_str().unwrap().to_string(),
+        branch: Some("b".to_string()),
+    };
+    let (v, code) = run_impl_main(&args, dir.path(), &nongit, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "path_outside_worktree");
+}
+
+#[test]
+fn rejects_rootless_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let home = dir.path();
+    // "/" is absolute with no `..` (passes path_shape_ok) but has
+    // no parent → path_inside_worktree returns false.
+    let (v, code) = run_impl_main(&lib_args("/"), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "path_outside_worktree");
+}
+
+#[test]
+fn rejects_when_parent_dir_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let home = dir.path();
+    // Parent directory does not exist → parent.canonicalize() Err
+    // → path_inside_worktree false.
+    let p = format!("{}/no_such_dir/Cargo.toml", canonical.display());
+    let (v, code) = run_impl_main(&lib_args(&p), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "path_outside_worktree");
+}
+
+#[test]
+fn rejects_when_state_unparseable() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let target = format!("{}/Cargo.toml", canonical.display());
+    let branch_dir = repo.join(".flow-states").join("b");
+    fs::create_dir_all(&branch_dir).unwrap();
+    fs::write(branch_dir.join("state.json"), "{not json").unwrap();
+    let (v, code) = run_impl_main(&lib_args(&target), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "no_state_file");
+}
+
+#[test]
+fn rejects_when_session_id_unsafe_and_no_transcript_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let target = format!("{}/Cargo.toml", canonical.display());
+    // session_id fails is_safe_session_id (slash) → filtered out;
+    // no transcript_path → resolve_transcript_path None.
+    write_state(&repo, "b", &json!({ "branch": "b", "session_id": "a/b" }));
+    let (v, code) = run_impl_main(&lib_args(&target), &repo, &repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "no_transcript_path");
+}
+
+#[test]
+fn approves_via_explicit_transcript_path_field() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical_repo = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let target = format!("{}/Cargo.toml", canonical_repo.display());
+    // State carries an explicit transcript_path (not session_id):
+    // exercises resolve_transcript_path's transcript_path branch.
+    let proj = home.join(".claude").join("projects").join("pj");
+    fs::create_dir_all(&proj).unwrap();
+    let tpath = proj.join("explicit.jsonl");
+    fs::write(&tpath, approving_jsonl("Cargo.toml", &target)).unwrap();
+    write_state(
+        &repo,
+        "b",
+        &json!({ "branch": "b", "transcript_path": tpath.to_str().unwrap() }),
+    );
+    let (v, code) = run_impl_main(&lib_args(&target), &repo, &repo, home);
+    assert_eq!(code, 0, "value: {v}");
+    assert_eq!(v["status"], "ok");
+}
+
+#[test]
+fn write_failed_when_marker_dir_blocked() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical_repo = repo.canonicalize().unwrap();
+    let home = dir.path();
+    let target = format!("{}/Cargo.toml", canonical_repo.display());
+    let session_id = "asc-wf-001";
+    write_transcript_for_session(
+        dir.path(),
+        &canonical_repo,
+        session_id,
+        &approving_jsonl("Cargo.toml", &target),
+    );
+    // root must be the canonical repo so derive_transcript_path
+    // encodes the same project-root path the transcript was
+    // written under.
+    let branch_dir = canonical_repo.join(".flow-states").join("b");
+    fs::create_dir_all(&branch_dir).unwrap();
+    fs::write(
+        branch_dir.join("state.json"),
+        serde_json::to_string(&json!({ "branch": "b", "session_id": session_id })).unwrap(),
+    )
+    .unwrap();
+    // A regular file where the approvals directory must be created
+    // makes write_approval's create_dir_all fail.
+    fs::write(branch_dir.join("shared-config-approvals"), "x").unwrap();
+    let (v, code) = run_impl_main(&lib_args(&target), &canonical_repo, &canonical_repo, home);
+    assert_eq!(code, 1);
+    assert_eq!(v["reason"], "write_failed");
+}
+
+// --- main-dispatch arm reachable (subprocess) ---
+
+#[test]
+fn main_dispatch_arm_is_reachable() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = create_git_repo_with_remote(dir.path());
+    let canonical = repo.canonicalize().unwrap();
+    let target = format!("{}/Cargo.toml", canonical.display());
+    // No state file → structured error through the real binary,
+    // proving Commands::ApproveSharedConfig dispatches.
+    let output = run_subcmd(&repo, dir.path(), &["--path", &target, "--branch", "b"]);
+    assert_eq!(output.status.code(), Some(1));
+    let data = parse_output(&output);
+    assert_eq!(data["status"], "error");
+    assert_eq!(data["reason"], "no_state_file");
+}

--- a/tests/approve_shared_config.rs
+++ b/tests/approve_shared_config.rs
@@ -63,14 +63,19 @@ fn write_state(repo: &Path, branch: &str, state: &Value) -> PathBuf {
 }
 
 /// An approving exchange: a real user request, an Edit, the
-/// system shared-config BLOCK for `<basename>`, then the user's
-/// fixed approval phrase for `<target>` as the most recent real
-/// user turn.
+/// system shared-config BLOCK, then the user's fixed approval
+/// phrase for `<target>` as the most recent real user turn. The
+/// BLOCK content mirrors the production message
+/// (`validate_worktree_paths::validate_shared_config`): the
+/// leading clause names `<basename>` and the FULL `<target>` path
+/// appears in the phrase and the `--path` argument, because
+/// `user_approved_shared_config_edit` corroborates on the full
+/// path (a same-basename sibling block must not cross-corroborate).
 fn approving_jsonl(basename: &str, target: &str) -> String {
     format!(
         "{{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":\"edit the manifest\"}}}}\n\
 {{\"type\":\"assistant\",\"message\":{{\"role\":\"assistant\",\"content\":[{{\"type\":\"tool_use\",\"name\":\"Edit\",\"id\":\"e1\",\"input\":{{\"file_path\":\"{target}\"}}}}]}}}}\n\
-{{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":[{{\"type\":\"tool_result\",\"tool_use_id\":\"e1\",\"content\":\"BLOCKED: {basename} is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}}]}}}}\n\
+{{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":[{{\"type\":\"tool_result\",\"tool_use_id\":\"e1\",\"content\":\"BLOCKED: {basename} is a shared configuration file that affects every engineer in the repository. To authorize this single edit, the USER must reply with the exact line `approve shared-config: {target}`, then run `bin/flow approve-shared-config --path {target}` and retry the edit.\",\"is_error\":true}}]}}}}\n\
 {{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":\"approve shared-config: {target}\"}}}}\n"
     )
 }

--- a/tests/hooks/transcript_walker.rs
+++ b/tests/hooks/transcript_walker.rs
@@ -1122,9 +1122,18 @@ fn approval_turn(target: &str) -> String {
     )
 }
 
-fn block_turn(basename: &str) -> String {
+// Mirrors the production block message
+// (`validate_worktree_paths::validate_shared_config`): the leading
+// clause names the basename, and the FULL file path appears in the
+// `approve shared-config:` phrase and the `--path` argument. The
+// walker corroborates on the full path, so the helper must carry it.
+fn block_turn(file_path: &str) -> String {
+    let basename = std::path::Path::new(file_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(file_path);
     format!(
-        "{{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":[{{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: {basename} is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}}]}}}}\n"
+        "{{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":[{{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: {basename} is a shared configuration file that affects every engineer in the repository. To authorize this single edit, the USER must reply with the exact line `approve shared-config: {file_path}`, then run `bin/flow approve-shared-config --path {file_path}` and retry the edit.\",\"is_error\":true}}]}}}}\n"
     )
 }
 
@@ -1138,7 +1147,7 @@ fn approve_true_when_real_user_grants_after_block() {
     let home = dir.path();
     let jsonl = format!(
         "{REQ}{EDIT}{}{}",
-        block_turn("Cargo.toml"),
+        block_turn("/repo/Cargo.toml"),
         approval_turn("/repo/Cargo.toml")
     );
     let path = crate::common::transcript_fixture(home, "p", &jsonl);
@@ -1155,7 +1164,7 @@ fn approve_false_when_latest_user_turn_is_not_an_approval() {
     let home = dir.path();
     let unrelated =
         "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"no, do something else\"}}\n";
-    let jsonl = format!("{REQ}{EDIT}{}{unrelated}", block_turn("Cargo.toml"));
+    let jsonl = format!("{REQ}{EDIT}{}{unrelated}", block_turn("/repo/Cargo.toml"));
     let path = crate::common::transcript_fixture(home, "p", &jsonl);
     assert!(!user_approved_shared_config_edit(
         &path,
@@ -1170,7 +1179,7 @@ fn approve_false_when_approval_names_different_path() {
     let home = dir.path();
     let jsonl = format!(
         "{REQ}{EDIT}{}{}",
-        block_turn("Cargo.toml"),
+        block_turn("/repo/Cargo.toml"),
         approval_turn("/repo/.gitignore")
     );
     let path = crate::common::transcript_fixture(home, "p", &jsonl);
@@ -1205,7 +1214,7 @@ fn approve_false_when_block_names_different_file() {
     // per-file binding rejects the cross-file replay.
     let jsonl = format!(
         "{REQ}{EDIT}{}{}",
-        block_turn(".gitignore"),
+        block_turn("/repo/.gitignore"),
         approval_turn("/repo/Cargo.toml")
     );
     let path = crate::common::transcript_fixture(home, "p", &jsonl);
@@ -1249,7 +1258,7 @@ fn approve_false_when_block_predates_prior_user_turn() {
         "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"earlier unrelated ask\"}}\n";
     let jsonl = format!(
         "{REQ}{EDIT}{}{older}{}",
-        block_turn("Cargo.toml"),
+        block_turn("/repo/Cargo.toml"),
         approval_turn("/repo/Cargo.toml")
     );
     let path = crate::common::transcript_fixture(home, "p", &jsonl);
@@ -1269,7 +1278,7 @@ fn approve_false_when_most_recent_user_turn_is_askuserquestion_toolresult() {
     // tool_result). An AskUserQuestion answer as the most recent
     // user-role turn does NOT authorize the edit.
     let askuq = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"aq1\",\"content\":\"User has answered your questions: \\\"May I edit Cargo.toml?\\\"=\\\"Yes\\\"\",\"is_error\":false}]}}\n";
-    let jsonl = format!("{REQ}{EDIT}{}{askuq}", block_turn("Cargo.toml"));
+    let jsonl = format!("{REQ}{EDIT}{}{askuq}", block_turn("/repo/Cargo.toml"));
     let path = crate::common::transcript_fixture(home, "p", &jsonl);
     assert!(!user_approved_shared_config_edit(
         &path,
@@ -1288,7 +1297,7 @@ fn approve_skips_hook_feedback_string_content_ismeta_true() {
     let refusal = "{\"type\":\"user\",\"isMeta\":true,\"message\":{\"role\":\"user\",\"content\":\"Stop hook feedback:\\nContinue.\"}}\n";
     let jsonl = format!(
         "{REQ}{EDIT}{}{}{refusal}",
-        block_turn("Cargo.toml"),
+        block_turn("/repo/Cargo.toml"),
         approval_turn("/repo/Cargo.toml")
     );
     let path = crate::common::transcript_fixture(home, "p", &jsonl);
@@ -1304,7 +1313,7 @@ fn approve_false_when_user_declined_in_prose() {
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path();
     let decline = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"do not touch Cargo.toml\"}}\n";
-    let jsonl = format!("{REQ}{EDIT}{}{decline}", block_turn("Cargo.toml"));
+    let jsonl = format!("{REQ}{EDIT}{}{decline}", block_turn("/repo/Cargo.toml"));
     let path = crate::common::transcript_fixture(home, "p", &jsonl);
     assert!(!user_approved_shared_config_edit(
         &path,
@@ -1321,7 +1330,7 @@ fn approve_normalizes_case_and_whitespace_in_approval() {
     // variant of the phrase still authorizes (same robustness the
     // clear-halt marker has).
     let approval = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"  APPROVE Shared-Config: /repo/Cargo.toml  \"}}\n";
-    let jsonl = format!("{REQ}{EDIT}{}{approval}", block_turn("Cargo.toml"));
+    let jsonl = format!("{REQ}{EDIT}{}{approval}", block_turn("/repo/Cargo.toml"));
     let path = crate::common::transcript_fixture(home, "p", &jsonl);
     assert!(user_approved_shared_config_edit(
         &path,
@@ -1395,7 +1404,7 @@ fn approve_false_when_target_has_no_basename() {
     let home = dir.path();
     let jsonl = format!(
         "{REQ}{EDIT}{}{}",
-        block_turn("Cargo.toml"),
+        block_turn("/repo/Cargo.toml"),
         approval_turn("/")
     );
     let path = crate::common::transcript_fixture(home, "p", &jsonl);
@@ -1408,7 +1417,7 @@ fn approve_skips_unparseable_lines() {
     let home = dir.path();
     let jsonl = format!(
         "not json\n{REQ}{EDIT}{}{}garbage line\n",
-        block_turn("Cargo.toml"),
+        block_turn("/repo/Cargo.toml"),
         approval_turn("/repo/Cargo.toml")
     );
     let path = crate::common::transcript_fixture(home, "p", &jsonl);
@@ -1429,7 +1438,8 @@ fn approve_false_when_block_outside_byte_cap() {
     // Block at HEAD, oversized padding pushes it (and REQ/EDIT)
     // out of the tail-bounded read; only the approval is visible —
     // without the block the predicate is false.
-    let mut content: Vec<u8> = format!("{REQ}{EDIT}{}", block_turn("Cargo.toml")).into_bytes();
+    let mut content: Vec<u8> =
+        format!("{REQ}{EDIT}{}", block_turn("/repo/Cargo.toml")).into_bytes();
     let pad = (SHARED_CONFIG_BLOCK_BYTE_CAP as usize) + 1024;
     content.extend(std::iter::repeat_n(b'\n', pad));
     content.extend_from_slice(approval_turn("/repo/Cargo.toml").as_bytes());
@@ -1438,6 +1448,49 @@ fn approve_false_when_block_outside_byte_cap() {
         &path,
         home,
         "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_block_is_for_same_basename_sibling() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // A2 regression: the system block fired for `/repo/Cargo.toml`
+    // but the user approved the same-basename sibling
+    // `/repo/sub/Cargo.toml`. Basename-only corroboration would
+    // cross-corroborate (both basenames are `Cargo.toml`); full-path
+    // corroboration rejects it — the block names `/repo/Cargo.toml`,
+    // never the substring `/repo/sub/Cargo.toml`.
+    let jsonl = format!(
+        "{REQ}{EDIT}{}{}",
+        block_turn("/repo/Cargo.toml"),
+        approval_turn("/repo/sub/Cargo.toml")
+    );
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/sub/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_true_when_block_is_for_the_exact_sibling_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Positive counterpart: a block naming the exact full path
+    // `/repo/sub/Cargo.toml` corroborates a grant for that path even
+    // though a same-basename file exists at `/repo/Cargo.toml`.
+    let jsonl = format!(
+        "{REQ}{EDIT}{}{}",
+        block_turn("/repo/sub/Cargo.toml"),
+        approval_turn("/repo/sub/Cargo.toml")
+    );
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/sub/Cargo.toml"
     ));
 }
 

--- a/tests/hooks/transcript_walker.rs
+++ b/tests/hooks/transcript_walker.rs
@@ -15,8 +15,9 @@ use flow_rs::hooks::transcript_walker::{
     any_skill_in_set_since_user, last_user_message_invokes_skill,
     most_recent_skill_in_user_only_set, most_recent_skill_since_user,
     most_recent_user_message_since_skill_action, read_full, read_recency_window, read_recent_turns,
-    recent_edit_blocked_on_shared_config, verify_agent_returned_in_phase,
-    SHARED_CONFIG_BLOCK_BYTE_CAP, TRANSCRIPT_BYTE_CAP, USER_ONLY_SKILLS,
+    recent_edit_blocked_on_shared_config, user_approved_shared_config_edit,
+    verify_agent_returned_in_phase, SHARED_CONFIG_BLOCK_BYTE_CAP, TRANSCRIPT_BYTE_CAP,
+    USER_ONLY_SKILLS,
 };
 
 // --- last_user_message_invokes_skill ---
@@ -1102,6 +1103,342 @@ fn helper_continues_when_tool_result_content_is_number() {
 {\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":7,\"is_error\":true}]}}\n";
     let path = crate::common::transcript_fixture(home, "p", jsonl);
     assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+// --- user_approved_shared_config_edit ---
+//
+// The forgery-resistant "proceed" predicate. Returns true iff the
+// most recent non-hook-feedback user-role turn is a REAL user turn
+// (string content, no isMeta — the model cannot synthesize it,
+// the same trust anchor as clear-halt) whose normalized content
+// contains the fixed phrase `approve shared-config: <target_path>`,
+// AND a system-emitted shared-config BLOCKED tool_result naming the
+// target basename appears earlier in the current exchange (between
+// the approval turn and the next-older real user turn).
+
+fn approval_turn(target: &str) -> String {
+    format!(
+        "{{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":\"approve shared-config: {target}\"}}}}\n"
+    )
+}
+
+fn block_turn(basename: &str) -> String {
+    format!(
+        "{{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":[{{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"BLOCKED: {basename} is a shared configuration file that affects every engineer in the repository.\",\"is_error\":true}}]}}}}\n"
+    )
+}
+
+const REQ: &str =
+    "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"please edit the manifest\"}}\n";
+const EDIT: &str = "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"id\":\"e1\",\"input\":{\"file_path\":\"/repo/Cargo.toml\"}}]}}\n";
+
+#[test]
+fn approve_true_when_real_user_grants_after_block() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = format!(
+        "{REQ}{EDIT}{}{}",
+        block_turn("Cargo.toml"),
+        approval_turn("/repo/Cargo.toml")
+    );
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_latest_user_turn_is_not_an_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let unrelated =
+        "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"no, do something else\"}}\n";
+    let jsonl = format!("{REQ}{EDIT}{}{unrelated}", block_turn("Cargo.toml"));
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_approval_names_different_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = format!(
+        "{REQ}{EDIT}{}{}",
+        block_turn("Cargo.toml"),
+        approval_turn("/repo/.gitignore")
+    );
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_no_system_block_in_exchange() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Approval phrase present, but no shared-config BLOCKED
+    // tool_result — the model cannot self-authorize without a
+    // genuine system block.
+    let jsonl = format!("{REQ}{EDIT}{}", approval_turn("/repo/Cargo.toml"));
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_block_names_different_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Block fired for .gitignore but approval is for Cargo.toml —
+    // per-file binding rejects the cross-file replay.
+    let jsonl = format!(
+        "{REQ}{EDIT}{}{}",
+        block_turn(".gitignore"),
+        approval_turn("/repo/Cargo.toml")
+    );
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_only_unrelated_error_block_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Approval phrase present, but the only error tool_result in the
+    // exchange is an unrelated block whose text lacks the
+    // shared-config substring — the block-corroboration predicate's
+    // first `contains` short-circuits to false, so no genuine
+    // shared-config block authorizes the grant.
+    let other_err = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"x\",\"content\":\"BLOCKED: rm -rf / matches a deny pattern.\",\"is_error\":true}]}}\n";
+    let jsonl = format!(
+        "{REQ}{EDIT}{other_err}{}",
+        approval_turn("/repo/Cargo.toml")
+    );
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_block_predates_prior_user_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Block belongs to an OLDER exchange: a fresh real user turn
+    // intervenes between the block and the approval, so the block
+    // is not part of the current exchange.
+    let older =
+        "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"earlier unrelated ask\"}}\n";
+    let jsonl = format!(
+        "{REQ}{EDIT}{}{older}{}",
+        block_turn("Cargo.toml"),
+        approval_turn("/repo/Cargo.toml")
+    );
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_most_recent_user_turn_is_askuserquestion_toolresult() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // The approval channel is a REAL user prose turn, never an
+    // AskUserQuestion answer (a model-mediated, non-forgery-resistant
+    // tool_result). An AskUserQuestion answer as the most recent
+    // user-role turn does NOT authorize the edit.
+    let askuq = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"aq1\",\"content\":\"User has answered your questions: \\\"May I edit Cargo.toml?\\\"=\\\"Yes\\\"\",\"is_error\":false}]}}\n";
+    let jsonl = format!("{REQ}{EDIT}{}{askuq}", block_turn("Cargo.toml"));
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_skips_hook_feedback_string_content_ismeta_true() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // A Stop-hook refusal (string content + isMeta:true) lands after
+    // the approval. The walker must skip it via the targeted
+    // hook-feedback skip and still see the approval.
+    let refusal = "{\"type\":\"user\",\"isMeta\":true,\"message\":{\"role\":\"user\",\"content\":\"Stop hook feedback:\\nContinue.\"}}\n";
+    let jsonl = format!(
+        "{REQ}{EDIT}{}{}{refusal}",
+        block_turn("Cargo.toml"),
+        approval_turn("/repo/Cargo.toml")
+    );
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_user_declined_in_prose() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let decline = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"do not touch Cargo.toml\"}}\n";
+    let jsonl = format!("{REQ}{EDIT}{}{decline}", block_turn("Cargo.toml"));
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_normalizes_case_and_whitespace_in_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // normalize_gate_input lowercases + trims, so a case/whitespace
+    // variant of the phrase still authorizes (same robustness the
+    // clear-halt marker has).
+    let approval = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"  APPROVE Shared-Config: /repo/Cargo.toml  \"}}\n";
+    let jsonl = format!("{REQ}{EDIT}{}{approval}", block_turn("Cargo.toml"));
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_transcript_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let missing = home
+        .join(".claude")
+        .join("projects")
+        .join("p")
+        .join("nope.jsonl");
+    assert!(!user_approved_shared_config_edit(
+        &missing,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_transcript_unreadable_as_utf8() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // File exists (so is_safe_transcript_path's canonicalize
+    // succeeds and the safety gate passes) but its bytes are not
+    // valid UTF-8, so read_recent_turns returns None — exercises the
+    // `None => return false` arm after the safety check.
+    let proj = home.join(".claude").join("projects").join("p");
+    std::fs::create_dir_all(&proj).unwrap();
+    let path = proj.join("session.jsonl");
+    std::fs::write(&path, [0xff_u8, 0xfe, 0xfd]).unwrap();
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_transcript_path_unsafe() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let relative = std::path::Path::new("relative/x.jsonl");
+    assert!(!user_approved_shared_config_edit(
+        relative,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_on_empty_transcript() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let path = crate::common::transcript_fixture(home, "p", "");
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_target_has_no_basename() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = format!(
+        "{REQ}{EDIT}{}{}",
+        block_turn("Cargo.toml"),
+        approval_turn("/")
+    );
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(!user_approved_shared_config_edit(&path, home, "/"));
+}
+
+#[test]
+fn approve_skips_unparseable_lines() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = format!(
+        "not json\n{REQ}{EDIT}{}{}garbage line\n",
+        block_turn("Cargo.toml"),
+        approval_turn("/repo/Cargo.toml")
+    );
+    let path = crate::common::transcript_fixture(home, "p", &jsonl);
+    assert!(user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn approve_false_when_block_outside_byte_cap() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let proj = home.join(".claude").join("projects").join("p");
+    std::fs::create_dir_all(&proj).unwrap();
+    let path = proj.join("capped.jsonl");
+    // Block at HEAD, oversized padding pushes it (and REQ/EDIT)
+    // out of the tail-bounded read; only the approval is visible —
+    // without the block the predicate is false.
+    let mut content: Vec<u8> = format!("{REQ}{EDIT}{}", block_turn("Cargo.toml")).into_bytes();
+    let pad = (SHARED_CONFIG_BLOCK_BYTE_CAP as usize) + 1024;
+    content.extend(std::iter::repeat_n(b'\n', pad));
+    content.extend_from_slice(approval_turn("/repo/Cargo.toml").as_bytes());
+    std::fs::write(&path, &content).unwrap();
+    assert!(!user_approved_shared_config_edit(
+        &path,
+        home,
+        "/repo/Cargo.toml"
+    ));
 }
 
 // --- most_recent_skill_since_user ---

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -414,8 +414,7 @@ fn shared_config_marker_is_single_use() {
 #[test]
 fn shared_config_blocks_on_corrupt_marker() {
     let (_d, root, cwd, file_path) = sc_fixture();
-    let mpath =
-        flow_rs::shared_config_approval::marker_path(&root, "feat", &file_path).unwrap();
+    let mpath = flow_rs::shared_config_approval::marker_path(&root, "feat", &file_path).unwrap();
     fs::create_dir_all(mpath.parent().unwrap()).unwrap();
     fs::write(&mpath, "{ not json").unwrap();
     let (allowed, _) = validate_shared_config(&file_path, &cwd, "Edit");

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -1,5 +1,6 @@
 //! Integration tests for `src/hooks/validate_worktree_paths.rs`.
 
+use std::fs;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
@@ -361,6 +362,105 @@ fn test_shared_config_empty_tool_name_allowed() {
     let (allowed, msg) = validate_shared_config(file_path, cwd, "");
     assert!(allowed);
     assert!(msg.is_empty());
+}
+
+// --- validate_shared_config approval consult ---
+//
+// The "proceed" half: before the block return, validate_shared_config
+// consults+consumes a single-use shared-config approval marker. A
+// valid unconsumed marker for the target allows the edit exactly
+// once; absence, corruption, per-file mismatch, or a second edit all
+// keep blocking (fail-closed).
+
+fn sc_fixture() -> (tempfile::TempDir, std::path::PathBuf, String, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let cwd = root.join(".worktrees").join("feat");
+    fs::create_dir_all(&cwd).unwrap();
+    let file_path = format!("{}/Cargo.toml", cwd.display());
+    let cwd_s = cwd.to_string_lossy().to_string();
+    (dir, root, cwd_s, file_path)
+}
+
+#[test]
+fn shared_config_allows_with_valid_marker() {
+    let (_d, root, cwd, file_path) = sc_fixture();
+    flow_rs::shared_config_approval::write_approval(&root, "feat", &file_path).unwrap();
+    let (allowed, msg) = validate_shared_config(&file_path, &cwd, "Edit");
+    assert!(allowed, "valid marker must allow the edit");
+    assert!(msg.is_empty());
+}
+
+#[test]
+fn shared_config_blocks_without_marker() {
+    let (_d, _root, cwd, file_path) = sc_fixture();
+    let (allowed, msg) = validate_shared_config(&file_path, &cwd, "Edit");
+    assert!(!allowed);
+    assert!(msg.contains("is a shared configuration file that affects every engineer"));
+    assert!(msg.contains("approve-shared-config"));
+}
+
+#[test]
+fn shared_config_marker_is_single_use() {
+    let (_d, root, cwd, file_path) = sc_fixture();
+    flow_rs::shared_config_approval::write_approval(&root, "feat", &file_path).unwrap();
+    let (a1, _) = validate_shared_config(&file_path, &cwd, "Edit");
+    assert!(a1, "first edit consumes the marker");
+    let (a2, msg2) = validate_shared_config(&file_path, &cwd, "Edit");
+    assert!(!a2, "second edit re-blocks (marker consumed)");
+    assert!(msg2.contains("approve-shared-config"));
+}
+
+#[test]
+fn shared_config_blocks_on_corrupt_marker() {
+    let (_d, root, cwd, file_path) = sc_fixture();
+    let mpath =
+        flow_rs::shared_config_approval::marker_path(&root, "feat", &file_path).unwrap();
+    fs::create_dir_all(mpath.parent().unwrap()).unwrap();
+    fs::write(&mpath, "{ not json").unwrap();
+    let (allowed, _) = validate_shared_config(&file_path, &cwd, "Edit");
+    assert!(!allowed, "corrupt marker must fail closed (still block)");
+}
+
+#[test]
+fn shared_config_marker_is_per_file() {
+    let (_d, root, cwd, file_path) = sc_fixture();
+    // Marker granted for Cargo.toml; an Edit of .gitignore must
+    // still block.
+    flow_rs::shared_config_approval::write_approval(&root, "feat", &file_path).unwrap();
+    let other = format!("{}/.gitignore", std::path::Path::new(&cwd).display());
+    let (allowed, _) = validate_shared_config(&other, &cwd, "Edit");
+    assert!(!allowed, "marker for Cargo.toml must not allow .gitignore");
+    // Cargo.toml's marker is untouched and still usable.
+    let (a, _) = validate_shared_config(&file_path, &cwd, "Edit");
+    assert!(a);
+}
+
+#[test]
+fn shared_config_marker_ignored_for_read_tool() {
+    // Read is never blocked regardless of marker state — the
+    // tool-name guard returns allow before the consult, so the
+    // marker is NOT consumed by a Read.
+    let (_d, root, cwd, file_path) = sc_fixture();
+    flow_rs::shared_config_approval::write_approval(&root, "feat", &file_path).unwrap();
+    let (allowed, _) = validate_shared_config(&file_path, &cwd, "Read");
+    assert!(allowed);
+    // Marker survives (was not consumed): an Edit can still use it.
+    let (a, _) = validate_shared_config(&file_path, &cwd, "Edit");
+    assert!(a, "Read must not consume the marker");
+}
+
+#[test]
+fn shared_config_blocks_when_worktree_unresolvable() {
+    // cwd contains ".worktrees/" (passes the flow-active proxy
+    // check) but NOT "/.worktrees/" (no leading slash before the
+    // marker), so compute_worktree_paths returns None and the
+    // approval consult is skipped — fail-closed, still blocks.
+    let cwd = "x.worktrees/feat";
+    let file_path = "x.worktrees/feat/Cargo.toml";
+    let (allowed, msg) = validate_shared_config(file_path, cwd, "Edit");
+    assert!(!allowed);
+    assert!(msg.contains("is a shared configuration file that affects every engineer"));
 }
 
 // Direct `run_impl_main` tests removed — decision core is now

--- a/tests/phase_enter.rs
+++ b/tests/phase_enter.rs
@@ -207,6 +207,56 @@ fn test_code_phase_happy_path() {
 }
 
 #[test]
+fn phase_enter_clears_stale_shared_config_markers() {
+    // A shared-config approval marker from an earlier phase must
+    // not bleed into the next phase: entering a new phase clears
+    // every marker for the branch (defense-in-depth alongside
+    // single-use consumption).
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "sc-marker-clear";
+    let repo = create_git_repo(dir.path(), branch);
+    create_state(&repo, branch, "flow-start", "complete", None);
+    let target = "/repo/Cargo.toml";
+    flow_rs::shared_config_approval::write_approval(&repo, branch, target).unwrap();
+    assert!(
+        flow_rs::shared_config_approval::marker_path(&repo, branch, target)
+            .unwrap()
+            .exists(),
+        "marker exists before phase-enter"
+    );
+
+    let output = run_phase_enter(&repo, &["--phase", "flow-code", "--branch", branch]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "phase-enter must not be blocked by marker clearing; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let data = parse_output(&output);
+    assert_eq!(data["status"], "ok");
+    // Marker cleared — a subsequent gate consult finds nothing.
+    assert!(
+        !flow_rs::shared_config_approval::check_and_consume_approval(&repo, branch, target),
+        "phase-enter must clear the stale marker"
+    );
+}
+
+#[test]
+fn phase_enter_marker_clear_is_best_effort_when_absent() {
+    // No markers exist — clear_all is a no-op and phase-enter
+    // succeeds normally (best-effort: a missing approvals dir never
+    // blocks or panics phase advance).
+    let dir = tempfile::tempdir().unwrap();
+    let branch = "sc-marker-noop";
+    let repo = create_git_repo(dir.path(), branch);
+    create_state(&repo, branch, "flow-start", "complete", None);
+
+    let output = run_phase_enter(&repo, &["--phase", "flow-code", "--branch", branch]);
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(parse_output(&output)["status"], "ok");
+}
+
+#[test]
 fn test_review_phase_happy_path() {
     let dir = tempfile::tempdir().unwrap();
     let branch = "review-happy";

--- a/tests/shared_config_approval.rs
+++ b/tests/shared_config_approval.rs
@@ -77,7 +77,11 @@ fn consume_deletes_the_marker_file() {
     write_approval(root, "feat-x", "/repo/Cargo.toml").expect("write succeeds");
     let p = marker_path(root, "feat-x", "/repo/Cargo.toml").unwrap();
     assert!(p.exists(), "marker exists after write");
-    assert!(check_and_consume_approval(root, "feat-x", "/repo/Cargo.toml"));
+    assert!(check_and_consume_approval(
+        root,
+        "feat-x",
+        "/repo/Cargo.toml"
+    ));
     assert!(!p.exists(), "marker deleted after consume");
 }
 

--- a/tests/shared_config_approval.rs
+++ b/tests/shared_config_approval.rs
@@ -1,0 +1,299 @@
+//! Tests for `src/shared_config_approval.rs` — the branch-scoped,
+//! per-file, single-use shared-config approval marker store.
+//!
+//! The marker store is the "proceed" half of the shared-config gate:
+//! `bin/flow approve-shared-config` writes a marker after the user
+//! approves an `AskUserQuestion`, and
+//! `validate_worktree_paths::validate_shared_config` consults and
+//! consumes it immediately before its block return. The contract this
+//! file locks in: single-use consumption (a marker authorizes exactly
+//! one edit), per-file scope (an approval for path A never satisfies a
+//! check for path B), corruption resilience (any unreadable/unparseable
+//! marker fails closed → no approval → the gate still blocks), and
+//! branch-path-safety (a `/`/`.`/`..`/NUL/empty branch never reaches
+//! filesystem path construction and never panics).
+
+use std::fs;
+
+use flow_rs::shared_config_approval::{
+    check_and_consume_approval, clear_all, marker_path, write_approval,
+};
+
+// --- marker_path ---
+
+#[test]
+fn marker_path_valid_branch_is_some_under_branch_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let p = marker_path(root, "feat-x", "/repo/Cargo.toml").expect("valid branch yields a path");
+    let s = p.to_string_lossy();
+    assert!(
+        s.contains(".flow-states/feat-x/shared-config-approvals/"),
+        "marker must live under the branch-scoped approvals dir: {s}"
+    );
+}
+
+#[test]
+fn marker_path_invalid_branch_is_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    assert!(marker_path(root, "", "/repo/Cargo.toml").is_none());
+    assert!(marker_path(root, ".", "/repo/Cargo.toml").is_none());
+    assert!(marker_path(root, "..", "/repo/Cargo.toml").is_none());
+    assert!(marker_path(root, "a/b", "/repo/Cargo.toml").is_none());
+    assert!(marker_path(root, "a\0b", "/repo/Cargo.toml").is_none());
+}
+
+#[test]
+fn marker_path_distinct_targets_distinct_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let a = marker_path(root, "feat-x", "/repo/Cargo.toml").unwrap();
+    let b = marker_path(root, "feat-x", "/repo/.gitignore").unwrap();
+    assert_ne!(a, b, "distinct target paths must map to distinct markers");
+}
+
+// --- write_approval / check_and_consume_approval ---
+
+#[test]
+fn write_then_consume_returns_true_once_then_false() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_approval(root, "feat-x", "/repo/Cargo.toml").expect("write succeeds");
+    assert!(
+        check_and_consume_approval(root, "feat-x", "/repo/Cargo.toml"),
+        "first consume returns true"
+    );
+    assert!(
+        !check_and_consume_approval(root, "feat-x", "/repo/Cargo.toml"),
+        "second consume returns false (single-use)"
+    );
+}
+
+#[test]
+fn consume_deletes_the_marker_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_approval(root, "feat-x", "/repo/Cargo.toml").expect("write succeeds");
+    let p = marker_path(root, "feat-x", "/repo/Cargo.toml").unwrap();
+    assert!(p.exists(), "marker exists after write");
+    assert!(check_and_consume_approval(root, "feat-x", "/repo/Cargo.toml"));
+    assert!(!p.exists(), "marker deleted after consume");
+}
+
+#[test]
+fn consume_without_marker_returns_false() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    assert!(!check_and_consume_approval(
+        root,
+        "feat-x",
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn per_file_scope_approval_for_a_does_not_satisfy_b() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_approval(root, "feat-x", "/repo/Cargo.toml").expect("write succeeds");
+    assert!(
+        !check_and_consume_approval(root, "feat-x", "/repo/.gitignore"),
+        "approval for Cargo.toml must not satisfy a check for .gitignore"
+    );
+    // The Cargo.toml approval is untouched and still consumable.
+    assert!(check_and_consume_approval(
+        root,
+        "feat-x",
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn per_branch_scope_approval_under_a_does_not_satisfy_b() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_approval(root, "feat-x", "/repo/Cargo.toml").expect("write succeeds");
+    assert!(
+        !check_and_consume_approval(root, "feat-y", "/repo/Cargo.toml"),
+        "approval written under feat-x must not satisfy feat-y"
+    );
+}
+
+// --- corruption resilience (fail closed → no approval) ---
+
+#[test]
+fn corruption_empty_marker_no_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let p = marker_path(root, "feat-x", "/repo/Cargo.toml").unwrap();
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(&p, "").unwrap();
+    assert!(!check_and_consume_approval(
+        root,
+        "feat-x",
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn corruption_non_json_marker_no_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let p = marker_path(root, "feat-x", "/repo/Cargo.toml").unwrap();
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(&p, "not json {{{").unwrap();
+    assert!(!check_and_consume_approval(
+        root,
+        "feat-x",
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn corruption_wrong_root_type_no_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let p = marker_path(root, "feat-x", "/repo/Cargo.toml").unwrap();
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(&p, "[1, 2, 3]").unwrap();
+    assert!(!check_and_consume_approval(
+        root,
+        "feat-x",
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn corruption_approved_false_no_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let p = marker_path(root, "feat-x", "/repo/Cargo.toml").unwrap();
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(&p, r#"{"approved": false, "target": "/repo/Cargo.toml"}"#).unwrap();
+    assert!(!check_and_consume_approval(
+        root,
+        "feat-x",
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn corruption_target_mismatch_no_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // Hand-write a marker at Cargo.toml's path slot but with a
+    // mismatched `target` field — per-file scope is enforced at the
+    // marker too (defense-in-depth alongside the filename key).
+    let p = marker_path(root, "feat-x", "/repo/Cargo.toml").unwrap();
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(&p, r#"{"approved": true, "target": "/repo/.gitignore"}"#).unwrap();
+    assert!(!check_and_consume_approval(
+        root,
+        "feat-x",
+        "/repo/Cargo.toml"
+    ));
+}
+
+// --- branch-path-safety (never panic, never approve) ---
+
+#[test]
+fn invalid_branch_check_returns_false_never_panics() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    for b in ["", ".", "..", "a/b", "a\0b"] {
+        assert!(
+            !check_and_consume_approval(root, b, "/repo/Cargo.toml"),
+            "invalid branch {b:?} must yield no approval"
+        );
+    }
+}
+
+#[test]
+fn invalid_branch_write_returns_err_never_panics() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    for b in ["", ".", "..", "a/b", "a\0b"] {
+        assert!(
+            write_approval(root, b, "/repo/Cargo.toml").is_err(),
+            "invalid branch {b:?} must fail to write"
+        );
+    }
+}
+
+#[test]
+fn write_approval_errors_when_root_is_a_file() {
+    // root is a regular file, so `<root>/.flow-states/<branch>/...`
+    // cannot be created — `fs::create_dir_all` returns Err and
+    // `write_approval` surfaces it rather than silently approving.
+    let dir = tempfile::tempdir().unwrap();
+    let file_root = dir.path().join("not-a-dir");
+    fs::write(&file_root, "x").unwrap();
+    assert!(write_approval(&file_root, "feat-x", "/repo/Cargo.toml").is_err());
+}
+
+#[test]
+fn corruption_non_utf8_marker_no_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let p = marker_path(root, "feat-x", "/repo/Cargo.toml").unwrap();
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    // Invalid UTF-8 bytes — read_to_string fails, no approval.
+    fs::write(&p, [0xff_u8, 0xfe, 0xfd]).unwrap();
+    assert!(!check_and_consume_approval(
+        root,
+        "feat-x",
+        "/repo/Cargo.toml"
+    ));
+}
+
+#[test]
+fn invalid_branch_clear_all_is_noop_never_panics() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    for b in ["", ".", "..", "a/b", "a\0b"] {
+        clear_all(root, b);
+    }
+}
+
+// --- clear_all ---
+
+#[test]
+fn clear_all_removes_every_marker_for_branch() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_approval(root, "feat-x", "/repo/Cargo.toml").unwrap();
+    write_approval(root, "feat-x", "/repo/.gitignore").unwrap();
+    clear_all(root, "feat-x");
+    assert!(!check_and_consume_approval(
+        root,
+        "feat-x",
+        "/repo/Cargo.toml"
+    ));
+    assert!(!check_and_consume_approval(
+        root,
+        "feat-x",
+        "/repo/.gitignore"
+    ));
+}
+
+#[test]
+fn clear_all_missing_dir_is_noop() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // No markers ever written — clear_all must not error or panic.
+    clear_all(root, "feat-x");
+}
+
+#[test]
+fn clear_all_does_not_touch_other_branch() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_approval(root, "feat-x", "/repo/Cargo.toml").unwrap();
+    write_approval(root, "feat-y", "/repo/Cargo.toml").unwrap();
+    clear_all(root, "feat-x");
+    assert!(
+        check_and_consume_approval(root, "feat-y", "/repo/Cargo.toml"),
+        "clear_all(feat-x) must leave feat-y's marker intact"
+    );
+}


### PR DESCRIPTION
## What

#1666.

Closes #1666

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/shared-config-edits-stay-blocked/log` |
| State | `.flow-states/shared-config-edits-stay-blocked/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/d86fe99f-5ccc-42fb-bb21-4f29a2580a1b.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 1h 29m |
| Review | 50m |
| Learn | 11m |
| Complete | <1m |
| **Total** | **2h 32m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 4.0M | $0.972 |
| Code | 355.3M | $113.128 |
| Review | 148.8M | $70.088 |
| Learn | 41.7M | $13.039 |
| Complete | 3.6M | $0.929 |
| **Total** | **553.5M** | **$198.156** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **Pre-mortem P1: single-use marker consumed at PreToolUse hook time before the Edit lands, so a failed edit burns the grant and forces re-approval**
  - Dismissed — By design and fail-closed. A PreToolUse hook cannot observe edit success so consume-on-attempt is the only implementable single-use semantics. The model re-mints the marker by re-running bin/flow approve-shared-config without a new user turn because user_approved_shared_config_edit anchors on the most-recent real user turn which remains the standing approve phrase plus the original in-window BLOCK before the next-older real user turn (transcript_walker.rs 1543-1601). Recovery is bounded and never over-grants. Acceptance criterion second edit re-blocks is satisfied. The re-mint behavior is documented in the Step 4 doc fix.
- ✗ **Pre-mortem P2: producer approve-shared-config derives branch via resolve_branch_in while consumer validate_shared_config derives branch from the worktree directory name, so markers could be written and looked up under different branch dirs**
  - Dismissed — Unreachable for valid FLOW flows. flow-start creates the worktree at .worktrees/branch and checks out git branch branch, so worktree-dir-name equals git-branch equals branch by construction. FlowPaths is_valid_branch rejects slash dot dotdot NUL empty consistently on both producer and consumer, and the block message passes no --branch override. Any forced mismatch yields no marker found which keeps the gate blocking (fail-closed, never an over-grant). Verified validate_worktree_paths.rs 136-152 and approve_shared_config.rs 189.
- ✗ **Pre-mortem P3: phase_enter clear_all resolves branch via resolve_branch while the gate uses the worktree directory name, so the cross-phase clear could target the wrong branch dir**
  - Dismissed — Same root as P2 and unreachable for the same reason. For every valid FLOW flow the resolve_branch result equals the worktree directory name equals branch. Worst case under a forced mismatch is a no-op clear, and single-use consume-on-allow in check_and_consume_approval is the primary stale-bleed guard regardless, so no over-grant results.
- ✗ **Pre-mortem P4: the 4MB read_recent_turns tail can drop the system BLOCK under a long autonomous flow, making a genuine grant un-honorable and looping**
  - Dismissed — The user types the approve phrase immediately after seeing the BLOCK message, so the BLOCK and the approve phrase are temporally adjacent and the whole exchange sits in the 4MB tail (kilobytes, not megabytes). Long-flow volume accumulates before the BLOCK, not between BLOCK and approval. The documented false-negative is fail-closed and bounded (re-trigger plus re-approve), and read_recent_turns is the rule-correct cap for this per-turn recency walker per transcript-walker-cap.md.
- ✗ **Reviewer R3 and Pre-mortem P5: gate-action divergence because the walker normalizes the path via normalize_gate_input while the marker key uses the raw path, deadlocking mixed-case paths like .github/CODEOWNERS**
  - Dismissed — Refuted by code. args.path is passed UNTRANSFORMED to both user_approved_shared_config_edit and write_approval (approve_shared_config.rs 232 and 242). target_key hashes it raw (shared_config_approval.rs 76-80), and the gate consults file_path raw and compares the marker target field raw (shared_config_approval.rs 164, validate_worktree_paths.rs 146-150). normalize_gate_input applies ONLY to the user-typed-phrase comparison (transcript_walker.rs 1584), a typing tolerance, never to the keying value. args.path and file_path both come from the single block-message path, so keying is raw end-to-end with no transformed value the action consumes. The contract is stated at approve_shared_config.rs 239-241.
- ✗ **Adversarial A1: the sanctioned probe command bin/flow ci --test --file cannot compile a crate-using probe because bin/test --file runs bare rustc with no extern wiring, so the adversarial gate is non-functional for Rust crate probes**
  - Dismissed — Pre-existing FLOW-plugin infrastructure limitation NOT introduced by this PR (the diff does not touch bin/test or the probe runner). Fixing the single-file Rust-crate compilation contract of bin/test --file is a separate design conversation on a shared toolchain script per permissions.md Shared Config Files, which is a valid exclusion under include-bias.md Narrow Valid Exclusions (different design conversation). Routed to the Learn phase as a process gap. The adversarial agent still produced a code-traced finding A2 which IS fixed in Step 4.
- ✗ **Documentation D6: add a CLAUDE.md Key Files section indexing src/shared_config_approval.rs and src/approve_shared_config.rs**
  - Dismissed — Bureaucracy-trap per review-scope.md value test. CLAUDE.md Architecture References explicitly states the convention Module-level doc comments in src slash star.rs describe each file purpose, discover via Glob Grep Read when relevant, do not pre-load. The project deliberately does not maintain a per-file index, so a Key Files section contradicts the file own stated convention. Discoverability resolves no (a future session greps) and forward-applicability resolves no (no behavior or workflow change). Module purpose lives in the module doc, whose accuracy is fixed by the DOC-2 module-doc fix. The genuinely behavioral CLAUDE.md drift (the state-mutation subcommand list omitting approve-shared-config) is REAL and folded into the DOC-1 fix.
- ✗ **Reviewer R6: validate_shared_config consult-and-consume mutates state inside a PreToolUse hook with no hook-state-timing read-window analysis against phase-transition writers**
  - Dismissed — The reviewer own Premise-Trace-Conclude refuted this and concluded No fix required. The marker lives in a separate per-branch directory, not state.json, so the classic current_phase advancing read-window bug does not apply. Single-use consume-on-allow plus phase_enter clear_all is sound, and a phase advance interleaving between write and consume merely forces fail-closed re-approval (never an over-grant). Recorded for the audit trail; not a finding.
- ✓ **DOC-1: permissions.md, autonomous-phase-discipline.md, hook-vs-instruction.md, and CLAUDE.md still described the shared-config gate as AskUserQuestion-only with no approve-shared-config proceed path (R1 R2 D1 D2 D3 D5)**
  - Fixed — Fixed. Updated permissions.md (added When the gate blocks an unapproved edit subsection describing the user-typed phrase plus bin/flow approve-shared-config plus single-use marker, corrected Enforcement and the Autonomous-phase carve-out subsection), autonomous-phase-discipline.md Shared-Config Carve-Out (reframed: model never fires AskUserQuestion for shared-config; carve-out is the system-initiated-prompt safety net), hook-vs-instruction.md shared-config sub-bullet, and CLAUDE.md (added approve-shared-config to the state-mutation subcommand list and a one-line Architecture References pointer). All routed via bin/flow write-rule, forward-facing prose. The validate-ask-user carve-out is documented as retained (uncertain-supersession treated as no per supersession.md), not deleted.
- ✓ **DOC-2: src/shared_config_approval.rs module doc referenced the superseded AskUserQuestion confirmation mechanism**
  - Fixed — Fixed. Rewrote the module doc comment to describe the actual mechanism: the gate instructs the user to reply with the exact line approve shared-config colon path, the subcommand self-gates on that user-typed phrase, and the model never fires an AskUserQuestion for shared-config. Forward-facing per comment-quality.md.
- ✓ **A2: user_approved_shared_config_edit corroborated the system block on the target basename, so a block for a same-basename sibling (workspace Cargo.toml, nested .gitignore) could cross-corroborate a grant for a different file, contradicting the function own not-a-cross-file doc claim**
  - Fixed — Fixed. Changed the corroboration in src/hooks/transcript_walker.rs from t.contains(basename) to t.contains(target_path) (the production block message interpolates the full file path twice, so full-path matching is exact and makes the not-a-cross-file claim true). Replaced the basename binding with a file_name None-guard. Updated the walker doc comment. Updated the test helper block_turn to mirror the production block message (full path) and all call sites, and added named regression tests approve_false_when_block_is_for_same_basename_sibling and approve_true_when_block_is_for_the_exact_sibling_path in tests/hooks/transcript_walker.rs.
- ✓ **R4: src/approve_shared_config.rs worktree_root used .expect on git rev-parse output, flagged against external-input-path-construction.md No-expect-in-CLI-subcommands without a complete unreachability proof**
  - Fixed — Fixed via the rule carve-out path (no new uncovered branch). Kept the .expect and rewrote the doc comment to state the precise unreachability proof required by the carve-out: cwd_scope::enforce runs before worktree_root in run_impl_main and itself .expect-panics on the identical git-spawn failure, so this arm is unreachable; documented the refactor-safety note (convert to .ok()? if the call ever moves ahead of the cwd guard). Adding a .ok()? early-return instead would introduce an unreachable branch that fails the 100/100/100 gate (git always present, and cwd_scope pre-empts), so the doc-proof option is the rule-compliant choice with zero coverage impact.
- ✓ **R5: the shared-config block message did not tell the model to wait for the user reply before running approve-shared-config, risking an autonomous loop on not_user_approved**
  - Fixed — Fixed. Strengthened the block message in src/hooks/validate_worktree_paths.rs: do NOT run bin/flow approve-shared-config until the user has sent the exact reply, and a not_user_approved result means keep waiting and do not retry the edit or re-run the subcommand in a loop. Preserved every load-bearing substring (is a shared configuration file that affects every engineer, approve shared-config colon path, bin/flow approve-shared-config, permissions.md) so the carve-out, the walker, and the contains-based tests still pass. Reflected the same guidance in permissions.md (DOC-1).
- ✓ **D7: docs/reference/flow-state-schema.md omitted the new .flow-states/branch/shared-config-approvals/ marker artifact**
  - Fixed — Fixed. Added a Shared-Config Approval Markers section documenting the path, the sha256 filename scheme, the marker body, and the create/consume/clear lifecycle, and generalized the up-to-four-files sentence to reference the optional subdirectory. docs/reference is not validate-claude-paths-gated so edited directly; additive only, no docs_sync keyword removed.

<!-- end:Review Findings -->

## Learn Findings

- → **Tenant 1 process gap: Review adversarial gate cannot execute crate-using Rust probes because bin/test --file compiles with bare rustc (no extern/-L/CARGO_MANIFEST_DIR) and the probe path is git-excluded from cargo nextest, so adversarial findings in the FLOW repo are code-trace-only with no executed failing-probe proof**
  - Filed — Confirmed by the learn-analyst reading bin/test (bare rustc --test invocation). Passes both gates: forward-facing (structural property of bin/test --file, understandable without the incident) and value (caught by the Review adversarial agent, NOT remediated in this PR — bin/test is shared toolchain and fixing the single-file Rust-crate compilation contract is a separate design conversation; permanent structural, not one-off friction). Filed on benkruger/flow.

<!-- end:Learn Findings -->

## State File

<details>
<summary>.flow-states/shared-config-edits-stay-blocked.json</summary>

````json
{
  "schema_version": 1,
  "branch": "shared-config-edits-stay-blocked",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1667,
  "pr_url": "https://github.com/benkruger/flow/pull/1667",
  "started_at": "2026-05-19T07:55:21-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/shared-config-edits-stay-blocked/log",
    "state": ".flow-states/shared-config-edits-stay-blocked/state.json"
  },
  "session_tty": "/dev/ttys005",
  "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/d86fe99f-5ccc-42fb-bb21-4f29a2580a1b.jsonl",
  "notes": [],
  "prompt": "#1666",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-19T07:55:21-07:00",
      "completed_at": "2026-05-19T07:56:04-07:00",
      "session_started_at": null,
      "cumulative_seconds": 43,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-19T07:55:21-07:00",
        "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 9,
        "session_input_tokens": 73,
        "session_output_tokens": 17849,
        "session_cache_creation_tokens": 732337,
        "session_cache_read_tokens": 9075249,
        "session_cost_usd": 3.8711375,
        "by_model": {
          "claude-opus-4-7": {
            "input": 73,
            "output": 17849,
            "cache_create": 732337,
            "cache_read": 9075249
          }
        },
        "turn_count": 39,
        "tool_call_count": 17,
        "context_at_last_turn_tokens": 264202,
        "context_window_pct": 132.101
      },
      "window_at_complete": {
        "captured_at": "2026-05-19T07:56:04-07:00",
        "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 9,
        "session_input_tokens": 103,
        "session_output_tokens": 20480,
        "session_cache_creation_tokens": 737033,
        "session_cache_read_tokens": 13049455,
        "session_cost_usd": 4.843027000000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 103,
            "output": 20480,
            "cache_create": 737033,
            "cache_read": 13049455
          }
        },
        "turn_count": 54,
        "tool_call_count": 24,
        "context_at_last_turn_tokens": 266129,
        "context_window_pct": 133.0645
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-19T07:56:14-07:00",
      "completed_at": "2026-05-19T09:25:22-07:00",
      "session_started_at": null,
      "cumulative_seconds": 5348,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-19T07:56:14-07:00",
        "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 9,
        "seven_day_pct": 9,
        "session_input_tokens": 112,
        "session_output_tokens": 22058,
        "session_cache_creation_tokens": 765434,
        "session_cache_read_tokens": 14646217,
        "session_cost_usd": 5.1814877500000005,
        "by_model": {
          "claude-opus-4-7": {
            "input": 112,
            "output": 22058,
            "cache_create": 765434,
            "cache_read": 14646217
          }
        },
        "turn_count": 60,
        "tool_call_count": 26,
        "context_at_last_turn_tokens": 275412,
        "context_window_pct": 137.706
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-19T08:00:20-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 11,
          "seven_day_pct": 9,
          "session_input_tokens": 180,
          "session_output_tokens": 55322,
          "session_cache_creation_tokens": 1511165,
          "session_cache_read_tokens": 29234357,
          "session_cost_usd": 10.8624,
          "by_model": {
            "claude-opus-4-7": {
              "input": 180,
              "output": 55322,
              "cache_create": 1511165,
              "cache_read": 29234357
            }
          },
          "turn_count": 94,
          "tool_call_count": 43,
          "context_at_last_turn_tokens": 538276,
          "context_window_pct": 269.138
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-19T08:03:14-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 11,
          "seven_day_pct": 9,
          "session_input_tokens": 224,
          "session_output_tokens": 76860,
          "session_cache_creation_tokens": 1541908,
          "session_cache_read_tokens": 41253025,
          "session_cost_usd": 14.7676445,
          "by_model": {
            "claude-opus-4-7": {
              "input": 224,
              "output": 76860,
              "cache_create": 1541908,
              "cache_read": 41253025
            }
          },
          "turn_count": 116,
          "tool_call_count": 56,
          "context_at_last_turn_tokens": 553828,
          "context_window_pct": 276.914
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-19T08:16:58-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 12,
          "seven_day_pct": 10,
          "session_input_tokens": 351,
          "session_output_tokens": 177894,
          "session_cache_creation_tokens": 1746424,
          "session_cache_read_tokens": 79755399,
          "session_cost_usd": 26.589586749999985,
          "by_model": {
            "claude-opus-4-7": {
              "input": 351,
              "output": 177894,
              "cache_create": 1746424,
              "cache_read": 79755399
            }
          },
          "turn_count": 181,
          "tool_call_count": 89,
          "context_at_last_turn_tokens": 639333,
          "context_window_pct": 319.6665
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-19T08:23:26-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 14,
          "seven_day_pct": 10,
          "session_input_tokens": 419,
          "session_output_tokens": 243214,
          "session_cache_creation_tokens": 1804201,
          "session_cache_read_tokens": 101998820,
          "session_cost_usd": 32.66837224999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 419,
              "output": 243214,
              "cache_create": 1804201,
              "cache_read": 101998820
            }
          },
          "turn_count": 215,
          "tool_call_count": 105,
          "context_at_last_turn_tokens": 669210,
          "context_window_pct": 334.605
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-19T08:56:13-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 11,
          "session_input_tokens": 741,
          "session_output_tokens": 463035,
          "session_cache_creation_tokens": 2117278,
          "session_cache_read_tokens": 223210395,
          "session_cost_usd": 75.30024124999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 741,
              "output": 463035,
              "cache_create": 2117278,
              "cache_read": 223210395
            }
          },
          "turn_count": 379,
          "tool_call_count": 197,
          "context_at_last_turn_tokens": 817738,
          "context_window_pct": 408.869
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-19T08:56:13-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 11,
          "session_input_tokens": 741,
          "session_output_tokens": 463035,
          "session_cache_creation_tokens": 2117278,
          "session_cache_read_tokens": 223210395,
          "session_cost_usd": 75.30024124999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 741,
              "output": 463035,
              "cache_create": 2117278,
              "cache_read": 223210395
            }
          },
          "turn_count": 379,
          "tool_call_count": 197,
          "context_at_last_turn_tokens": 817738,
          "context_window_pct": 408.869
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-19T09:09:38-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 21,
          "seven_day_pct": 11,
          "session_input_tokens": 876,
          "session_output_tokens": 518510,
          "session_cache_creation_tokens": 2283197,
          "session_cache_read_tokens": 281866722,
          "session_cost_usd": 94.32161224999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 876,
              "output": 518510,
              "cache_create": 2283197,
              "cache_read": 281866722
            }
          },
          "turn_count": 448,
          "tool_call_count": 239,
          "context_at_last_turn_tokens": 885813,
          "context_window_pct": 442.9065
        },
        {
          "step": 8,
          "field": "code_task",
          "captured_at": "2026-05-19T09:13:02-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 21,
          "seven_day_pct": 11,
          "session_input_tokens": 924,
          "session_output_tokens": 548761,
          "session_cache_creation_tokens": 2317164,
          "session_cache_read_tokens": 303310855,
          "session_cost_usd": 100.07481999999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 924,
              "output": 548761,
              "cache_create": 2317164,
              "cache_read": 303310855
            }
          },
          "turn_count": 472,
          "tool_call_count": 251,
          "context_at_last_turn_tokens": 902190,
          "context_window_pct": 451.095
        },
        {
          "step": 9,
          "field": "code_task",
          "captured_at": "2026-05-19T09:19:34-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 21,
          "seven_day_pct": 11,
          "session_input_tokens": 995,
          "session_output_tokens": 576599,
          "session_cache_creation_tokens": 2386955,
          "session_cache_read_tokens": 337338827,
          "session_cost_usd": 110.27667649999997,
          "by_model": {
            "claude-opus-4-7": {
              "input": 995,
              "output": 576599,
              "cache_create": 2386955,
              "cache_read": 337338827
            }
          },
          "turn_count": 509,
          "tool_call_count": 272,
          "context_at_last_turn_tokens": 938404,
          "context_window_pct": 469.202
        },
        {
          "step": 10,
          "field": "code_task",
          "captured_at": "2026-05-19T09:19:34-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 21,
          "seven_day_pct": 11,
          "session_input_tokens": 995,
          "session_output_tokens": 576599,
          "session_cache_creation_tokens": 2386955,
          "session_cache_read_tokens": 337338827,
          "session_cost_usd": 110.27667649999997,
          "by_model": {
            "claude-opus-4-7": {
              "input": 995,
              "output": 576599,
              "cache_create": 2386955,
              "cache_read": 337338827
            }
          },
          "turn_count": 509,
          "tool_call_count": 272,
          "context_at_last_turn_tokens": 938404,
          "context_window_pct": 469.202
        },
        {
          "step": 11,
          "field": "code_task",
          "captured_at": "2026-05-19T09:24:50-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 22,
          "seven_day_pct": 11,
          "session_input_tokens": 1034,
          "session_output_tokens": 602018,
          "session_cache_creation_tokens": 2424508,
          "session_cache_read_tokens": 357171261,
          "session_cost_usd": 115.80208899999997,
          "by_model": {
            "claude-opus-4-7": {
              "input": 1034,
              "output": 602018,
              "cache_create": 2424508,
              "cache_read": 357171261
            }
          },
          "turn_count": 530,
          "tool_call_count": 283,
          "context_at_last_turn_tokens": 953582,
          "context_window_pct": 476.791
        },
        {
          "step": 12,
          "field": "code_task",
          "captured_at": "2026-05-19T09:24:50-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 22,
          "seven_day_pct": 11,
          "session_input_tokens": 1034,
          "session_output_tokens": 602018,
          "session_cache_creation_tokens": 2424508,
          "session_cache_read_tokens": 357171261,
          "session_cost_usd": 115.80208899999997,
          "by_model": {
            "claude-opus-4-7": {
              "input": 1034,
              "output": 602018,
              "cache_create": 2424508,
              "cache_read": 357171261
            }
          },
          "turn_count": 530,
          "tool_call_count": 283,
          "context_at_last_turn_tokens": 953582,
          "context_window_pct": 476.791
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-19T09:25:22-07:00",
        "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 22,
        "seven_day_pct": 11,
        "session_input_tokens": 1053,
        "session_output_tokens": 604851,
        "session_cache_creation_tokens": 2465257,
        "session_cache_read_tokens": 367693656,
        "session_cost_usd": 118.30929974999997,
        "by_model": {
          "claude-opus-4-7": {
            "input": 1053,
            "output": 604851,
            "cache_create": 2465257,
            "cache_read": 367693656
          }
        },
        "turn_count": 541,
        "tool_call_count": 288,
        "context_at_last_turn_tokens": 967494,
        "context_window_pct": 483.747
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-19T09:27:20-07:00",
      "completed_at": "2026-05-19T10:18:15-07:00",
      "session_started_at": null,
      "cumulative_seconds": 3055,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-19T09:27:20-07:00",
        "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 22,
        "seven_day_pct": 12,
        "session_input_tokens": 1065,
        "session_output_tokens": 606966,
        "session_cache_creation_tokens": 4665331,
        "session_cache_read_tokens": 367790592,
        "session_cost_usd": 123.60499049999996,
        "by_model": {
          "claude-opus-4-7": {
            "input": 1065,
            "output": 606966,
            "cache_create": 4665331,
            "cache_read": 367790592
          }
        },
        "turn_count": 547,
        "tool_call_count": 290,
        "context_at_last_turn_tokens": 494890,
        "context_window_pct": 247.445
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-19T09:28:36-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 24,
          "seven_day_pct": 12,
          "session_input_tokens": 1101,
          "session_output_tokens": 625172,
          "session_cache_creation_tokens": 4779823,
          "session_cache_read_tokens": 376906846,
          "session_cost_usd": 125.13685049999997,
          "by_model": {
            "claude-opus-4-7": {
              "input": 1101,
              "output": 625172,
              "cache_create": 4779823,
              "cache_read": 376906846
            }
          },
          "turn_count": 565,
          "tool_call_count": 300,
          "context_at_last_turn_tokens": 520596,
          "context_window_pct": 260.298
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-19T09:44:12-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 33,
          "seven_day_pct": 13,
          "session_input_tokens": 1145,
          "session_output_tokens": 692195,
          "session_cache_creation_tokens": 5066036,
          "session_cache_read_tokens": 388834800,
          "session_cost_usd": 160.8687963499999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 1145,
              "output": 692195,
              "cache_create": 5066036,
              "cache_read": 388834800
            }
          },
          "turn_count": 587,
          "tool_call_count": 313,
          "context_at_last_turn_tokens": 572112,
          "context_window_pct": 286.056
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-19T09:54:14-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 34,
          "seven_day_pct": 14,
          "session_input_tokens": 1213,
          "session_output_tokens": 823286,
          "session_cache_creation_tokens": 5393349,
          "session_cache_read_tokens": 409824500,
          "session_cost_usd": 166.13227134999988,
          "by_model": {
            "claude-opus-4-7": {
              "input": 1213,
              "output": 823286,
              "cache_create": 5393349,
              "cache_read": 409824500
            }
          },
          "turn_count": 621,
          "tool_call_count": 332,
          "context_at_last_turn_tokens": 658576,
          "context_window_pct": 329.288
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-19T10:17:57-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 37,
          "seven_day_pct": 14,
          "session_input_tokens": 2195,
          "session_output_tokens": 1034128,
          "session_cache_creation_tokens": 5774790,
          "session_cache_read_tokens": 511763813,
          "session_cost_usd": 192.7633828499999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2195,
              "output": 1034128,
              "cache_create": 5774790,
              "cache_read": 511763813
            }
          },
          "turn_count": 756,
          "tool_call_count": 401,
          "context_at_last_turn_tokens": 812870,
          "context_window_pct": 406.435
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-19T09:37:19-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-19T09:37:20-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-19T09:37:20-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-19T09:44:11-07:00"
        }
      ],
      "agent_retry_counts": {
        "documentation": 1
      },
      "window_at_complete": {
        "captured_at": "2026-05-19T10:18:15-07:00",
        "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 37,
        "seven_day_pct": 14,
        "session_input_tokens": 2203,
        "session_output_tokens": 1035164,
        "session_cache_creation_tokens": 5823652,
        "session_cache_read_tokens": 515018492,
        "session_cost_usd": 193.69305534999992,
        "by_model": {
          "claude-opus-4-7": {
            "input": 2203,
            "output": 1035164,
            "cache_create": 5823652,
            "cache_read": 515018492
          }
        },
        "turn_count": 760,
        "tool_call_count": 403,
        "context_at_last_turn_tokens": 829870,
        "context_window_pct": 414.935
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-19T10:18:30-07:00",
      "completed_at": "2026-05-19T10:30:01-07:00",
      "session_started_at": null,
      "cumulative_seconds": 691,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-19T10:18:30-07:00",
        "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 37,
        "seven_day_pct": 14,
        "session_input_tokens": 2212,
        "session_output_tokens": 1037006,
        "session_cache_creation_tokens": 5868370,
        "session_cache_read_tokens": 519999188,
        "session_cost_usd": 194.6316988499999,
        "by_model": {
          "claude-opus-4-7": {
            "input": 2212,
            "output": 1037006,
            "cache_create": 5868370,
            "cache_read": 519999188
          }
        },
        "turn_count": 766,
        "tool_call_count": 405,
        "context_at_last_turn_tokens": 844775,
        "context_window_pct": 422.3875
      },
      "agent_retry_counts": {
        "learn-analyst": 3
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-19T10:27:28-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-19T10:27:29-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 39,
          "seven_day_pct": 14,
          "session_input_tokens": 2258,
          "session_output_tokens": 1078535,
          "session_cache_creation_tokens": 5917063,
          "session_cache_read_tokens": 539626218,
          "session_cost_usd": 202.4992790499999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2258,
              "output": 1078535,
              "cache_create": 5917063,
              "cache_read": 539626218
            }
          },
          "turn_count": 789,
          "tool_call_count": 417,
          "context_at_last_turn_tokens": 865042,
          "context_window_pct": 432.521
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-19T10:27:46-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 39,
          "seven_day_pct": 14,
          "session_input_tokens": 2266,
          "session_output_tokens": 1083399,
          "session_cache_creation_tokens": 5925671,
          "session_cache_read_tokens": 543086378,
          "session_cost_usd": 202.9756590499999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2266,
              "output": 1083399,
              "cache_create": 5925671,
              "cache_read": 543086378
            }
          },
          "turn_count": 793,
          "tool_call_count": 419,
          "context_at_last_turn_tokens": 867194,
          "context_window_pct": 433.597
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-19T10:27:47-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 39,
          "seven_day_pct": 14,
          "session_input_tokens": 2266,
          "session_output_tokens": 1083399,
          "session_cache_creation_tokens": 5925671,
          "session_cache_read_tokens": 543086378,
          "session_cost_usd": 202.9756590499999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2266,
              "output": 1083399,
              "cache_create": 5925671,
              "cache_read": 543086378
            }
          },
          "turn_count": 793,
          "tool_call_count": 419,
          "context_at_last_turn_tokens": 867194,
          "context_window_pct": 433.597
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-19T10:28:00-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 39,
          "seven_day_pct": 14,
          "session_input_tokens": 2274,
          "session_output_tokens": 1084619,
          "session_cache_creation_tokens": 5927539,
          "session_cache_read_tokens": 546559130,
          "session_cost_usd": 203.8657100499999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2274,
              "output": 1084619,
              "cache_create": 5927539,
              "cache_read": 546559130
            }
          },
          "turn_count": 797,
          "tool_call_count": 422,
          "context_at_last_turn_tokens": 868702,
          "context_window_pct": 434.351
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-19T10:28:01-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 37,
          "seven_day_pct": 14,
          "session_input_tokens": 2274,
          "session_output_tokens": 1084619,
          "session_cache_creation_tokens": 5927539,
          "session_cache_read_tokens": 546559130,
          "session_cost_usd": 203.8657100499999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2274,
              "output": 1084619,
              "cache_create": 5927539,
              "cache_read": 546559130
            }
          },
          "turn_count": 797,
          "tool_call_count": 422,
          "context_at_last_turn_tokens": 868702,
          "context_window_pct": 434.351
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-19T10:28:37-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 39,
          "seven_day_pct": 14,
          "session_input_tokens": 2284,
          "session_output_tokens": 1090579,
          "session_cache_creation_tokens": 5971574,
          "session_cache_read_tokens": 550904031,
          "session_cost_usd": 204.87882604999993,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2284,
              "output": 1090579,
              "cache_create": 5971574,
              "cache_read": 550904031
            }
          },
          "turn_count": 802,
          "tool_call_count": 424,
          "context_at_last_turn_tokens": 883536,
          "context_window_pct": 441.768
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-19T10:29:46-07:00",
          "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
          "model": "claude-opus-4-7",
          "five_hour_pct": 39,
          "seven_day_pct": 14,
          "session_input_tokens": 2302,
          "session_output_tokens": 1095927,
          "session_cache_creation_tokens": 5978089,
          "session_cache_read_tokens": 558883775,
          "session_cost_usd": 207.19589929999992,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2302,
              "output": 1095927,
              "cache_create": 5978089,
              "cache_read": 558883775
            }
          },
          "turn_count": 811,
          "tool_call_count": 430,
          "context_at_last_turn_tokens": 888145,
          "context_window_pct": 444.0725
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-19T10:30:01-07:00",
        "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 39,
        "seven_day_pct": 14,
        "session_input_tokens": 2308,
        "session_output_tokens": 1098714,
        "session_cache_creation_tokens": 5982091,
        "session_cache_read_tokens": 561546020,
        "session_cost_usd": 207.67117929999992,
        "by_model": {
          "claude-opus-4-7": {
            "input": 2308,
            "output": 1098714,
            "cache_create": 5982091,
            "cache_read": 561546020
          }
        },
        "turn_count": 814,
        "tool_call_count": 431,
        "context_at_last_turn_tokens": 888751,
        "context_window_pct": 444.3755
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-19T10:30:39-07:00",
      "completed_at": "2026-05-19T10:31:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 26,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-19T10:30:39-07:00",
        "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 39,
        "seven_day_pct": 15,
        "session_input_tokens": 2325,
        "session_output_tokens": 1105035,
        "session_cache_creation_tokens": 6052830,
        "session_cache_read_tokens": 571368882,
        "session_cost_usd": 209.1444710499999,
        "by_model": {
          "claude-opus-4-7": {
            "input": 2325,
            "output": 1105035,
            "cache_create": 6052830,
            "cache_read": 571368882
          }
        },
        "turn_count": 825,
        "tool_call_count": 436,
        "context_at_last_turn_tokens": 903682,
        "context_window_pct": 451.841
      },
      "window_at_complete": {
        "captured_at": "2026-05-19T10:31:05-07:00",
        "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
        "model": "claude-opus-4-7",
        "five_hour_pct": 39,
        "seven_day_pct": 15,
        "session_input_tokens": 2333,
        "session_output_tokens": 1106696,
        "session_cache_creation_tokens": 6055136,
        "session_cache_read_tokens": 574984208,
        "session_cost_usd": 210.07318654999997,
        "by_model": {
          "claude-opus-4-7": {
            "input": 2333,
            "output": 1106696,
            "cache_create": 6055136,
            "cache_read": 574984208
          }
        },
        "turn_count": 829,
        "tool_call_count": 438,
        "context_at_last_turn_tokens": 904776,
        "context_window_pct": 452.388
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-19T07:56:14-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-19T09:27:20-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-19T10:18:30-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-19T10:30:39-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": "auto",
    "flow-abort": "auto"
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-19T07:55:21-07:00",
    "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
    "model": "claude-opus-4-7",
    "five_hour_pct": 9,
    "seven_day_pct": 9,
    "session_input_tokens": 73,
    "session_output_tokens": 17849,
    "session_cache_creation_tokens": 732337,
    "session_cache_read_tokens": 9075249,
    "session_cost_usd": 3.8711375,
    "by_model": {
      "claude-opus-4-7": {
        "input": 73,
        "output": 17849,
        "cache_create": 732337,
        "cache_read": 9075249
      }
    },
    "turn_count": 39,
    "tool_call_count": 17,
    "context_at_last_turn_tokens": 264202,
    "context_window_pct": 132.101
  },
  "code_tasks_total": 12,
  "code_task": 12,
  "code_task_name": "Docs routed + verification",
  "compact_summary": "<analysis>\nLet me analyze this conversation carefully:\n\n1. **User's Initial Request**: The user provided a specific task: \"decide ONE Tenant-1 question for FLOW PR #1666, then emit the report.\" This is a compliance-audit task with very specific steps outlined.\n\n2. **Task Structure**: The user gave explicit Step-by-step instructions:\n   - Step A: Read exactly one file (`/Users/ben/code/flow/.worktrees/shared-config-edits-stay-blocked/bin/test`)\n   - Step B: Determine if `bin/test --file` uses bare `rustc` or cargo\n   - Step C: Apply context about PR #1666 and the adversarial probe\n   - Step D: Emit a report with a specific finding format\n\n3. **Critical Constraint**: The user emphasized the reading discipline - \"Read exactly one file\" and \"Read nothing else.\" This is a hard constraint.\n\n4. **The File Read**: I did read the bash script at `/Users/ben/code/flow/.worktrees/shared-config-edits-stay-blocked/bin/test`. The relevant section for Step B was lines 99-108, which clearly show:\n   ```bash\n   if [ \"${1:-}\" = \"--file\" ]; then\n     shift\n     file=\"$1\"\n     shift\n     temp_bin=\".flow-test-binary\"\n     trap 'rm -f \"$temp_bin\"' EXIT\n     rustc --test \"$file\" -o \"$temp_bin\"\n     ./\"$temp_bin\" \"$@\"\n     exit\n   fi\n   ```\n\n5. **Analysis of the Finding**: \n   - The `--file` mode uses bare `rustc --test \"$file\"` with NO `--extern`, `-L`, or `CARGO_MANIFEST_DIR`\n   - PR #1666 does NOT modify `bin/test` (per the provided context)\n   - The adversarial probe path is git-excluded, so `cargo nextest` never builds it\n   - This means the Review adversarial agent cannot EXECUTE a single-file probe that uses the `flow_rs` crate - it can only code-trace\n   - Per the \"Value test\": this gap is caught (by Review adversarial agent), NOT remediated (out of PR scope), and is a permanent structural property (not one-off friction)\n   - This meets the filing criteria\n\n6. **The Report Should Emit**:\n   - Since `bin/test --file` uses bare `rustc` (no crate wiring), I should emit ONE Tenant-1 process-gap finding\n   - The finding should be marked forward-facing: yes; value: open gap\n   - Include the specific recommendation about making `bin/test --file` compile against the workspace crate\n\n7. **Current State**: The user has given me all the information needed, I read the required file, and now I need to emit the structured report.\n\n8. **User's Latest Message**: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.\" This is a NEW instruction that overrides the normal format. The user is asking me to provide a text summary of this conversation, not to continue with the original task.\n\nWait - re-reading the user's latest message more carefully: This appears to be a request for a conversation summary (compaction), not a continuation of the original task. The user is asking me to summarize what has happened so far in the conversation. The \"critical\" instruction says I should NOT use tools and should provide TEXT ONLY with <analysis> and <summary> blocks.\n\nBut looking at the conversation history provided to me - the ONLY real user message is the initial task description. There are NO previous turns where I completed steps or showed work. The context includes the bin/test file content (which I was instructed to read) and extensive CLAUDE.md rules/context, but I have not yet responded to the original task.\n\nThis appears to be a meta-request: the user wants me to summarize the task that was given to me, not to have actually completed it yet. The user is essentially asking \"summarize what you need to do\" before proceeding.\n\nThe task is clear and singular:\n- Read `/Users/ben/code/flow/.worktrees/shared-config-edits-stay-blocked/bin/test`\n- Determine if `bin/test --file` uses bare rustc or cargo\n- Based on findings, emit appropriate Tenant-1 report\n- The file DOES show bare rustc, so a process-gap finding is warranted\n</analysis>\n\n<summary>\n\n1. Primary Request and Intent:\n   The user has provided a standalone compliance-audit task to \"decide ONE Tenant-1 question for FLOW PR #1666, then emit the report.\" The task follows a specific 4-step process: (A) Read exactly one file (`/Users/ben/code/flow/.worktrees/shared-config-edits-stay-blocked/bin/test`) and nothing else, (B) Determine how `bin/test --file` mode compiles a single test file (specifically whether it uses cargo or bare `rustc --test`), (C) Apply established context about PR #1666, the adversarial probe, and test execution, and (D) Emit a structured report with findings. The user emphasizes this is a \"text-only\" response requirement with no tool usage permitted.\n\n2. Key Technical Concepts:\n   - FLOW Review phase adversarial gate and its role in detecting process gaps\n   - `bin/test --file` mode for single-file test compilation\n   - Distinction between bare `rustc` compilation vs. `cargo` workspace-aware compilation\n   - Crate-dependent test probes that require `--extern`, `-L`, and `CARGO_MANIFEST_DIR` flags\n   - Git-excluded probe paths and their relationship to `cargo nextest` discovery\n   - Tenant-1 process-gap findings and their filing criteria\n   - Forward-facing vs. backward-facing reporting discipline\n   - Value test for gap filing: gap must be caught by phase gate, NOT remediated in PR, and NOT be mere one-off friction\n\n3. Files and Code Sections:\n   - `/Users/ben/code/flow/.worktrees/shared-config-edits-stay-blocked/bin/test` (lines 99-108):\n     This is the critical section examined. It shows the `--file` mode implementation:\n     ```bash\n     if [ \"${1:-}\" = \"--file\" ]; then\n       shift\n       file=\"$1\"\n       shift\n       temp_bin=\".flow-test-binary\"\n       trap 'rm -f \"$temp_bin\"' EXIT\n       rustc --test \"$file\" -o \"$temp_bin\"\n       ./\"$temp_bin\" \"$@\"\n       exit\n     fi\n     ```\n     This demonstrates that `--file` uses bare `rustc --test \"$file\"` with NO `--extern`, `-L`, or `CARGO_MANIFEST_DIR` parameters. This is the determining fact for the audit.\n\n4. Errors and fixes:\n   No errors encountered. The task is straightforward and the file read was successful on first attempt.\n\n5. Problem Solving:\n   No problems to solve at this stage. The task has been clearly defined and the required file has been provided in the context.\n\n6. All user messages:\n   - Primary user message: Task specification provided with explicit Step A-D instructions for the compliance audit, including context about PR #1666, the adversarial probe mechanism, the value test for gaps, and specific report format requirements (Tenant-1 finding vs. \"No findings\", forward-facing marking, value designation as \"open gap\").\n   - Meta instruction: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools\" followed by request for a conversation summary in <analysis> and <summary> block format.\n\n7. Pending Tasks:\n   - None explicitly pending beyond the current summary request. The original audit task definition is complete and awaiting execution/response.\n\n8. Current Work:\n   The work is at the initial analysis stage. The user has defined a compliance-audit task requiring examination of `/Users/ben/code/flow/.worktrees/shared-config-edits-stay-blocked/bin/test` to determine if the `--file` compilation mode uses bare `rustc` or cargo-based compilation. The file has been provided in context. Key finding from Step B analysis: lines 99-108 show bare `rustc --test \"$file\"` compilation with no crate wiring. This satisfies the condition for emitting a Tenant-1 process-gap finding per Step D criteria.\n\n9. Optional Next Step:\n   Upon confirmation to proceed with the original audit task (not this summary), the next step would be to emit the structured report per Step D: \"If `bin/test --file` uses bare `rustc` (no crate wiring): emit ONE Tenant-1 process-gap finding\" with specific text: \"FLOW's Review adversarial gate is structurally non-functional for the FLOW plugin repo's own Rust crate-using adversarial probes: `bin/test --file` compiles with bare `rustc --test` (no `--extern`/`-L`/`CARGO_MANIFEST_DIR`) and the probe path is git-excluded from `cargo nextest`, so crate-using probes can only be code-traced, never executed; adversarial findings in the FLOW repo therefore lack executable failing-probe proof. Recommend a `benkruger/flow` issue: make `bin/test --file` compile the single file against the workspace crate (or give the adversarial agent a sanctioned crate-aware single-test command).\" Mark as forward-facing: yes; value: open gap. Tenant 2 and 3: \"No findings\".\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/shared-config-edits-stay-blocked",
  "compact_count": 13,
  "diff_stats": {
    "files_changed": 12,
    "insertions": 1942,
    "deletions": 22,
    "captured_at": "2026-05-19T09:25:22-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "findings": [
    {
      "finding": "Pre-mortem P1: single-use marker consumed at PreToolUse hook time before the Edit lands, so a failed edit burns the grant and forces re-approval",
      "reason": "By design and fail-closed. A PreToolUse hook cannot observe edit success so consume-on-attempt is the only implementable single-use semantics. The model re-mints the marker by re-running bin/flow approve-shared-config without a new user turn because user_approved_shared_config_edit anchors on the most-recent real user turn which remains the standing approve phrase plus the original in-window BLOCK before the next-older real user turn (transcript_walker.rs 1543-1601). Recovery is bounded and never over-grants. Acceptance criterion second edit re-blocks is satisfied. The re-mint behavior is documented in the Step 4 doc fix.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T09:53:11-07:00"
    },
    {
      "finding": "Pre-mortem P2: producer approve-shared-config derives branch via resolve_branch_in while consumer validate_shared_config derives branch from the worktree directory name, so markers could be written and looked up under different branch dirs",
      "reason": "Unreachable for valid FLOW flows. flow-start creates the worktree at .worktrees/branch and checks out git branch branch, so worktree-dir-name equals git-branch equals branch by construction. FlowPaths is_valid_branch rejects slash dot dotdot NUL empty consistently on both producer and consumer, and the block message passes no --branch override. Any forced mismatch yields no marker found which keeps the gate blocking (fail-closed, never an over-grant). Verified validate_worktree_paths.rs 136-152 and approve_shared_config.rs 189.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T09:53:12-07:00"
    },
    {
      "finding": "Pre-mortem P3: phase_enter clear_all resolves branch via resolve_branch while the gate uses the worktree directory name, so the cross-phase clear could target the wrong branch dir",
      "reason": "Same root as P2 and unreachable for the same reason. For every valid FLOW flow the resolve_branch result equals the worktree directory name equals branch. Worst case under a forced mismatch is a no-op clear, and single-use consume-on-allow in check_and_consume_approval is the primary stale-bleed guard regardless, so no over-grant results.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T09:53:12-07:00"
    },
    {
      "finding": "Pre-mortem P4: the 4MB read_recent_turns tail can drop the system BLOCK under a long autonomous flow, making a genuine grant un-honorable and looping",
      "reason": "The user types the approve phrase immediately after seeing the BLOCK message, so the BLOCK and the approve phrase are temporally adjacent and the whole exchange sits in the 4MB tail (kilobytes, not megabytes). Long-flow volume accumulates before the BLOCK, not between BLOCK and approval. The documented false-negative is fail-closed and bounded (re-trigger plus re-approve), and read_recent_turns is the rule-correct cap for this per-turn recency walker per transcript-walker-cap.md.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T09:53:13-07:00"
    },
    {
      "finding": "Reviewer R3 and Pre-mortem P5: gate-action divergence because the walker normalizes the path via normalize_gate_input while the marker key uses the raw path, deadlocking mixed-case paths like .github/CODEOWNERS",
      "reason": "Refuted by code. args.path is passed UNTRANSFORMED to both user_approved_shared_config_edit and write_approval (approve_shared_config.rs 232 and 242). target_key hashes it raw (shared_config_approval.rs 76-80), and the gate consults file_path raw and compares the marker target field raw (shared_config_approval.rs 164, validate_worktree_paths.rs 146-150). normalize_gate_input applies ONLY to the user-typed-phrase comparison (transcript_walker.rs 1584), a typing tolerance, never to the keying value. args.path and file_path both come from the single block-message path, so keying is raw end-to-end with no transformed value the action consumes. The contract is stated at approve_shared_config.rs 239-241.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T09:53:37-07:00"
    },
    {
      "finding": "Adversarial A1: the sanctioned probe command bin/flow ci --test --file cannot compile a crate-using probe because bin/test --file runs bare rustc with no extern wiring, so the adversarial gate is non-functional for Rust crate probes",
      "reason": "Pre-existing FLOW-plugin infrastructure limitation NOT introduced by this PR (the diff does not touch bin/test or the probe runner). Fixing the single-file Rust-crate compilation contract of bin/test --file is a separate design conversation on a shared toolchain script per permissions.md Shared Config Files, which is a valid exclusion under include-bias.md Narrow Valid Exclusions (different design conversation). Routed to the Learn phase as a process gap. The adversarial agent still produced a code-traced finding A2 which IS fixed in Step 4.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T09:53:37-07:00"
    },
    {
      "finding": "Documentation D6: add a CLAUDE.md Key Files section indexing src/shared_config_approval.rs and src/approve_shared_config.rs",
      "reason": "Bureaucracy-trap per review-scope.md value test. CLAUDE.md Architecture References explicitly states the convention Module-level doc comments in src slash star.rs describe each file purpose, discover via Glob Grep Read when relevant, do not pre-load. The project deliberately does not maintain a per-file index, so a Key Files section contradicts the file own stated convention. Discoverability resolves no (a future session greps) and forward-applicability resolves no (no behavior or workflow change). Module purpose lives in the module doc, whose accuracy is fixed by the DOC-2 module-doc fix. The genuinely behavioral CLAUDE.md drift (the state-mutation subcommand list omitting approve-shared-config) is REAL and folded into the DOC-1 fix.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T09:53:38-07:00"
    },
    {
      "finding": "Reviewer R6: validate_shared_config consult-and-consume mutates state inside a PreToolUse hook with no hook-state-timing read-window analysis against phase-transition writers",
      "reason": "The reviewer own Premise-Trace-Conclude refuted this and concluded No fix required. The marker lives in a separate per-branch directory, not state.json, so the classic current_phase advancing read-window bug does not apply. Single-use consume-on-allow plus phase_enter clear_all is sound, and a phase advance interleaving between write and consume merely forces fail-closed re-approval (never an over-grant). Recorded for the audit trail; not a finding.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T09:53:39-07:00"
    },
    {
      "finding": "DOC-1: permissions.md, autonomous-phase-discipline.md, hook-vs-instruction.md, and CLAUDE.md still described the shared-config gate as AskUserQuestion-only with no approve-shared-config proceed path (R1 R2 D1 D2 D3 D5)",
      "reason": "Fixed. Updated permissions.md (added When the gate blocks an unapproved edit subsection describing the user-typed phrase plus bin/flow approve-shared-config plus single-use marker, corrected Enforcement and the Autonomous-phase carve-out subsection), autonomous-phase-discipline.md Shared-Config Carve-Out (reframed: model never fires AskUserQuestion for shared-config; carve-out is the system-initiated-prompt safety net), hook-vs-instruction.md shared-config sub-bullet, and CLAUDE.md (added approve-shared-config to the state-mutation subcommand list and a one-line Architecture References pointer). All routed via bin/flow write-rule, forward-facing prose. The validate-ask-user carve-out is documented as retained (uncertain-supersession treated as no per supersession.md), not deleted.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T10:10:24-07:00"
    },
    {
      "finding": "DOC-2: src/shared_config_approval.rs module doc referenced the superseded AskUserQuestion confirmation mechanism",
      "reason": "Fixed. Rewrote the module doc comment to describe the actual mechanism: the gate instructs the user to reply with the exact line approve shared-config colon path, the subcommand self-gates on that user-typed phrase, and the model never fires an AskUserQuestion for shared-config. Forward-facing per comment-quality.md.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T10:10:44-07:00"
    },
    {
      "finding": "A2: user_approved_shared_config_edit corroborated the system block on the target basename, so a block for a same-basename sibling (workspace Cargo.toml, nested .gitignore) could cross-corroborate a grant for a different file, contradicting the function own not-a-cross-file doc claim",
      "reason": "Fixed. Changed the corroboration in src/hooks/transcript_walker.rs from t.contains(basename) to t.contains(target_path) (the production block message interpolates the full file path twice, so full-path matching is exact and makes the not-a-cross-file claim true). Replaced the basename binding with a file_name None-guard. Updated the walker doc comment. Updated the test helper block_turn to mirror the production block message (full path) and all call sites, and added named regression tests approve_false_when_block_is_for_same_basename_sibling and approve_true_when_block_is_for_the_exact_sibling_path in tests/hooks/transcript_walker.rs.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T10:10:44-07:00"
    },
    {
      "finding": "R4: src/approve_shared_config.rs worktree_root used .expect on git rev-parse output, flagged against external-input-path-construction.md No-expect-in-CLI-subcommands without a complete unreachability proof",
      "reason": "Fixed via the rule carve-out path (no new uncovered branch). Kept the .expect and rewrote the doc comment to state the precise unreachability proof required by the carve-out: cwd_scope::enforce runs before worktree_root in run_impl_main and itself .expect-panics on the identical git-spawn failure, so this arm is unreachable; documented the refactor-safety note (convert to .ok()? if the call ever moves ahead of the cwd guard). Adding a .ok()? early-return instead would introduce an unreachable branch that fails the 100/100/100 gate (git always present, and cwd_scope pre-empts), so the doc-proof option is the rule-compliant choice with zero coverage impact.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T10:10:45-07:00"
    },
    {
      "finding": "R5: the shared-config block message did not tell the model to wait for the user reply before running approve-shared-config, risking an autonomous loop on not_user_approved",
      "reason": "Fixed. Strengthened the block message in src/hooks/validate_worktree_paths.rs: do NOT run bin/flow approve-shared-config until the user has sent the exact reply, and a not_user_approved result means keep waiting and do not retry the edit or re-run the subcommand in a loop. Preserved every load-bearing substring (is a shared configuration file that affects every engineer, approve shared-config colon path, bin/flow approve-shared-config, permissions.md) so the carve-out, the walker, and the contains-based tests still pass. Reflected the same guidance in permissions.md (DOC-1).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T10:10:46-07:00"
    },
    {
      "finding": "D7: docs/reference/flow-state-schema.md omitted the new .flow-states/branch/shared-config-approvals/ marker artifact",
      "reason": "Fixed. Added a Shared-Config Approval Markers section documenting the path, the sha256 filename scheme, the marker body, and the create/consume/clear lifecycle, and generalized the up-to-four-files sentence to reference the optional subdirectory. docs/reference is not validate-claude-paths-gated so edited directly; additive only, no docs_sync keyword removed.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-19T10:10:53-07:00"
    },
    {
      "finding": "Tenant 1 process gap: Review adversarial gate cannot execute crate-using Rust probes because bin/test --file compiles with bare rustc (no extern/-L/CARGO_MANIFEST_DIR) and the probe path is git-excluded from cargo nextest, so adversarial findings in the FLOW repo are code-trace-only with no executed failing-probe proof",
      "reason": "Confirmed by the learn-analyst reading bin/test (bare rustc --test invocation). Passes both gates: forward-facing (structural property of bin/test --file, understandable without the incident) and value (caught by the Review adversarial agent, NOT remediated in this PR — bin/test is shared toolchain and fixing the single-file Rust-crate compilation contract is a separate design conversation; permanent structural, not one-off friction). Filed on benkruger/flow.",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-19T10:29:33-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1673"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "Review adversarial gate cannot execute crate-using Rust probes (bin/test --file uses bare rustc)",
      "url": "https://github.com/benkruger/flow/issues/1673",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-19T10:29:33-07:00"
    }
  ],
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-19T10:31:05-07:00",
    "session_id": "d86fe99f-5ccc-42fb-bb21-4f29a2580a1b",
    "model": "claude-opus-4-7",
    "five_hour_pct": 39,
    "seven_day_pct": 15,
    "session_input_tokens": 2333,
    "session_output_tokens": 1106696,
    "session_cache_creation_tokens": 6055136,
    "session_cache_read_tokens": 574984208,
    "session_cost_usd": 210.07318654999997,
    "by_model": {
      "claude-opus-4-7": {
        "input": 2333,
        "output": 1106696,
        "cache_create": 6055136,
        "cache_read": 574984208
      }
    },
    "turn_count": 829,
    "tool_call_count": 438,
    "context_at_last_turn_tokens": 904776,
    "context_window_pct": 452.388
  },
  "_auto_continue": "/flow:flow-complete"
}
````

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | Review adversarial gate cannot execute crate-using Rust probes (bin/test --file uses bare rustc) | Learn | #1673 |

<!-- end:Issues Filed -->