### PR TITLE
Finalize Commit Doesnt Re Stage

### DIFF
--- a/docs/skills/flow-commit.md
+++ b/docs/skills/flow-commit.md
@@ -19,7 +19,7 @@ Reviews all pending changes before committing. You see the full diff and propose
 1. Stages changes
 2. Shows `git status` and `git diff --cached` in parallel
 3. Proposes a commit message in the `tl;dr` format
-4. Commits, pulls, and pushes via `bin/flow finalize-commit` (which enforces CI internally)
+4. Commits, pulls, and pushes via `bin/flow finalize-commit` (which enforces CI internally and re-stages tracked-file modifications after CI so in-place auto-fixes are captured in the same commit)
 
 ---
 
@@ -61,8 +61,17 @@ The banner is versioned (`FLOW v1.1.0`) when a `.flow-states/*.json` state file 
 
 ---
 
+## Re-staging
+
+After CI completes (and only when CI passed), `finalize-commit` runs `git add -u` to capture in-place modifications CI made to already-tracked files. This handles the canonical pattern where `bin/format` and `bin/lint` auto-fix tracked files in their default non-`CI=1` mode: without re-staging, the commit would record the pre-CI bytes from the index while CI tested the post-CI bytes in the working tree, and remote strict CI would fail on the unfixed bytes.
+
+`git add -u` updates already-tracked files only — untracked artifacts (the commit-message file, scratch files, CI outputs the user has not yet `.gitignore`d) are NOT swept. The commit's scope stays bounded to what the user staged plus any in-place modifications CI made to those tracked files. A failed re-stage returns `step:"restage"` in the JSON envelope.
+
+---
+
 ## Gates
 
 - Never commits without showing the diff first
 - Never uses `--no-verify`
 - CI enforced inside `finalize-commit` before every commit
+- Post-CI re-stage captures tracked-file modifications via `git add -u`; untracked files are not swept

--- a/skills/flow-commit/SKILL.md
+++ b/skills/flow-commit/SKILL.md
@@ -212,7 +212,11 @@ Display the full message under the heading **Commit Message**.
 
 ### Round 5 — Commit and push
 
-Files are already staged from Round 3. No need to `git add -A` again.
+Files are already staged from Round 3. `bin/flow finalize-commit` runs
+its CI gate next and then re-stages internally before composing the
+commit, so any in-place auto-fixes that `bin/format` or `bin/lint`
+make during CI (running in their default non-`CI=1` mode) are
+captured in the same commit alongside the manually-staged content.
 
 Use the Write tool to write the commit message content to
 `<project_root>/.flow-states/<branch>/commit-msg-content.txt` — a

--- a/skills/flow-commit/SKILL.md
+++ b/skills/flow-commit/SKILL.md
@@ -213,10 +213,13 @@ Display the full message under the heading **Commit Message**.
 ### Round 5 — Commit and push
 
 Files are already staged from Round 3. `bin/flow finalize-commit` runs
-its CI gate next and then re-stages internally before composing the
-commit, so any in-place auto-fixes that `bin/format` or `bin/lint`
-make during CI (running in their default non-`CI=1` mode) are
-captured in the same commit alongside the manually-staged content.
+its CI gate next and then re-stages tracked-file modifications (via
+`git add -u`) before composing the commit, so any in-place changes
+the project's `bin/*` tools made to already-tracked files during CI
+(running in their default non-`CI=1` mode) are captured in the same
+commit alongside the manually-staged content. Untracked files are NOT
+swept by the re-stage — only modifications to files already tracked
+by git.
 
 Use the Write tool to write the commit message content to
 `<project_root>/.flow-states/<branch>/commit-msg-content.txt` — a

--- a/src/finalize_commit.rs
+++ b/src/finalize_commit.rs
@@ -12,12 +12,22 @@
 //! feature-branch worktree that flow-start created at
 //! `<project_root>/.worktrees/<branch>/`.
 //!
-//! Two gates run before committing:
+//! Two gates and a post-CI re-stage run before committing:
 //!
 //! 1. **CI gate** — calls [`ci::run_impl`]. If CI fails, returns an error
 //!    and commits nothing. When the CI sentinel is fresh (CI already passed
 //!    for this tree state), the check noops instantly.
-//! 2. **Plan-deviation gate** — calls [`plan_deviation::run_impl`] to
+//! 2. **Post-CI re-stage** — runs `git add -A` after CI completes. Project
+//!    `bin/*` tools run in their default auto-fix mode during the commit-
+//!    time CI gate (CI=true is not set), so formatters like `ruff format`
+//!    and `prettier --write` modify tracked files in place. Re-staging
+//!    captures those modifications in the index so the commit records the
+//!    same bytes CI validated, and the plan-deviation gate inspects identical
+//!    content. Returns `step = "restage"` on `git add` failure. Files
+//!    matched by `.gitignore` are not swept (`git add -A` respects the
+//!    ignore list); un-ignored artifacts in the working tree land in the
+//!    commit just as they would with a manual `git add -A`.
+//! 3. **Plan-deviation gate** — calls [`plan_deviation::run_impl`] to
 //!    cross-reference plan-named test fixture values against the staged
 //!    diff. If an unacknowledged drift is detected, returns an error with
 //!    `step = "plan_deviation"` and a structured stderr message.
@@ -28,7 +38,7 @@
 //! Output (JSON to stdout):
 //!   Success:   {"status": "ok", "sha": "<commit-hash>", "pull_merged": <bool>}
 //!   Conflict:  {"status": "conflict", "files": ["file1.py", ...]}
-//!   Error:     {"status": "error", "step": "ci|plan_deviation|commit|pull|push", "message": "..."}
+//!   Error:     {"status": "error", "step": "ci|restage|plan_deviation|commit|pull|push", "message": "..."}
 
 use std::fs;
 
@@ -314,56 +324,90 @@ pub fn run_impl(args: &Args, root: &std::path::Path) -> Result<Value, String> {
                 &format!("[Phase {}] finalize-commit — ci (ok)", pn),
             );
 
-            // Capture the staged diff for the plan-deviation gate.
-            // The working_tree_dirty gate at the top of run_impl
-            // already proved git is alive and the cwd is a real
-            // repo, so .expect() is safe — Err and non-zero arms
-            // for `git diff --cached` are unreachable in practice
-            // per `.claude/rules/testability-means-simplicity.md`.
-            let (_, staged_diff, _) =
-                run_git_in_dir(&commit_cwd, &["diff", "--cached"], LOCAL_TIMEOUT)
+            // Re-stage every working-tree modification so the commit
+            // captures the bytes CI actually validated. Project `bin/*`
+            // tools run in their default auto-fix mode during the
+            // commit-time CI gate (CI=true is not set; see
+            // `src/ci.rs`), so formatters like `ruff format` and
+            // `prettier --write` modify tracked files in place. Without
+            // this step, the staged-diff capture below would see the
+            // pre-CI index bytes and `git commit -F` would record them
+            // — diverging from what CI tested. The working_tree_dirty
+            // gate at line 257 already proved git is alive, so
+            // `.expect()` is safe here in the same sense as the
+            // `git diff --cached` call below.
+            let (add_code, _, add_stderr) =
+                run_git_in_dir(&commit_cwd, &["add", "-A"], LOCAL_TIMEOUT)
                     .expect("git located by working_tree_dirty gate");
+            if add_code != 0 {
+                let _ = append_log(
+                    root,
+                    &args.branch,
+                    &format!("[Phase {}] finalize-commit — restage (failed)", pn),
+                );
+                json!({
+                    "status": "error",
+                    "step": "restage",
+                    "message": add_stderr.trim(),
+                })
+            } else {
+                let _ = append_log(
+                    root,
+                    &args.branch,
+                    &format!("[Phase {}] finalize-commit — restage (ok)", pn),
+                );
 
-            // Plan signature deviation gate. Blocks the commit when
-            // a plan-named test's fixture value drifts without a
-            // matching log acknowledgment. The gate is mechanical
-            // enforcement of `.claude/rules/plan-commit-atomicity.md`
-            // "Plan Signature Deviations Must Be Logged".
-            match crate::plan_deviation::run_impl(root, &args.branch, &staged_diff) {
-                Ok(()) => finalize_commit(&args.message_file, &args.branch, &commit_cwd),
-                Err(deviations) => {
-                    emit_deviation_stderr(&args.branch, &deviations);
-                    let _ = append_log(
-                        root,
-                        &args.branch,
-                        &format!(
-                            "[Phase {}] finalize-commit — plan_deviation (blocked: {} deviation{})",
-                            pn,
-                            deviations.len(),
-                            if deviations.len() == 1 { "" } else { "s" }
-                        ),
-                    );
-                    let deviation_json: Vec<Value> = deviations
-                        .iter()
-                        .map(|d| {
-                            json!({
-                                "test_name": d.test_name,
-                                "fixture_key": d.fixture_key,
-                                "plan_value": d.plan_value,
-                                "plan_line": d.plan_line,
+                // Capture the staged diff for the plan-deviation gate.
+                // The working_tree_dirty gate at the top of run_impl
+                // already proved git is alive and the cwd is a real
+                // repo, so .expect() is safe — Err and non-zero arms
+                // for `git diff --cached` are unreachable in practice
+                // per `.claude/rules/testability-means-simplicity.md`.
+                let (_, staged_diff, _) =
+                    run_git_in_dir(&commit_cwd, &["diff", "--cached"], LOCAL_TIMEOUT)
+                        .expect("git located by working_tree_dirty gate");
+
+                // Plan signature deviation gate. Blocks the commit when
+                // a plan-named test's fixture value drifts without a
+                // matching log acknowledgment. The gate is mechanical
+                // enforcement of `.claude/rules/plan-commit-atomicity.md`
+                // "Plan Signature Deviations Must Be Logged".
+                match crate::plan_deviation::run_impl(root, &args.branch, &staged_diff) {
+                    Ok(()) => finalize_commit(&args.message_file, &args.branch, &commit_cwd),
+                    Err(deviations) => {
+                        emit_deviation_stderr(&args.branch, &deviations);
+                        let _ = append_log(
+                            root,
+                            &args.branch,
+                            &format!(
+                                "[Phase {}] finalize-commit — plan_deviation (blocked: {} deviation{})",
+                                pn,
+                                deviations.len(),
+                                if deviations.len() == 1 { "" } else { "s" }
+                            ),
+                        );
+                        let deviation_json: Vec<Value> = deviations
+                            .iter()
+                            .map(|d| {
+                                json!({
+                                    "test_name": d.test_name,
+                                    "fixture_key": d.fixture_key,
+                                    "plan_value": d.plan_value,
+                                    "plan_line": d.plan_line,
+                                })
                             })
+                            .collect();
+                        json!({
+                            "status": "error",
+                            "step": "plan_deviation",
+                            "message": format!(
+                                "{} unacknowledged plan signature deviation{}",
+                                deviations.len(),
+                                if deviations.len() == 1 { "" } else { "s" }
+                            ),
+                            "deviations": deviation_json,
                         })
-                        .collect();
-                    json!({
-                        "status": "error",
-                        "step": "plan_deviation",
-                        "message": format!(
-                            "{} unacknowledged plan signature deviation{}",
-                            deviations.len(),
-                            if deviations.len() == 1 { "" } else { "s" }
-                        ),
-                        "deviations": deviation_json,
-                    })
+                    }
                 }
             }
         }

--- a/src/finalize_commit.rs
+++ b/src/finalize_commit.rs
@@ -17,16 +17,18 @@
 //! 1. **CI gate** — calls [`ci::run_impl`]. If CI fails, returns an error
 //!    and commits nothing. When the CI sentinel is fresh (CI already passed
 //!    for this tree state), the check noops instantly.
-//! 2. **Post-CI re-stage** — runs `git add -A` after CI completes. Project
+//! 2. **Post-CI re-stage** — runs `git add -u` after CI completes. Project
 //!    `bin/*` tools run in their default auto-fix mode during the commit-
 //!    time CI gate (CI=true is not set), so formatters like `ruff format`
 //!    and `prettier --write` modify tracked files in place. Re-staging
 //!    captures those modifications in the index so the commit records the
 //!    same bytes CI validated, and the plan-deviation gate inspects identical
-//!    content. Returns `step = "restage"` on `git add` failure. Files
-//!    matched by `.gitignore` are not swept (`git add -A` respects the
-//!    ignore list); un-ignored artifacts in the working tree land in the
-//!    commit just as they would with a manual `git add -A`.
+//!    content. `git add -u` updates already-tracked files only — it does
+//!    NOT sweep untracked files (commit-message files, scratch artifacts,
+//!    CI outputs the user has not yet `.gitignore`d), so the commit's
+//!    scope stays bounded to what the user staged in `/flow:flow-commit`
+//!    Round 3 plus any in-place modifications CI made to those tracked
+//!    files. Returns `step = "restage"` on `git add` failure.
 //! 3. **Plan-deviation gate** — calls [`plan_deviation::run_impl`] to
 //!    cross-reference plan-named test fixture values against the staged
 //!    diff. If an unacknowledged drift is detected, returns an error with
@@ -324,7 +326,7 @@ pub fn run_impl(args: &Args, root: &std::path::Path) -> Result<Value, String> {
                 &format!("[Phase {}] finalize-commit — ci (ok)", pn),
             );
 
-            // Re-stage every working-tree modification so the commit
+            // Re-stage tracked-file modifications so the commit
             // captures the bytes CI actually validated. Project `bin/*`
             // tools run in their default auto-fix mode during the
             // commit-time CI gate (CI=true is not set; see
@@ -332,12 +334,19 @@ pub fn run_impl(args: &Args, root: &std::path::Path) -> Result<Value, String> {
             // `prettier --write` modify tracked files in place. Without
             // this step, the staged-diff capture below would see the
             // pre-CI index bytes and `git commit -F` would record them
-            // — diverging from what CI tested. The working_tree_dirty
-            // gate at line 257 already proved git is alive, so
-            // `.expect()` is safe here in the same sense as the
-            // `git diff --cached` call below.
+            // — diverging from what CI tested. `git add -u` updates
+            // already-tracked files only: it does NOT sweep untracked
+            // files (the commit-message file under
+            // `.flow-states/<branch>/commit-msg.txt`, scratch files,
+            // CI artifacts the user has not yet `.gitignore`d), so the
+            // commit's scope stays bounded to what the user already
+            // staged in `/flow:flow-commit` Round 3 plus any in-place
+            // modifications CI made to those tracked files. The
+            // working_tree_dirty gate above already proved git is
+            // alive, so `.expect()` is safe here in the same sense as
+            // the `git diff --cached` call below.
             let (add_code, _, add_stderr) =
-                run_git_in_dir(&commit_cwd, &["add", "-A"], LOCAL_TIMEOUT)
+                run_git_in_dir(&commit_cwd, &["add", "-u"], LOCAL_TIMEOUT)
                     .expect("git located by working_tree_dirty gate");
             if add_code != 0 {
                 let _ = append_log(

--- a/tests/finalize_commit.rs
+++ b/tests/finalize_commit.rs
@@ -1879,3 +1879,445 @@ fn finalize_commit_passes_ci_reason() {
         stderr
     );
 }
+
+// --- run_impl: post-CI re-stage ---
+
+/// Regression test: finalize-commit must re-stage tracked files
+/// that CI modifies during its auto-fix pass (the canonical pattern
+/// in target repos: `CI=true → strict / CI unset → auto-fix in
+/// place`). Without re-staging between CI completion and the
+/// `git diff --cached` capture, `git commit -F` records the pre-CI
+/// index bytes while CI tested the post-CI working-tree bytes; the
+/// remote strict CI then fails on the unfixed content.
+///
+/// Fixture: overwrite the worktree's `bin/test` with a script that
+/// appends a newline to `README.md` on every invocation. Stage a
+/// separate `feature.rs` so `git commit` has something to land
+/// independent of the README modification. Skip the CI sentinel so
+/// CI actually runs and triggers the auto-fix.
+///
+/// Asserts `git show HEAD:README.md` returns the appended-newline
+/// bytes. Fails against current code because the commit captures
+/// the pre-CI staged bytes.
+#[test]
+fn finalize_commit_restages_after_ci_modifies_tracked_file() {
+    let (clone_dir, _bare_dir, worktree_path) =
+        setup_worktree_fixture("restage-after-ci");
+    let clone_path = clone_dir.path();
+    let wt_str = worktree_path.to_str().unwrap();
+
+    // Replace bin/test with an auto-fix script that unconditionally
+    // appends a newline to README.md. CI dispatches bin/test as
+    // part of its [format, lint, build, test] sequence, so the
+    // script fires during run_impl's CI gate. Commit and push the
+    // modified script so the worktree starts clean (the
+    // working-tree-dirty gate would otherwise block the run).
+    let bin_test = worktree_path.join("bin").join("test");
+    let auto_fix_script = r#"#!/usr/bin/env bash
+printf '\n' >> "$(dirname "$0")/../README.md"
+exit 0
+"#;
+    fs::write(&bin_test, auto_fix_script).unwrap();
+    #[cfg(unix)]
+    {
+        fs::set_permissions(&bin_test, fs::Permissions::from_mode(0o755))
+            .unwrap();
+    }
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "add", "bin/test"])
+            .output()
+            .unwrap(),
+    );
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "commit", "-m", "Configure auto-fix bin/test"])
+            .output()
+            .unwrap(),
+    );
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "push"])
+            .output()
+            .unwrap(),
+    );
+
+    // Stage a new file so `git commit` has content to land
+    // independent of the README modification. Without this, the
+    // commit's index would be empty before re-staging and `git
+    // commit -F` would refuse with "nothing to commit".
+    fs::write(worktree_path.join("feature.rs"), "fn main() {}\n").unwrap();
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "add", "feature.rs"])
+            .output()
+            .unwrap(),
+    );
+
+    // Capture README's bytes at HEAD (and in the index, since the
+    // working tree matches HEAD after the auto-fix script commit).
+    let pre_fix_output = Command::new("git")
+        .args(["-C", wt_str, "show", "HEAD:README.md"])
+        .output()
+        .unwrap();
+    git_assert_ok(&pre_fix_output);
+    let pre_fix_bytes =
+        String::from_utf8_lossy(&pre_fix_output.stdout).to_string();
+    let expected_post_fix_bytes = format!("{}\n", pre_fix_bytes);
+
+    let msg_path = worktree_path.join(".flow-commit-msg");
+    fs::write(&msg_path, "Add feature.rs (post-CI re-stage test).").unwrap();
+
+    // Do NOT write a CI sentinel — CI must actually run so bin/test
+    // fires the auto-fix and modifies README.md in the working
+    // tree.
+
+    let args = Args {
+        message_file: msg_path.to_str().unwrap().to_string(),
+        branch: "restage-after-ci".to_string(),
+    };
+    let result = run_impl(&args, clone_path).unwrap();
+    assert_eq!(result["status"], "ok", "got: {}", result);
+
+    let head_readme = Command::new("git")
+        .args(["-C", wt_str, "show", "HEAD:README.md"])
+        .output()
+        .unwrap();
+    git_assert_ok(&head_readme);
+    let committed_bytes =
+        String::from_utf8_lossy(&head_readme.stdout).to_string();
+    assert_eq!(
+        committed_bytes, expected_post_fix_bytes,
+        "commit must capture post-CI bytes (re-staged) — pre={:?}, expected_post={:?}, committed={:?}",
+        pre_fix_bytes, expected_post_fix_bytes, committed_bytes,
+    );
+}
+
+/// Invariant: projects whose `bin/*` tools never modify the working
+/// tree (the strict `--check` shape) experience zero behavior change
+/// from the post-CI re-stage. The committed file must read exactly the
+/// pre-staged bytes, and `git add -A` must not sweep extra files into
+/// the commit. Locks the non-regression contract for checker-only
+/// projects against future changes that might widen what the re-stage
+/// includes.
+#[test]
+fn finalize_commit_restage_noop_when_ci_leaves_working_tree_clean() {
+    let (clone_dir, _bare_dir, worktree_path) =
+        setup_worktree_fixture("restage-noop");
+    let clone_path = clone_dir.path();
+    let wt_str = worktree_path.to_str().unwrap();
+
+    // The fixture's default bin/test only writes a marker file
+    // (gitignored via .git/info/exclude) — no working-tree
+    // modifications to tracked files. Stage a source file with
+    // known bytes and verify those exact bytes land in the commit.
+    let staged_path = worktree_path.join("source.rs");
+    let staged_bytes = "fn main() {}\n";
+    fs::write(&staged_path, staged_bytes).unwrap();
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "add", "source.rs"])
+            .output()
+            .unwrap(),
+    );
+
+    // Use the canonical gitignored commit-msg path
+    // (`.flow-states/` is gitignored by the fixture) so the
+    // tree-listing assertion below sees only the staged source.rs.
+    // Production callers always use `FlowPaths::commit_msg()`,
+    // which resolves under `.flow-states/<branch>/`; the test
+    // fixture follows the same convention here so the no-op
+    // invariant is exercised against the path the model uses.
+    let branch_state_dir =
+        clone_path.join(".flow-states").join("restage-noop");
+    fs::create_dir_all(&branch_state_dir).unwrap();
+    let msg_path = branch_state_dir.join("commit-msg.txt");
+    fs::write(&msg_path, "Add source.rs (no-op re-stage test).").unwrap();
+
+    write_ci_sentinel_for_worktree(clone_path, "restage-noop", &worktree_path);
+
+    let args = Args {
+        message_file: msg_path.to_str().unwrap().to_string(),
+        branch: "restage-noop".to_string(),
+    };
+    let result = run_impl(&args, clone_path).unwrap();
+    assert_eq!(result["status"], "ok", "got: {}", result);
+
+    // Committed file bytes must be exactly what was staged.
+    let head_source = Command::new("git")
+        .args(["-C", wt_str, "show", "HEAD:source.rs"])
+        .output()
+        .unwrap();
+    git_assert_ok(&head_source);
+    let committed_bytes =
+        String::from_utf8_lossy(&head_source.stdout).to_string();
+    assert_eq!(
+        committed_bytes, staged_bytes,
+        "committed bytes must match staged bytes when CI does not modify",
+    );
+
+    // The new commit's tree must list only source.rs — `git add -A`
+    // must not sweep any other working-tree entries (the marker file
+    // is gitignored; verify nothing else slipped through).
+    let tree_listing = Command::new("git")
+        .args([
+            "-C",
+            wt_str,
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            "HEAD",
+        ])
+        .output()
+        .unwrap();
+    git_assert_ok(&tree_listing);
+    let names = String::from_utf8_lossy(&tree_listing.stdout).to_string();
+    let listed: Vec<&str> = names.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        listed,
+        vec!["source.rs"],
+        "commit must include only the staged source.rs; got: {:?}",
+        listed,
+    );
+}
+
+/// Stub a `git` binary on PATH that exits non-zero on every `add`
+/// invocation while forwarding every other subcommand to real git.
+/// Returns the directory to prepend to PATH.
+fn write_git_add_failing_stub(parent: &Path) -> PathBuf {
+    let stubs = parent.join("git-add-fail-stubs");
+    fs::create_dir_all(&stubs).unwrap();
+    let script = r#"#!/bin/sh
+REPO_PATH=""
+if [ "$1" = "-C" ]; then
+    REPO_PATH="$2"
+    shift 2
+fi
+SUBCMD="$1"
+shift
+if [ "$SUBCMD" = "add" ]; then
+    echo "simulated git add -A failure" >&2
+    exit 1
+fi
+exec /usr/bin/git -C "$REPO_PATH" "$SUBCMD" "$@"
+"#;
+    let git_path = stubs.join("git");
+    fs::write(&git_path, script).unwrap();
+    #[cfg(unix)]
+    {
+        fs::set_permissions(&git_path, fs::Permissions::from_mode(0o755))
+            .unwrap();
+    }
+    stubs
+}
+
+/// Coverage for the `add_code != 0` branch added by the post-CI
+/// re-stage. Skips CI via the sentinel, installs a `git` stub on
+/// PATH that fails on `add` invocations, and runs finalize-commit
+/// as a subprocess so the stub is reachable. Asserts the structured
+/// `step:"restage"` error envelope.
+#[test]
+fn finalize_commit_restage_failure_returns_step_restage() {
+    let (clone_dir, _bare_dir, worktree_path) =
+        setup_worktree_fixture("restage-fail");
+    let clone_path = clone_dir.path();
+    let wt_str = worktree_path.to_str().unwrap();
+
+    let staged_path = worktree_path.join("feature.rs");
+    fs::write(&staged_path, "fn main() {}\n").unwrap();
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "add", "feature.rs"])
+            .output()
+            .unwrap(),
+    );
+
+    let msg_path = worktree_path.join(".flow-commit-msg");
+    fs::write(&msg_path, "Add feature.rs (restage-fail test).").unwrap();
+
+    write_ci_sentinel_for_worktree(clone_path, "restage-fail", &worktree_path);
+
+    let stubs = write_git_add_failing_stub(clone_path);
+
+    let output = run_finalize_with_stub(
+        clone_path,
+        &msg_path,
+        "restage-fail",
+        &stubs,
+        &[],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let result = last_json_line(&stdout);
+
+    assert_eq!(result["status"], "error", "got: {}", result);
+    assert_eq!(result["step"], "restage", "got: {}", result);
+    let msg = result["message"]
+        .as_str()
+        .unwrap_or_else(|| panic!("message must be a string, got: {}", result));
+    assert!(
+        !msg.is_empty(),
+        "restage error message must be non-empty, got: {:?}",
+        msg,
+    );
+}
+
+/// Locks the invariant that the pre-existing working-tree-dirty gate
+/// at the top of run_impl continues to fire before CI runs, even with
+/// the post-CI re-stage in place. A future refactor that moved the
+/// re-stage in front of the gate would silently land the working
+/// tree's unstaged edits in the commit; this test catches that.
+#[test]
+fn finalize_commit_working_tree_dirty_gate_still_fires_pre_ci() {
+    let (clone_dir, _bare_dir, worktree_path) =
+        setup_worktree_fixture("dirty-pre-ci");
+    let clone_path = clone_dir.path();
+    let wt_str = worktree_path.to_str().unwrap();
+
+    // Commit a baseline README contents so we have a stable index
+    // entry to diverge from.
+    fs::write(worktree_path.join("README.md"), "baseline\n").unwrap();
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "add", "README.md"])
+            .output()
+            .unwrap(),
+    );
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "commit", "-m", "Baseline README"])
+            .output()
+            .unwrap(),
+    );
+
+    // Modify the working tree without staging — index still has the
+    // baseline bytes, working tree has different bytes.
+    fs::write(worktree_path.join("README.md"), "unstaged user edit\n")
+        .unwrap();
+
+    let msg_path = worktree_path.join(".flow-commit-msg");
+    fs::write(&msg_path, "Baseline + dirty tree.").unwrap();
+
+    let args = Args {
+        message_file: msg_path.to_str().unwrap().to_string(),
+        branch: "dirty-pre-ci".to_string(),
+    };
+    let result = run_impl(&args, clone_path).unwrap();
+
+    assert_eq!(result["status"], "error", "got: {}", result);
+    assert_eq!(result["step"], "working_tree_dirty", "got: {}", result);
+}
+
+/// Topology test: `.gitignore` correctly bounds the `git add -A` sweep
+/// added by the post-CI re-stage. A CI tool that writes a gitignored
+/// artifact (e.g. `coverage.profraw`) must not introduce that artifact
+/// into the commit. Locks the bound between "files CI auto-fixes (must
+/// be re-staged)" and "files CI happens to drop in the working tree
+/// (must not be swept)".
+#[test]
+fn finalize_commit_restage_respects_gitignore_for_ci_artifacts() {
+    let (clone_dir, _bare_dir, worktree_path) =
+        setup_worktree_fixture("restage-gitignore");
+    let clone_path = clone_dir.path();
+    let wt_str = worktree_path.to_str().unwrap();
+
+    // Track a .gitignore that excludes a CI-artifact pattern.
+    fs::write(
+        worktree_path.join(".gitignore"),
+        ".flow-states/\ncoverage.profraw\n",
+    )
+    .unwrap();
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "add", ".gitignore"])
+            .output()
+            .unwrap(),
+    );
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "commit", "-m", "Track gitignore"])
+            .output()
+            .unwrap(),
+    );
+
+    // Replace bin/test with a script that drops a gitignored CI
+    // artifact into the worktree on every invocation.
+    let bin_test = worktree_path.join("bin").join("test");
+    let artifact_script = r#"#!/usr/bin/env bash
+printf 'coverage data' > "$(dirname "$0")/../coverage.profraw"
+exit 0
+"#;
+    fs::write(&bin_test, artifact_script).unwrap();
+    #[cfg(unix)]
+    {
+        fs::set_permissions(&bin_test, fs::Permissions::from_mode(0o755))
+            .unwrap();
+    }
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "add", "bin/test"])
+            .output()
+            .unwrap(),
+    );
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "commit", "-m", "Configure artifact-emitting bin/test"])
+            .output()
+            .unwrap(),
+    );
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "push"])
+            .output()
+            .unwrap(),
+    );
+
+    let staged_path = worktree_path.join("source.rs");
+    let staged_bytes = "fn main() {}\n";
+    fs::write(&staged_path, staged_bytes).unwrap();
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "add", "source.rs"])
+            .output()
+            .unwrap(),
+    );
+
+    let msg_path = worktree_path.join(".flow-commit-msg");
+    fs::write(&msg_path, "Add source.rs (gitignore-respect test).").unwrap();
+
+    // Do NOT write a CI sentinel — CI must actually run so bin/test
+    // produces the gitignored artifact.
+
+    let args = Args {
+        message_file: msg_path.to_str().unwrap().to_string(),
+        branch: "restage-gitignore".to_string(),
+    };
+    let result = run_impl(&args, clone_path).unwrap();
+    assert_eq!(result["status"], "ok", "got: {}", result);
+
+    // The staged source file must land at HEAD with the staged bytes.
+    let head_source = Command::new("git")
+        .args(["-C", wt_str, "show", "HEAD:source.rs"])
+        .output()
+        .unwrap();
+    git_assert_ok(&head_source);
+    let committed_bytes =
+        String::from_utf8_lossy(&head_source.stdout).to_string();
+    assert_eq!(
+        committed_bytes, staged_bytes,
+        "committed bytes must match staged bytes",
+    );
+
+    // HEAD's tree must NOT contain the gitignored artifact.
+    let tree_listing = Command::new("git")
+        .args(["-C", wt_str, "ls-tree", "-r", "--name-only", "HEAD"])
+        .output()
+        .unwrap();
+    git_assert_ok(&tree_listing);
+    let names = String::from_utf8_lossy(&tree_listing.stdout).to_string();
+    assert!(
+        !names.lines().any(|l| l == "coverage.profraw"),
+        "HEAD must not include gitignored CI artifact; got: {}",
+        names,
+    );
+}

--- a/tests/finalize_commit.rs
+++ b/tests/finalize_commit.rs
@@ -1901,8 +1901,7 @@ fn finalize_commit_passes_ci_reason() {
 /// the pre-CI staged bytes.
 #[test]
 fn finalize_commit_restages_after_ci_modifies_tracked_file() {
-    let (clone_dir, _bare_dir, worktree_path) =
-        setup_worktree_fixture("restage-after-ci");
+    let (clone_dir, _bare_dir, worktree_path) = setup_worktree_fixture("restage-after-ci");
     let clone_path = clone_dir.path();
     let wt_str = worktree_path.to_str().unwrap();
 
@@ -1920,8 +1919,7 @@ exit 0
     fs::write(&bin_test, auto_fix_script).unwrap();
     #[cfg(unix)]
     {
-        fs::set_permissions(&bin_test, fs::Permissions::from_mode(0o755))
-            .unwrap();
+        fs::set_permissions(&bin_test, fs::Permissions::from_mode(0o755)).unwrap();
     }
     git_assert_ok(
         &Command::new("git")
@@ -1961,8 +1959,7 @@ exit 0
         .output()
         .unwrap();
     git_assert_ok(&pre_fix_output);
-    let pre_fix_bytes =
-        String::from_utf8_lossy(&pre_fix_output.stdout).to_string();
+    let pre_fix_bytes = String::from_utf8_lossy(&pre_fix_output.stdout).to_string();
     let expected_post_fix_bytes = format!("{}\n", pre_fix_bytes);
 
     let msg_path = worktree_path.join(".flow-commit-msg");
@@ -1984,8 +1981,7 @@ exit 0
         .output()
         .unwrap();
     git_assert_ok(&head_readme);
-    let committed_bytes =
-        String::from_utf8_lossy(&head_readme.stdout).to_string();
+    let committed_bytes = String::from_utf8_lossy(&head_readme.stdout).to_string();
     assert_eq!(
         committed_bytes, expected_post_fix_bytes,
         "commit must capture post-CI bytes (re-staged) — pre={:?}, expected_post={:?}, committed={:?}",
@@ -2002,8 +1998,7 @@ exit 0
 /// includes.
 #[test]
 fn finalize_commit_restage_noop_when_ci_leaves_working_tree_clean() {
-    let (clone_dir, _bare_dir, worktree_path) =
-        setup_worktree_fixture("restage-noop");
+    let (clone_dir, _bare_dir, worktree_path) = setup_worktree_fixture("restage-noop");
     let clone_path = clone_dir.path();
     let wt_str = worktree_path.to_str().unwrap();
 
@@ -2028,8 +2023,7 @@ fn finalize_commit_restage_noop_when_ci_leaves_working_tree_clean() {
     // which resolves under `.flow-states/<branch>/`; the test
     // fixture follows the same convention here so the no-op
     // invariant is exercised against the path the model uses.
-    let branch_state_dir =
-        clone_path.join(".flow-states").join("restage-noop");
+    let branch_state_dir = clone_path.join(".flow-states").join("restage-noop");
     fs::create_dir_all(&branch_state_dir).unwrap();
     let msg_path = branch_state_dir.join("commit-msg.txt");
     fs::write(&msg_path, "Add source.rs (no-op re-stage test).").unwrap();
@@ -2049,8 +2043,7 @@ fn finalize_commit_restage_noop_when_ci_leaves_working_tree_clean() {
         .output()
         .unwrap();
     git_assert_ok(&head_source);
-    let committed_bytes =
-        String::from_utf8_lossy(&head_source.stdout).to_string();
+    let committed_bytes = String::from_utf8_lossy(&head_source.stdout).to_string();
     assert_eq!(
         committed_bytes, staged_bytes,
         "committed bytes must match staged bytes when CI does not modify",
@@ -2106,8 +2099,7 @@ exec /usr/bin/git -C "$REPO_PATH" "$SUBCMD" "$@"
     fs::write(&git_path, script).unwrap();
     #[cfg(unix)]
     {
-        fs::set_permissions(&git_path, fs::Permissions::from_mode(0o755))
-            .unwrap();
+        fs::set_permissions(&git_path, fs::Permissions::from_mode(0o755)).unwrap();
     }
     stubs
 }
@@ -2116,13 +2108,22 @@ exec /usr/bin/git -C "$REPO_PATH" "$SUBCMD" "$@"
 /// re-stage. Skips CI via the sentinel, installs a `git` stub on
 /// PATH that fails on `add` invocations, and runs finalize-commit
 /// as a subprocess so the stub is reachable. Asserts the structured
-/// `step:"restage"` error envelope.
+/// `step:"restage"` error envelope AND the post-error side effect:
+/// the error-tail path at the end of `run_impl` must clear
+/// `_continue_pending` and `_continue_context` for every error
+/// status, restage included. Mirrors the assertion shape of the
+/// sibling `error_clears_continue_pending` test for the ci-fail
+/// branch so the restage-failure path is locked into the same
+/// state-clearing contract.
 #[test]
 fn finalize_commit_restage_failure_returns_step_restage() {
-    let (clone_dir, _bare_dir, worktree_path) =
-        setup_worktree_fixture("restage-fail");
+    let (clone_dir, _bare_dir, worktree_path) = setup_worktree_fixture("restage-fail");
     let clone_path = clone_dir.path();
     let wt_str = worktree_path.to_str().unwrap();
+
+    // Seed _continue_pending="commit" so the post-error clearing
+    // assertion below has something to verify.
+    write_state_with_continue_pending(clone_path, "restage-fail");
 
     let staged_path = worktree_path.join("feature.rs");
     fs::write(&staged_path, "fn main() {}\n").unwrap();
@@ -2140,13 +2141,7 @@ fn finalize_commit_restage_failure_returns_step_restage() {
 
     let stubs = write_git_add_failing_stub(clone_path);
 
-    let output = run_finalize_with_stub(
-        clone_path,
-        &msg_path,
-        "restage-fail",
-        &stubs,
-        &[],
-    );
+    let output = run_finalize_with_stub(clone_path, &msg_path, "restage-fail", &stubs, &[]);
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let result = last_json_line(&stdout);
 
@@ -2160,6 +2155,102 @@ fn finalize_commit_restage_failure_returns_step_restage() {
         "restage error message must be non-empty, got: {:?}",
         msg,
     );
+
+    // Verify the error-tail clearing fires on the restage-failure
+    // path. The stop-continue hook reads _continue_pending —
+    // leaving "commit" set after an error would force-advance the
+    // parent phase past the failed commit.
+    let state = read_state(clone_path, "restage-fail");
+    let pending = state
+        .get("_continue_pending")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert!(
+        pending.is_empty(),
+        "_continue_pending must be cleared on restage error, got: {:?}",
+        pending,
+    );
+    let ctx = state
+        .get("_continue_context")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert!(
+        ctx.is_empty(),
+        "_continue_context must be cleared on restage error, got: {:?}",
+        ctx,
+    );
+}
+
+/// Regression test: `git add -u` (the re-stage primitive) updates
+/// already-tracked files only. An untracked, non-gitignored file
+/// present in the worktree when CI completes must NOT land in the
+/// commit's tree — the bound prevents the re-stage from silently
+/// sweeping scratch files, generated artifacts, or editor-temp
+/// files into commits the user never reviewed in
+/// `/flow:flow-commit` Round 4. Also asserts the worktree-root
+/// commit-message file (`.flow-commit-msg`) stays out of HEAD even
+/// though it lives at a non-gitignored path inside the worktree.
+#[test]
+fn finalize_commit_restage_does_not_sweep_untracked_artifacts() {
+    let (clone_dir, _bare_dir, worktree_path) = setup_worktree_fixture("restage-untracked-bound");
+    let clone_path = clone_dir.path();
+    let wt_str = worktree_path.to_str().unwrap();
+
+    // Stage a tracked source file so the commit has explicit
+    // user-staged content to land.
+    fs::write(worktree_path.join("feature.rs"), "fn main() {}\n").unwrap();
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", wt_str, "add", "feature.rs"])
+            .output()
+            .unwrap(),
+    );
+
+    // Drop an untracked, non-gitignored scratch file in the
+    // worktree. With `git add -A` this would sweep into HEAD; with
+    // `git add -u` it must not.
+    fs::write(
+        worktree_path.join("scratch-notes.txt"),
+        "unrelated leftover\n",
+    )
+    .unwrap();
+
+    let msg_path = worktree_path.join(".flow-commit-msg");
+    fs::write(&msg_path, "Add feature.rs (untracked-bound test).").unwrap();
+
+    write_ci_sentinel_for_worktree(clone_path, "restage-untracked-bound", &worktree_path);
+
+    let args = Args {
+        message_file: msg_path.to_str().unwrap().to_string(),
+        branch: "restage-untracked-bound".to_string(),
+    };
+    let result = run_impl(&args, clone_path).unwrap();
+    assert_eq!(result["status"], "ok", "got: {}", result);
+
+    // Assert HEAD's tree does NOT include the untracked scratch
+    // file or the worktree-root commit-message file.
+    let tree_listing = Command::new("git")
+        .args(["-C", wt_str, "ls-tree", "-r", "--name-only", "HEAD"])
+        .output()
+        .unwrap();
+    git_assert_ok(&tree_listing);
+    let names = String::from_utf8_lossy(&tree_listing.stdout).to_string();
+    let listed: Vec<&str> = names.lines().collect();
+    assert!(
+        !listed.contains(&"scratch-notes.txt"),
+        "HEAD must not include untracked scratch file; tree was: {}",
+        names,
+    );
+    assert!(
+        !listed.contains(&".flow-commit-msg"),
+        "HEAD must not include untracked commit-message file; tree was: {}",
+        names,
+    );
+    assert!(
+        listed.contains(&"feature.rs"),
+        "HEAD must include the user-staged feature.rs; tree was: {}",
+        names,
+    );
 }
 
 /// Locks the invariant that the pre-existing working-tree-dirty gate
@@ -2169,8 +2260,7 @@ fn finalize_commit_restage_failure_returns_step_restage() {
 /// tree's unstaged edits in the commit; this test catches that.
 #[test]
 fn finalize_commit_working_tree_dirty_gate_still_fires_pre_ci() {
-    let (clone_dir, _bare_dir, worktree_path) =
-        setup_worktree_fixture("dirty-pre-ci");
+    let (clone_dir, _bare_dir, worktree_path) = setup_worktree_fixture("dirty-pre-ci");
     let clone_path = clone_dir.path();
     let wt_str = worktree_path.to_str().unwrap();
 
@@ -2192,8 +2282,7 @@ fn finalize_commit_working_tree_dirty_gate_still_fires_pre_ci() {
 
     // Modify the working tree without staging — index still has the
     // baseline bytes, working tree has different bytes.
-    fs::write(worktree_path.join("README.md"), "unstaged user edit\n")
-        .unwrap();
+    fs::write(worktree_path.join("README.md"), "unstaged user edit\n").unwrap();
 
     let msg_path = worktree_path.join(".flow-commit-msg");
     fs::write(&msg_path, "Baseline + dirty tree.").unwrap();
@@ -2216,8 +2305,7 @@ fn finalize_commit_working_tree_dirty_gate_still_fires_pre_ci() {
 /// (must not be swept)".
 #[test]
 fn finalize_commit_restage_respects_gitignore_for_ci_artifacts() {
-    let (clone_dir, _bare_dir, worktree_path) =
-        setup_worktree_fixture("restage-gitignore");
+    let (clone_dir, _bare_dir, worktree_path) = setup_worktree_fixture("restage-gitignore");
     let clone_path = clone_dir.path();
     let wt_str = worktree_path.to_str().unwrap();
 
@@ -2250,8 +2338,7 @@ exit 0
     fs::write(&bin_test, artifact_script).unwrap();
     #[cfg(unix)]
     {
-        fs::set_permissions(&bin_test, fs::Permissions::from_mode(0o755))
-            .unwrap();
+        fs::set_permissions(&bin_test, fs::Permissions::from_mode(0o755)).unwrap();
     }
     git_assert_ok(
         &Command::new("git")
@@ -2261,7 +2348,13 @@ exit 0
     );
     git_assert_ok(
         &Command::new("git")
-            .args(["-C", wt_str, "commit", "-m", "Configure artifact-emitting bin/test"])
+            .args([
+                "-C",
+                wt_str,
+                "commit",
+                "-m",
+                "Configure artifact-emitting bin/test",
+            ])
             .output()
             .unwrap(),
     );
@@ -2301,8 +2394,7 @@ exit 0
         .output()
         .unwrap();
     git_assert_ok(&head_source);
-    let committed_bytes =
-        String::from_utf8_lossy(&head_source.stdout).to_string();
+    let committed_bytes = String::from_utf8_lossy(&head_source.stdout).to_string();
     assert_eq!(
         committed_bytes, staged_bytes,
         "committed bytes must match staged bytes",


### PR DESCRIPTION
## What

/flow:flow-start #1683.

Closes #1683

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/finalize-commit-doesnt-re-stage/log` |
| State | `.flow-states/finalize-commit-doesnt-re-stage/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/b0dc724a-f55c-4085-951a-c2a6ca152378.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 18m |
| Review | 24m |
| Learn | 3m |
| Complete | <1m |
| **Total** | **46m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 3.6M | $0.939 |
| Code | 64.5M | $20.946 |
| Review | 86.0M | $48.311 |
| Learn | 15.2M | $5.160 |
| Complete | 3.3M | $0.838 |
| **Total** | **172.6M** | **$76.194** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **Reviewer: plan missing Gate Consumer Enumeration Table for step:restage**
  - Dismissed — Reviewer's own consumer audit confirms SKILL.md:273's generic error handler covers the new step value with no code change required; the procedural gap in the plan is a Learn-phase concern, not a Review code fix
- ✗ **Reviewer: batching decision not logged via bin/flow log**
  - Dismissed — The batching decision was logged via 'bin/flow log finalize-commit-doesnt-re-stage [Phase 2] Batch decision...' at the start of Phase 2 before any commit landed; the reviewer agent lacked access to the state log file and could not verify
- ✗ **Pre-Mortem: .expect() on git add -A panics on transient git failures**
  - Dismissed — Matches the existing .expect pattern in the same function for git diff --cached (line 367 of pre-fix code) with the same working_tree_dirty-gate justification; converting all .expect() in run_impl to fallible match arms is a separate structural change out of scope for this PR
- ✗ **Pre-Mortem: plan-deviation gate consumes post-stage diff**
  - Dismissed — Speculative — the gate already documents single-line-literal v1 limit per .claude/rules/plan-commit-atomicity.md; the central fix (git add -u rather than -A) shrinks the diff surface to tracked-file modifications, which are the same surface the gate was designed to scan; no concrete bug demonstrated
- ✓ **Reviewer/Pre-Mortem/Adversarial: unbounded git add -A sweep includes untracked non-gitignored files**
  - Fixed — Changed git add -A to git add -u in src/finalize_commit.rs so the post-CI re-stage updates already-tracked files only; untracked artifacts (commit-message files, scratch files, CI outputs not yet gitignored) are no longer swept into the commit. Added regression test finalize_commit_restage_does_not_sweep_untracked_artifacts that fails under -A and passes under -u.
- ✓ **Reviewer: SKILL.md prose narrows scope to format/lint while implementation re-stages any tracked-file modification**
  - Fixed — Updated Round 5 prose in skills/flow-commit/SKILL.md to describe the scope precisely: tracked-file modifications by any CI tool (no longer 'format or lint'), captured via git add -u. Added explicit note that untracked files are NOT swept.
- ✓ **Reviewer: finalize_commit_restage_failure_returns_step_restage does not assert _continue_pending clearing**
  - Fixed — Extended the test to seed _continue_pending=commit before the run and assert both _continue_pending and _continue_context are cleared after the restage-failure error envelope returns. Locks the contract that the error-tail clearing fires on the new restage-failure path as it does for ci-fail.
- ✓ **Documentation: docs/skills/flow-commit.md does not reflect new post-CI re-staging behavior**
  - Fixed — Added a Re-staging section to docs/skills/flow-commit.md describing the git add -u re-stage, the motivation (auto-fix capture), the bound (tracked files only — no untracked sweep), and the failure mode (step:restage error envelope). Extended the What It Does step 4 and Gates list to mention the re-stage.
- ✓ **Documentation: inline .expect() comment references line 257 which will drift on refactor**
  - Fixed — Replaced the line-number reference with a named-guard reference: 'The working_tree_dirty gate above already proved git is alive' instead of 'The working_tree_dirty gate at line 257'. Survives any future reordering because it names the guard by its logical identity rather than its physical location.

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/finalize-commit-doesnt-re-stage.json</summary>

```json
{
  "schema_version": 1,
  "branch": "finalize-commit-doesnt-re-stage",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1701,
  "pr_url": "https://github.com/benkruger/flow/pull/1701",
  "started_at": "2026-05-23T14:10:25-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/finalize-commit-doesnt-re-stage/log",
    "state": ".flow-states/finalize-commit-doesnt-re-stage/state.json"
  },
  "session_tty": "/dev/ttys012",
  "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/b0dc724a-f55c-4085-951a-c2a6ca152378.jsonl",
  "notes": [],
  "prompt": "/flow:flow-start #1683",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-23T14:10:25-07:00",
      "completed_at": "2026-05-23T14:11:06-07:00",
      "session_started_at": null,
      "cumulative_seconds": 41,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-23T14:10:25-07:00",
        "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
        "model": "claude-opus-4-7",
        "five_hour_pct": 53,
        "seven_day_pct": 22,
        "session_input_tokens": 31,
        "session_output_tokens": 4156,
        "session_cache_creation_tokens": 482056,
        "session_cache_read_tokens": 1025533,
        "session_cost_usd": 25.478473249999997,
        "by_model": {
          "claude-opus-4-7": {
            "input": 31,
            "output": 4156,
            "cache_create": 482056,
            "cache_read": 1025533
          }
        },
        "turn_count": 6,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 254419,
        "context_window_pct": 127.2095
      },
      "window_at_complete": {
        "captured_at": "2026-05-23T14:11:06-07:00",
        "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
        "model": "claude-opus-4-7",
        "five_hour_pct": 53,
        "seven_day_pct": 22,
        "session_input_tokens": 45,
        "session_output_tokens": 7003,
        "session_cache_creation_tokens": 486177,
        "session_cache_read_tokens": 4598754,
        "session_cost_usd": 26.41771925,
        "by_model": {
          "claude-opus-4-7": {
            "input": 45,
            "output": 7003,
            "cache_create": 486177,
            "cache_read": 4598754
          }
        },
        "turn_count": 20,
        "tool_call_count": 10,
        "context_at_last_turn_tokens": 256499,
        "context_window_pct": 128.2495
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-23T14:11:18-07:00",
      "completed_at": "2026-05-23T14:29:26-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1088,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-23T14:11:18-07:00",
        "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
        "model": "claude-opus-4-7",
        "five_hour_pct": 53,
        "seven_day_pct": 22,
        "session_input_tokens": 57,
        "session_output_tokens": 7833,
        "session_cache_creation_tokens": 504933,
        "session_cache_read_tokens": 5625192,
        "session_cost_usd": 26.74334625,
        "by_model": {
          "claude-opus-4-7": {
            "input": 57,
            "output": 7833,
            "cache_create": 504933,
            "cache_read": 5625192
          }
        },
        "turn_count": 24,
        "tool_call_count": 12,
        "context_at_last_turn_tokens": 265881,
        "context_window_pct": 132.9405
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-23T14:16:09-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 55,
          "seven_day_pct": 22,
          "session_input_tokens": 100,
          "session_output_tokens": 48731,
          "session_cache_creation_tokens": 1276922,
          "session_cache_read_tokens": 24579203,
          "session_cost_usd": 34.2312575,
          "by_model": {
            "claude-opus-4-7": {
              "input": 100,
              "output": 48731,
              "cache_create": 1276922,
              "cache_read": 24579203
            }
          },
          "turn_count": 67,
          "tool_call_count": 36,
          "context_at_last_turn_tokens": 541706,
          "context_window_pct": 270.853
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-23T14:18:52-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 55,
          "seven_day_pct": 22,
          "session_input_tokens": 123,
          "session_output_tokens": 67589,
          "session_cache_creation_tokens": 1332578,
          "session_cache_read_tokens": 37249405,
          "session_cost_usd": 38.2252265,
          "by_model": {
            "claude-opus-4-7": {
              "input": 123,
              "output": 67589,
              "cache_create": 1332578,
              "cache_read": 37249405
            }
          },
          "turn_count": 90,
          "tool_call_count": 49,
          "context_at_last_turn_tokens": 567140,
          "context_window_pct": 283.57
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-23T14:19:15-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 55,
          "seven_day_pct": 22,
          "session_input_tokens": 126,
          "session_output_tokens": 69166,
          "session_cache_creation_tokens": 1335612,
          "session_cache_read_tokens": 38951714,
          "session_cost_usd": 38.83829849999999,
          "by_model": {
            "claude-opus-4-7": {
              "input": 126,
              "output": 69166,
              "cache_create": 1335612,
              "cache_read": 38951714
            }
          },
          "turn_count": 93,
          "tool_call_count": 51,
          "context_at_last_turn_tokens": 568880,
          "context_window_pct": 284.44
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-23T14:20:10-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 55,
          "seven_day_pct": 22,
          "session_input_tokens": 132,
          "session_output_tokens": 77992,
          "session_cache_creation_tokens": 1340791,
          "session_cache_read_tokens": 42369616,
          "session_cost_usd": 40.08896375,
          "by_model": {
            "claude-opus-4-7": {
              "input": 132,
              "output": 77992,
              "cache_create": 1340791,
              "cache_read": 42369616
            }
          },
          "turn_count": 99,
          "tool_call_count": 55,
          "context_at_last_turn_tokens": 573185,
          "context_window_pct": 286.5925
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-23T14:22:39-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 56,
          "seven_day_pct": 22,
          "session_input_tokens": 139,
          "session_output_tokens": 106481,
          "session_cache_creation_tokens": 1354099,
          "session_cache_read_tokens": 46405701,
          "session_cost_usd": 41.604743,
          "by_model": {
            "claude-opus-4-7": {
              "input": 139,
              "output": 106481,
              "cache_create": 1354099,
              "cache_read": 46405701
            }
          },
          "turn_count": 106,
          "tool_call_count": 59,
          "context_at_last_turn_tokens": 585344,
          "context_window_pct": 292.672
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-23T14:22:39-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 56,
          "seven_day_pct": 22,
          "session_input_tokens": 139,
          "session_output_tokens": 106481,
          "session_cache_creation_tokens": 1354099,
          "session_cache_read_tokens": 46405701,
          "session_cost_usd": 41.604743,
          "by_model": {
            "claude-opus-4-7": {
              "input": 139,
              "output": 106481,
              "cache_create": 1354099,
              "cache_read": 46405701
            }
          },
          "turn_count": 106,
          "tool_call_count": 59,
          "context_at_last_turn_tokens": 585344,
          "context_window_pct": 292.672
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-23T14:22:39-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 56,
          "seven_day_pct": 22,
          "session_input_tokens": 139,
          "session_output_tokens": 106481,
          "session_cache_creation_tokens": 1354099,
          "session_cache_read_tokens": 46405701,
          "session_cost_usd": 41.604743,
          "by_model": {
            "claude-opus-4-7": {
              "input": 139,
              "output": 106481,
              "cache_create": 1354099,
              "cache_read": 46405701
            }
          },
          "turn_count": 106,
          "tool_call_count": 59,
          "context_at_last_turn_tokens": 585344,
          "context_window_pct": 292.672
        },
        {
          "step": 8,
          "field": "code_task",
          "captured_at": "2026-05-23T14:22:39-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 56,
          "seven_day_pct": 22,
          "session_input_tokens": 139,
          "session_output_tokens": 106481,
          "session_cache_creation_tokens": 1354099,
          "session_cache_read_tokens": 46405701,
          "session_cost_usd": 41.604743,
          "by_model": {
            "claude-opus-4-7": {
              "input": 139,
              "output": 106481,
              "cache_create": 1354099,
              "cache_read": 46405701
            }
          },
          "turn_count": 106,
          "tool_call_count": 59,
          "context_at_last_turn_tokens": 585344,
          "context_window_pct": 292.672
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-23T14:29:26-07:00",
        "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
        "model": "claude-opus-4-7",
        "five_hour_pct": 57,
        "seven_day_pct": 23,
        "session_input_tokens": 195,
        "session_output_tokens": 130116,
        "session_cache_creation_tokens": 1420919,
        "session_cache_read_tokens": 69074563,
        "session_cost_usd": 47.689088,
        "by_model": {
          "claude-opus-4-7": {
            "input": 195,
            "output": 130116,
            "cache_create": 1420919,
            "cache_read": 69074563
          }
        },
        "turn_count": 144,
        "tool_call_count": 78,
        "context_at_last_turn_tokens": 616980,
        "context_window_pct": 308.49
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-23T14:29:35-07:00",
      "completed_at": "2026-05-23T14:53:57-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1462,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-23T14:29:35-07:00",
        "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
        "model": "claude-opus-4-7",
        "five_hour_pct": 57,
        "seven_day_pct": 23,
        "session_input_tokens": 207,
        "session_output_tokens": 130924,
        "session_cache_creation_tokens": 1453797,
        "session_cache_read_tokens": 71543051,
        "session_cost_usd": 48.41908375,
        "by_model": {
          "claude-opus-4-7": {
            "input": 207,
            "output": 130924,
            "cache_create": 1453797,
            "cache_read": 71543051
          }
        },
        "turn_count": 148,
        "tool_call_count": 80,
        "context_at_last_turn_tokens": 633423,
        "context_window_pct": 316.7115
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-23T14:30:20-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 57,
          "seven_day_pct": 23,
          "session_input_tokens": 218,
          "session_output_tokens": 133801,
          "session_cache_creation_tokens": 1456515,
          "session_cache_read_tokens": 78521893,
          "session_cost_usd": 51.0142425,
          "by_model": {
            "claude-opus-4-7": {
              "input": 218,
              "output": 133801,
              "cache_create": 1456515,
              "cache_read": 78521893
            }
          },
          "turn_count": 159,
          "tool_call_count": 88,
          "context_at_last_turn_tokens": 635580,
          "context_window_pct": 317.79
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-23T14:36:51-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 65,
          "seven_day_pct": 24,
          "session_input_tokens": 261,
          "session_output_tokens": 171745,
          "session_cache_creation_tokens": 1558000,
          "session_cache_read_tokens": 90305884,
          "session_cost_usd": 74.99842114999997,
          "by_model": {
            "claude-opus-4-7": {
              "input": 261,
              "output": 171745,
              "cache_create": 1558000,
              "cache_read": 90305884
            }
          },
          "turn_count": 177,
          "tool_call_count": 101,
          "context_at_last_turn_tokens": 675124,
          "context_window_pct": 337.562
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-23T14:39:06-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 65,
          "seven_day_pct": 24,
          "session_input_tokens": 284,
          "session_output_tokens": 197002,
          "session_cache_creation_tokens": 1615364,
          "session_cache_read_tokens": 95797565,
          "session_cost_usd": 77.45440864999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 284,
              "output": 197002,
              "cache_create": 1615364,
              "cache_read": 95797565
            }
          },
          "turn_count": 185,
          "tool_call_count": 107,
          "context_at_last_turn_tokens": 700436,
          "context_window_pct": 350.218
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-23T14:53:42-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 67,
          "seven_day_pct": 24,
          "session_input_tokens": 386,
          "session_output_tokens": 254484,
          "session_cache_creation_tokens": 1771925,
          "session_cache_read_tokens": 154006882,
          "session_cost_usd": 95.45985115,
          "by_model": {
            "claude-opus-4-7": {
              "input": 386,
              "output": 254484,
              "cache_create": 1771925,
              "cache_read": 154006882
            }
          },
          "turn_count": 264,
          "tool_call_count": 153,
          "context_at_last_turn_tokens": 764986,
          "context_window_pct": 382.493
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-23T14:36:32-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-23T14:36:37-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-23T14:36:42-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-23T14:36:46-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-23T14:53:57-07:00",
        "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
        "model": "claude-opus-4-7",
        "five_hour_pct": 67,
        "seven_day_pct": 24,
        "session_input_tokens": 400,
        "session_output_tokens": 255084,
        "session_cache_creation_tokens": 1804612,
        "session_cache_read_tokens": 157084090,
        "session_cost_usd": 96.7304019,
        "by_model": {
          "claude-opus-4-7": {
            "input": 400,
            "output": 255084,
            "cache_create": 1804612,
            "cache_read": 157084090
          }
        },
        "turn_count": 268,
        "tool_call_count": 156,
        "context_at_last_turn_tokens": 781647,
        "context_window_pct": 390.8235
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-23T14:54:08-07:00",
      "completed_at": "2026-05-23T14:57:21-07:00",
      "session_started_at": null,
      "cumulative_seconds": 193,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-23T14:54:08-07:00",
        "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
        "model": "claude-opus-4-7",
        "five_hour_pct": 67,
        "seven_day_pct": 24,
        "session_input_tokens": 412,
        "session_output_tokens": 255894,
        "session_cache_creation_tokens": 1834270,
        "session_cache_read_tokens": 160211042,
        "session_cost_usd": 97.61497615,
        "by_model": {
          "claude-opus-4-7": {
            "input": 412,
            "output": 255894,
            "cache_create": 1834270,
            "cache_read": 160211042
          }
        },
        "turn_count": 272,
        "tool_call_count": 158,
        "context_at_last_turn_tokens": 796480,
        "context_window_pct": 398.24
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-23T14:56:33-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-23T14:56:46-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 67,
          "seven_day_pct": 24,
          "session_input_tokens": 424,
          "session_output_tokens": 262555,
          "session_cache_creation_tokens": 1844171,
          "session_cache_read_tokens": 169790228,
          "session_cost_usd": 101.5206535,
          "by_model": {
            "claude-opus-4-7": {
              "input": 424,
              "output": 262555,
              "cache_create": 1844171,
              "cache_read": 169790228
            }
          },
          "turn_count": 284,
          "tool_call_count": 165,
          "context_at_last_turn_tokens": 801568,
          "context_window_pct": 400.784
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-23T14:56:46-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 67,
          "seven_day_pct": 24,
          "session_input_tokens": 424,
          "session_output_tokens": 262555,
          "session_cache_creation_tokens": 1844171,
          "session_cache_read_tokens": 169790228,
          "session_cost_usd": 101.5206535,
          "by_model": {
            "claude-opus-4-7": {
              "input": 424,
              "output": 262555,
              "cache_create": 1844171,
              "cache_read": 169790228
            }
          },
          "turn_count": 284,
          "tool_call_count": 165,
          "context_at_last_turn_tokens": 801568,
          "context_window_pct": 400.784
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-23T14:56:46-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 67,
          "seven_day_pct": 24,
          "session_input_tokens": 424,
          "session_output_tokens": 262555,
          "session_cache_creation_tokens": 1844171,
          "session_cache_read_tokens": 169790228,
          "session_cost_usd": 101.5206535,
          "by_model": {
            "claude-opus-4-7": {
              "input": 424,
              "output": 262555,
              "cache_create": 1844171,
              "cache_read": 169790228
            }
          },
          "turn_count": 284,
          "tool_call_count": 165,
          "context_at_last_turn_tokens": 801568,
          "context_window_pct": 400.784
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-23T14:57:10-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 68,
          "seven_day_pct": 24,
          "session_input_tokens": 429,
          "session_output_tokens": 265245,
          "session_cache_creation_tokens": 1846651,
          "session_cache_read_tokens": 173800838,
          "session_cost_usd": 102.35368675,
          "by_model": {
            "claude-opus-4-7": {
              "input": 429,
              "output": 265245,
              "cache_create": 1846651,
              "cache_read": 173800838
            }
          },
          "turn_count": 289,
          "tool_call_count": 167,
          "context_at_last_turn_tokens": 802703,
          "context_window_pct": 401.3515
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-23T14:57:10-07:00",
          "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
          "model": "claude-opus-4-7",
          "five_hour_pct": 68,
          "seven_day_pct": 24,
          "session_input_tokens": 429,
          "session_output_tokens": 265245,
          "session_cache_creation_tokens": 1846651,
          "session_cache_read_tokens": 173800838,
          "session_cost_usd": 102.35368675,
          "by_model": {
            "claude-opus-4-7": {
              "input": 429,
              "output": 265245,
              "cache_create": 1846651,
              "cache_read": 173800838
            }
          },
          "turn_count": 289,
          "tool_call_count": 167,
          "context_at_last_turn_tokens": 802703,
          "context_window_pct": 401.3515
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-23T14:57:21-07:00",
        "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
        "model": "claude-opus-4-7",
        "five_hour_pct": 68,
        "seven_day_pct": 24,
        "session_input_tokens": 431,
        "session_output_tokens": 266449,
        "session_cache_creation_tokens": 1848315,
        "session_cache_read_tokens": 175406242,
        "session_cost_usd": 102.77529275,
        "by_model": {
          "claude-opus-4-7": {
            "input": 431,
            "output": 266449,
            "cache_create": 1848315,
            "cache_read": 175406242
          }
        },
        "turn_count": 291,
        "tool_call_count": 168,
        "context_at_last_turn_tokens": 803535,
        "context_window_pct": 401.7675
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-23T14:57:47-07:00",
      "completed_at": "2026-05-23T14:58:09-07:00",
      "session_started_at": null,
      "cumulative_seconds": 22,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-23T14:57:47-07:00",
        "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
        "model": "claude-opus-4-7",
        "five_hour_pct": 68,
        "seven_day_pct": 24,
        "session_input_tokens": 447,
        "session_output_tokens": 268245,
        "session_cache_creation_tokens": 1875921,
        "session_cache_read_tokens": 181889090,
        "session_cost_usd": 104.5047635,
        "by_model": {
          "claude-opus-4-7": {
            "input": 447,
            "output": 268245,
            "cache_create": 1875921,
            "cache_read": 181889090
          }
        },
        "turn_count": 299,
        "tool_call_count": 172,
        "context_at_last_turn_tokens": 817338,
        "context_window_pct": 408.669
      },
      "window_at_complete": {
        "captured_at": "2026-05-23T14:58:09-07:00",
        "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
        "model": "claude-opus-4-7",
        "five_hour_pct": 68,
        "seven_day_pct": 24,
        "session_input_tokens": 451,
        "session_output_tokens": 269572,
        "session_cache_creation_tokens": 1877518,
        "session_cache_read_tokens": 185158844,
        "session_cost_usd": 105.34254475000002,
        "by_model": {
          "claude-opus-4-7": {
            "input": 451,
            "output": 269572,
            "cache_create": 1877518,
            "cache_read": 185158844
          }
        },
        "turn_count": 303,
        "tool_call_count": 174,
        "context_at_last_turn_tokens": 818123,
        "context_window_pct": 409.0615
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-23T14:11:18-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-23T14:29:35-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-23T14:54:08-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-23T14:57:47-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-23T14:10:25-07:00",
    "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
    "model": "claude-opus-4-7",
    "five_hour_pct": 53,
    "seven_day_pct": 22,
    "session_input_tokens": 31,
    "session_output_tokens": 4156,
    "session_cache_creation_tokens": 482056,
    "session_cache_read_tokens": 1025533,
    "session_cost_usd": 25.478473249999997,
    "by_model": {
      "claude-opus-4-7": {
        "input": 31,
        "output": 4156,
        "cache_create": 482056,
        "cache_read": 1025533
      }
    },
    "turn_count": 6,
    "tool_call_count": 3,
    "context_at_last_turn_tokens": 254419,
    "context_window_pct": 127.2095
  },
  "code_tasks_total": 8,
  "code_task_name": "Task 8: gitignore-respect topology test (final task)",
  "code_task": 8,
  "diff_stats": {
    "files_changed": 3,
    "insertions": 540,
    "deletions": 50,
    "captured_at": "2026-05-23T14:29:26-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThis conversation is about auditing a completed FLOW PR during the Learn phase. The user's intent is clearly stated at the beginning: audit the PR for the `finalize-commit-doesnt-re-stage` branch against three tenants (Tenant 1: did FLOW process work, Tenant 2: did Claude follow the rules, Tenant 3: what rules should exist but don't) using a two-gate filter to decide what findings to report.\n\nThe user provided extensive context through system reminders that are loads of FLOW rule files (.claude/rules/) covering everything from subprocess test hygiene, coverage requirements, scope expansion, hook discipline, and many other technical and process governance rules. These were loaded after the initial summary was provided.\n\nKey observation: The user explicitly requested \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools\" at the very end, and stated that tool calls would be REJECTED and waste the only turn. This is a constraint I must follow absolutely.\n\nThe conversation consists of:\n1. An initial summary describing a completed PR that implemented a post-CI re-stage mechanism for the finalize-commit command\n2. A massive set of system reminders loading all the FLOW rule files as context\n3. A Read tool call that loaded the skill-authoring rules file (noted in the system reminder at the top)\n4. A final critical instruction to respond with TEXT ONLY and create a summary\n\nThe completed work was:\n- A PR that added `git add -u` call in finalize_commit after CI completes (lines 348-361 in src/finalize_commit.rs)\n- Updated module doc to document this re-stage step\n- Added five regression tests to lock the behavior\n- Updated SKILL.md prose to document the behavior for users\n\nThe user's explicit request is to audit this PR using the two-gate filter and report findings only where:\n1. The principle is forward-facing and would help future sessions\n2. The gap was NOT caught and remediated in this PR\n\nThe summary at the beginning indicated all work was completed through Phase 3 Review with CI passing. The state shows the PR implementation is complete.\n\nThe user then loaded extensive rule context and finally asks for a summary with no tool usage allowed.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user requested an audit of a completed FLOW PR for the `finalize-commit-doesnt-re-stage` branch during the Learn phase. The audit should evaluate the PR against three tenants:\n   - Tenant 1: Did the FLOW process work? (gaps in workflow/tools/skills/hooks/gates)\n   - Tenant 2: Did Claude follow the rules? (CLAUDE.md/.claude/rules/ compliance)\n   - Tenant 3: What rules should exist but don't?\n   \n   The user explicitly defined a two-gate filter for findings:\n   - Gate 1 (Forward-facing): Would a future session understand and apply this principle? If no, drop.\n   - Gate 2 (Value): Was the gap caught and remediated in this PR? If yes, drop (system already closed it).\n   \n   User emphasized: \"No findings in any category is the most common correct answer. Return only findings that pass both gates.\"\n\n2. Key Technical Concepts:\n   - FLOW lifecycle: 5-phase workflow (Start, Code, Review, Learn, Complete)\n   - Post-CI re-stage mechanism: `git add -u` inserted after CI completes to capture auto-fix modifications\n   - Phase gates and state mutations via `bin/flow` subcommands\n   - State file schema at `.flow-states/<branch>/state.json`\n   - 100% code coverage requirement with no waivers permitted\n   - Mechanical enforcement via hooks, rules, and contract tests\n   - Cognitive isolation of Review agents\n   - Plan-commit atomicity requirements\n   - Subprocess test hygiene and environment neutralization\n   - No escape hatches principle for security gates\n\n3. Files and Code Sections:\n   - `src/finalize_commit.rs`: Core implementation of post-CI re-stage\n     - Module doc block (lines 1-31): Updated to document the new re-stage step as \"Two gates and a post-CI re-stage\"\n     - `run_impl` function (lines 198-418): Inserted `git add -u` call between CI completion and plan-deviation gate (lines 348-361)\n     - New error envelope: `step:\"restage\"` added to JSON output contract\n     - Lines 323-325: `git diff --cached` capture moved after re-stage\n     - Lines 332-368: Plan-deviation match logic (unchanged structure, sees post-restage diff)\n   \n   - `skills/flow-commit/SKILL.md`: Updated Round 5 prose\n     - Lines 215-222: Replaced statement that files don't need re-staging with documentation that finalize-commit re-stages internally after CI via `git add -u`\n     - Explicitly notes that untracked files are NOT swept by re-stage, only modifications to already-tracked files\n   \n   - `tests/finalize_commit.rs`: Added five regression tests\n     - `finalize_commit_restages_after_ci_modifies_tracked_file`: Proves CI auto-fixes are re-staged\n     - `finalize_commit_restage_noop_when_ci_leaves_working_tree_clean`: Proves no-op behavior for checker-only projects\n     - `finalize_commit_restage_failure_returns_step_restage`: Tests failure path with `step:\"restage\"` envelope\n     - `finalize_commit_working_tree_dirty_gate_still_fires_pre_ci`: Locks invariant that pre-CI gate persists\n     - `finalize_commit_restage_respects_gitignore_for_ci_artifacts`: Tests `.gitignore` boundary for untracked files\n\n4. Errors and fixes:\n   No errors were reported during execution. The session log shows clean completion through Phase 3 Review with CI passing (`finalize-commit — ci (ok)`). Phase 2 includes a documented batching decision per `.claude/rules/plan-commit-atomicity.md` optimization-driven batching that combined Tasks 1-8 into one commit to satisfy the 100% coverage gate while maintaining per-task independence.\n\n5. Problem Solving:\n   The primary challenge solved was satisfying the 100% code coverage gate while maintaining atomicity. The Phase 2 log entry documents: \"Batch decision: combining Tasks 1-8 (atomic group 1-4 + parallel test additions 5-8) into one commit. Reason: Task 6 (restage-failure test) covers the only uncovered branch added by Task 2's implementation; without it, the commit-time CI gate (100% coverage) blocks the atomic-group commit. Each task remains independently shippable; no test assertion spans the boundary; the split would force a wasted 4-minute CI re-run against the same source snapshot.\"\n\n6. All user messages:\n   - Initial message: Framing statement establishing two-gate filter test for findings, emphasizing \"No findings in any category is the most common correct answer. Return only findings that pass both gates.\"\n   - Final message: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools. You already have all the context you need in the conversation above. Tool calls will be REJECTED and will waste your only turn — you will fail the task. Your entire response must be plain text: an <analysis> block followed by a <summary> block.\"\n\n7. Pending Tasks:\n   None explicitly pending. The PR execution is complete through Phase 3 Review.\n\n8. Current Work:\n   The immediate preceding work was the user providing extensive FLOW rule documentation as system reminders (all the .claude/rules/*.md files) to provide context for the audit. The user then issued the critical instruction to respond with TEXT ONLY and create this summary without using any tools. The conversation shows the PR is complete and ready for Learn phase audit/summary.\n\n9. Optional Next Step:\n   Based on the user's explicit two-gate filter and emphasis that \"No findings in any category is the most common correct answer,\" the next step would be to provide the Learn phase audit result. However, the user's current request is specifically for this summary in TEXT ONLY format with no tools. After the summary is delivered, the user may request the actual audit findings, but that should be addressed in the next turn if requested.\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/finalize-commit-doesnt-re-stage",
  "compact_count": 4,
  "findings": [
    {
      "finding": "Reviewer: plan missing Gate Consumer Enumeration Table for step:restage",
      "reason": "Reviewer's own consumer audit confirms SKILL.md:273's generic error handler covers the new step value with no code change required; the procedural gap in the plan is a Learn-phase concern, not a Review code fix",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T14:38:42-07:00"
    },
    {
      "finding": "Reviewer: batching decision not logged via bin/flow log",
      "reason": "The batching decision was logged via 'bin/flow log finalize-commit-doesnt-re-stage [Phase 2] Batch decision...' at the start of Phase 2 before any commit landed; the reviewer agent lacked access to the state log file and could not verify",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T14:38:48-07:00"
    },
    {
      "finding": "Pre-Mortem: .expect() on git add -A panics on transient git failures",
      "reason": "Matches the existing .expect pattern in the same function for git diff --cached (line 367 of pre-fix code) with the same working_tree_dirty-gate justification; converting all .expect() in run_impl to fallible match arms is a separate structural change out of scope for this PR",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T14:38:55-07:00"
    },
    {
      "finding": "Pre-Mortem: plan-deviation gate consumes post-stage diff",
      "reason": "Speculative — the gate already documents single-line-literal v1 limit per .claude/rules/plan-commit-atomicity.md; the central fix (git add -u rather than -A) shrinks the diff surface to tracked-file modifications, which are the same surface the gate was designed to scan; no concrete bug demonstrated",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T14:39:02-07:00"
    },
    {
      "finding": "Reviewer/Pre-Mortem/Adversarial: unbounded git add -A sweep includes untracked non-gitignored files",
      "reason": "Changed git add -A to git add -u in src/finalize_commit.rs so the post-CI re-stage updates already-tracked files only; untracked artifacts (commit-message files, scratch files, CI outputs not yet gitignored) are no longer swept into the commit. Added regression test finalize_commit_restage_does_not_sweep_untracked_artifacts that fails under -A and passes under -u.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T14:45:48-07:00"
    },
    {
      "finding": "Reviewer: SKILL.md prose narrows scope to format/lint while implementation re-stages any tracked-file modification",
      "reason": "Updated Round 5 prose in skills/flow-commit/SKILL.md to describe the scope precisely: tracked-file modifications by any CI tool (no longer 'format or lint'), captured via git add -u. Added explicit note that untracked files are NOT swept.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T14:45:54-07:00"
    },
    {
      "finding": "Reviewer: finalize_commit_restage_failure_returns_step_restage does not assert _continue_pending clearing",
      "reason": "Extended the test to seed _continue_pending=commit before the run and assert both _continue_pending and _continue_context are cleared after the restage-failure error envelope returns. Locks the contract that the error-tail clearing fires on the new restage-failure path as it does for ci-fail.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T14:46:02-07:00"
    },
    {
      "finding": "Documentation: docs/skills/flow-commit.md does not reflect new post-CI re-staging behavior",
      "reason": "Added a Re-staging section to docs/skills/flow-commit.md describing the git add -u re-stage, the motivation (auto-fix capture), the bound (tracked files only — no untracked sweep), and the failure mode (step:restage error envelope). Extended the What It Does step 4 and Gates list to mention the re-stage.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T14:46:08-07:00"
    },
    {
      "finding": "Documentation: inline .expect() comment references line 257 which will drift on refactor",
      "reason": "Replaced the line-number reference with a named-guard reference: 'The working_tree_dirty gate above already proved git is alive' instead of 'The working_tree_dirty gate at line 257'. Survives any future reordering because it names the guard by its logical identity rather than its physical location.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-23T14:46:15-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-23T14:58:09-07:00",
    "session_id": "b0dc724a-f55c-4085-951a-c2a6ca152378",
    "model": "claude-opus-4-7",
    "five_hour_pct": 68,
    "seven_day_pct": 24,
    "session_input_tokens": 451,
    "session_output_tokens": 269572,
    "session_cache_creation_tokens": 1877518,
    "session_cache_read_tokens": 185158844,
    "session_cost_usd": 105.34254475000002,
    "by_model": {
      "claude-opus-4-7": {
        "input": 451,
        "output": 269572,
        "cache_create": 1877518,
        "cache_read": 185158844
      }
    },
    "turn_count": 303,
    "tool_call_count": 174,
    "context_at_last_turn_tokens": 818123,
    "context_window_pct": 409.0615
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>