### PR TITLE
Model Can Self Impose Autonomous

### DIFF
--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -286,6 +286,16 @@ rejected field. The deny applies to single-segment paths only —
 nested attempts (`phases.X._halt_pending`) are a no-op for the
 Stop hook, which reads the top-level field only.
 
+The gate covers the `bin/flow set-timestamp` CLI write path only.
+Direct Edit/Write tool calls against
+`<project_root>/.flow-states/<branch>/state.json` from inside an
+active-flow worktree are not blocked by `validate-worktree-paths`
+(which only blocks misplaced worktree-internal copies under
+`.worktrees/<branch>/.flow-states/`) or `validate-claude-paths`
+(which protects `.claude/` paths, not `.flow-states/`), so a model
+with Edit/Write access remains a broader trust surface tracked
+separately from this gate.
+
 **State-field lifecycle.**
 
 - `_halt_pending: bool` — owned by `check_autonomous_stop` and

--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -267,6 +267,25 @@ two writers:
   belt-and-suspenders defense per
   `src/phase_transition.rs::phase_enter`.
 
+**Who writes `_halt_pending=true`.** The Stop hook
+(`stop_continue::check_autonomous_stop`) is the sole production
+writer of `_halt_pending=true`. It writes the field via in-process
+`mutate_state` calls in response to a real conversational-prose
+user turn — never via the CLI. The model is denied the
+`bin/flow set-timestamp` write path entirely:
+`src/commands/set_timestamp.rs::apply_updates` rejects every
+`--set <field>=...` whose field name (after NUL-strip + trim +
+ASCII-lowercase normalization per
+`.claude/rules/security-gates.md` "Normalize Before Comparing")
+matches an entry in the module-private `MODEL_DENIED_FIELDS`
+constant. `_halt_pending` is in that set, so a model invocation
+of `bin/flow set-timestamp --set _halt_pending=true` (or any
+case/whitespace/NUL-bypass variant, in either truthy or falsy
+direction) exits 1 with a structured error envelope naming the
+rejected field. The deny applies to single-segment paths only —
+nested attempts (`phases.X._halt_pending`) are a no-op for the
+Stop hook, which reads the top-level field only.
+
 **State-field lifecycle.**
 
 - `_halt_pending: bool` — owned by `check_autonomous_stop` and

--- a/src/commands/set_timestamp.rs
+++ b/src/commands/set_timestamp.rs
@@ -182,6 +182,21 @@ pub fn validate_code_task(state: &Value, new_value: i64) -> Result<(), String> {
 /// Apply a list of path=value updates to the state Value.
 ///
 /// Returns the list of updates that were applied.
+///
+/// **Non-atomic across multiple `--set` args.** Updates are
+/// applied sequentially in place; an Err return from a later
+/// arg (deny check, `code_task` validation, or `set_nested`
+/// type error) propagates via `?` WITHOUT rolling back prior
+/// in-place mutations to `state`. Callers that need
+/// transactional semantics MUST snapshot `state` before
+/// invocation and restore from the snapshot on Err — this is
+/// what [`run_impl_main`] does via the `backup` / `*state =
+/// backup` pattern inside the `mutate_state` closure. A direct
+/// library caller that omits the snapshot will observe partial
+/// mutation (e.g. `state["code_task"] == 1` even when the call
+/// returns Err from a later denied arg). The current production
+/// caller chain is the only consumer; future cross-module
+/// consumers must follow the same pattern.
 pub fn apply_updates(state: &mut Value, set_args: &[String]) -> Result<Vec<Update>, String> {
     let mut updates = Vec::new();
 

--- a/src/commands/set_timestamp.rs
+++ b/src/commands/set_timestamp.rs
@@ -108,6 +108,47 @@ pub fn set_nested(obj: &mut Value, path_parts: &[&str], value: Value) -> Result<
     Ok(())
 }
 
+/// Closed set of state fields the model is denied writing through
+/// the `bin/flow set-timestamp` CLI boundary. These fields carry
+/// trust signals that the autonomous `continue: auto` contract
+/// relies on — the model must not be able to counterfeit them
+/// through the CLI.
+///
+/// `_halt_pending` is set by the Stop hook
+/// (`stop_continue::check_autonomous_stop`) in response to a real
+/// user message and read by every subsequent Stop event to refuse
+/// the turn-end. The hook writes the field via in-process
+/// `mutate_state` calls — never via the CLI — so denying the CLI
+/// path leaves the legitimate writer untouched. See
+/// `.claude/rules/autonomous-phase-discipline.md` "Mechanical
+/// halt-pause contract".
+const MODEL_DENIED_FIELDS: &[&str] = &["_halt_pending"];
+
+/// Strip NULs, trim, and ASCII-lowercase the input so case,
+/// whitespace, and embedded-NUL bypass shapes are folded before
+/// the equality check in [`validate_model_denied_field`]. See
+/// `.claude/rules/security-gates.md` "Normalize Before Comparing".
+fn normalize_field_name(s: &str) -> String {
+    s.replace('\0', "").trim().to_ascii_lowercase()
+}
+
+/// Reject writes to fields in [`MODEL_DENIED_FIELDS`]. The deny
+/// applies to both truthy and falsy writes — the model has no
+/// business setting OR clearing these fields. The normalization
+/// closes case, whitespace, and embedded-NUL bypass shapes.
+fn validate_model_denied_field(field: &str) -> Result<(), String> {
+    let normalized = normalize_field_name(field);
+    if MODEL_DENIED_FIELDS.contains(&normalized.as_str()) {
+        return Err(format!(
+            "Field '{}' cannot be written via set-timestamp — it is owned by FLOW \
+             hooks. See .claude/rules/autonomous-phase-discipline.md \
+             'Mechanical halt-pause contract'.",
+            field
+        ));
+    }
+    Ok(())
+}
+
 /// Validate that code_task can only increment by 1 or reset to 0.
 pub fn validate_code_task(state: &Value, new_value: i64) -> Result<(), String> {
     if new_value == 0 {
@@ -161,6 +202,15 @@ pub fn apply_updates(state: &mut Value, set_args: &[String]) -> Result<Vec<Updat
         };
 
         let path_parts: Vec<&str> = path.split('.').collect();
+
+        // Reject CLI writes to model-denied top-level fields before
+        // any state mutation. Scoped to single-segment paths because
+        // the protected fields (e.g. `_halt_pending`) are read by
+        // hooks at the top level only; a nested attempt is a no-op
+        // for those readers.
+        if path_parts.len() == 1 {
+            validate_model_denied_field(path_parts[0])?;
+        }
 
         if path_parts == ["code_task"] {
             let int_val = match value.as_i64() {

--- a/tests/commands/set_timestamp.rs
+++ b/tests/commands/set_timestamp.rs
@@ -318,8 +318,7 @@ fn apply_updates_allows_code_task_increment() {
 #[test]
 fn apply_updates_allows_continue_pending_commit() {
     let mut state = json!({});
-    let updates =
-        apply_updates(&mut state, &["_continue_pending=commit".to_string()]).unwrap();
+    let updates = apply_updates(&mut state, &["_continue_pending=commit".to_string()]).unwrap();
     assert_eq!(updates.len(), 1);
     assert_eq!(state["_continue_pending"], "commit");
 }
@@ -329,10 +328,31 @@ fn apply_updates_allows_continue_pending_commit() {
 #[test]
 fn apply_updates_allows_custom_field() {
     let mut state = json!({});
-    let updates =
-        apply_updates(&mut state, &["arbitrary_field=value".to_string()]).unwrap();
+    let updates = apply_updates(&mut state, &["arbitrary_field=value".to_string()]).unwrap();
     assert_eq!(updates.len(), 1);
     assert_eq!(state["arbitrary_field"], "value");
+}
+
+/// A `--set _halt_pending.=anything` argument splits on `.` into
+/// `["_halt_pending", ""]` (len=2), so the deny check (scoped to
+/// single-segment paths) is skipped. `set_nested` then tries to
+/// navigate into `state["_halt_pending"]`; when the field holds the
+/// boolean `true` the Stop hook owns, the Bool-intermediate guard
+/// in `set_nested` rejects the navigation and the call returns Err
+/// — the active halt is preserved. This locks the property in so a
+/// future relaxation of the Bool guard cannot silently expose a
+/// halt-clobber bypass via the trailing-dot shape.
+#[test]
+fn apply_updates_trailing_dot_does_not_clobber_halt_pending_boolean() {
+    let mut state = json!({"_halt_pending": true});
+    let _ = apply_updates(&mut state, &["_halt_pending.=anything".to_string()]);
+    assert_eq!(
+        state["_halt_pending"],
+        Value::Bool(true),
+        "_halt_pending top-level boolean must survive the trailing-dot write. \
+         got: state[\"_halt_pending\"]={:?}",
+        state["_halt_pending"]
+    );
 }
 
 // --- validate_code_task tests ---

--- a/tests/commands/set_timestamp.rs
+++ b/tests/commands/set_timestamp.rs
@@ -232,6 +232,109 @@ fn test_apply_updates_invalid_format() {
     assert!(result.unwrap_err().contains("Invalid format"));
 }
 
+// --- apply_updates model-denied fields ---
+
+/// Model-direct writes to `_halt_pending=true` counterfeit the
+/// user-typed-halt signal that the autonomous Stop refusal trusts.
+/// `apply_updates` rejects this at the boundary so the CLI cannot
+/// be used to forge the signal.
+#[test]
+fn apply_updates_rejects_halt_pending_true() {
+    let mut state = json!({});
+    let result = apply_updates(&mut state, &["_halt_pending=true".to_string()]);
+    assert!(result.is_err());
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("_halt_pending"),
+        "error message must name the rejected field, got: {}",
+        msg
+    );
+}
+
+/// Clearing the halt by writing `_halt_pending=false` is the inverse
+/// counterfeiting shape (model unsetting a halt the user typed). The
+/// helper denies both directions — the model has no business writing
+/// the field at all.
+#[test]
+fn apply_updates_rejects_halt_pending_false() {
+    let mut state = json!({});
+    let result = apply_updates(&mut state, &["_halt_pending=false".to_string()]);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("_halt_pending"));
+}
+
+/// ASCII-case bypass: `_HALT_PENDING=true` must be rejected by the
+/// normalize-then-compare check. Per `.claude/rules/security-gates.md`
+/// "Normalize Before Comparing", normalization strips NULs, trims,
+/// and ASCII-lowercases before the equality check.
+#[test]
+fn apply_updates_rejects_halt_pending_uppercase() {
+    let mut state = json!({});
+    let result = apply_updates(&mut state, &["_HALT_PENDING=true".to_string()]);
+    assert!(result.is_err());
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("_HALT_PENDING") || msg.contains("_halt_pending"),
+        "error message must name the rejected field, got: {}",
+        msg
+    );
+}
+
+/// Whitespace-padding bypass: ` _halt_pending =true` must be rejected
+/// by the trim arm of the normalizer.
+#[test]
+fn apply_updates_rejects_halt_pending_whitespace_padded() {
+    let mut state = json!({});
+    let result = apply_updates(&mut state, &[" _halt_pending =true".to_string()]);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("_halt_pending"));
+}
+
+/// Embedded NUL bypass: `_halt_pending\0=true` must be rejected by
+/// the NUL-strip arm of the normalizer. Embedded NULs from truncated
+/// writes or editor artifacts otherwise defeat byte-equality.
+#[test]
+fn apply_updates_rejects_halt_pending_nul_embedded() {
+    let mut state = json!({});
+    let result = apply_updates(&mut state, &["_halt_pending\0=true".to_string()]);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("_halt_pending"));
+}
+
+/// `code_task` increment is unaffected by the deny check — `code_task`
+/// is not in the deny list, and the existing `validate_code_task`
+/// discipline continues to apply.
+#[test]
+fn apply_updates_allows_code_task_increment() {
+    let mut state = json!({"code_task": 0});
+    let updates = apply_updates(&mut state, &["code_task=1".to_string()]).unwrap();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(state["code_task"], 1);
+}
+
+/// `_continue_pending=commit` is the load-bearing chain marker the
+/// commit-window skills set before invoking `/flow:flow-commit`. It
+/// is NOT in the deny list — only `_halt_pending` is denied in v1.
+#[test]
+fn apply_updates_allows_continue_pending_commit() {
+    let mut state = json!({});
+    let updates =
+        apply_updates(&mut state, &["_continue_pending=commit".to_string()]).unwrap();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(state["_continue_pending"], "commit");
+}
+
+/// Arbitrary field names outside the deny list continue to work — the
+/// deny set is closed; fields not named in it pass through unchanged.
+#[test]
+fn apply_updates_allows_custom_field() {
+    let mut state = json!({});
+    let updates =
+        apply_updates(&mut state, &["arbitrary_field=value".to_string()]).unwrap();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(state["arbitrary_field"], "value");
+}
+
 // --- validate_code_task tests ---
 
 #[test]
@@ -1020,5 +1123,31 @@ fn test_cli_set_nested_vivifies_missing_intermediate() {
     assert_eq!(
         on_disk["phases"]["flow-review"]["agent_retry_counts"]["reviewer"],
         1
+    );
+}
+
+/// CLI-level rejection of `_halt_pending` writes. Guards the
+/// model-side trust boundary at the actual subprocess surface a
+/// model would reach: `bin/flow set-timestamp --set
+/// _halt_pending=true` must exit 1 with a structured error envelope
+/// whose message names the rejected field. Issue #1695's repro is a
+/// CLI invocation, so the library-level test is not sufficient on
+/// its own.
+#[test]
+fn test_cli_rejects_halt_pending_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = make_cli_state();
+    setup_cli_state(dir.path(), "test-feature", &state);
+
+    let (code, output) = run_cli(dir.path(), &["--set", "_halt_pending=true"]);
+    assert_eq!(code, 1);
+    assert_eq!(output["status"], "error");
+    assert!(
+        output["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("_halt_pending"),
+        "error message must name the rejected field, got: {:?}",
+        output["message"]
     );
 }


### PR DESCRIPTION
## What

#1695.

Closes #1695

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/model-can-self-impose-autonomous/log` |
| State | `.flow-states/model-can-self-impose-autonomous/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/6202b0b2-fb36-4fa4-969d-194e220c6bc3.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 12m |
| Review | 26m |
| Learn | 3m |
| Complete | <1m |
| **Total** | **43m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 1.0M | — |
| Code | 62.8M | $27.154 |
| Review | 84.9M | $68.362 |
| Learn | 13.6M | $5.809 |
| Complete | 1.7M | $0.447 |
| **Total** | **164.1M** | **$101.771**\* |

*Partial: some phases had no cost data.*

<!-- end:Token Cost -->

## Review Findings

- ✗ **Reviewer F1: No Consumer Enumeration Table for new error envelope**
  - Dismissed — The Consumer Enumeration Table is in fact present in the plan's Risks section (lines 88-109) and lists every set-timestamp consumer in the skill corpus as Exempt. The reviewer agent based its claim on the summarized Risks section embedded in the agent prompt, which omitted the table.
- ✗ **Pre-mortem F1: Trailing-dot variant _halt_pending. not rejected by deny check**
  - Dismissed — The rule prose explicitly says 'single-segment paths only'; the trailing-dot variant is a 2-segment shape that the prose correctly says is out of deny scope. The adversarial probe test apply_updates_trailing_dot_does_not_clobber_halt_pending_boolean confirms that when _halt_pending: true exists, set_nested errors on the Bool guard and the bypass cannot escape an active halt. The non-existent-field branch writes an Object to the top-level key, which the Stop hook reads as is_truthy(Object) -&gt; false (no halt-escape). The security property (Stop hook reads top-level _halt_pending and is_truthy returns false on non-Bool) holds.
- ✗ **Pre-mortem F2: apply_updates error path still writes the state file via mutate_state**
  - Dismissed — Pre-existing concern explicitly acknowledged by the agent as 'not introduced by this PR'. The rejected-write path restores backup before mutate_state serializes, so file content is unchanged. Per review-scope.md, pre-existing concerns outside the PR scope are out of scope unless the PR makes them materially worse, which it does not.
- ✗ **Pre-mortem F3: ANSI escape interpolation in error message via unsanitized field name**
  - Dismissed — serde_json escapes control characters (including ESC 0x1b) by default per the JSON spec: all control chars 0x00-0x1f are written as \\u00XX escapes. The CLI output is JSON (run_impl_main returns {status: error, message}), so the consumer parses JSON-decoded strings — raw ANSI bytes never reach the terminal interpreter. Subprocess-argument-escaping rule does not apply because the field name is not interpolated into a shell/AppleScript/SQL/Markdown context — it is JSON-encoded by serde_json before output.
- ✗ **Documentation F1: Ambiguous 'no-op' phrasing for nested field writes**
  - Dismissed — The existing rule prose already qualifies 'no-op' with 'for the Stop hook, which reads the top-level field only' — the qualifier the agent recommends is already present and explains both producer and consumer semantics. The inline comment in src/commands/set_timestamp.rs similarly says 'for those readers' specifically naming the hooks.
- ✗ **Documentation F2: MODEL_DENIED_FIELDS extension protocol undocumented**
  - Dismissed — The extension obligations the agent enumerates (bypass-variant tests, owner documentation, normalization) are already covered by existing rule files: security-gates.md 'Normalize Before Comparing' and 'Enumerate Bypass Variants Before Coding', test-placement.md, and docs-with-behavior.md. Adding a checklist to the constant's doc comment duplicates the rule corpus without adding signal. Per review-scope.md Value-vs-Bureaucracy triage 'discoverability' arm: a future maintainer extending the deny set would read the rule files via the existing cross-references.
- ✗ **Documentation F3: 'Pass through' description in halt-gate section now inaccurate for _halt_pending**
  - Dismissed — The 'Defense in depth — halt gates on Skill and Bash' section describes halt-gate behavior specifically; bin/flow set-timestamp on non-counter fields does still pass through the halt gate. The library-layer rejection of _halt_pending happens at apply_updates inside the process, not at validate-pretool. The new behavior is already documented in the 'Who writes _halt_pending=true' subsection immediately above, which names set_timestamp::apply_updates + MODEL_DENIED_FIELDS as the boundary enforcer. Conflating the two layers in the halt-gate section would mislead readers about which gate fires for which command.
- ✓ **Adversarial F1: apply_updates non-atomic across multiple --set args when later arg is denied**
  - Fixed — Added doc comment to apply_updates documenting non-atomicity and the required caller-side snapshot pattern (run_impl_main backup/restore via mutate_state closure). Migrated the useful regression guard (apply_updates_trailing_dot_does_not_clobber_halt_pending_boolean) from the throwaway adversarial probe to tests/commands/set_timestamp.rs per .claude/rules/test-placement.md. Disposed of the adversarial probe file per .claude/rules/adversarial-probe-lifecycle.md by overwriting with a doc-comment-only placeholder; Phase 5 Complete removes it via fs::remove_file. Production callers continue to use the snapshot pattern unchanged; no behavior change.
- ✓ **Reviewer F2: Edit/Write tool bypass surface left undocumented in rule update**
  - Fixed — Added a clarifier paragraph to .claude/rules/autonomous-phase-discipline.md 'Who writes _halt_pending=true' subsection naming Direct Edit/Write tool calls to .flow-states/&lt;branch&gt;/state.json as a broader trust surface tracked separately from this gate. validate-worktree-paths blocks only misplaced .worktrees/&lt;branch&gt;/.flow-states/ copies; validate-claude-paths protects .claude/ paths only. The rule's primary claim (CLI write path denied) remains accurate; the clarifier prevents future readers from overestimating the protection scope.

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/model-can-self-impose-autonomous.json</summary>

```json
{
  "schema_version": 1,
  "branch": "model-can-self-impose-autonomous",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1696,
  "pr_url": "https://github.com/benkruger/flow/pull/1696",
  "started_at": "2026-05-23T07:54:42-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/model-can-self-impose-autonomous/log",
    "state": ".flow-states/model-can-self-impose-autonomous/state.json"
  },
  "session_tty": "/dev/ttys015",
  "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/6202b0b2-fb36-4fa4-969d-194e220c6bc3.jsonl",
  "notes": [],
  "prompt": "#1695",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-23T07:54:42-07:00",
      "completed_at": "2026-05-23T07:55:19-07:00",
      "session_started_at": null,
      "cumulative_seconds": 37,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-23T07:54:42-07:00",
        "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
        "five_hour_pct": 22,
        "seven_day_pct": 4,
        "session_cost_usd": 22.90559625000001
      },
      "window_at_complete": {
        "captured_at": "2026-05-23T07:55:19-07:00",
        "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
        "model": "claude-opus-4-7",
        "five_hour_pct": 23,
        "seven_day_pct": 4,
        "session_input_tokens": 19,
        "session_output_tokens": 5721,
        "session_cache_creation_tokens": 709693,
        "session_cache_read_tokens": 301238,
        "session_cost_usd": 24.576502500000007,
        "by_model": {
          "claude-opus-4-7": {
            "input": 19,
            "output": 5721,
            "cache_create": 709693,
            "cache_read": 301238
          }
        },
        "turn_count": 4,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 254179,
        "context_window_pct": 127.0895
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-23T07:55:28-07:00",
      "completed_at": "2026-05-23T08:08:27-07:00",
      "session_started_at": null,
      "cumulative_seconds": 779,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-23T07:55:28-07:00",
        "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
        "model": "claude-opus-4-7",
        "five_hour_pct": 23,
        "seven_day_pct": 4,
        "session_input_tokens": 22,
        "session_output_tokens": 6543,
        "session_cache_creation_tokens": 710359,
        "session_cache_read_tokens": 1063772,
        "session_cost_usd": 24.711834000000007,
        "by_model": {
          "claude-opus-4-7": {
            "input": 22,
            "output": 6543,
            "cache_create": 710359,
            "cache_read": 1063772
          }
        },
        "turn_count": 7,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 254401,
        "context_window_pct": 127.2005
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-23T07:58:51-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 26,
          "seven_day_pct": 5,
          "session_input_tokens": 96,
          "session_output_tokens": 21635,
          "session_cache_creation_tokens": 2632475,
          "session_cache_read_tokens": 21727491,
          "session_cost_usd": 37.05865075000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 96,
              "output": 21635,
              "cache_create": 2632475,
              "cache_read": 21727491
            }
          },
          "turn_count": 57,
          "tool_call_count": 36,
          "context_at_last_turn_tokens": 625138,
          "context_window_pct": 312.569
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-23T07:59:19-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 26,
          "seven_day_pct": 5,
          "session_input_tokens": 96,
          "session_output_tokens": 21635,
          "session_cache_creation_tokens": 2632475,
          "session_cache_read_tokens": 21727491,
          "session_cost_usd": 37.05865075000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 96,
              "output": 21635,
              "cache_create": 2632475,
              "cache_read": 21727491
            }
          },
          "turn_count": 57,
          "tool_call_count": 36,
          "context_at_last_turn_tokens": 625138,
          "context_window_pct": 312.569
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-23T07:59:54-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 26,
          "seven_day_pct": 5,
          "session_input_tokens": 96,
          "session_output_tokens": 21635,
          "session_cache_creation_tokens": 2632475,
          "session_cache_read_tokens": 21727491,
          "session_cost_usd": 37.05865075000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 96,
              "output": 21635,
              "cache_create": 2632475,
              "cache_read": 21727491
            }
          },
          "turn_count": 57,
          "tool_call_count": 36,
          "context_at_last_turn_tokens": 625138,
          "context_window_pct": 312.569
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-23T08:00:15-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 27,
          "seven_day_pct": 5,
          "session_input_tokens": 96,
          "session_output_tokens": 21635,
          "session_cache_creation_tokens": 2632475,
          "session_cache_read_tokens": 21727491,
          "session_cost_usd": 37.05865075000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 96,
              "output": 21635,
              "cache_create": 2632475,
              "cache_read": 21727491
            }
          },
          "turn_count": 57,
          "tool_call_count": 36,
          "context_at_last_turn_tokens": 625138,
          "context_window_pct": 312.569
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-23T08:08:27-07:00",
        "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
        "model": "claude-opus-4-7",
        "five_hour_pct": 28,
        "seven_day_pct": 5,
        "session_input_tokens": 165,
        "session_output_tokens": 79712,
        "session_cache_creation_tokens": 2723720,
        "session_cache_read_tokens": 61762820,
        "session_cost_usd": 51.86548299999999,
        "by_model": {
          "claude-opus-4-7": {
            "input": 165,
            "output": 79712,
            "cache_create": 2723720,
            "cache_read": 61762820
          }
        },
        "turn_count": 118,
        "tool_call_count": 78,
        "context_at_last_turn_tokens": 678821,
        "context_window_pct": 339.4105
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-23T08:08:41-07:00",
      "completed_at": "2026-05-23T08:34:45-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1564,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-23T08:08:41-07:00",
        "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
        "model": "claude-opus-4-7",
        "five_hour_pct": 28,
        "seven_day_pct": 5,
        "session_input_tokens": 165,
        "session_output_tokens": 79712,
        "session_cache_creation_tokens": 2723720,
        "session_cache_read_tokens": 61762820,
        "session_cost_usd": 51.86548299999999,
        "by_model": {
          "claude-opus-4-7": {
            "input": 165,
            "output": 79712,
            "cache_create": 2723720,
            "cache_read": 61762820
          }
        },
        "turn_count": 118,
        "tool_call_count": 78,
        "context_at_last_turn_tokens": 678821,
        "context_window_pct": 339.4105
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-23T08:09:25-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 28,
          "seven_day_pct": 5,
          "session_input_tokens": 167,
          "session_output_tokens": 80288,
          "session_cache_creation_tokens": 2729764,
          "session_cache_read_tokens": 63120460,
          "session_cost_usd": 52.23098549999999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 167,
              "output": 80288,
              "cache_create": 2729764,
              "cache_read": 63120460
            }
          },
          "turn_count": 120,
          "tool_call_count": 79,
          "context_at_last_turn_tokens": 681843,
          "context_window_pct": 340.9215
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-23T08:23:04-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 45,
          "seven_day_pct": 8,
          "session_input_tokens": 275,
          "session_output_tokens": 110671,
          "session_cache_creation_tokens": 2858916,
          "session_cache_read_tokens": 99732795,
          "session_cost_usd": 95.92204184999991,
          "by_model": {
            "claude-opus-4-7": {
              "input": 275,
              "output": 110671,
              "cache_create": 2858916,
              "cache_read": 99732795
            }
          },
          "turn_count": 171,
          "tool_call_count": 113,
          "context_at_last_turn_tokens": 752639,
          "context_window_pct": 376.3195
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-23T08:26:16-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 46,
          "seven_day_pct": 8,
          "session_input_tokens": 299,
          "session_output_tokens": 125931,
          "session_cache_creation_tokens": 2937872,
          "session_cache_read_tokens": 106570572,
          "session_cost_usd": 105.80796319999992,
          "by_model": {
            "claude-opus-4-7": {
              "input": 299,
              "output": 125931,
              "cache_create": 2937872,
              "cache_read": 106570572
            }
          },
          "turn_count": 180,
          "tool_call_count": 118,
          "context_at_last_turn_tokens": 779616,
          "context_window_pct": 389.808
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-23T08:34:35-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 47,
          "seven_day_pct": 8,
          "session_input_tokens": 380,
          "session_output_tokens": 141363,
          "session_cache_creation_tokens": 3045936,
          "session_cache_read_tokens": 146320666,
          "session_cost_usd": 120.22702069999988,
          "by_model": {
            "claude-opus-4-7": {
              "input": 380,
              "output": 141363,
              "cache_create": 3045936,
              "cache_read": 146320666
            }
          },
          "turn_count": 229,
          "tool_call_count": 152,
          "context_at_last_turn_tokens": 846305,
          "context_window_pct": 423.1525
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-23T08:22:40-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-23T08:22:47-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-23T08:22:51-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-23T08:23:00-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-23T08:34:45-07:00",
        "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
        "model": "claude-opus-4-7",
        "five_hour_pct": 47,
        "seven_day_pct": 8,
        "session_input_tokens": 380,
        "session_output_tokens": 141363,
        "session_cache_creation_tokens": 3045936,
        "session_cache_read_tokens": 146320666,
        "session_cost_usd": 120.22702069999988,
        "by_model": {
          "claude-opus-4-7": {
            "input": 380,
            "output": 141363,
            "cache_create": 3045936,
            "cache_read": 146320666
          }
        },
        "turn_count": 229,
        "tool_call_count": 152,
        "context_at_last_turn_tokens": 846305,
        "context_window_pct": 423.1525
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-23T08:34:57-07:00",
      "completed_at": "2026-05-23T08:38:22-07:00",
      "session_started_at": null,
      "cumulative_seconds": 205,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-23T08:34:57-07:00",
        "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
        "model": "claude-opus-4-7",
        "five_hour_pct": 48,
        "seven_day_pct": 8,
        "session_input_tokens": 380,
        "session_output_tokens": 141363,
        "session_cache_creation_tokens": 3045936,
        "session_cache_read_tokens": 146320666,
        "session_cost_usd": 120.22702069999988,
        "by_model": {
          "claude-opus-4-7": {
            "input": 380,
            "output": 141363,
            "cache_create": 3045936,
            "cache_read": 146320666
          }
        },
        "turn_count": 229,
        "tool_call_count": 152,
        "context_at_last_turn_tokens": 846305,
        "context_window_pct": 423.1525
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-23T08:37:39-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-23T08:37:44-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 49,
          "seven_day_pct": 9,
          "session_input_tokens": 388,
          "session_output_tokens": 147601,
          "session_cache_creation_tokens": 3057559,
          "session_cache_read_tokens": 153113894,
          "session_cost_usd": 123.86876169999988,
          "by_model": {
            "claude-opus-4-7": {
              "input": 388,
              "output": 147601,
              "cache_create": 3057559,
              "cache_read": 153113894
            }
          },
          "turn_count": 237,
          "tool_call_count": 158,
          "context_at_last_turn_tokens": 852142,
          "context_window_pct": 426.071
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-23T08:37:49-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 49,
          "seven_day_pct": 9,
          "session_input_tokens": 390,
          "session_output_tokens": 147975,
          "session_cache_creation_tokens": 3057883,
          "session_cache_read_tokens": 154818176,
          "session_cost_usd": 124.30052469999988,
          "by_model": {
            "claude-opus-4-7": {
              "input": 390,
              "output": 147975,
              "cache_create": 3057883,
              "cache_read": 154818176
            }
          },
          "turn_count": 239,
          "tool_call_count": 159,
          "context_at_last_turn_tokens": 852304,
          "context_window_pct": 426.152
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-23T08:37:55-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 49,
          "seven_day_pct": 9,
          "session_input_tokens": 391,
          "session_output_tokens": 148097,
          "session_cache_creation_tokens": 3058245,
          "session_cache_read_tokens": 155670479,
          "session_cost_usd": 124.73199369999988,
          "by_model": {
            "claude-opus-4-7": {
              "input": 391,
              "output": 148097,
              "cache_create": 3058245,
              "cache_read": 155670479
            }
          },
          "turn_count": 240,
          "tool_call_count": 160,
          "context_at_last_turn_tokens": 852666,
          "context_window_pct": 426.333
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-23T08:38:05-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 49,
          "seven_day_pct": 9,
          "session_input_tokens": 393,
          "session_output_tokens": 148397,
          "session_cache_creation_tokens": 3058569,
          "session_cache_read_tokens": 157375809,
          "session_cost_usd": 125.16309369999988,
          "by_model": {
            "claude-opus-4-7": {
              "input": 393,
              "output": 148397,
              "cache_create": 3058569,
              "cache_read": 157375809
            }
          },
          "turn_count": 242,
          "tool_call_count": 161,
          "context_at_last_turn_tokens": 852828,
          "context_window_pct": 426.414
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-23T08:38:09-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 49,
          "seven_day_pct": 9,
          "session_input_tokens": 395,
          "session_output_tokens": 149339,
          "session_cache_creation_tokens": 3058949,
          "session_cache_read_tokens": 159081463,
          "session_cost_usd": 125.60247469999987,
          "by_model": {
            "claude-opus-4-7": {
              "input": 395,
              "output": 149339,
              "cache_create": 3058949,
              "cache_read": 159081463
            }
          },
          "turn_count": 244,
          "tool_call_count": 162,
          "context_at_last_turn_tokens": 853018,
          "context_window_pct": 426.509
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-23T08:38:14-07:00",
          "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
          "model": "claude-opus-4-7",
          "five_hour_pct": 49,
          "seven_day_pct": 9,
          "session_input_tokens": 395,
          "session_output_tokens": 149339,
          "session_cache_creation_tokens": 3058949,
          "session_cache_read_tokens": 159081463,
          "session_cost_usd": 125.60247469999987,
          "by_model": {
            "claude-opus-4-7": {
              "input": 395,
              "output": 149339,
              "cache_create": 3058949,
              "cache_read": 159081463
            }
          },
          "turn_count": 244,
          "tool_call_count": 162,
          "context_at_last_turn_tokens": 853018,
          "context_window_pct": 426.509
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-23T08:38:22-07:00",
        "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
        "model": "claude-opus-4-7",
        "five_hour_pct": 49,
        "seven_day_pct": 9,
        "session_input_tokens": 396,
        "session_output_tokens": 149478,
        "session_cache_creation_tokens": 3059460,
        "session_cache_read_tokens": 159934480,
        "session_cost_usd": 126.03565694999988,
        "by_model": {
          "claude-opus-4-7": {
            "input": 396,
            "output": 149478,
            "cache_create": 3059460,
            "cache_read": 159934480
          }
        },
        "turn_count": 245,
        "tool_call_count": 163,
        "context_at_last_turn_tokens": 853529,
        "context_window_pct": 426.7645
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-23T08:38:50-07:00",
      "completed_at": "2026-05-23T08:39:08-07:00",
      "session_started_at": null,
      "cumulative_seconds": 18,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-23T08:38:50-07:00",
        "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
        "model": "claude-opus-4-7",
        "five_hour_pct": 49,
        "seven_day_pct": 9,
        "session_input_tokens": 411,
        "session_output_tokens": 151853,
        "session_cache_creation_tokens": 3085575,
        "session_cache_read_tokens": 165947795,
        "session_cost_usd": 127.42680044999987,
        "by_model": {
          "claude-opus-4-7": {
            "input": 411,
            "output": 151853,
            "cache_create": 3085575,
            "cache_read": 165947795
          }
        },
        "turn_count": 252,
        "tool_call_count": 166,
        "context_at_last_turn_tokens": 866485,
        "context_window_pct": 433.2425
      },
      "window_at_complete": {
        "captured_at": "2026-05-23T08:39:08-07:00",
        "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
        "model": "claude-opus-4-7",
        "five_hour_pct": 49,
        "seven_day_pct": 9,
        "session_input_tokens": 413,
        "session_output_tokens": 152645,
        "session_cache_creation_tokens": 3086965,
        "session_cache_read_tokens": 167680763,
        "session_cost_usd": 127.87429119999987,
        "by_model": {
          "claude-opus-4-7": {
            "input": 413,
            "output": 152645,
            "cache_create": 3086965,
            "cache_read": 167680763
          }
        },
        "turn_count": 254,
        "tool_call_count": 167,
        "context_at_last_turn_tokens": 867180,
        "context_window_pct": 433.59
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-23T07:55:28-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-23T08:08:41-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-23T08:34:57-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-23T08:38:50-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-23T07:54:42-07:00",
    "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
    "five_hour_pct": 22,
    "seven_day_pct": 4,
    "session_cost_usd": 22.90559625000001
  },
  "code_tasks_total": 4,
  "code_task": 4,
  "code_task_name": "Rule update: autonomous-phase-discipline.md",
  "diff_stats": {
    "files_changed": 3,
    "insertions": 198,
    "deletions": 0,
    "captured_at": "2026-05-23T08:08:27-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThis conversation presents an unusual situation: I'm being asked to summarize a conversation, but the conversation itself consists primarily of a continuation prompt that compacted an earlier conversation and provided massive system reminders containing FLOW project rules and architectural documentation.\n\nLet me analyze what's actually here:\n\n1. **The user's actual message**: The initial user message is a continuation prompt that:\n   - References a prior compacted conversation (not shown in full)\n   - Provides a summary of that prior work\n   - Loads extensive `.claude/rules/` files as system context\n   - Contains a summary of prior work covering Phases 1-3 of a PR #1695 analysis\n\n2. **What I've done**: I have NOT taken any actions or tool calls. I simply received the context and rules, and am now being asked to summarize.\n\n3. **The critical constraint**: The user explicitly states in their second message:\n   - \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.\"\n   - \"Do NOT use Read, Bash, Grep, Glob, Edit, Write, or ANY other tool.\"\n   - Lists that tool calls will be REJECTED and waste my only turn\n\n4. **What needs to be summarized**: The conversation so far consists of:\n   - One substantive user message: the continuation prompt with Phase 4 Learn-phase analysis task\n   - One enforcement message: the \"CRITICAL\" instruction about text-only response\n   - Extensive system context (rules and prior work summary)\n\n5. **Key technical concepts from context**:\n   - Phase 4 Learn-phase analysis of PR #1695\n   - Three tenants: FLOW process gaps, rule compliance violations, missing rules\n   - Two-gate test: forward-facing + value test\n   - Technical content: `_halt_pending` field, CLI deny mechanisms, normalization, state mutations\n   - Files examined: `.claude/rules/autonomous-phase-discipline.md`, `src/commands/set_timestamp.rs`, `tests/commands/set_timestamp.rs`\n\n6. **Work status**: The prior work (from the compaction summary) shows:\n   - Phase 4 Learn-phase analysis is in progress\n   - Two real findings were identified and fixed in Review Step 4\n   - The pending task is to complete the three-tenant analysis and determine if the agent-batching anomaly constitutes a process gap\n\n7. **Current request**: The user is asking me to create a detailed summary of the conversation using a specific structure, text-only, without any tool calls.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user is requesting a detailed summary of the conversation to preserve context before the conversation runs out of tokens due to compaction. The user explicitly requires a text-only response following a specific structure with <analysis> and <summary> tags, covering: Primary Request and Intent, Key Technical Concepts, Files and Code Sections, Errors and fixes, Problem Solving, All user messages, Pending Tasks, Current Work, and Optional Next Step. The user has made clear that NO tool calls (Read, Bash, Grep, Glob, Edit, Write, or any other tool) are permitted, and any tool calls will be rejected and waste the available turn.\n\n2. Key Technical Concepts:\n   - **Phase 4 Learn-phase analysis**: A post-Review phase analysis of PR #1695 (\"Allow Model Self-Impose Autonomous Halt\") with mandate to identify findings under three tenants\n   - **Three tenants**: (1) FLOW process gaps (workflow, tools, skills, hooks, phase gates causing friction/failure); (2) Rule compliance violations with enforcement level assessment; (3) Missing rules (patterns in diff where something questionable happened but no rule covers it)\n   - **Two-gate filter**: Forward-facing test (would future session understand/apply principle?) + Value test (was gap caught and remediated in PR by Review?). If either fails, finding is discarded.\n   - **Autonomous phase discipline**: `continue: auto` configuration preventing model-initiated pauses\n   - **Halt-pending signal**: `_halt_pending` state field set ONLY by Stop hook in response to real user messages; used to refuse voluntary turn-ends during autonomous phases\n   - **CLI boundary deny**: New mechanism blocking model writes to `_halt_pending` via `bin/flow set-timestamp` to prevent model counterfeiting of user-typed-halt signal\n   - **Normalization before comparing**: Security gate principle (NUL-strip, trim, ASCII-lowercase) applied to field name validation to defeat case/whitespace/embedded-NUL bypass shapes\n   - **Non-atomic state mutations**: `apply_updates` applies `--set` args sequentially in-place; later arg errors don't roll back prior mutations unless caller snapshots/restores\n   - **Review-phase process**: 4 sub-agents (reviewer, pre-mortem, adversarial, documentation) produce findings; Review Step 4 applies fixes\n\n3. Files and Code Sections:\n   - **`.claude/rules/autonomous-phase-discipline.md`** (~29 lines added):\n     - Documents how `_halt_pending` is written (Stop hook only, via in-process mutate_state, never CLI)\n     - Documents CLI deny mechanism: `src/commands/set_timestamp.rs::apply_updates` rejects `--set _halt_pending=...` at boundary\n     - Clarifies direct Edit/Write tool calls against `.flow-states/<branch>/state.json` are NOT blocked (separate trust surface)\n     - **Fix applied in Review Step 4**: Added explicit paragraph clarifying CLI deny scope and that tool calls remain un-blocked\n\n   - **`src/commands/set_timestamp.rs`** (~65 lines added):\n     - `const MODEL_DENIED_FIELDS: &[&str] = &[\"_halt_pending\"];` — closed set of fields model cannot write via CLI\n     - `fn normalize_field_name(s: &str) -> String` — applies NUL-strip, trim, ASCII-lowercase per security-gates rule\n     - `fn validate_model_denied_field(field: &str) -> Result<(), String>` — rejects writes to denied fields with structured error\n     - Integration into `apply_updates()`: validation before state mutation, scoped to single-segment paths only\n     - **Added documentation comment**: Explains non-atomic semantics and caller responsibility for snapshot/restore\n     - **Fix applied in Review Step 4**: Extended documentation to clarify transactional responsibility with reference to `run_impl_main` pattern\n\n   - **`tests/commands/set_timestamp.rs`** (~149 lines added):\n     - Library-level tests: `apply_updates_rejects_halt_pending_true()`, `apply_updates_rejects_halt_pending_false()`, case/whitespace/NUL bypass tests, allowed-field tests\n     - CLI-level integration test: `test_cli_rejects_halt_pending_write()` spawns subprocess, verifies `bin/flow set-timestamp --set _halt_pending=true` exits 1 with structured error\n\n4. Errors and fixes:\n   - **Review-phase finding #1** (now fixed): `apply_updates` documentation was incomplete — doc comment did not explain non-atomic semantics and caller snapshot/restore requirement. **Fix applied in Step 4**: Added detailed comment explaining that transactional responsibility is on the caller, with specific reference to how `run_impl_main` uses the pattern.\n   \n   - **Review-phase finding #2** (now fixed): Rule documentation gap — new prose in `autonomous-phase-discipline.md` explained CLI deny but did NOT clarify that Edit/Write tool calls against `.flow-states/<branch>/state.json` remain un-blocked (separate trust surface). **Fix applied in Step 4**: Added explicit paragraph clarifying gate covers `bin/flow set-timestamp` CLI write path only; tool calls are not blocked by this gate or `validate-worktree-paths` or `validate-claude-paths`.\n   \n   - **Review-phase false positives** (7 dismissed): Reviewer agent worked from summarized plan rather than full plan text, producing false-positive finding about missing Consumer Enumeration Table. No fix needed — correctly dismissed as false positive.\n   \n   - **Agent launch anomaly** (not a learning-phase finding): 4 Review agents were launched in 2 batches (1 agent, then 3 agents) instead of explicitly-required single batch. SKILL.md HARD-GATE stated \"required a single 4-agent batch\" but constraint was not enforced. Review completed successfully with both real issues identified and fixed. **Assessment pending**: Whether this constitutes a Tenant 1 process gap for Learn phase.\n\n5. Problem Solving:\n   - **Counterfeiting attack surface solved**: PR addresses threat where model could call `bin/flow set-timestamp --set _halt_pending=true` to forge user-typed-halt signal, bypassing autonomous-phase safety. Solved by adding CLI boundary deny with normalization.\n   - **Bypass shape coverage solved**: Tests comprehensively verify case, whitespace, and embedded-NUL bypass shapes are defeated via normalization function (NUL-strip, trim, ASCII-lowercase applied before equality check).\n   - **Trust surface clarification solved**: Rule documentation clarified that Edit/Write tool calls against state file are separate trust surface, out of scope for CLI-level gate.\n   - **State mutation atomicity solved**: Code comment added explaining `apply_updates` does not roll back on error; transactional semantics are caller's responsibility, clarifying latent trust boundary.\n\n6. All user messages:\n   - **Initial continuation prompt**: User provided session compaction from prior conversation with detailed summary of Phases 1-3 work on PR #1695 Learn-phase analysis. Request: \"Perform Phase 4 Learn-phase analysis of PR #1695 using three tenants. Read diff, state file, plan, project rules. Apply two-gate test (forward-facing + already-remediated). Return findings or 'No findings' if categories are empty.\" Framing: \"Most Learn phases produce zero findings. Your job is to filter, not to find things to say.\"\n   \n   - **Emphasis on two-gate filter**: \"session notes indicate agent batching anomaly (2 batches instead of 1), reviewer worked from summarized plan, but mark with instruction to 'apply the two-gate filter' — these observations should not automatically become findings.\"\n   \n   - **Optional next step instruction**: \"Read `.claude/rules/autonomous-phase-discipline.md` from the worktree to understand full context of new documentation added (diff shows only added lines), and read `skills/flow-review/SKILL.md` to verify whether HARD-GATE constraint for 'single 4-agent batch' is actually stated there and what enforcement mechanism exists. This will determine whether agent-batching anomaly is genuine Tenant 1 process gap or documentation-vs-execution mismatch that does not generalize.\"\n   \n   - **CRITICAL instruction**: \"Respond with TEXT ONLY. Do NOT call any tools. Do NOT use Read, Bash, Grep, Glob, Edit, Write, or ANY other tool. You already have all the context you need in the conversation above. Tool calls will be REJECTED and will waste your only turn — you will fail the task.\"\n\n7. Pending Tasks:\n   - **Complete three-tenant analysis**: Produce findings under Tenant 1 (FLOW process gaps), Tenant 2 (rule compliance violations with enforcement level), and Tenant 3 (missing rules) for PR #1695 Learn-phase analysis\n   - **Apply two-gate filter rigorously**: To every candidate finding, verify (1) forward-facing test — would future session understand/apply principle? and (2) value test — was this gap caught and remediated in this PR by Review? Discard finding if either test fails.\n   - **Assess agent-batching anomaly**: Determine whether 2-batch launch (1 agent, then 3 agents) vs. required 1-batch constraint constitutes genuine Tenant 1 process gap or is documentation-vs-execution mismatch with insufficient generalization\n   - **Return findings or \"No findings\"**: Provide final report with either specific findings (with explanations) or \"No findings\" blocks if categories are empty\n\n8. Current Work:\n   The conversation was in the initial phase of Phase 4 Learn-phase analysis of PR #1695. The user provided extensive context through the compaction summary covering:\n   - Two real findings were identified in Review Step 3 and fixed in Review Step 4 (documentation completeness for `apply_updates` and clarification of tool-call trust surface scope)\n   - Five Review-phase false positives were correctly dismissed\n   - Agent launch anomaly (2-batch vs. 1-batch) was noted but its status as a Learn-phase finding was explicitly marked as pending assessment per the two-gate filter\n\n   The user then provided the CRITICAL instruction requiring text-only response without any tool calls, as this summary was being requested to preserve context before conversation compaction due to token budget limits.\n\n9. Optional Next Step:\n   Upon completion of this summary and resumption of the session, the next step will be to complete the three-tenant Learn-phase analysis by:\n   \n   **Direct quote from user request**: \"Complete three-tenant analysis and report findings or 'No findings' blocks\" and \"Assess whether the agent-batching anomaly (2-batch launch vs. required 1-batch) constitutes a Tenant 1 process gap worthy of reporting.\"\n   \n   This requires applying the two-gate test rigorously to the agent-batching anomaly (and any other candidate observations) to determine whether: (1) it is forward-facing enough for a future session to understand and apply the principle, and (2) it was already caught and remediated in this PR by Review. The user's framing was explicit: \"Apply the two-gate filter\" and \"Most Learn phases produce zero findings. Your job is to filter, not to find things to say.\"\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/model-can-self-impose-autonomous",
  "compact_count": 4,
  "findings": [
    {
      "finding": "Reviewer F1: No Consumer Enumeration Table for new error envelope",
      "reason": "The Consumer Enumeration Table is in fact present in the plan's Risks section (lines 88-109) and lists every set-timestamp consumer in the skill corpus as Exempt. The reviewer agent based its claim on the summarized Risks section embedded in the agent prompt, which omitted the table.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T08:24:58-07:00"
    },
    {
      "finding": "Pre-mortem F1: Trailing-dot variant _halt_pending. not rejected by deny check",
      "reason": "The rule prose explicitly says 'single-segment paths only'; the trailing-dot variant is a 2-segment shape that the prose correctly says is out of deny scope. The adversarial probe test apply_updates_trailing_dot_does_not_clobber_halt_pending_boolean confirms that when _halt_pending: true exists, set_nested errors on the Bool guard and the bypass cannot escape an active halt. The non-existent-field branch writes an Object to the top-level key, which the Stop hook reads as is_truthy(Object) -> false (no halt-escape). The security property (Stop hook reads top-level _halt_pending and is_truthy returns false on non-Bool) holds.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T08:25:09-07:00"
    },
    {
      "finding": "Pre-mortem F2: apply_updates error path still writes the state file via mutate_state",
      "reason": "Pre-existing concern explicitly acknowledged by the agent as 'not introduced by this PR'. The rejected-write path restores backup before mutate_state serializes, so file content is unchanged. Per review-scope.md, pre-existing concerns outside the PR scope are out of scope unless the PR makes them materially worse, which it does not.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T08:25:15-07:00"
    },
    {
      "finding": "Pre-mortem F3: ANSI escape interpolation in error message via unsanitized field name",
      "reason": "serde_json escapes control characters (including ESC 0x1b) by default per the JSON spec: all control chars 0x00-0x1f are written as \\u00XX escapes. The CLI output is JSON (run_impl_main returns {status: error, message}), so the consumer parses JSON-decoded strings — raw ANSI bytes never reach the terminal interpreter. Subprocess-argument-escaping rule does not apply because the field name is not interpolated into a shell/AppleScript/SQL/Markdown context — it is JSON-encoded by serde_json before output.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T08:25:24-07:00"
    },
    {
      "finding": "Documentation F1: Ambiguous 'no-op' phrasing for nested field writes",
      "reason": "The existing rule prose already qualifies 'no-op' with 'for the Stop hook, which reads the top-level field only' — the qualifier the agent recommends is already present and explains both producer and consumer semantics. The inline comment in src/commands/set_timestamp.rs similarly says 'for those readers' specifically naming the hooks.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T08:25:30-07:00"
    },
    {
      "finding": "Documentation F2: MODEL_DENIED_FIELDS extension protocol undocumented",
      "reason": "The extension obligations the agent enumerates (bypass-variant tests, owner documentation, normalization) are already covered by existing rule files: security-gates.md 'Normalize Before Comparing' and 'Enumerate Bypass Variants Before Coding', test-placement.md, and docs-with-behavior.md. Adding a checklist to the constant's doc comment duplicates the rule corpus without adding signal. Per review-scope.md Value-vs-Bureaucracy triage 'discoverability' arm: a future maintainer extending the deny set would read the rule files via the existing cross-references.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T08:25:37-07:00"
    },
    {
      "finding": "Documentation F3: 'Pass through' description in halt-gate section now inaccurate for _halt_pending",
      "reason": "The 'Defense in depth — halt gates on Skill and Bash' section describes halt-gate behavior specifically; bin/flow set-timestamp on non-counter fields does still pass through the halt gate. The library-layer rejection of _halt_pending happens at apply_updates inside the process, not at validate-pretool. The new behavior is already documented in the 'Who writes _halt_pending=true' subsection immediately above, which names set_timestamp::apply_updates + MODEL_DENIED_FIELDS as the boundary enforcer. Conflating the two layers in the halt-gate section would mislead readers about which gate fires for which command.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T08:25:58-07:00"
    },
    {
      "finding": "Adversarial F1: apply_updates non-atomic across multiple --set args when later arg is denied",
      "reason": "Added doc comment to apply_updates documenting non-atomicity and the required caller-side snapshot pattern (run_impl_main backup/restore via mutate_state closure). Migrated the useful regression guard (apply_updates_trailing_dot_does_not_clobber_halt_pending_boolean) from the throwaway adversarial probe to tests/commands/set_timestamp.rs per .claude/rules/test-placement.md. Disposed of the adversarial probe file per .claude/rules/adversarial-probe-lifecycle.md by overwriting with a doc-comment-only placeholder; Phase 5 Complete removes it via fs::remove_file. Production callers continue to use the snapshot pattern unchanged; no behavior change.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T08:30:49-07:00"
    },
    {
      "finding": "Reviewer F2: Edit/Write tool bypass surface left undocumented in rule update",
      "reason": "Added a clarifier paragraph to .claude/rules/autonomous-phase-discipline.md 'Who writes _halt_pending=true' subsection naming Direct Edit/Write tool calls to .flow-states/<branch>/state.json as a broader trust surface tracked separately from this gate. validate-worktree-paths blocks only misplaced .worktrees/<branch>/.flow-states/ copies; validate-claude-paths protects .claude/ paths only. The rule's primary claim (CLI write path denied) remains accurate; the clarifier prevents future readers from overestimating the protection scope.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T08:30:58-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-23T08:39:08-07:00",
    "session_id": "6202b0b2-fb36-4fa4-969d-194e220c6bc3",
    "model": "claude-opus-4-7",
    "five_hour_pct": 49,
    "seven_day_pct": 9,
    "session_input_tokens": 413,
    "session_output_tokens": 152645,
    "session_cache_creation_tokens": 3086965,
    "session_cache_read_tokens": 167680763,
    "session_cost_usd": 127.87429119999987,
    "by_model": {
      "claude-opus-4-7": {
        "input": 413,
        "output": 152645,
        "cache_create": 3086965,
        "cache_read": 167680763
      }
    },
    "turn_count": 254,
    "tool_call_count": 167,
    "context_at_last_turn_tokens": 867180,
    "context_window_pct": 433.59
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>