### PR TITLE
Autonomous Flow Stalls

### DIFF
--- a/.claude/rules/cognitive-isolation.md
+++ b/.claude/rules/cognitive-isolation.md
@@ -177,12 +177,14 @@ to the SKILL.md HARD-GATE in `skills/flow-review/SKILL.md` Step 2:
   never reaches the sub-agent's prompt, so the sub-agent never
   Reads it.
 - **Autonomous-flow-strict response shape** in
-  `src/hooks/validate_worktree_paths.rs::validate()` at the
-  existing out-of-worktree block path. When the flow is
+  `src/hooks/validate_worktree_paths.rs::validate()` at both
+  block surfaces (the in-project-but-out-of-worktree redirect
+  and the out-of-project fail-closed gate). When the flow is
   configured for autonomous execution (per
   `crate::flow_paths::is_autonomous_flow_active`), the hook
   returns a structured JSON envelope keyed on
-  `out_of_worktree_in_autonomous` instead of the
+  `out_of_worktree_in_autonomous` (out-of-worktree) or
+  `out_of_bounds_in_autonomous` (out-of-project) instead of the
   human-readable BLOCKED message. Both forms are exit-2 blocks
   fed back as a tool rejection (the block itself is identical);
   the `reason` field lets the autonomous flow classify the
@@ -190,14 +192,17 @@ to the SKILL.md HARD-GATE in `skills/flow-review/SKILL.md` Step 2:
   message, and serves as the stable detection anchor for a
   future system-initiated-prompt carve-out.
 
-Residual gap: paths outside `project_root` (`~/.config`, `/tmp`,
-`.venv` outside the worktree) remain in Claude Code's built-in
-permission jurisdiction at this hook layer. Closing the gap
-entirely requires either a Claude Code feature or a project
-`settings.json` allow-list extension. The retry-prompt
-HARD-GATE is the upstream defense — drop the requirement from
-the prompt rather than redirecting toward a different
-out-of-worktree path.
+Residual gap: out-of-project paths (`~/.config`, `/tmp`, `.venv`
+outside the worktree) are now fail-closed during an active flow —
+allowed only for the approved memory + `/tmp` scratch surface
+(`is_approved_out_of_project_path`) and blocked otherwise, so the
+earlier "deferred to Claude Code's permission jurisdiction" gap
+is closed for the active-flow case. The remaining boundary is
+non-flow contexts (cwd not inside a worktree), where the early
+"not in a worktree" return leaves path jurisdiction to Claude
+Code. The retry-prompt HARD-GATE is the upstream defense — drop
+the requirement from the prompt rather than redirecting toward a
+different out-of-worktree path.
 
 When in doubt, drop the path from the retry prompt entirely.
 The agent's investigation can succeed by reading in-worktree

--- a/.claude/rules/cognitive-isolation.md
+++ b/.claude/rules/cognitive-isolation.md
@@ -192,16 +192,15 @@ to the SKILL.md HARD-GATE in `skills/flow-review/SKILL.md` Step 2:
   message, and serves as the stable detection anchor for a
   future system-initiated-prompt carve-out.
 
-Residual gap: out-of-project paths (`~/.config`, `/tmp`, `.venv`
-outside the worktree) are now fail-closed during an active flow —
-allowed only for the approved memory + `/tmp` scratch surface
-(`is_approved_out_of_project_path`) and blocked otherwise, so the
-earlier "deferred to Claude Code's permission jurisdiction" gap
-is closed for the active-flow case. The remaining boundary is
-non-flow contexts (cwd not inside a worktree), where the early
-"not in a worktree" return leaves path jurisdiction to Claude
-Code. The retry-prompt HARD-GATE is the upstream defense — drop
-the requirement from the prompt rather than redirecting toward a
+Residual gap: out-of-project paths (`~/.config`, `.venv` outside
+the worktree, arbitrary source files) are fail-closed during an
+active flow — allowed only for the approved memory + `/tmp`
+scratch surface (`is_approved_out_of_project_path`) and blocked
+(exit 2, no prompt) otherwise. The remaining boundary is non-flow
+contexts (cwd not inside a worktree), where the early "not in a
+worktree" return leaves path jurisdiction to Claude Code. The
+retry-prompt HARD-GATE is the upstream defense — drop the
+requirement from the prompt rather than redirecting toward a
 different out-of-worktree path.
 
 When in doubt, drop the path from the retry prompt entirely.

--- a/.claude/rules/hook-vs-instruction.md
+++ b/.claude/rules/hook-vs-instruction.md
@@ -200,15 +200,15 @@ insufficient:
   in the approved memory + `/tmp` scratch surface). Default
   (non-autonomous-flow) behavior is the human-readable BLOCKED
   prose for either surface. During an active flow (cwd inside
-  a worktree) out-of-project paths are NO LONGER deferred to
-  Claude Code's native permission system — they are
-  fail-closed except the approved surface
-  (`is_approved_out_of_project_path`), closing the prior
-  residual gap that let those paths reach a native prompt and
-  hang an unattended flow. The remaining boundary is non-flow
-  contexts (cwd not inside a worktree), where the early "not
-  in a worktree" return leaves path jurisdiction to Claude
-  Code. See `src/hooks/validate_worktree_paths.rs`.
+  a worktree), out-of-project paths are fail-closed except the
+  approved surface (`is_approved_out_of_project_path`: memory
+  dir + `/tmp` scratch); a blocked path returns exit 2 with no
+  native prompt, so an unattended flow never hangs on a native
+  permission prompt for an out-of-project path. The remaining
+  boundary is non-flow contexts (cwd not inside a worktree),
+  where the early "not in a worktree" return leaves path
+  jurisdiction to Claude Code. See
+  `src/hooks/validate_worktree_paths.rs`.
 - **`AskUserQuestion` during an autonomous in-progress phase**
   — `validate-ask-user` rejects with exit 2 when
   `phases.<current_phase>.status == "in_progress"` AND

--- a/.claude/rules/hook-vs-instruction.md
+++ b/.claude/rules/hook-vs-instruction.md
@@ -184,23 +184,31 @@ insufficient:
   `src/hooks/agent_prompt_scan.rs` and
   `.claude/rules/cognitive-isolation.md` "Retry-prompt
   path-scoping constraint".
-- **Autonomous-flow-strict response shape on out-of-worktree
-  paths** — `validate-worktree-paths::validate()` at the
-  existing out-of-worktree block path checks
+- **Autonomous-flow-strict response shape on blocked paths** —
+  `validate-worktree-paths::validate()` checks
   `crate::flow_paths::is_autonomous_flow_active(project_root,
-  branch)` (branch derived from `worktree_root.file_name()`).
-  When the predicate returns true, the hook returns a
-  structured JSON envelope `{"status":"error","reason":
-  "out_of_worktree_in_autonomous","blocked_path":...,
+  branch)` (branch derived from `worktree_root.file_name()`)
+  at both block surfaces. When the predicate returns true, the
+  hook returns a structured JSON envelope
+  `{"status":"error","reason":...,"blocked_path":...,
   "worktree":...,"autonomous":true}` instead of the
-  human-readable BLOCKED message; exit 2 is preserved.
-  Default (non-autonomous-flow) behavior unchanged.
-  Residual gap: paths outside `project_root` (`~/.config`,
-  `/tmp`, `.venv`) remain in Claude Code's built-in
-  permission jurisdiction at this hook layer. Closing the
-  gap entirely requires either a Claude Code feature or a
-  project `settings.json` allow-list extension. See
-  `src/hooks/validate_worktree_paths.rs`.
+  human-readable BLOCKED message; exit 2 is preserved. The
+  `reason` is `out_of_worktree_in_autonomous` for the
+  in-project-but-out-of-worktree redirect and
+  `out_of_bounds_in_autonomous` for the out-of-project
+  fail-closed gate (a path outside `project_root` that is not
+  in the approved memory + `/tmp` scratch surface). Default
+  (non-autonomous-flow) behavior is the human-readable BLOCKED
+  prose for either surface. During an active flow (cwd inside
+  a worktree) out-of-project paths are NO LONGER deferred to
+  Claude Code's native permission system — they are
+  fail-closed except the approved surface
+  (`is_approved_out_of_project_path`), closing the prior
+  residual gap that let those paths reach a native prompt and
+  hang an unattended flow. The remaining boundary is non-flow
+  contexts (cwd not inside a worktree), where the early "not
+  in a worktree" return leaves path jurisdiction to Claude
+  Code. See `src/hooks/validate_worktree_paths.rs`.
 - **`AskUserQuestion` during an autonomous in-progress phase**
   — `validate-ask-user` rejects with exit 2 when
   `phases.<current_phase>.status == "in_progress"` AND

--- a/.claude/rules/subprocess-test-hygiene.md
+++ b/.claude/rules/subprocess-test-hygiene.md
@@ -63,6 +63,48 @@ environment — must explicitly neutralize these surfaces:
      `*.profraw` pattern plus `bin/test`'s `default_*.profraw`
      sweep)
 
+## Working Directory Isolation
+
+Environment neutralization (above) controls what the child reads
+from the environment. The child's **working directory** is a
+second leak surface: a spawned FLOW binary resolves the active
+branch — and therefore the `.flow-states/<branch>/state.json` it
+reads — from its cwd. A subprocess test that does NOT set
+`.current_dir(...)` inherits the test runner's cwd (the real
+worktree), so the child resolves the REAL flow's branch and reads
+its live state file. When an in-flight field such as
+`_halt_pending` is set on that real state, a hook under test reads
+it and changes its decision (a halt gate blocks an
+otherwise-allowed call, for example), producing a failure that
+depends on the surrounding flow's state rather than on the test's
+fixture.
+
+This is the spawned-binary sibling of
+`.claude/rules/testing-gotchas.md` "Host Environment Leaks": that
+rule covers an in-process call to `current_branch()` /
+`project_root()`; this covers a spawned binary that runs the same
+resolution from its inherited cwd.
+
+### The Rule
+
+Every test that spawns a FLOW binary whose code path reads the
+state file — hook validators especially (`validate-skill`,
+`validate-ask-user`, `validate-pretool`, `validate-worktree-paths`,
+`stop_*`) — MUST set `.current_dir(fixture_root)` to a directory
+that does NOT resolve to an active flow: either a plain tempdir
+(no `.flow-states/` entry for the resolved branch) or a fixture
+worktree with a state file the test controls. Inheriting the
+runner's cwd is forbidden — it couples the test's outcome to
+whatever flow happens to be active when CI runs.
+
+### How to Apply
+
+When writing or reviewing a subprocess test that spawns a FLOW
+binary, confirm `.current_dir(...)` points at a fixture. The
+symptom of the missing call is a test that passes in isolation
+and on a fresh flow but fails mid-flow when an in-flight state
+field is set; the fix is to add `.current_dir(fixture_root)`.
+
 ## Canonical Helper Pattern
 
 Every test file that spawns the binary should define a
@@ -102,7 +144,7 @@ reaches, and neutralize exactly those:
 | `bin/flow issue`, `close-issue`, `close-issues`, `link-blocked-by`, `auto-close-parent`, `label-issues` | `gh` CLI → GitHub API | `GH_TOKEN=invalid`, `HOME=<tempdir>` |
 | `bin/flow notify-slack` | Slack webhook POST | `env_remove("SLACK_WEBHOOK_URL")`, `env_remove("SLACK_BOT_TOKEN")` |
 | `bin/flow ci`, `build`, `test`, `lint`, `format` | recursion guard | `env_remove("FLOW_CI_RUNNING")` |
-| `bin/flow hook <name>` | state file reads, stdin | `HOME=<tempdir>` if the hook might read ~/.config |
+| `bin/flow hook <name>` | state file reads, stdin | `HOME=<tempdir>` if the hook might read ~/.config; `.current_dir(fixture)` so the hook resolves a fixture branch/state, not the real worktree (see "Working Directory Isolation") |
 
 ## Plan-Phase Trigger
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Module-level doc comments in `src/*.rs` describe each file's purpose. Discover v
 
 Permanent on-main artifacts that future-session readers should know about by name + one-line purpose. Architecture detail lives in each artifact's module doc comment.
 
-- `src/hooks/agent_prompt_scan.rs` — scans Agent tool prompts for out-of-worktree path tokens during active flows; blocks the Agent call before the sub-agent's Read would prompt the user (paired with the autonomous-flow-strict response shape in `validate-worktree-paths` for paths the hook already blocks; paths outside `project_root` remain in Claude Code's permission jurisdiction).
+- `src/hooks/agent_prompt_scan.rs` — scans Agent tool prompts for out-of-worktree path tokens during active flows; blocks the Agent call before the sub-agent's Read would prompt the user (paired with the autonomous-flow-strict response shape in `validate-worktree-paths`, whose file-tool gate now also fail-closes out-of-project paths during an active flow except the approved memory + `/tmp` scratch surface).
 
 ## Maintainer Skills (private to this repo)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Module-level doc comments in `src/*.rs` describe each file's purpose. Discover v
 
 Permanent on-main artifacts that future-session readers should know about by name + one-line purpose. Architecture detail lives in each artifact's module doc comment.
 
-- `src/hooks/agent_prompt_scan.rs` — scans Agent tool prompts for out-of-worktree path tokens during active flows; blocks the Agent call before the sub-agent's Read would prompt the user (paired with the autonomous-flow-strict response shape in `validate-worktree-paths`, whose file-tool gate now also fail-closes out-of-project paths during an active flow except the approved memory + `/tmp` scratch surface).
+- `src/hooks/agent_prompt_scan.rs` — scans Agent tool prompts for out-of-worktree path tokens during active flows and blocks the Agent call before a sub-agent Read would surface a permission prompt.
 
 ## Maintainer Skills (private to this repo)
 

--- a/bin/test
+++ b/bin/test
@@ -459,7 +459,13 @@ if [ $# -eq 0 ]; then
   COV_ARGS+=(--fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100)
 fi
 echo "=== nextest: cargo llvm-cov nextest ==="
-time_start=$SECONDS
+# Suite wall-clock via date(1) (absolute epoch seconds) rather than
+# bash $SECONDS: $SECONDS can carry an inherited offset from a
+# long-lived parent shell that does not reflect this process's own
+# runtime, which would trip the gate below on an otherwise-fast suite.
+# date(1) is immune to that inheritance. The display-only timers in the
+# per-file/audit/meta modes above are non-gating and stay on $SECONDS.
+time_start=$(date +%s)
 # Heartbeat + coverage filter + failure classification. The pipeline:
 #   cargo llvm-cov ... 2>&1 | tee <log> | awk <filter>
 # (a) nextest sees a non-TTY and skips its multi-line animated progress
@@ -518,7 +524,7 @@ if [ "$rc" -ne 0 ]; then
 fi
 # Slow tests are terminated by nextest (terminate-after=1) and
 # appear as TIMEOUT failures, already caught by the rc check above.
-elapsed=$((SECONDS - time_start))
+elapsed=$(($(date +%s) - time_start))
 if [ "$elapsed" -gt "$SUITE_TIMEOUT_SECS" ]; then
   echo ""
   echo "=== FAIL: suite took ${elapsed}s, limit ${SUITE_TIMEOUT_SECS}s ==="

--- a/src/hooks/validate_worktree_paths.rs
+++ b/src/hooks/validate_worktree_paths.rs
@@ -293,6 +293,97 @@ fn sanitize_canonical_suffix(suffix: &str) -> String {
         .join("/")
 }
 
+/// Approved `/tmp/` file extensions for the out-of-project surface,
+/// matched ASCII-case-insensitively.
+///
+/// This list MUST equal the `/tmp` extensions in
+/// `crate::prime_check::UNIVERSAL_ALLOW` so the out-of-project gate
+/// only ever blocks a `/tmp` path that Claude Code's native
+/// permission system would itself have prompted on. The drift
+/// contract test
+/// `tests/hooks/validate_worktree_paths.rs::approved_tmp_extensions_match_universal_allow`
+/// pins the two sets equal — adding a `/tmp` extension to
+/// `UNIVERSAL_ALLOW` without adding it here re-opens a native prompt
+/// the gate is meant to suppress.
+pub const APPROVED_TMP_EXTENSIONS: &[&str] = &["txt", "diff", "patch", "md", "json", "jsonl"];
+
+/// Decide whether an out-of-project `file_path` falls in the small
+/// approved surface that Claude Code's native permission system already
+/// allows without a prompt. Returns `true` for exactly two classes:
+///
+/// 1. **Auto-memory dir** — a path rooted at
+///    `<home>/.claude/projects/<id>/memory/<file>`. Home-anchored
+///    (tight): the `<home>` prefix matches case-sensitively and must
+///    be followed by a segment boundary, while the
+///    `.claude/projects/<id>/memory/` structure matches
+///    ASCII-case-insensitively (macOS APFS is case-insensitive).
+///    Matches the `UNIVERSAL_ALLOW Read(~/.claude/projects/*/memory/*)`
+///    entry. A crafted path such as `/tmp/.claude/projects/x/memory/y`
+///    cannot masquerade as memory because it is not rooted at `<home>`.
+/// 2. **`/tmp/` scratch** — a path whose ASCII-lowercased form begins
+///    with `/tmp/` and whose extension (ASCII-lowercased) is in
+///    `APPROVED_TMP_EXTENSIONS`. Extensionless and unapproved-extension
+///    `/tmp` paths return `false`.
+///
+/// Everything else out-of-project (plugin cache, arbitrary paths)
+/// returns `false` so the caller fail-closes the gate — the deliberate
+/// asymmetry from the loose out-of-worktree block, because an
+/// over-broad allow re-opens the native prompt this gate exists to
+/// suppress.
+///
+/// `home` is the env-var-derived `$HOME`. An empty or non-absolute
+/// `home` early-returns `false` per
+/// `.claude/rules/external-input-path-construction.md` item #5 — an
+/// unset or relative `HOME` would otherwise build a cwd-relative
+/// memory prefix that resolves against the worktree root, letting an
+/// in-worktree `.claude/projects/<id>/memory/...` masquerade as the
+/// approved surface. A `file_path` containing a NUL byte also
+/// fail-closes (a NUL truncates the path in syscalls).
+///
+/// Pure string operations only — no `Path` construction or filesystem
+/// reads on `file_path` (untrusted model output) per the same rule.
+pub fn is_approved_out_of_project_path(file_path: &str, home: &str) -> bool {
+    if home.is_empty() || !home.starts_with('/') {
+        return false;
+    }
+    if file_path.contains('\0') {
+        return false;
+    }
+
+    // Class 1: home-anchored auto-memory directory. The `<home>` prefix
+    // is case-sensitive (a different-cased home on a case-sensitive FS
+    // is a different location native would not allow); the structural
+    // segments are case-insensitive.
+    if let Some(rest) = file_path.strip_prefix(home) {
+        if let Some(rest) = rest.strip_prefix('/') {
+            let comps: Vec<&str> = rest.split('/').collect();
+            if comps.len() >= 5
+                && comps[0].eq_ignore_ascii_case(".claude")
+                && comps[1].eq_ignore_ascii_case("projects")
+                && !comps[2].is_empty()
+                && comps[3].eq_ignore_ascii_case("memory")
+                && !comps[4].is_empty()
+            {
+                return true;
+            }
+        }
+    }
+
+    // Class 2: /tmp/ scratch with an approved extension. Prefix and
+    // extension are matched ASCII-case-insensitively.
+    let lower = file_path.to_ascii_lowercase();
+    if let Some(rest) = lower.strip_prefix("/tmp/") {
+        if let Some(dot) = rest.rfind('.') {
+            let ext = &rest[dot + 1..];
+            if !ext.is_empty() && APPROVED_TMP_EXTENSIONS.contains(&ext) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
 /// Validate that `file_path` targets the worktree, not the main repo.
 ///
 /// Returns `(allowed, message)`.

--- a/src/hooks/validate_worktree_paths.rs
+++ b/src/hooks/validate_worktree_paths.rs
@@ -7,11 +7,11 @@
 //! 2. **Out-of-project fail-closed gate** — when the CWD is inside a worktree
 //!    (the flow-active proxy), a path outside `project_root` is allowed ONLY
 //!    if it falls in the small approved surface
-//!    (`is_approved_out_of_project_path`: auto-memory dir + `/tmp` scratch
-//!    matching `UNIVERSAL_ALLOW`). Every other out-of-project path is blocked
-//!    so an unattended autonomous flow never hangs on Claude Code's native
-//!    permission prompt for an out-of-project path. An unconditional allow
-//!    here (the prior behavior) deferred to that native prompt.
+//!    (`is_approved_out_of_project_path`: `/tmp` scratch + auto-memory dir, a
+//!    deliberate subset of `UNIVERSAL_ALLOW`'s out-of-project entries). Every
+//!    other out-of-project path is blocked (exit 2, no prompt) so an
+//!    unattended autonomous flow never hangs on Claude Code's native
+//!    permission prompt for an out-of-project path.
 //! 3. **Shared config protection** — blocks Edit/Write calls on shared
 //!    configuration files (`.gitignore`, `Cargo.toml`, `.github/`, etc.) when
 //!    the CWD is inside a `.worktrees/` directory (the flow-active proxy).
@@ -321,74 +321,116 @@ fn sanitize_canonical_suffix(suffix: &str) -> String {
 pub const APPROVED_TMP_EXTENSIONS: &[&str] = &["txt", "diff", "patch", "md", "json", "jsonl"];
 
 /// Decide whether an out-of-project `file_path` falls in the small
-/// approved surface that Claude Code's native permission system already
-/// allows without a prompt. Returns `true` for exactly two classes:
+/// approved surface an active flow legitimately reaches. Returns
+/// `true` for exactly two classes:
 ///
-/// 1. **Auto-memory dir** — a path rooted at
-///    `<home>/.claude/projects/<id>/memory/<file>`. Home-anchored
+/// 1. **`/tmp/` scratch** — a path whose collapsed, ASCII-lowercased
+///    form begins with `/tmp/` and whose extension (ASCII-lowercased)
+///    is in `APPROVED_TMP_EXTENSIONS`. This class is home-independent
+///    and is checked BEFORE the home guard so an unset or relative
+///    `$HOME` (CI/cron/launchd) does not suppress it. Extensionless
+///    and unapproved-extension `/tmp` paths return `false`. Matches
+///    the `/tmp` Read+Write entries in `UNIVERSAL_ALLOW`.
+/// 2. **Auto-memory dir** — a path rooted at
+///    `<home>/.claude/projects/<id>/memory/<file...>`. Home-anchored
 ///    (tight): the `<home>` prefix matches case-sensitively and must
 ///    be followed by a segment boundary, while the
 ///    `.claude/projects/<id>/memory/` structure matches
-///    ASCII-case-insensitively (macOS APFS is case-insensitive).
-///    Matches the `UNIVERSAL_ALLOW Read(~/.claude/projects/*/memory/*)`
-///    entry. A crafted path such as `/tmp/.claude/projects/x/memory/y`
-///    cannot masquerade as memory because it is not rooted at `<home>`.
-/// 2. **`/tmp/` scratch** — a path whose ASCII-lowercased form begins
-///    with `/tmp/` and whose extension (ASCII-lowercased) is in
-///    `APPROVED_TMP_EXTENSIONS`. Extensionless and unapproved-extension
-///    `/tmp` paths return `false`.
+///    ASCII-case-insensitively (macOS APFS is case-insensitive). Any
+///    empty, `.`, or `..` segment fails closed so a memory-rooted
+///    path cannot escape via traversal. Matches the
+///    `Read(~/.claude/projects/*/memory/*)` entry in `UNIVERSAL_ALLOW`.
+///    A crafted path such as `/tmp/.claude/projects/x/memory/y` cannot
+///    masquerade as memory because it is not rooted at `<home>`.
 ///
-/// Everything else out-of-project (plugin cache, arbitrary paths)
-/// returns `false` so the caller fail-closes the gate — the deliberate
-/// asymmetry from the loose out-of-worktree block, because an
-/// over-broad allow re-opens the native prompt this gate exists to
-/// suppress.
+/// The surface is a DELIBERATE SUBSET of `UNIVERSAL_ALLOW`'s
+/// out-of-project entries — the two path shapes a flow actually needs
+/// (its scratch files and its own memory). Everything else
+/// out-of-project (plugin cache, user rule files, arbitrary source
+/// paths) returns `false` so the caller fail-closes the gate.
+/// Over-blocking an out-of-project path is the safe direction: the
+/// model receives a recoverable exit-2 block instead of hanging on a
+/// native prompt. Over-allowing is the dangerous direction (it
+/// re-opens the prompt), so the surface stays narrow.
+///
+/// The check is path-shaped (tool-agnostic): it gates on the path, not
+/// the tool. The `UNIVERSAL_ALLOW` memory entry is Read-only, so an
+/// Edit/Write to the memory dir is outside what the native system
+/// grants silently; the gate does not specially gate that case — such
+/// a write is left to the native permission system to resolve.
 ///
 /// `home` is the env-var-derived `$HOME`. An empty or non-absolute
-/// `home` early-returns `false` per
-/// `.claude/rules/external-input-path-construction.md` item #5 — an
-/// unset or relative `HOME` would otherwise build a cwd-relative
-/// memory prefix that resolves against the worktree root, letting an
-/// in-worktree `.claude/projects/<id>/memory/...` masquerade as the
-/// approved surface. A `file_path` containing a NUL byte also
-/// fail-closes (a NUL truncates the path in syscalls).
+/// `home` fails the memory class closed (the `/tmp` class is reached
+/// first and is home-independent) per
+/// `.claude/rules/external-input-path-construction.md` item #5 — a
+/// relative `HOME` would otherwise build a cwd-relative memory prefix
+/// that resolves against the worktree root, letting an in-worktree
+/// `.claude/projects/<id>/memory/...` masquerade as the approved
+/// surface. A trailing-slash `home` names the same directory and is
+/// normalized before the prefix comparison. A `file_path` containing
+/// a NUL byte fails closed (a NUL truncates the path in syscalls).
 ///
 /// Pure string operations only — no `Path` construction or filesystem
 /// reads on `file_path` (untrusted model output) per the same rule.
 pub fn is_approved_out_of_project_path(file_path: &str, home: &str) -> bool {
-    if home.is_empty() || !home.starts_with('/') {
-        return false;
-    }
+    // A NUL byte truncates the path in syscalls; fail closed before any
+    // matching runs.
     if file_path.contains('\0') {
         return false;
     }
 
-    // Class 1: home-anchored auto-memory directory. The `<home>` prefix
-    // is case-sensitive (a different-cased home on a case-sensitive FS
-    // is a different location native would not allow); the structural
-    // segments are case-insensitive.
-    if let Some(rest) = file_path.strip_prefix(home) {
-        if let Some(rest) = rest.strip_prefix('/') {
-            let comps: Vec<&str> = rest.split('/').collect();
-            if comps.len() >= 5
-                && comps[0].eq_ignore_ascii_case(".claude")
-                && comps[1].eq_ignore_ascii_case("projects")
-                && !comps[2].is_empty()
-                && comps[3].eq_ignore_ascii_case("memory")
-                && !comps[4].is_empty()
-            {
+    // Doubled slashes resolve to the same path at the FS layer, so
+    // normalize once up front and match every class against the
+    // collapsed form. This keeps the two approved classes consistent —
+    // a doubled-slash memory path is treated the same as the
+    // single-slash form, the way the /tmp class already accepts
+    // `/tmp//x.md`.
+    let normalized = collapse_double_slashes(file_path);
+
+    // Class 1: /tmp/ scratch with an approved extension. Home-independent,
+    // so it is checked BEFORE the home guard below — an unset or relative
+    // $HOME must not suppress an approved /tmp path the native permission
+    // system grants regardless of $HOME. Prefix and extension are matched
+    // ASCII-case-insensitively.
+    let lower = normalized.to_ascii_lowercase();
+    if let Some(rest) = lower.strip_prefix("/tmp/") {
+        if let Some(dot) = rest.rfind('.') {
+            let ext = &rest[dot + 1..];
+            if !ext.is_empty() && APPROVED_TMP_EXTENSIONS.contains(&ext) {
                 return true;
             }
         }
     }
 
-    // Class 2: /tmp/ scratch with an approved extension. Prefix and
-    // extension are matched ASCII-case-insensitively.
-    let lower = file_path.to_ascii_lowercase();
-    if let Some(rest) = lower.strip_prefix("/tmp/") {
-        if let Some(dot) = rest.rfind('.') {
-            let ext = &rest[dot + 1..];
-            if !ext.is_empty() && APPROVED_TMP_EXTENSIONS.contains(&ext) {
+    // The remaining class is home-anchored, so it needs a valid absolute
+    // $HOME. Empty/relative fails closed (a relative $HOME would resolve
+    // cwd-relative against the worktree root). A trailing-slash $HOME
+    // names the same directory, so strip it before the prefix comparison
+    // rather than failing the segment-boundary check.
+    if home.is_empty() || !home.starts_with('/') {
+        return false;
+    }
+    let home = home.strip_suffix('/').unwrap_or(home);
+
+    // Class 2: home-anchored auto-memory directory. The `<home>` prefix
+    // is case-sensitive (a different-cased home on a case-sensitive FS
+    // is a different location native would not allow); the structural
+    // segments are case-insensitive. Any empty, `.`, or `..` segment
+    // fails closed so a memory-rooted path cannot escape via traversal.
+    if let Some(rest) = normalized.strip_prefix(home) {
+        if let Some(rest) = rest.strip_prefix('/') {
+            let comps: Vec<&str> = rest.split('/').collect();
+            if comps
+                .iter()
+                .any(|c| c.is_empty() || *c == "." || *c == "..")
+            {
+                return false;
+            }
+            if comps.len() >= 5
+                && comps[0].eq_ignore_ascii_case(".claude")
+                && comps[1].eq_ignore_ascii_case("projects")
+                && comps[3].eq_ignore_ascii_case("memory")
+            {
                 return true;
             }
         }

--- a/src/hooks/validate_worktree_paths.rs
+++ b/src/hooks/validate_worktree_paths.rs
@@ -1,20 +1,33 @@
 //! PreToolUse hook that validates file tool calls in FLOW worktrees.
 //!
-//! Two enforcement layers:
+//! Three enforcement layers:
 //! 1. **Worktree path redirection** — blocks file tool calls that target the
 //!    main repo when the working directory is inside a FLOW worktree, directing
 //!    the caller to use the worktree copy instead.
-//! 2. **Shared config protection** — blocks Edit/Write calls on shared
+//! 2. **Out-of-project fail-closed gate** — when the CWD is inside a worktree
+//!    (the flow-active proxy), a path outside `project_root` is allowed ONLY
+//!    if it falls in the small approved surface
+//!    (`is_approved_out_of_project_path`: auto-memory dir + `/tmp` scratch
+//!    matching `UNIVERSAL_ALLOW`). Every other out-of-project path is blocked
+//!    so an unattended autonomous flow never hangs on Claude Code's native
+//!    permission prompt for an out-of-project path. An unconditional allow
+//!    here (the prior behavior) deferred to that native prompt.
+//! 3. **Shared config protection** — blocks Edit/Write calls on shared
 //!    configuration files (`.gitignore`, `Cargo.toml`, `.github/`, etc.) when
 //!    the CWD is inside a `.worktrees/` directory (the flow-active proxy).
 //!    Only Edit and Write tool names trigger the block — Read/Glob/Grep are
 //!    allowed so codebase exploration is not impacted. The block message
 //!    directs the caller to confirm with the user before proceeding.
 //!
+//! Block surfaces 1 and 2 emit a structured `..._in_autonomous` JSON envelope
+//! (`out_of_worktree_in_autonomous` / `out_of_bounds_in_autonomous`) when the
+//! active flow is autonomous, and a human-readable `BLOCKED:` prose message
+//! otherwise.
+//!
 //! Fires on Edit, Write, Read, Glob, and Grep tool calls.
 //!
 //! Exit 0 — allow (path is fine or not in a worktree)
-//! Exit 2 — block (path targets main repo, or shared config Edit/Write)
+//! Exit 2 — block (path targets main repo, out-of-project, or shared config Edit/Write)
 
 use std::path::Path;
 
@@ -395,7 +408,29 @@ pub fn is_approved_out_of_project_path(file_path: &str, home: &str) -> bool {
 /// false match) and the empty-branch edge case (cwd ending exactly in
 /// `.worktrees/` returns `None` — treat as "not in a worktree" and
 /// allow). See `compute_worktree_paths` doc for the full branch table.
-pub fn validate(file_path: &str, cwd: &str) -> (bool, String) {
+///
+/// Two block surfaces produce an `..._in_autonomous` JSON envelope when
+/// the active flow is configured for autonomous execution, and a
+/// human-readable `BLOCKED:` prose message otherwise:
+///
+/// - **Out-of-project** (`file_path` not under `project_root`) —
+///   fail-closed during an active flow. The path is allowed only if it
+///   falls in the small approved surface
+///   (`is_approved_out_of_project_path`: auto-memory dir + `/tmp`
+///   scratch); otherwise it is blocked so an unattended autonomous
+///   flow never hangs on a native permission prompt for an
+///   out-of-project path. Autonomous envelope `reason` is
+///   `out_of_bounds_in_autonomous`. `home` is the env-var-derived
+///   `$HOME`, resolved in `run_impl_main`; an empty/relative `home`
+///   makes the approved-memory class fail closed.
+/// - **Out-of-worktree** (`file_path` under `project_root` but outside
+///   the worktree) — the existing main-repo redirect. Autonomous
+///   envelope `reason` is `out_of_worktree_in_autonomous`.
+///
+/// `validate_claude_paths.rs` is deliberately NOT extended for either
+/// surface per the plan's Mirror-Pattern Audit — its fail-closed
+/// posture and protected-path scope differ from this hook.
+pub fn validate(file_path: &str, cwd: &str, home: &str) -> (bool, String) {
     if file_path.is_empty() {
         return (true, String::new());
     }
@@ -405,10 +440,44 @@ pub fn validate(file_path: &str, cwd: &str) -> (bool, String) {
         None => return (true, String::new()), // not in a worktree
     };
 
-    // Paths outside the project are always fine (~/.claude, /tmp, etc.)
+    // Out-of-project paths are fail-closed during an active flow (cwd
+    // inside a worktree is the only context this branch is reached). An
+    // unconditional allow here would defer to Claude Code's native
+    // permission system, which prompts — and an unattended autonomous
+    // flow hangs on the prompt forever. Allow only the small approved
+    // surface the native system already permits without a prompt
+    // (auto-memory dir + /tmp scratch); block everything else. The
+    // autonomous flow gets a structured envelope it can classify; a
+    // manual flow gets the human-readable BLOCKED prose.
     let prefix = format!("{}/", project_root);
     if !file_path.starts_with(&prefix) {
-        return (true, String::new());
+        if is_approved_out_of_project_path(file_path, home) {
+            return (true, String::new());
+        }
+        let branch = Path::new(worktree_root)
+            .file_name()
+            .and_then(|n| n.to_str());
+        if crate::flow_paths::is_autonomous_flow_active(Path::new(project_root), branch) {
+            let envelope = serde_json::json!({
+                "status": "error",
+                "reason": "out_of_bounds_in_autonomous",
+                "blocked_path": file_path,
+                "worktree": worktree_root,
+                "autonomous": true,
+            });
+            return (false, envelope.to_string());
+        }
+        return (
+            false,
+            format!(
+                "BLOCKED: {} is outside the active flow's project root {}. \
+                 An active flow's surface is the worktree plus \
+                 .flow-states/ and the approved memory + /tmp scratch \
+                 surface; out-of-project paths are otherwise refused so \
+                 the flow never hangs on a native permission prompt.",
+                file_path, project_root
+            ),
+        );
     }
 
     // Reject worktree-internal `.flow-states/` writes BEFORE the
@@ -458,16 +527,12 @@ pub fn validate(file_path: &str, cwd: &str) -> (bool, String) {
     // this hook use a `BLOCKED:` prose prefix). Default
     // (non-autonomous-flow) behavior unchanged.
     //
-    // Residual gap: this branch fires ONLY when the path is inside
-    // `project_root` but outside the worktree (the existing block
-    // path). Paths outside `project_root` (~/.config, /tmp, etc.)
-    // are allowed by validate() earlier and stay outside this
-    // hook's jurisdiction — see the `paths outside the project are
-    // always fine` branch above and the residual-gap negative test.
+    // This branch fires when the path is inside `project_root` but
+    // outside the worktree. Paths outside `project_root` entirely are
+    // handled by the fail-closed out-of-project gate above (allowed
+    // only for the approved memory + /tmp surface), so both surfaces
+    // are now covered during an active flow.
     //
-    // `validate_claude_paths.rs` is deliberately NOT extended here
-    // per the plan's Mirror-Pattern Audit — its fail-closed
-    // posture and protected-path scope differ from this hook.
     // `worktree_root` is the canonical `<main_root>/.worktrees/<branch>/`
     // path resolved upstream by `compute_worktree_root`. The basename
     // (`file_name`) of that path is the branch — derived structurally
@@ -524,7 +589,12 @@ fn run_impl_main(hook_input: Option<Value>, cwd: Option<String>) -> (i32, Option
         None => return (0, None),
     };
 
-    let (allowed, message) = validate(&file_path, &cwd);
+    // Env-var-derived $HOME for the out-of-project approved-memory
+    // class. An unset HOME yields an empty string, which
+    // `is_approved_out_of_project_path` treats as fail-closed.
+    let home = std::env::var("HOME").unwrap_or_default();
+
+    let (allowed, message) = validate(&file_path, &cwd, &home);
     if !allowed {
         return (2, Some(message));
     }

--- a/tests/hooks/dispatcher.rs
+++ b/tests/hooks/dispatcher.rs
@@ -1395,13 +1395,17 @@ fn validate_worktree_paths_inside_worktree_allows_flow_states() {
 }
 
 #[test]
-fn validate_worktree_paths_inside_worktree_allows_home_path() {
-    // Paths outside the project prefix are always allowed
-    // (~/.claude, plugin cache, /tmp, etc.). `/Users/example/...` is
+fn validate_worktree_paths_inside_worktree_blocks_out_of_project_home_path() {
+    // Out-of-project paths are fail-closed during an active flow (cwd
+    // inside a worktree). `/Users/example/.claude/plans/p.md` is not
+    // the approved auto-memory dir (`.claude/projects/<id>/memory/`)
+    // nor /tmp scratch, so the hook blocks it (exit 2) end-to-end
+    // through run_impl_main's $HOME read rather than deferring to a
+    // native permission prompt. No state file → human-readable prose
+    // BLOCKED, not the autonomous envelope. `/Users/example/...` is
     // never a prefix of the canonical `/private/var/folders/...`
-    // tempdir cwd, so this test exercises the real "outside project"
-    // allow branch whether or not the root is canonicalized. We still
-    // canonicalize for symmetry with the sibling tests.
+    // tempdir cwd, so the path genuinely lands in the out-of-project
+    // branch; canonicalize for symmetry with the sibling tests.
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path().canonicalize().unwrap();
     let worktree = root.join(".worktrees").join("feat");
@@ -1411,7 +1415,7 @@ fn validate_worktree_paths_inside_worktree_allows_home_path() {
     }))
     .unwrap();
     let output = run_worktree_hook(&worktree, &input);
-    assert_eq!(output.status.code().unwrap(), 0);
+    assert_eq!(output.status.code().unwrap(), 2);
 }
 
 // --- validate-worktree-paths shared-config integration tests (issue #1170) ---

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -5,7 +5,8 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 
 use flow_rs::hooks::validate_worktree_paths::{
-    detect_misplaced_flow_states, get_file_path, is_shared_config, validate, validate_shared_config,
+    detect_misplaced_flow_states, get_file_path, is_approved_out_of_project_path, is_shared_config,
+    validate, validate_shared_config, APPROVED_TMP_EXTENSIONS,
 };
 use serde_json::json;
 
@@ -286,6 +287,252 @@ fn autonomous_strict_still_allows_paths_outside_project_root_documents_residual_
         allowed,
         "paths outside project_root remain allowed at this layer; got msg={}",
         msg
+    );
+}
+
+// --- is_approved_out_of_project_path tests ---
+
+// Class 1: home-anchored auto-memory directory.
+
+#[test]
+fn approved_oop_memory_path_under_valid_home_is_allowed() {
+    assert!(is_approved_out_of_project_path(
+        "/Users/ben/.claude/projects/abc123/memory/MEMORY.md",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_memory_path_case_variant_is_allowed() {
+    // macOS APFS is case-insensitive — the .claude/projects/.../memory
+    // structure matches regardless of case so a case-variant path
+    // resolves to the same inode native already allows.
+    assert!(is_approved_out_of_project_path(
+        "/Users/ben/.CLAUDE/Projects/abc123/Memory/notes.md",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_memory_path_under_empty_home_is_blocked() {
+    // Env-var validator: an empty $HOME fails closed before any memory
+    // prefix is built.
+    assert!(!is_approved_out_of_project_path(
+        "/Users/ben/.claude/projects/abc123/memory/MEMORY.md",
+        ""
+    ));
+}
+
+#[test]
+fn approved_oop_memory_path_under_relative_home_is_blocked() {
+    // A relative $HOME (no leading slash) fails closed — otherwise it
+    // would resolve cwd-relative against the worktree root.
+    assert!(!is_approved_out_of_project_path(
+        "relative/dir/.claude/projects/abc123/memory/MEMORY.md",
+        "relative/dir"
+    ));
+}
+
+#[test]
+fn approved_oop_memory_shaped_path_not_under_home_is_blocked() {
+    // A /tmp path shaped like the memory dir but NOT rooted at <home>
+    // must not be allowed (tight allow — home-anchored).
+    assert!(!is_approved_out_of_project_path(
+        "/tmp/.claude/projects/x/memory/y",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_memory_prefix_substring_of_longer_home_is_blocked() {
+    // home="/Users/ben" must not match "/Users/benjamin/..." via a
+    // bare string prefix — the segment boundary after home is required.
+    assert!(!is_approved_out_of_project_path(
+        "/Users/benjamin/.claude/projects/abc/memory/MEMORY.md",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_memory_empty_id_segment_is_blocked() {
+    assert!(!is_approved_out_of_project_path(
+        "/Users/ben/.claude/projects//memory/MEMORY.md",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_memory_no_file_after_memory_is_blocked() {
+    // A directory-only memory path (trailing slash, no file) is not an
+    // approved file target.
+    assert!(!is_approved_out_of_project_path(
+        "/Users/ben/.claude/projects/abc/memory/",
+        "/Users/ben"
+    ));
+}
+
+// Class 2: /tmp/ scratch with an approved extension (one assertion per
+// extension to satisfy per-branch coverage of the extension set).
+
+#[test]
+fn approved_oop_tmp_txt_is_allowed() {
+    assert!(is_approved_out_of_project_path(
+        "/tmp/scratch.txt",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_tmp_diff_is_allowed() {
+    assert!(is_approved_out_of_project_path(
+        "/tmp/scratch.diff",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_tmp_patch_is_allowed() {
+    assert!(is_approved_out_of_project_path(
+        "/tmp/scratch.patch",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_tmp_md_is_allowed() {
+    assert!(is_approved_out_of_project_path(
+        "/tmp/scratch.md",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_tmp_json_is_allowed() {
+    assert!(is_approved_out_of_project_path(
+        "/tmp/scratch.json",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_tmp_jsonl_is_allowed() {
+    assert!(is_approved_out_of_project_path(
+        "/tmp/scratch.jsonl",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_tmp_case_variant_is_allowed() {
+    // /TMP/X.MD resolves to the same inode as /tmp/x.md on a
+    // case-insensitive filesystem.
+    assert!(is_approved_out_of_project_path("/TMP/X.MD", "/Users/ben"));
+}
+
+#[test]
+fn approved_oop_tmp_unapproved_extension_is_blocked() {
+    assert!(!is_approved_out_of_project_path(
+        "/tmp/scratch.csv",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_tmp_no_extension_is_blocked() {
+    assert!(!is_approved_out_of_project_path(
+        "/tmp/scratch",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_tmp_directory_only_is_blocked() {
+    // The bare "/tmp/" prefix with no file segment has no extension.
+    assert!(!is_approved_out_of_project_path("/tmp/", "/Users/ben"));
+}
+
+#[test]
+fn approved_oop_tmp_doubled_slash_is_allowed() {
+    // /tmp//x.md normalizes to /tmp/x.md at the FS layer; allowing it
+    // matches the native same-inode resolution.
+    assert!(is_approved_out_of_project_path(
+        "/tmp//scratch.md",
+        "/Users/ben"
+    ));
+}
+
+// Everything else out-of-project is fail-closed.
+
+#[test]
+fn approved_oop_plugin_cache_is_blocked() {
+    // The plugin cache is deliberately NOT in the approved surface —
+    // an active flow has no reason to reach plugin source.
+    assert!(!is_approved_out_of_project_path(
+        "/Users/ben/.claude/plugins/cache/flow/0.28.5/skills/flow-code/SKILL.md",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_arbitrary_path_is_blocked() {
+    assert!(!is_approved_out_of_project_path(
+        "/Users/x/other/file.rs",
+        "/Users/ben"
+    ));
+}
+
+#[test]
+fn approved_oop_nul_byte_path_is_blocked() {
+    // Embedded NUL fails closed — a NUL truncates the path in syscalls.
+    assert!(!is_approved_out_of_project_path(
+        "/tmp/x\0.md",
+        "/Users/ben"
+    ));
+}
+
+// --- APPROVED_TMP_EXTENSIONS drift contract ---
+
+/// Named regression: a `/tmp` extension added to `UNIVERSAL_ALLOW`
+/// (the native-permission allow-list in `src/prime_check.rs`) but NOT
+/// to `APPROVED_TMP_EXTENSIONS` would re-open a native permission
+/// prompt for that extension during an active flow — exactly the hang
+/// the out-of-project gate exists to prevent. The named consumer is
+/// `is_approved_out_of_project_path`, whose `/tmp` class is only safe
+/// while its extension set equals the native allow-list's.
+///
+/// The two sources cannot share a single `const` (UNIVERSAL_ALLOW
+/// entries are full permission strings like `Read(//tmp/*.md)`), so
+/// this test extracts the `/tmp` extensions from UNIVERSAL_ALLOW at
+/// test time and asserts set-equality with APPROVED_TMP_EXTENSIONS.
+#[test]
+fn approved_tmp_extensions_match_universal_allow() {
+    use flow_rs::prime_check::UNIVERSAL_ALLOW;
+    use std::collections::BTreeSet;
+
+    let marker = "//tmp/*.";
+    let mut from_allow: BTreeSet<String> = BTreeSet::new();
+    for entry in UNIVERSAL_ALLOW {
+        if let Some(idx) = entry.find(marker) {
+            let after = &entry[idx + marker.len()..];
+            if let Some(close) = after.find(')') {
+                let ext = &after[..close];
+                if !ext.is_empty() {
+                    from_allow.insert(ext.to_ascii_lowercase());
+                }
+            }
+        }
+    }
+
+    let from_const: BTreeSet<String> = APPROVED_TMP_EXTENSIONS
+        .iter()
+        .map(|e| e.to_ascii_lowercase())
+        .collect();
+
+    assert_eq!(
+        from_allow, from_const,
+        "APPROVED_TMP_EXTENSIONS must equal the /tmp extensions in \
+         UNIVERSAL_ALLOW (src/prime_check.rs). Drift re-opens a native \
+         permission prompt for the missing extension during an active flow."
     );
 }
 

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -580,6 +580,93 @@ fn approved_oop_nul_byte_path_is_blocked() {
     ));
 }
 
+// --- out-of-project edge cases (A1/A2/A3/R2 regression guards) ---
+
+/// A1: the /tmp class is home-independent, so an empty $HOME must not
+/// suppress an approved /tmp scratch path. Regression: ordering the
+/// home guard ahead of the /tmp class blocks /tmp under an unset $HOME
+/// (CI/cron/launchd), forcing a native-prompt-equivalent block on a
+/// path UNIVERSAL_ALLOW grants regardless of $HOME.
+#[test]
+fn approved_oop_tmp_allowed_with_empty_home() {
+    assert!(is_approved_out_of_project_path("/tmp/scratch.md", ""));
+}
+
+/// A1: a relative $HOME likewise has no bearing on the /tmp class.
+#[test]
+fn approved_oop_tmp_allowed_with_relative_home() {
+    assert!(is_approved_out_of_project_path(
+        "/tmp/scratch.json",
+        "relative/home"
+    ));
+}
+
+/// A2: a doubled-slash memory path resolves to the same inode as the
+/// single-slash form, so it must be approved the way the /tmp class
+/// accepts /tmp//x.md. Regression: dropping the up-front slash collapse
+/// rejects the doubled-slash memory shape while approving the
+/// equivalent /tmp shape.
+#[test]
+fn approved_oop_memory_doubled_slash_is_allowed() {
+    assert!(is_approved_out_of_project_path(
+        "/Users/ben//.claude/projects/abc/memory/MEMORY.md",
+        "/Users/ben"
+    ));
+}
+
+/// A3: a trailing-slash $HOME names the same home directory; the memory
+/// class must still approve the path rather than failing the
+/// segment-boundary check. Regression: removing the home trailing-slash
+/// strip blocks a legitimate MEMORY.md under a trailing-slash $HOME.
+#[test]
+fn approved_oop_memory_trailing_slash_home_is_allowed() {
+    assert!(is_approved_out_of_project_path(
+        "/Users/ben/.claude/projects/abc/memory/MEMORY.md",
+        "/Users/ben/"
+    ));
+}
+
+/// R2: a `..` segment past memory/ escapes the memory dir and is not a
+/// native-allowed single-segment match, so it must fail closed.
+/// Regression: dropping the traversal-segment rejection approves a
+/// memory-rooted path that escapes via `..` (and defers to a native
+/// prompt that would hang an unattended flow).
+#[test]
+fn approved_oop_memory_parent_traversal_segment_is_blocked() {
+    assert!(!is_approved_out_of_project_path(
+        "/Users/ben/.claude/projects/abc/memory/../../../etc/passwd",
+        "/Users/ben"
+    ));
+}
+
+/// R2: a `.` segment likewise fails closed.
+#[test]
+fn approved_oop_memory_dot_segment_is_blocked() {
+    assert!(!is_approved_out_of_project_path(
+        "/Users/ben/.claude/projects/abc/memory/./notes.md",
+        "/Users/ben"
+    ));
+}
+
+/// A1 through the public validate() surface: an approved /tmp scratch
+/// path is allowed even when $HOME is empty (the /tmp class is
+/// home-independent). Drives the home-independence through validate()
+/// rather than the helper alone — no state file written, so the flow
+/// is non-autonomous and an over-block would surface as prose BLOCKED.
+#[test]
+fn validate_out_of_project_tmp_allowed_with_empty_home() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+    let worktree = format!("{}/.worktrees/feat", root.display());
+    let (allowed, msg) = validate("/tmp/flow-scratch.md", &worktree, "");
+    assert!(
+        allowed,
+        "approved /tmp scratch must be allowed with empty $HOME; got: {}",
+        msg
+    );
+    assert!(msg.is_empty());
+}
+
 // --- APPROVED_TMP_EXTENSIONS drift contract ---
 
 /// Named regression: a `/tmp` extension added to `UNIVERSAL_ALLOW`
@@ -599,7 +686,11 @@ fn approved_tmp_extensions_match_universal_allow() {
     use flow_rs::prime_check::UNIVERSAL_ALLOW;
     use std::collections::BTreeSet;
 
-    let marker = "//tmp/*.";
+    // Single-slash marker matches both the double-slash entries
+    // (`Read(//tmp/*.md)`) and a single-slash shape (`Read(/tmp/*.md)`),
+    // so a future /tmp entry in either shape is still extracted rather
+    // than silently missed by a shape-specific marker.
+    let marker = "/tmp/*.";
     let mut from_allow: BTreeSet<String> = BTreeSet::new();
     for entry in UNIVERSAL_ALLOW {
         if let Some(idx) = entry.find(marker) {
@@ -1358,6 +1449,32 @@ fn worktree_fixture(tmp: &tempfile::TempDir) -> (std::path::PathBuf, std::path::
     let worktree_cwd = root.join(".worktrees").join("feat");
     std::fs::create_dir_all(&worktree_cwd).expect("mkdir worktree");
     (root, worktree_cwd)
+}
+
+/// R3: drive run_impl_main's $HOME resolution into the memory-allow
+/// path. The helper unit tests pass `home` directly; only a subprocess
+/// test proves run_impl_main reads $HOME from the environment and
+/// threads it into validate() so an out-of-project memory Read under
+/// that $HOME is allowed (exit 0). Regression: a change that drops or
+/// mis-resolves $HOME in run_impl_main would block the approved memory
+/// surface even under a correct $HOME. The memory dir lives under a
+/// separate tempdir from the worktree root so it is genuinely
+/// out-of-project.
+#[test]
+fn validate_subprocess_memory_read_allowed_via_resolved_home() {
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    let home = home_tmp.path().canonicalize().expect("canonicalize home");
+    let wt_tmp = tempfile::tempdir().expect("worktree tempdir");
+    let (_root, worktree_cwd) = worktree_fixture(&wt_tmp);
+    let memory_path = format!("{}/.claude/projects/abc/memory/MEMORY.md", home.display());
+    let (code, _stdout, stderr) =
+        spawn_hook_with_cwd(&worktree_cwd, &home, "Read", "file_path", &memory_path);
+    assert_eq!(
+        code, 0,
+        "an out-of-project memory Read under the resolved $HOME must be \
+         allowed (exit 0); stderr: {}",
+        stderr
+    );
 }
 
 #[test]

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -14,7 +14,11 @@ use serde_json::json;
 
 #[test]
 fn test_allows_when_not_in_worktree() {
-    let (allowed, msg) = validate("/Users/ben/code/flow/lib/foo.py", "/Users/ben/code/flow");
+    let (allowed, msg) = validate(
+        "/Users/ben/code/flow/lib/foo.py",
+        "/Users/ben/code/flow",
+        "/Users/ben",
+    );
     assert!(allowed);
     assert!(msg.is_empty());
 }
@@ -24,6 +28,7 @@ fn test_allows_file_inside_worktree() {
     let (allowed, msg) = validate(
         "/Users/ben/code/flow/.worktrees/my-feature/lib/foo.py",
         "/Users/ben/code/flow/.worktrees/my-feature",
+        "/Users/ben",
     );
     assert!(allowed);
     assert!(msg.is_empty());
@@ -32,7 +37,7 @@ fn test_allows_file_inside_worktree() {
 #[test]
 fn test_blocks_main_repo_path_from_worktree() {
     let cwd = "/Users/ben/code/flow/.worktrees/my-feature";
-    let (allowed, msg) = validate("/Users/ben/code/flow/lib/foo.py", cwd);
+    let (allowed, msg) = validate("/Users/ben/code/flow/lib/foo.py", cwd, "/Users/ben");
     assert!(!allowed);
     assert!(msg.contains("BLOCKED"));
     assert!(msg.contains(cwd));
@@ -43,26 +48,7 @@ fn test_allows_flow_states_path() {
     let (allowed, msg) = validate(
         "/Users/ben/code/flow/.flow-states/my-feature.json",
         "/Users/ben/code/flow/.worktrees/my-feature",
-    );
-    assert!(allowed);
-    assert!(msg.is_empty());
-}
-
-#[test]
-fn test_allows_home_directory_paths() {
-    let (allowed, msg) = validate(
-        "/Users/ben/.claude/plans/some-plan.md",
-        "/Users/ben/code/flow/.worktrees/my-feature",
-    );
-    assert!(allowed);
-    assert!(msg.is_empty());
-}
-
-#[test]
-fn test_allows_plugin_cache_paths() {
-    let (allowed, msg) = validate(
-        "/Users/ben/.claude/plugins/cache/flow/0.28.5/skills/flow-code/SKILL.md",
-        "/Users/ben/code/flow/.worktrees/my-feature",
+        "/Users/ben",
     );
     assert!(allowed);
     assert!(msg.is_empty());
@@ -72,7 +58,7 @@ fn test_allows_plugin_cache_paths() {
 fn test_error_message_includes_corrected_path() {
     let cwd = "/Users/ben/code/flow/.worktrees/my-feature";
     let file_path = "/Users/ben/code/flow/skills/flow-prime/SKILL.md";
-    let (allowed, msg) = validate(file_path, cwd);
+    let (allowed, msg) = validate(file_path, cwd, "/Users/ben");
     assert!(!allowed);
     let corrected = "/Users/ben/code/flow/.worktrees/my-feature/skills/flow-prime/SKILL.md";
     assert!(msg.contains(corrected));
@@ -81,14 +67,18 @@ fn test_error_message_includes_corrected_path() {
 
 #[test]
 fn test_allows_empty_file_path() {
-    let (allowed, _) = validate("", "/Users/ben/code/flow/.worktrees/my-feature");
+    let (allowed, _) = validate(
+        "",
+        "/Users/ben/code/flow/.worktrees/my-feature",
+        "/Users/ben",
+    );
     assert!(allowed);
 }
 
 #[test]
 fn test_allows_worktree_root_path_exactly() {
     let cwd = "/Users/ben/code/flow/.worktrees/my-feature";
-    let (allowed, _) = validate(cwd, cwd);
+    let (allowed, _) = validate(cwd, cwd, "/Users/ben");
     assert!(allowed);
 }
 
@@ -98,7 +88,7 @@ fn test_allows_worktree_root_path_exactly() {
 fn validate_allows_worktree_root_path_from_subdir_cwd() {
     let cwd = "/Users/ben/code/flow/.worktrees/my-feature/synapse";
     let file_path = "/Users/ben/code/flow/.worktrees/my-feature/CLAUDE.md";
-    let (allowed, msg) = validate(file_path, cwd);
+    let (allowed, msg) = validate(file_path, cwd, "/Users/ben");
     assert!(allowed);
     assert!(msg.is_empty());
 }
@@ -109,7 +99,7 @@ fn validate_allows_worktree_root_path_from_subdir_cwd() {
 fn validate_allows_claude_rules_path_from_subdir_cwd() {
     let cwd = "/Users/ben/code/flow/.worktrees/my-feature/cortex";
     let file_path = "/Users/ben/code/flow/.worktrees/my-feature/.claude/rules/testing-gotchas.md";
-    let (allowed, _) = validate(file_path, cwd);
+    let (allowed, _) = validate(file_path, cwd, "/Users/ben");
     assert!(allowed);
 }
 
@@ -119,7 +109,7 @@ fn validate_allows_claude_rules_path_from_subdir_cwd() {
 fn validate_redirect_uses_worktree_root_not_cwd_subdir() {
     let cwd = "/Users/ben/code/flow/.worktrees/my-feature/synapse";
     let file_path = "/Users/ben/code/flow/lib/foo.py";
-    let (allowed, msg) = validate(file_path, cwd);
+    let (allowed, msg) = validate(file_path, cwd, "/Users/ben");
     assert!(!allowed);
     assert!(msg.contains("/Users/ben/code/flow/.worktrees/my-feature/lib/foo.py"));
     assert!(!msg.contains("/synapse/.worktrees/"));
@@ -131,7 +121,7 @@ fn validate_redirect_uses_worktree_root_not_cwd_subdir() {
 fn validate_redirect_uses_worktree_root_multi_level_subdir() {
     let cwd = "/Users/ben/code/flow/.worktrees/my-feature/packages/api";
     let file_path = "/Users/ben/code/flow/lib/foo.py";
-    let (_, msg) = validate(file_path, cwd);
+    let (_, msg) = validate(file_path, cwd, "/Users/ben");
     assert!(msg.contains("/Users/ben/code/flow/.worktrees/my-feature/lib/foo.py"));
     assert!(!msg.contains("/packages/api/.worktrees/"));
 }
@@ -146,7 +136,7 @@ fn validate_redirect_uses_worktree_root_multi_level_subdir() {
 fn validate_allows_when_cwd_ends_in_marker_no_branch() {
     let cwd = "/proj/.worktrees/";
     let file_path = "/proj/lib/foo.py";
-    let (allowed, msg) = validate(file_path, cwd);
+    let (allowed, msg) = validate(file_path, cwd, "/Users/ben");
     assert!(allowed);
     assert!(msg.is_empty());
 }
@@ -160,7 +150,7 @@ fn validate_allows_when_cwd_ends_in_marker_no_branch() {
 fn validate_uses_rightmost_worktrees_segment_in_redirect() {
     let cwd = "/home/dev/my.worktrees/proj/.worktrees/feat/cortex";
     let file_path = "/home/dev/my.worktrees/proj/lib/foo.py";
-    let (allowed, msg) = validate(file_path, cwd);
+    let (allowed, msg) = validate(file_path, cwd, "/Users/ben");
     assert!(!allowed);
     assert!(msg.contains("/home/dev/my.worktrees/proj/.worktrees/feat/lib/foo.py"));
 }
@@ -193,7 +183,7 @@ fn autonomous_strict_emits_json_envelope_on_existing_block_path() {
     write_state_for(&root, "feat", AUTO_IN_PROGRESS);
     let worktree = format!("{}/.worktrees/feat", root.display());
     let file_path = format!("{}/lib/foo.py", root.display());
-    let (allowed, msg) = validate(&file_path, &worktree);
+    let (allowed, msg) = validate(&file_path, &worktree, "/Users/ben");
     assert!(!allowed);
     assert!(
         msg.contains("\"reason\":\"out_of_worktree_in_autonomous\""),
@@ -211,7 +201,7 @@ fn non_autonomous_preserves_existing_block_message_shape() {
     write_state_for(&root, "feat", MANUAL_IN_PROGRESS);
     let worktree = format!("{}/.worktrees/feat", root.display());
     let file_path = format!("{}/lib/foo.py", root.display());
-    let (allowed, msg) = validate(&file_path, &worktree);
+    let (allowed, msg) = validate(&file_path, &worktree, "/Users/ben");
     assert!(!allowed);
     assert!(
         msg.starts_with("BLOCKED:"),
@@ -228,7 +218,7 @@ fn autonomous_strict_allows_in_worktree_path() {
     write_state_for(&root, "feat", AUTO_IN_PROGRESS);
     let worktree = format!("{}/.worktrees/feat", root.display());
     let file_path = format!("{}/.worktrees/feat/src/lib.rs", root.display());
-    let (allowed, msg) = validate(&file_path, &worktree);
+    let (allowed, msg) = validate(&file_path, &worktree, "/Users/ben");
     assert!(allowed, "in-worktree path must be allowed; got msg={}", msg);
 }
 
@@ -239,7 +229,7 @@ fn non_active_flow_preserves_existing_block_message_shape() {
     let root = tmp.path().canonicalize().unwrap();
     let worktree = format!("{}/.worktrees/feat", root.display());
     let file_path = format!("{}/lib/foo.py", root.display());
-    let (allowed, msg) = validate(&file_path, &worktree);
+    let (allowed, msg) = validate(&file_path, &worktree, "/Users/ben");
     assert!(!allowed);
     assert!(
         msg.starts_with("BLOCKED:"),
@@ -259,7 +249,7 @@ fn autonomous_strict_preserves_flow_states_redirect_message() {
     write_state_for(&root, "feat", AUTO_IN_PROGRESS);
     let worktree = format!("{}/.worktrees/feat", root.display());
     let file_path = format!("{}/.worktrees/feat/.flow-states/feat/log", root.display());
-    let (allowed, msg) = validate(&file_path, &worktree);
+    let (allowed, msg) = validate(&file_path, &worktree, "/Users/ben");
     assert!(!allowed);
     assert!(
         msg.contains(".flow-states/"),
@@ -269,25 +259,125 @@ fn autonomous_strict_preserves_flow_states_redirect_message() {
     assert!(!msg.contains("out_of_worktree_in_autonomous"));
 }
 
+// --- validate() out-of-project gate matrix ---
+//
+// Out-of-project paths (not under project_root) are fail-closed during
+// an active flow (cwd inside a worktree). Only the approved surface
+// (auto-memory dir + /tmp scratch) is allowed; everything else is
+// blocked — autonomous flows get the `out_of_bounds_in_autonomous`
+// JSON envelope, manual flows get the prose BLOCKED message. Fixtures
+// canonicalize the tempdir root per
+// `.claude/rules/testing-gotchas.md` "macOS Subprocess Path
+// Canonicalization" so the project_root prefix comparison inside
+// validate() matches.
+
 #[test]
-fn autonomous_strict_still_allows_paths_outside_project_root_documents_residual_gap() {
-    // Branch C residual gap: paths outside `project_root` (e.g.
-    // ~/.config) are still allowed by validate() even during
-    // autonomous flows. The hook layer disclaims jurisdiction over
-    // those paths (line 318-321 of the source). Closing this gap
-    // requires either a Claude Code feature or a project settings
-    // allow-list extension — outside the scope of this PR. See
-    // CLAUDE.md "Key Files" entry for `src/hooks/agent_prompt_scan.rs`.
+fn validate_out_of_project_plugin_read_autonomous_emits_envelope() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path().canonicalize().unwrap();
     write_state_for(&root, "feat", AUTO_IN_PROGRESS);
     let worktree = format!("{}/.worktrees/feat", root.display());
-    let (allowed, msg) = validate("/etc/hosts", &worktree);
+    // home is OUTSIDE the project root so the path reaches the
+    // out-of-project branch (a home under root would be in-project).
+    let home = "/Users/testuser";
+    let plugin_path = "/Users/testuser/.claude/plugins/cache/flow/0.1/SKILL.md";
+    let (allowed, msg) = validate(plugin_path, &worktree, home);
+    assert!(!allowed);
     assert!(
-        allowed,
-        "paths outside project_root remain allowed at this layer; got msg={}",
+        msg.contains("\"reason\":\"out_of_bounds_in_autonomous\""),
+        "expected out_of_bounds envelope; got: {}",
         msg
     );
+    assert!(msg.contains("\"autonomous\":true"));
+    assert!(msg.contains(plugin_path));
+}
+
+#[test]
+fn validate_out_of_project_plugin_read_manual_emits_prose() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+    write_state_for(&root, "feat", MANUAL_IN_PROGRESS);
+    let worktree = format!("{}/.worktrees/feat", root.display());
+    let home = "/Users/testuser";
+    let plugin_path = "/Users/testuser/.claude/plugins/cache/flow/0.1/SKILL.md";
+    let (allowed, msg) = validate(plugin_path, &worktree, home);
+    assert!(!allowed);
+    assert!(
+        msg.starts_with("BLOCKED:"),
+        "manual flow should emit prose BLOCKED; got: {}",
+        msg
+    );
+    assert!(!msg.contains("out_of_bounds_in_autonomous"));
+}
+
+#[test]
+fn validate_out_of_project_memory_read_is_allowed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+    write_state_for(&root, "feat", AUTO_IN_PROGRESS);
+    let worktree = format!("{}/.worktrees/feat", root.display());
+    let home = "/Users/testuser";
+    let memory_path = "/Users/testuser/.claude/projects/abc/memory/MEMORY.md";
+    let (allowed, msg) = validate(memory_path, &worktree, home);
+    assert!(
+        allowed,
+        "approved memory path must be allowed; got: {}",
+        msg
+    );
+}
+
+#[test]
+fn validate_out_of_project_tmp_scratch_is_allowed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+    write_state_for(&root, "feat", AUTO_IN_PROGRESS);
+    let worktree = format!("{}/.worktrees/feat", root.display());
+    // /tmp/x.md is out-of-project relative to the tempdir root and in
+    // the approved extension set.
+    let (allowed, msg) = validate("/tmp/flow-scratch.md", &worktree, "/Users/ben");
+    assert!(
+        allowed,
+        "approved /tmp scratch must be allowed; got: {}",
+        msg
+    );
+}
+
+#[test]
+fn validate_out_of_project_arbitrary_path_is_blocked() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+    // No state file → not autonomous → prose BLOCKED.
+    let worktree = format!("{}/.worktrees/feat", root.display());
+    let (allowed, msg) = validate("/etc/hosts", &worktree, "/Users/ben");
+    assert!(!allowed, "arbitrary out-of-project path must be blocked");
+    assert!(msg.starts_with("BLOCKED:"));
+}
+
+#[test]
+fn validate_cwd_not_in_worktree_allows_out_of_project_path() {
+    // The fail-closed gate is scoped to cwd-inside-a-worktree (the
+    // active-flow proxy). On a plain repo cwd, out-of-project behavior
+    // is unchanged — the "not in a worktree" early return allows.
+    let (allowed, msg) = validate("/etc/hosts", "/Users/ben/code/flow", "/Users/ben");
+    assert!(allowed, "non-worktree cwd must not block; got: {}", msg);
+    assert!(msg.is_empty());
+}
+
+#[test]
+fn validate_out_of_project_block_is_tool_agnostic() {
+    // validate() does not branch on tool name — an out-of-project path
+    // blocks identically whether the caller is a Read or an Edit/Write
+    // (run_impl_main reaches validate() before any tool-name check).
+    // The regression guard is against a future tool-name carve-out
+    // inside validate() that would let an out-of-project Edit slip.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+    let worktree = format!("{}/.worktrees/feat", root.display());
+    // Out-of-project (not under the tempdir root), not memory, not /tmp.
+    let edit_target = "/Users/someone/other-repo/config.toml";
+    let (allowed, msg) = validate(edit_target, &worktree, "/Users/ben");
+    assert!(!allowed, "out-of-project Edit/Write target must block");
+    assert!(msg.starts_with("BLOCKED:"));
 }
 
 // --- is_approved_out_of_project_path tests ---
@@ -1166,7 +1256,7 @@ fn detect_misplaced_collapses_doubled_slashes_inside_suffix() {
 fn validate_rejects_worktree_flow_states_write() {
     let cwd = "/Users/ben/code/flow/.worktrees/feat/api";
     let file_path = "/Users/ben/code/flow/.worktrees/feat/.flow-states/plan.md";
-    let (allowed, msg) = validate(file_path, cwd);
+    let (allowed, msg) = validate(file_path, cwd, "/Users/ben");
     assert!(!allowed);
     assert!(msg.contains("BLOCKED"));
     assert!(msg.contains(".flow-states/"));
@@ -1178,7 +1268,7 @@ fn validate_rejects_worktree_flow_states_write() {
 fn validate_rejects_service_subdir_flow_states_write() {
     let cwd = "/Users/ben/code/flow/.worktrees/feat/api";
     let file_path = "/Users/ben/code/flow/.worktrees/feat/api/.flow-states/plan.md";
-    let (allowed, msg) = validate(file_path, cwd);
+    let (allowed, msg) = validate(file_path, cwd, "/Users/ben");
     assert!(!allowed);
     assert!(msg.contains("BLOCKED"));
     assert!(msg.contains("/Users/ben/code/flow/.flow-states/plan.md"));
@@ -1188,7 +1278,7 @@ fn validate_rejects_service_subdir_flow_states_write() {
 fn validate_accepts_main_repo_flow_states_write_from_subdir_cwd() {
     let cwd = "/Users/ben/code/flow/.worktrees/feat/api";
     let file_path = "/Users/ben/code/flow/.flow-states/feat/plan.md";
-    let (allowed, msg) = validate(file_path, cwd);
+    let (allowed, msg) = validate(file_path, cwd, "/Users/ben");
     assert!(allowed);
     assert!(msg.is_empty());
 }
@@ -1197,7 +1287,7 @@ fn validate_accepts_main_repo_flow_states_write_from_subdir_cwd() {
 fn validate_accepts_worktree_non_flow_states_write() {
     let cwd = "/Users/ben/code/flow/.worktrees/feat/api";
     let file_path = "/Users/ben/code/flow/.worktrees/feat/api/src/main.rs";
-    let (allowed, msg) = validate(file_path, cwd);
+    let (allowed, msg) = validate(file_path, cwd, "/Users/ben");
     assert!(allowed);
     assert!(msg.is_empty());
 }
@@ -1208,7 +1298,7 @@ fn validate_plain_repo_no_op() {
     // pre-existing "not in a worktree" early-return.
     let cwd = "/Users/ben/code/flow";
     let file_path = "/Users/ben/code/flow/.flow-states/feat/plan.md";
-    let (allowed, msg) = validate(file_path, cwd);
+    let (allowed, msg) = validate(file_path, cwd, "/Users/ben");
     assert!(allowed);
     assert!(msg.is_empty());
 }


### PR DESCRIPTION
## What

#1711.

Closes #1711

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/autonomous-flow-stalls/log` |
| State | `.flow-states/autonomous-flow-stalls/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 30m |
| Review | 10h 54m |
| Learn | 14m |
| Complete | <1m |
| **Total** | **11h 40m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 4.0M | $0.964 |
| Code | 182.7M | $48.686 ↻ |
| Review | 194.0M | $89.883 |
| Learn | 45.7M | $17.322 |
| Complete | 0 | $0.630 |
| **Total** | **426.3M** | **$157.485** |

| Model | Tokens |
|-------|--------|
| claude-opus-4-7 | 426.3M |
| <synthetic> | 0 |

*↻ rate-limit window reset observed mid-flow.*

<!-- end:Token Cost -->

## Review Findings

- ✗ **Pre-mortem P1: out-of-project gate blocks ~/.claude/rules/\* (in UNIVERSAL_ALLOW as Read) so it over-blocks a path native allows without a prompt.**
  - Dismissed — Deliberate scope, not a defect. Issue 1711 Approach scoped the approved surface to memory + /tmp and excluded other UNIVERSAL_ALLOW out-of-project entries by design (plugin cache named explicitly). No FLOW phase Reads user-global ~/.claude/rules during a flow; FLOW rules live in-worktree at .claude/rules. Over-blocking an out-of-project path is hang-safe (exit 2, recoverable) and does not reintroduce the reported plugin-source-read bug. Adding rules tool-agnostically (is_approved_out_of_project_path is tool-agnostic, validate_worktree_paths.rs) would re-open a rules-Write native-prompt hang the current code safely blocks; a tool-aware variant needs unverified Claude Code per-tool permission semantics (research-before-design). The underlying doc over-claim is the real defect, fixed as R1/D1. Per filing-issues Mechanical Blocks Are Presumptively Intentional.
- ✗ **Pre-mortem P4: a Review/Learn sub-agent that Reads ~/.claude/rules/\* during a flow would be blocked by the out-of-project gate.**
  - Dismissed — Same root as P1, dismissed for the same reasons. Sub-agents in FLOW phases are scoped to the worktree per research-target-project.md and do not Read user-global ~/.claude/rules; the agent_prompt_scan hook already blocks out-of-worktree path tokens in agent prompts upstream. A blocked out-of-project Read returns exit 2 (recoverable), not a hang. The approved-surface scope (memory + /tmp) is deliberate; see P1 dismissal.
- ✗ **Pre-mortem P2: the out-of-project block fires whenever cwd contains .worktrees/, including a stale or manually-created worktree with no active flow (no state file).**
  - Dismissed — The cwd-in-.worktrees/ flow-active proxy is the established, deliberate design. The sibling shared-config gate in the same file (validate_shared_config, validate_worktree_paths.rs ~line 127) uses the identical proxy, and the plan states scope is automatic via compute_worktree_paths(cwd). A non-flow worktree gets the prose BLOCKED message (is_autonomous_flow_active reads the state file and returns false), and the block is hang-safe (exit 2). Adding an is_flow_active state-file precondition here would diverge from the sibling gate without preventing any hang or security issue. Per filing-issues Mechanical Blocks Are Presumptively Intentional.
- ✓ **Adversarial A1/A2/A3: is_approved_out_of_project_path edge cases in src/hooks/validate_worktree_paths.rs.**
  - Fixed — Fixed. A1: the /tmp class is home-independent and is now checked BEFORE the home guard, so an unset/relative $HOME no longer suppresses approved /tmp scratch. A2: input is collapse_double_slashes-normalized once up front so a doubled-slash memory path is approved like the /tmp class already accepts /tmp//x.md. A3: a trailing-slash $HOME is stripped before the prefix comparison so a legitimate MEMORY.md is not blocked. Guards added in tests/hooks/validate_worktree_paths.rs (approved_oop_tmp_allowed_with_empty_home, approved_oop_tmp_allowed_with_relative_home, approved_oop_memory_doubled_slash_is_allowed, approved_oop_memory_trailing_slash_home_is_allowed, validate_out_of_project_tmp_allowed_with_empty_home).
- ✓ **Reviewer R2: the memory class in is_approved_out_of_project_path admitted '.', '..', and empty path segments, approving a memory-rooted path that escapes via traversal.**
  - Fixed — Fixed. After collapsing slashes and splitting the post-home tail, the helper now rejects the path when any segment is empty, '.', or '..' before the structural memory match — a '..' past memory/ is not a native single-segment match and would otherwise defer to a native prompt (hang) while also allowing traversal. Guards added in tests/hooks/validate_worktree_paths.rs: approved_oop_memory_parent_traversal_segment_is_blocked and approved_oop_memory_dot_segment_is_blocked.
- ✓ **Reviewer R1 + Documentation D1: the validate_worktree_paths.rs module doc and is_approved_out_of_project_path doc over-claimed the approved surface as 'everything native allows without a prompt' (memory/rules UNIVERSAL_ALLOW entries are Read-only; the gate is tool-agnostic), and used backward-facing prose ('the prior behavior').**
  - Fixed — Fixed. The doc now describes the approved surface as a DELIBERATE SUBSET of UNIVERSAL_ALLOW's out-of-project entries (memory dir + /tmp scratch), states the check is path-shaped/tool-agnostic, notes a memory Edit/Write is left to the native system (the entry is Read-only), and explains over-blocking is the hang-safe direction. All forward-facing per forward-facing-authoring.md; the backward-facing '(the prior behavior)' sentence in the module doc is removed.
- ✓ **Reviewer R3: no subprocess test drove run_impl_main's $HOME resolution into the memory-allow path; the helper unit tests pass home directly, bypassing the env-var wiring.**
  - Fixed — Fixed. Added validate_subprocess_memory_read_allowed_via_resolved_home in tests/hooks/validate_worktree_paths.rs: it spawns the hook with HOME pinned to a tempdir and an out-of-project memory file_path rooted at that HOME (memory dir under a separate tempdir from the worktree root), asserting exit 0. Guards against a change that drops or mis-resolves $HOME in run_impl_main.
- ✓ **Reviewer R4: the drift contract test's extraction marker '//tmp/\*.' was shape-specific and would silently miss a /tmp entry added to UNIVERSAL_ALLOW in a single-slash shape.**
  - Fixed — Fixed. Broadened the marker in approved_tmp_extensions_match_universal_allow (tests/hooks/validate_worktree_paths.rs) to '/tmp/\*.', a substring of both 'Read(//tmp/\*.md)' and a hypothetical 'Read(/tmp/\*.md)', so a future /tmp entry in either shape is still extracted rather than silently missed.
- ✓ **Documentation D2: the 'Autonomous-flow-strict response shape' bullet in .claude/rules/hook-vs-instruction.md used backward-facing prose ('out-of-project paths are NO LONGER deferred', 'closing the prior residual gap').**
  - Fixed — Fixed via bin/flow write-rule. The sentence now reads forward-facing: out-of-project paths are fail-closed except the approved surface (memory dir + /tmp scratch); a blocked path returns exit 2 with no native prompt so an unattended flow never hangs. git diff confirmed only that paragraph changed.
- ✓ **Documentation D3: the 'Residual gap' paragraph in .claude/rules/cognitive-isolation.md used backward-facing prose ('are now fail-closed', 'the earlier ... gap is closed for the active-flow case').**
  - Fixed — Fixed via bin/flow write-rule. The paragraph now reads forward-facing: out-of-project paths are fail-closed during an active flow — allowed only for the approved memory + /tmp scratch surface and blocked (exit 2, no prompt) otherwise. git diff confirmed only that paragraph changed.
- ✓ **Documentation D4: the CLAUDE.md Key Files entry for agent_prompt_scan.rs was over-long, backward-facing ('now also fail-closes'), and described another file's mechanics (validate-worktree-paths).**
  - Fixed — Fixed via bin/flow write-rule. The entry is trimmed to agent_prompt_scan.rs's own name + 1-line purpose per docs-with-behavior.md Key Files shape, removing the validate-worktree-paths parenthetical and the backward-facing 'now also fail-closes'. git diff confirmed only that bullet changed.
- ✓ **Infrastructure (discovered during Review Step 4 CI): bin/test's full-suite wall-clock gate used bash $SECONDS, which carried an inherited offset under the hours-old parent shell, reporting ~1956s for a run ci.rs's monotonic Instant measured at 116s — a FALSE suite-timeout failure (5187/5187 tests pass, 100/100/100 coverage).**
  - Fixed — Fixed. Changed the full-suite gate timer in bin/test (the cargo llvm-cov nextest span) from $SECONDS to date +%s (absolute epoch, immune to inherited $SECONDS). The display-only timers in per-file/audit/meta modes are non-gating and intentionally left on $SECONDS. Pre-existing bug surfaced because this autonomous session is 5+ hours old; per fix-infrastructure-bugs.md the blocking infra bug was fixed in-flow rather than worked around. Re-running full CI to confirm green.

<!-- end:Review Findings -->

## Learn Findings

- + **Missing discipline: subprocess-test-hygiene.md covered env-var neutralization but not working-directory isolation for spawned-binary tests; a hook subprocess test without .current_dir(fixture) resolves the real worktree branch+state and can false-fail on in-flight state fields.**
  - Rule clarified — Surfaced by the learn-analyst from the Review-phase validate_skill false failure. Added a 'Working Directory Isolation' section to .claude/rules/subprocess-test-hygiene.md (the spawned-binary sibling of testing-gotchas Host Environment Leaks), requiring .current_dir(fixture_root) for FLOW-binary subprocess tests that read the state file, plus a hook table-row update. Forward-facing and generic; future hook subprocess tests now have explicit guidance.

<!-- end:Learn Findings -->

## State File

<details>
<summary>.flow-states/autonomous-flow-stalls.json</summary>

```json
{
  "schema_version": 1,
  "branch": "autonomous-flow-stalls",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1712,
  "pr_url": "https://github.com/benkruger/flow/pull/1712",
  "started_at": "2026-05-24T19:03:04-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/autonomous-flow-stalls/log",
    "state": ".flow-states/autonomous-flow-stalls/state.json"
  },
  "session_tty": "/dev/ttys015",
  "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5.jsonl",
  "notes": [],
  "prompt": "#1711",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-24T19:03:04-07:00",
      "completed_at": "2026-05-24T19:03:35-07:00",
      "session_started_at": null,
      "cumulative_seconds": 31,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-24T19:03:04-07:00",
        "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
        "model": "claude-opus-4-7",
        "five_hour_pct": 5,
        "seven_day_pct": 11,
        "session_input_tokens": 16,
        "session_output_tokens": 4813,
        "session_cache_creation_tokens": 787211,
        "session_cache_read_tokens": 1288152,
        "session_cost_usd": 23.98703025,
        "by_model": {
          "claude-opus-4-7": {
            "input": 16,
            "output": 4813,
            "cache_create": 787211,
            "cache_read": 1288152
          }
        },
        "turn_count": 8,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 262812,
        "context_window_pct": 131.406
      },
      "window_at_complete": {
        "captured_at": "2026-05-24T19:03:35-07:00",
        "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
        "model": "claude-opus-4-7",
        "five_hour_pct": 5,
        "seven_day_pct": 11,
        "session_input_tokens": 46,
        "session_output_tokens": 7377,
        "session_cache_creation_tokens": 791124,
        "session_cache_read_tokens": 5242788,
        "session_cost_usd": 24.95063175,
        "by_model": {
          "claude-opus-4-7": {
            "input": 46,
            "output": 7377,
            "cache_create": 791124,
            "cache_read": 5242788
          }
        },
        "turn_count": 23,
        "tool_call_count": 10,
        "context_at_last_turn_tokens": 264672,
        "context_window_pct": 132.336
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-24T19:03:42-07:00",
      "completed_at": "2026-05-24T19:34:22-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1840,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-24T19:03:42-07:00",
        "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
        "model": "claude-opus-4-7",
        "five_hour_pct": 5,
        "seven_day_pct": 11,
        "session_input_tokens": 52,
        "session_output_tokens": 8189,
        "session_cache_creation_tokens": 810084,
        "session_cache_read_tokens": 6301854,
        "session_cost_usd": 25.28481325,
        "by_model": {
          "claude-opus-4-7": {
            "input": 52,
            "output": 8189,
            "cache_create": 810084,
            "cache_read": 6301854
          }
        },
        "turn_count": 27,
        "tool_call_count": 12,
        "context_at_last_turn_tokens": 274151,
        "context_window_pct": 137.0755
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-24T19:08:51-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 6,
          "seven_day_pct": 11,
          "session_input_tokens": 166,
          "session_output_tokens": 108813,
          "session_cache_creation_tokens": 1690472,
          "session_cache_read_tokens": 33156657,
          "session_cost_usd": 34.00666875,
          "by_model": {
            "claude-opus-4-7": {
              "input": 166,
              "output": 108813,
              "cache_create": 1690472,
              "cache_read": 33156657
            }
          },
          "turn_count": 84,
          "tool_call_count": 37,
          "context_at_last_turn_tokens": 585678,
          "context_window_pct": 292.839
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-24T19:09:36-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 6,
          "seven_day_pct": 11,
          "session_input_tokens": 188,
          "session_output_tokens": 124572,
          "session_cache_creation_tokens": 1710901,
          "session_cache_read_tokens": 39619889,
          "session_cost_usd": 35.37254550000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 188,
              "output": 124572,
              "cache_create": 1710901,
              "cache_read": 39619889
            }
          },
          "turn_count": 95,
          "tool_call_count": 41,
          "context_at_last_turn_tokens": 592601,
          "context_window_pct": 296.3005
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-24T19:09:36-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 6,
          "seven_day_pct": 11,
          "session_input_tokens": 188,
          "session_output_tokens": 124572,
          "session_cache_creation_tokens": 1710901,
          "session_cache_read_tokens": 39619889,
          "session_cost_usd": 35.37254550000001,
          "by_model": {
            "claude-opus-4-7": {
              "input": 188,
              "output": 124572,
              "cache_create": 1710901,
              "cache_read": 39619889
            }
          },
          "turn_count": 95,
          "tool_call_count": 41,
          "context_at_last_turn_tokens": 592601,
          "context_window_pct": 296.3005
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-24T19:26:56-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 11,
          "session_input_tokens": 479,
          "session_output_tokens": 403656,
          "session_cache_creation_tokens": 2098150,
          "session_cache_read_tokens": 137782370,
          "session_cost_usd": 60.769918000000025,
          "by_model": {
            "claude-opus-4-7": {
              "input": 479,
              "output": 403656,
              "cache_create": 2098150,
              "cache_read": 137782370
            }
          },
          "turn_count": 242,
          "tool_call_count": 107,
          "context_at_last_turn_tokens": 766337,
          "context_window_pct": 383.1685
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-24T19:26:56-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 11,
          "session_input_tokens": 479,
          "session_output_tokens": 403656,
          "session_cache_creation_tokens": 2098150,
          "session_cache_read_tokens": 137782370,
          "session_cost_usd": 60.769918000000025,
          "by_model": {
            "claude-opus-4-7": {
              "input": 479,
              "output": 403656,
              "cache_create": 2098150,
              "cache_read": 137782370
            }
          },
          "turn_count": 242,
          "tool_call_count": 107,
          "context_at_last_turn_tokens": 766337,
          "context_window_pct": 383.1685
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-24T19:26:56-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 11,
          "session_input_tokens": 479,
          "session_output_tokens": 403656,
          "session_cache_creation_tokens": 2098150,
          "session_cache_read_tokens": 137782370,
          "session_cost_usd": 60.769918000000025,
          "by_model": {
            "claude-opus-4-7": {
              "input": 479,
              "output": 403656,
              "cache_create": 2098150,
              "cache_read": 137782370
            }
          },
          "turn_count": 242,
          "tool_call_count": 107,
          "context_at_last_turn_tokens": 766337,
          "context_window_pct": 383.1685
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-24T19:26:56-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 8,
          "seven_day_pct": 11,
          "session_input_tokens": 479,
          "session_output_tokens": 403656,
          "session_cache_creation_tokens": 2098150,
          "session_cache_read_tokens": 137782370,
          "session_cost_usd": 60.769918000000025,
          "by_model": {
            "claude-opus-4-7": {
              "input": 479,
              "output": 403656,
              "cache_create": 2098150,
              "cache_read": 137782370
            }
          },
          "turn_count": 242,
          "tool_call_count": 107,
          "context_at_last_turn_tokens": 766337,
          "context_window_pct": 383.1685
        },
        {
          "step": 8,
          "field": "code_task",
          "captured_at": "2026-05-24T19:33:55-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 0,
          "seven_day_pct": 11,
          "session_input_tokens": 583,
          "session_output_tokens": 459400,
          "session_cache_creation_tokens": 2224498,
          "session_cache_read_tokens": 179722716,
          "session_cost_usd": 71.45841149999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 583,
              "output": 459400,
              "cache_create": 2224498,
              "cache_read": 179722716
            }
          },
          "turn_count": 295,
          "tool_call_count": 132,
          "context_at_last_turn_tokens": 817339,
          "context_window_pct": 408.6695
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-24T19:34:22-07:00",
        "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
        "model": "claude-opus-4-7",
        "five_hour_pct": 0,
        "seven_day_pct": 11,
        "session_input_tokens": 599,
        "session_output_tokens": 461575,
        "session_cache_creation_tokens": 2233295,
        "session_cache_read_tokens": 187098227,
        "session_cost_usd": 73.97121524999997,
        "by_model": {
          "claude-opus-4-7": {
            "input": 599,
            "output": 461575,
            "cache_create": 2233295,
            "cache_read": 187098227
          }
        },
        "turn_count": 304,
        "tool_call_count": 138,
        "context_at_last_turn_tokens": 822022,
        "context_window_pct": 411.011
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-24T19:34:37-07:00",
      "completed_at": "2026-05-25T06:29:34-07:00",
      "session_started_at": null,
      "cumulative_seconds": 39297,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-24T19:34:37-07:00",
        "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
        "model": "claude-opus-4-7",
        "five_hour_pct": 0,
        "seven_day_pct": 12,
        "session_input_tokens": 605,
        "session_output_tokens": 462399,
        "session_cache_creation_tokens": 2267447,
        "session_cache_read_tokens": 190387579,
        "session_cost_usd": 74.91059324999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 605,
            "output": 462399,
            "cache_create": 2267447,
            "cache_read": 190387579
          }
        },
        "turn_count": 308,
        "tool_call_count": 140,
        "context_at_last_turn_tokens": 839097,
        "context_window_pct": 419.5485
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-24T19:35:38-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 0,
          "seven_day_pct": 12,
          "session_input_tokens": 633,
          "session_output_tokens": 474570,
          "session_cache_creation_tokens": 2270973,
          "session_cache_read_tokens": 202148296,
          "session_cost_usd": 78.39487149999997,
          "by_model": {
            "claude-opus-4-7": {
              "input": 633,
              "output": 474570,
              "cache_create": 2270973,
              "cache_read": 202148296
            }
          },
          "turn_count": 322,
          "tool_call_count": 148,
          "context_at_last_turn_tokens": 841159,
          "context_window_pct": 420.5795
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-24T21:10:08-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 12,
          "seven_day_pct": 14,
          "session_input_tokens": 28767,
          "session_output_tokens": 1034284,
          "session_cache_creation_tokens": 4512301,
          "session_cache_read_tokens": 263794909,
          "session_cost_usd": 127.26504835,
          "by_model": {
            "claude-opus-4-7": {
              "input": 28767,
              "output": 1034284,
              "cache_create": 4512301,
              "cache_read": 263794909
            }
          },
          "turn_count": 411,
          "tool_call_count": 193,
          "context_at_last_turn_tokens": 642299,
          "context_window_pct": 321.1495
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-25T06:29:01-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 2,
          "seven_day_pct": 15,
          "session_input_tokens": 29057,
          "session_output_tokens": 1562615,
          "session_cache_creation_tokens": 9585446,
          "session_cache_read_tokens": 370659272,
          "session_cost_usd": 163.72714985000005,
          "by_model": {
            "claude-opus-4-7": {
              "input": 29057,
              "output": 1562615,
              "cache_create": 9585446,
              "cache_read": 370659272
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 561,
          "tool_call_count": 250,
          "context_at_last_turn_tokens": 867004,
          "context_window_pct": 433.502
        }
      ],
      "agents_returned": [
        {
          "agent": "adversarial",
          "timestamp": "2026-05-24T19:43:39-07:00"
        },
        {
          "agent": "reviewer",
          "timestamp": "2026-05-24T19:46:29-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-24T19:51:38-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-24T19:58:17-07:00"
        }
      ],
      "agent_retry_counts": {
        "reviewer": 1,
        "pre-mortem": 1,
        "documentation": 1
      },
      "window_at_complete": {
        "captured_at": "2026-05-25T06:29:34-07:00",
        "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
        "model": "claude-opus-4-7",
        "five_hour_pct": 2,
        "seven_day_pct": 16,
        "session_input_tokens": 29069,
        "session_output_tokens": 1572137,
        "session_cache_creation_tokens": 9642611,
        "session_cache_read_tokens": 375868517,
        "session_cost_usd": 164.79382110000006,
        "by_model": {
          "claude-opus-4-7": {
            "input": 29069,
            "output": 1572137,
            "cache_create": 9642611,
            "cache_read": 375868517
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 567,
        "tool_call_count": 252,
        "context_at_last_turn_tokens": 886059,
        "context_window_pct": 443.0295
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-25T06:29:54-07:00",
      "completed_at": "2026-05-25T06:44:23-07:00",
      "session_started_at": null,
      "cumulative_seconds": 869,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-25T06:29:54-07:00",
        "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
        "model": "claude-opus-4-7",
        "five_hour_pct": 2,
        "seven_day_pct": 16,
        "session_input_tokens": 29078,
        "session_output_tokens": 1577378,
        "session_cache_creation_tokens": 9696308,
        "session_cache_read_tokens": 381193655,
        "session_cost_usd": 165.83690285000006,
        "by_model": {
          "claude-opus-4-7": {
            "input": 29078,
            "output": 1577378,
            "cache_create": 9696308,
            "cache_read": 381193655
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 573,
        "tool_call_count": 254,
        "context_at_last_turn_tokens": 903957,
        "context_window_pct": 451.9785
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-25T06:35:35-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-25T06:35:44-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 3,
          "seven_day_pct": 16,
          "session_input_tokens": 29116,
          "session_output_tokens": 1693578,
          "session_cache_creation_tokens": 9820452,
          "session_cache_read_tokens": 398638606,
          "session_cost_usd": 170.20444375000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 29116,
              "output": 1693578,
              "cache_create": 9820452,
              "cache_read": 398638606
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 592,
          "tool_call_count": 261,
          "context_at_last_turn_tokens": 944935,
          "context_window_pct": 472.4675
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-25T06:36:24-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 3,
          "seven_day_pct": 16,
          "session_input_tokens": 29122,
          "session_output_tokens": 1708320,
          "session_cache_creation_tokens": 9822018,
          "session_cache_read_tokens": 401473405,
          "session_cost_usd": 170.80303275000003,
          "by_model": {
            "claude-opus-4-7": {
              "input": 29122,
              "output": 1708320,
              "cache_create": 9822018,
              "cache_read": 401473405
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 595,
          "tool_call_count": 262,
          "context_at_last_turn_tokens": 945457,
          "context_window_pct": 472.7285
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-25T06:37:36-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 3,
          "seven_day_pct": 16,
          "session_input_tokens": 29152,
          "session_output_tokens": 1728340,
          "session_cache_creation_tokens": 9863407,
          "session_cache_read_tokens": 415780384,
          "session_cost_usd": 173.93384975,
          "by_model": {
            "claude-opus-4-7": {
              "input": 29152,
              "output": 1728340,
              "cache_create": 9863407,
              "cache_read": 415780384
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 610,
          "tool_call_count": 268,
          "context_at_last_turn_tokens": 960981,
          "context_window_pct": 480.4905
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-25T06:37:58-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 3,
          "seven_day_pct": 16,
          "session_input_tokens": 29160,
          "session_output_tokens": 1733166,
          "session_cache_creation_tokens": 9864449,
          "session_cache_read_tokens": 419625860,
          "session_cost_usd": 174.94214625,
          "by_model": {
            "claude-opus-4-7": {
              "input": 29160,
              "output": 1733166,
              "cache_create": 9864449,
              "cache_read": 419625860
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 614,
          "tool_call_count": 270,
          "context_at_last_turn_tokens": 961675,
          "context_window_pct": 480.8375
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-25T06:42:47-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 5,
          "seven_day_pct": 16,
          "session_input_tokens": 35964,
          "session_output_tokens": 1738230,
          "session_cache_creation_tokens": 9904442,
          "session_cache_read_tokens": 426527962,
          "session_cost_usd": 181.60612525,
          "by_model": {
            "claude-opus-4-7": {
              "input": 35964,
              "output": 1738230,
              "cache_create": 9904442,
              "cache_read": 426527962
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 622,
          "tool_call_count": 274,
          "context_at_last_turn_tokens": 582345,
          "context_window_pct": 291.1725
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-25T06:44:00-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 5,
          "seven_day_pct": 16,
          "session_input_tokens": 35964,
          "session_output_tokens": 1738230,
          "session_cache_creation_tokens": 9904442,
          "session_cache_read_tokens": 426527962,
          "session_cost_usd": 182.47667,
          "by_model": {
            "claude-opus-4-7": {
              "input": 35964,
              "output": 1738230,
              "cache_create": 9904442,
              "cache_read": 426527962
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 622,
          "tool_call_count": 274,
          "context_at_last_turn_tokens": 582345,
          "context_window_pct": 291.1725
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-25T06:44:11-07:00",
          "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
          "model": "claude-opus-4-7",
          "five_hour_pct": 5,
          "seven_day_pct": 16,
          "session_input_tokens": 35964,
          "session_output_tokens": 1738230,
          "session_cache_creation_tokens": 9904442,
          "session_cache_read_tokens": 426527962,
          "session_cost_usd": 182.84334325,
          "by_model": {
            "claude-opus-4-7": {
              "input": 35964,
              "output": 1738230,
              "cache_create": 9904442,
              "cache_read": 426527962
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 622,
          "tool_call_count": 274,
          "context_at_last_turn_tokens": 582345,
          "context_window_pct": 291.1725
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-25T06:44:23-07:00",
        "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
        "model": "claude-opus-4-7",
        "five_hour_pct": 5,
        "seven_day_pct": 16,
        "session_input_tokens": 35964,
        "session_output_tokens": 1738230,
        "session_cache_creation_tokens": 9904442,
        "session_cache_read_tokens": 426527962,
        "session_cost_usd": 183.15899525,
        "by_model": {
          "claude-opus-4-7": {
            "input": 35964,
            "output": 1738230,
            "cache_create": 9904442,
            "cache_read": 426527962
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 622,
        "tool_call_count": 274,
        "context_at_last_turn_tokens": 582345,
        "context_window_pct": 291.1725
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-25T06:44:50-07:00",
      "completed_at": "2026-05-25T06:45:12-07:00",
      "session_started_at": null,
      "cumulative_seconds": 22,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-25T06:44:50-07:00",
        "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
        "model": "claude-opus-4-7",
        "five_hour_pct": 5,
        "seven_day_pct": 16,
        "session_input_tokens": 35964,
        "session_output_tokens": 1738230,
        "session_cache_creation_tokens": 9904442,
        "session_cache_read_tokens": 426527962,
        "session_cost_usd": 184.18738675,
        "by_model": {
          "claude-opus-4-7": {
            "input": 35964,
            "output": 1738230,
            "cache_create": 9904442,
            "cache_read": 426527962
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 622,
        "tool_call_count": 274,
        "context_at_last_turn_tokens": 582345,
        "context_window_pct": 291.1725
      },
      "window_at_complete": {
        "captured_at": "2026-05-25T06:45:12-07:00",
        "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
        "model": "claude-opus-4-7",
        "five_hour_pct": 5,
        "seven_day_pct": 16,
        "session_input_tokens": 35964,
        "session_output_tokens": 1738230,
        "session_cache_creation_tokens": 9904442,
        "session_cache_read_tokens": 426527962,
        "session_cost_usd": 184.81722325,
        "by_model": {
          "claude-opus-4-7": {
            "input": 35964,
            "output": 1738230,
            "cache_create": 9904442,
            "cache_read": 426527962
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 622,
        "tool_call_count": 274,
        "context_at_last_turn_tokens": 582345,
        "context_window_pct": 291.1725
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-24T19:03:42-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-24T19:34:37-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-25T06:29:54-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-25T06:44:50-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-24T19:03:04-07:00",
    "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
    "model": "claude-opus-4-7",
    "five_hour_pct": 5,
    "seven_day_pct": 11,
    "session_input_tokens": 16,
    "session_output_tokens": 4813,
    "session_cache_creation_tokens": 787211,
    "session_cache_read_tokens": 1288152,
    "session_cost_usd": 23.98703025,
    "by_model": {
      "claude-opus-4-7": {
        "input": 16,
        "output": 4813,
        "cache_create": 787211,
        "cache_read": 1288152
      }
    },
    "turn_count": 8,
    "tool_call_count": 3,
    "context_at_last_turn_tokens": 262812,
    "context_window_pct": 131.406
  },
  "code_tasks_total": 8,
  "code_task_name": "Verify coverage and full CI",
  "code_task": 8,
  "diff_stats": {
    "files_changed": 6,
    "insertions": 617,
    "deletions": 102,
    "captured_at": "2026-05-24T19:34:22-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThe conversation is a continuation (post-compaction) of an autonomous FLOW lifecycle run (`/flow:flow-start #1711`) on the FLOW plugin repo itself. The flow is fully autonomous (`continue=auto`, `commit=auto`). Branch: `autonomous-flow-stalls`, worktree `/Users/ben/code/flow/.worktrees/autonomous-flow-stalls`, PR #1712, base `main`, project root `/Users/ben/code/flow`.\n\nLet me trace chronologically:\n\n1. **Resume after compaction (Review Step 2→3)**: The summary at the top established I was mid-Review-Phase-3, all four Review agents returned (adversarial, reviewer, pre-mortem, documentation), with findings A1/A2/A3 (adversarial), R1/R2/R3/R4 (reviewer), P1/P2/P4 (pre-mortem), D1/D2/D3/D4 (documentation). I re-oriented: read state.json (current_phase=flow-review, review_step=1, all 4 agents in agents_returned), read the production file `src/hooks/validate_worktree_paths.rs`, verified `Read(~/.claude/rules/*)` IS in `UNIVERSAL_ALLOW` (prime_check.rs:145, Read-only), read the committed plan (issue #1711).\n\n2. **Key analysis decision on P1/R1**: The plan deliberately scoped the approved out-of-project surface to \"memory + /tmp only\" (plugin cache explicitly excluded), but its stated invariant was \"only block paths native would prompt on.\" Blocking `~/.claude/rules/*` violates that invariant (P1). I decided: DISMISS P1/P4 (rules class) because (a) deliberate scope, (b) over-block is hang-safe, (c) no flow reads user-global rules, (d) adding it tool-agnostically reopens a rules-write hang, tool-aware needs unverified Claude Code per-tool semantics. Fix the underlying doc over-claim (R1/D1) instead.\n\n3. **Read Review skill Step 3/4 mechanics**, read the adversarial probe (`tests/test_adversarial_flow.rs` — confirmed A1/A2/A3 with failing assertions), read test file regions for R2/R3/R4.\n\n4. **Step 3 Triage**: Recorded 3 dismissals (P1, P4, P2) via `bin/flow add-finding --outcome dismissed`. Rendered triage summary (11 real, 3 false). Set review_step=3.\n\n5. **Step 4 Fix**: \n   - Edited `src/hooks/validate_worktree_paths.rs`: module doc (D1), `is_approved_out_of_project_path` doc (R1), and the function body (A1: /tmp before home guard; A2: collapse_double_slashes; A3: strip trailing-slash home; R2: reject `.`/`..`/empty segments). Then a follow-up edit to fix backward-facing phrases in my own doc.\n   - Edited `tests/hooks/validate_worktree_paths.rs`: added 6 helper guards + 1 validate() guard + 1 subprocess test (R3) + broadened drift marker (R4).\n   - Doc fixes via `bin/flow write-rule` (full-file reproduction + git-diff verify): CLAUDE.md (D4), `.claude/rules/hook-vs-instruction.md` (D2), `.claude/rules/cognitive-isolation.md` (D3). `cp` was blocked (not in allow list).\n   - Emptied the adversarial probe `tests/test_adversarial_flow.rs`.\n   - Recorded fixed findings via add-finding.\n\n6. **CI failures (critical infra discovery)**: First two CI runs FAILED on `=== FAIL: suite took 1956s/2080s, limit 600s ===` despite 5187/5187 passing at 100/100/100. I read `bin/test` (suite guard uses bash `$SECONDS`, lines 462/521) and `src/ci.rs` (Rust `Instant` measured bin/test at 116s). Concluded `$SECONDS` was corrupted by inheritance from the 5+ hour-old parent shell. Fixed `bin/test` suite guard to use `date +%s` (lines 462, 521). Recorded as a finding.\n\n7. **User typed `/flow:flow-continue`** mid-flow. I executed the flow-continue skill: git worktree list, `bin/flow clear-halt` (returned ok). Then diagnosed a NEW CI failure: `validate_skill::subprocess_validate_skill_allows_when_skill_not_user_only` exit 2 — read the test (no `.current_dir`, leaks real state, `_halt_pending=true` blocked it). Logged it for Learn as a process gap.\n\n8. **Re-ran CI green** (5187/5187, 100/100/100, suite 142s with date timer). Committed via `/flow:flow-commit` → sha `bd0a65d4`. Recorded findings. Set review_step=4.\n\n9. **Review Done**: phase-finalize (continue_action=invoke, 10h 54m). Invoked flow:flow-learn.\n\n10. **Learn Phase**: phase-enter (ok), resolve-skill-mode (commit=auto, continue=auto), base-branch=main. Read session log. Launched learn-analyst (first attempt blocked by agent_prompt_scan on `/flow:flow-note` token; re-launched scrubbed). Agent returned cleanly with one finding: hook subprocess-test cwd isolation (the validate_skill class). Recorded agent return. set learn_step=1. Synthesized. set learn_step=2. Updated `.claude/rules/subprocess-test-hygiene.md` via write-rule (added \"Working Directory Isolation\" section + table row), git-diff verified. Recorded finding (rule_clarified). set learn_step=3. promote-permissions (skipped, no_local_file). set learn_step=4 + continuation. Invoked /flow:flow-commit. Staged (1 file changed).\n\nThe most recent action: in the flow-commit skill (Learn's commit), I ran `git add -A` which staged 1 file (subprocess-test-hygiene.md, 43 insertions, 1 deletion). I need to continue: show diff, draft commit message, finalize-commit, then continue Learn to Step 6 (file the Tenant 1 issue), Step 7 (report), Done.\n\nLet me capture all user messages verbatim and security constraints.\n\nUser messages: (1) the compaction-summary system context (start), (2) `/flow:flow-continue` (the skill invocation), and the various skill-launch injections (flow-commit, flow-review, flow-learn) which are skill bodies not user prose. The only genuine user prose/command in THIS continuation was `/flow:flow-continue`.\n\nSecurity/process constraints to preserve: never raw git commit (use /flow:flow-commit), never bin/flow in background, .claude/+CLAUDE.md writes route through write-rule, never cd && git (use git -C), all real Review findings fixed in-PR (no filing), 100% coverage no waivers, forward-facing prose only, no TaskCreate/TaskUpdate, cognitive isolation (don't supplement agent findings), agent prompts must not contain out-of-worktree absolute path tokens.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   - The user ran `/flow:flow-start #1711` to execute FLOW's autonomous 5-phase lifecycle (Start→Code→Review→Learn→Complete) on issue #1711 in the FLOW plugin repo itself (dogfooding). Mode: fully autonomous (`continue=auto`, `commit=auto`).\n   - Issue #1711's fix: `validate()` in `src/hooks/validate_worktree_paths.rs` returned an unconditional allow for any out-of-project path during an active flow, deferring to Claude Code's native permission system which prompts and hangs an unattended autonomous flow. The fix turns it into a fail-closed gate: out-of-project paths allowed only in a small approved surface (memory dir + /tmp scratch ONLY; plugin cache deliberately blocked), else blocked exit 2 (no prompt). Autonomous flows get a JSON envelope `out_of_bounds_in_autonomous`; manual flows get prose `BLOCKED:`.\n   - Code phase already shipped (commits 8eac49e1, 09a467b). The continuation work is Phases 3 (Review), 4 (Learn), 5 (Complete).\n   - The user typed `/flow:flow-continue` mid-flow (the only direct user message in this continuation) — a resume directive; I cleared the halt and resumed.\n\n2. Key Technical Concepts:\n   - FLOW 5-phase lifecycle via SKILL.md + PreToolUse hooks (`bin/flow hook <name>`) + Rust subcommands + contract tests. State at `.flow-states/<branch>/state.json`, worktrees at `.worktrees/<branch>/`.\n   - `agent_prompt_scan` hook: blocks Agent tool calls whose `prompt` field contains out-of-worktree absolute path tokens (leading `/` like `/flow:flow-note`, `/tmp/...`, `/Users/...`; relative paths resolve under worktree → allowed).\n   - `validate-claude-paths` redirects Edit/Write on CLAUDE.md, `.claude/rules/`, `.claude/skills/` to `bin/flow write-rule` (full-file `fs::write`); blocks transcript-root access.\n   - `validate-worktree-paths`: out-of-project fail-closed gate (`is_approved_out_of_project_path`), shared-config gate, misplaced-flow-states detection. Allows `.flow-states/` reads.\n   - `UNIVERSAL_ALLOW` (src/prime_check.rs:145-158): out-of-project entries are `Read(~/.claude/rules/*)`, `Read(~/.claude/projects/*/memory/*)` (both Read-only), `Read+Write(//tmp/*.{txt,diff,patch,md,json,jsonl})`.\n   - `bin/test` suite timer uses bash `$SECONDS` (lines 462/521); `src/ci.rs` uses Rust `Instant` (lines 501/520/523, `cmd.status()`). `SUITE_TIMEOUT_SECS=600`. nextest capped at floor(cores/3) threads.\n   - Cognitive isolation: never supplement agent findings; agents self-gather to avoid agent_prompt_scan blocks.\n   - Layer 10 commit gate active-flow carve-out: requires `_continue_pending==\"commit\"` + transcript shows most-recent assistant Skill is `flow:flow-commit`.\n   - `_halt_pending` set by Stop hook on user prose; cleared only by `/flow:flow-continue` → `bin/flow clear-halt`.\n\n3. Files and Code Sections:\n   - `src/hooks/validate_worktree_paths.rs` (MODIFIED, committed bd0a65d4): Rewrote `is_approved_out_of_project_path(file_path, home)` — NUL check first, `collapse_double_slashes` normalize, /tmp class checked BEFORE the home guard (A1, home-independent), `home.strip_suffix('/')` (A3), reject any empty/`.`/`..` segment in the memory tail (R2), memory match `comps.len()>=5 && comps[0].eq_ignore_ascii_case(\".claude\") && comps[1]==\"projects\" && comps[3]==\"memory\"`. Rewrote module doc + helper doc forward-facing (R1/D1): \"DELIBERATE SUBSET of UNIVERSAL_ALLOW's out-of-project entries\", tool-agnostic, over-block-is-hang-safe.\n   - `tests/hooks/validate_worktree_paths.rs` (MODIFIED, committed): added `approved_oop_tmp_allowed_with_empty_home`, `approved_oop_tmp_allowed_with_relative_home`, `approved_oop_memory_doubled_slash_is_allowed`, `approved_oop_memory_trailing_slash_home_is_allowed`, `approved_oop_memory_parent_traversal_segment_is_blocked`, `approved_oop_memory_dot_segment_is_blocked`, `validate_out_of_project_tmp_allowed_with_empty_home`, `validate_subprocess_memory_read_allowed_via_resolved_home` (R3); broadened drift marker `//tmp/*.` → `/tmp/*.` (R4).\n   - `bin/test` (MODIFIED, committed bd0a65d4): suite-guard timer changed from `$SECONDS` to `date +%s` (lines ~462 `time_start=$(date +%s)`, ~524 `elapsed=$(($(date +%s) - time_start))`) with forward-facing comment. Display-only per-phase timers left on `$SECONDS`.\n   - `CLAUDE.md` (MODIFIED, committed bd0a65d4): trimmed agent_prompt_scan Key Files entry, forward-facing (D4).\n   - `.claude/rules/hook-vs-instruction.md` (MODIFIED, committed bd0a65d4): autonomous-strict response-shape note forward-facing (D2).\n   - `.claude/rules/cognitive-isolation.md` (MODIFIED, committed bd0a65d4): residual-gap note forward-facing (D3).\n   - `tests/test_adversarial_flow.rs` (git-ignored probe): emptied to a doc-comment placeholder.\n   - `.claude/rules/subprocess-test-hygiene.md` (MODIFIED, STAGED but NOT yet committed — Learn change): added \"## Working Directory Isolation\" section (require `.current_dir(fixture_root)` for FLOW-binary subprocess tests reading state) + updated the `bin/flow hook <name>` table row. git-diff verified: 43 insertions, 1 deletion.\n   - `tests/hooks/validate_skill.rs:572-598`: `subprocess_validate_skill_allows_when_skill_not_user_only` — spawns flow-rs with HOME but NO `.current_dir`, leaking real worktree state (the root of the false CI failure).\n\n4. Errors and fixes:\n   - CI false failure \"suite took 1956s/2080s, limit 600s\": ci.rs measured bin/test at 116s; bash `$SECONDS` corrupted by inheritance from 5+ hr session. Fixed bin/test suite guard to `date +%s`.\n   - `validate_skill` subprocess test exit 2: test lacks `.current_dir`, reads real `_halt_pending=true`. Resolved by `/flow:flow-continue` clearing the halt; logged as Learn finding (not fixed in this PR — out of scope).\n   - learn-analyst Agent launch blocked by agent_prompt_scan on `/flow:flow-note` token → re-launched with that token scrubbed.\n   - `cp` blocked (not in allow list) → used full-file write-rule + git-diff verification for all `.claude/`/CLAUDE.md edits.\n   - Compound commands (`&&`, `;`, `||`) and `echo`/`printenv` Bash calls blocked → split into separate calls; could not probe env directly.\n\n5. Problem Solving:\n   - P1 dismissal: blocking `~/.claude/rules/*` is deliberate plan scope + hang-safe; fix the doc over-claim (R1/D1) not the surface.\n   - bin/test `$SECONDS` infra bug: fixed per `fix-infrastructure-bugs.md` (blocking, no workaround).\n   - validate_skill test isolation: real but pre-existing/unrelated bug; logged for Learn → became the learn-analyst's sole finding → rule update (Step 3 done) + pending Tenant 1 issue (Step 6).\n\n6. All user messages:\n   - (System-provided compaction summary at start — context, not a request.)\n   - `/flow:flow-continue` (slash command — resume directive; I cleared `_halt_pending` and resumed). No other genuine user prose in this continuation; subsequent messages were skill-body injections (flow-commit, flow-review, flow-learn) and tool results.\n   - Standing constraints (must persist): never raw `git commit` (always `/flow:flow-commit`); never run `bin/flow` in background; route `.claude/`+CLAUDE.md writes through `bin/flow write-rule`; never `cd <path> && git` (use `git -C`); all real Review findings fixed in-PR (no filing); 100% coverage no waivers; forward-facing prose only; no TaskCreate/TaskUpdate; never supplement cognitively-isolated agent findings; agent prompts must contain no out-of-worktree absolute path tokens; never `--no-verify`; never rebase.\n\n7. Pending Tasks:\n   - Finish Learn Step 5 commit (in progress — flow-commit launched, staged).\n   - Learn Step 6: file a Tenant 1 process-gap GitHub issue to `benkruger/flow` for the existing hook subprocess tests' missing `.current_dir` (systematic audit + contract test). Record via `bin/flow add-issue` + `add-finding --outcome filed`.\n   - Learn Step 7: present the Learn report (set learn_step=6). Then Done: `phase-finalize --phase flow-learn` → continue=auto → invoke `flow:flow-complete`.\n   - Phase 5 (Complete): merge PR #1712, remove worktree, delete state.\n\n8. Current Work:\n   I am inside the `/flow:flow-commit` skill invoked by Learn Step 5 to commit the `.claude/rules/subprocess-test-hygiene.md` rule addition. I just ran `git add -A` which returned \"ok 1 file changed, 43 insertions(+), 1 deletion(-)\". The continuation context is set: `_continue_context=\"Set learn_step=5, then self-invoke flow:flow-learn --continue-step.\"` and `_continue_pending=commit`. Next in flow-commit: Round 4 (show `git status` + `git diff --cached`), Step 1 (draft full-format commit message), Round 5 (write commit-msg-content.txt → write-rule to commit-msg.txt), Round 6 (`finalize-commit /Users/ben/code/flow/.flow-states/autonomous-flow-stalls/commit-msg.txt autonomous-flow-stalls` — its internal ci will re-run, ~116s warm, date-timer now correct, should pass). learn-analyst already recorded; finding_count=13. notes=[] (no correction notes).\n\n9. Optional Next Step:\n   Continue the flow-commit skill for the Learn rule change: run `git status` + `git diff --cached` (showing the single subprocess-test-hygiene.md change), draft and display the full-format commit message, write it to `.flow-states/autonomous-flow-stalls/commit-msg-content.txt`, route via `write-rule` to `commit-msg.txt`, then run `bin/flow finalize-commit .../commit-msg.txt autonomous-flow-stalls` (timeout 600000). Then per the continuation context: set learn_step=5 and self-invoke `flow:flow-learn --continue-step` to reach Step 6 (file the Tenant 1 issue for \"hook subprocess tests inherit real worktree state — sweep `.current_dir` + add contract test\", to `benkruger/flow`), Step 7 (report), and Done (phase-finalize → flow-complete). This is directly in line with the active autonomous flow (`commit=auto`, `continue=auto`) the user authorized via `/flow:flow-start #1711` and resumed via `/flow:flow-continue`.\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/autonomous-flow-stalls",
  "compact_count": 5,
  "findings": [
    {
      "finding": "Pre-mortem P1: out-of-project gate blocks ~/.claude/rules/* (in UNIVERSAL_ALLOW as Read) so it over-blocks a path native allows without a prompt.",
      "reason": "Deliberate scope, not a defect. Issue 1711 Approach scoped the approved surface to memory + /tmp and excluded other UNIVERSAL_ALLOW out-of-project entries by design (plugin cache named explicitly). No FLOW phase Reads user-global ~/.claude/rules during a flow; FLOW rules live in-worktree at .claude/rules. Over-blocking an out-of-project path is hang-safe (exit 2, recoverable) and does not reintroduce the reported plugin-source-read bug. Adding rules tool-agnostically (is_approved_out_of_project_path is tool-agnostic, validate_worktree_paths.rs) would re-open a rules-Write native-prompt hang the current code safely blocks; a tool-aware variant needs unverified Claude Code per-tool permission semantics (research-before-design). The underlying doc over-claim is the real defect, fixed as R1/D1. Per filing-issues Mechanical Blocks Are Presumptively Intentional.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-24T21:09:41-07:00"
    },
    {
      "finding": "Pre-mortem P4: a Review/Learn sub-agent that Reads ~/.claude/rules/* during a flow would be blocked by the out-of-project gate.",
      "reason": "Same root as P1, dismissed for the same reasons. Sub-agents in FLOW phases are scoped to the worktree per research-target-project.md and do not Read user-global ~/.claude/rules; the agent_prompt_scan hook already blocks out-of-worktree path tokens in agent prompts upstream. A blocked out-of-project Read returns exit 2 (recoverable), not a hang. The approved-surface scope (memory + /tmp) is deliberate; see P1 dismissal.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-24T21:09:47-07:00"
    },
    {
      "finding": "Pre-mortem P2: the out-of-project block fires whenever cwd contains .worktrees/, including a stale or manually-created worktree with no active flow (no state file).",
      "reason": "The cwd-in-.worktrees/ flow-active proxy is the established, deliberate design. The sibling shared-config gate in the same file (validate_shared_config, validate_worktree_paths.rs ~line 127) uses the identical proxy, and the plan states scope is automatic via compute_worktree_paths(cwd). A non-flow worktree gets the prose BLOCKED message (is_autonomous_flow_active reads the state file and returns false), and the block is hang-safe (exit 2). Adding an is_flow_active state-file precondition here would diverge from the sibling gate without preventing any hang or security issue. Per filing-issues Mechanical Blocks Are Presumptively Intentional.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-24T21:09:54-07:00"
    },
    {
      "finding": "Adversarial A1/A2/A3: is_approved_out_of_project_path edge cases in src/hooks/validate_worktree_paths.rs.",
      "reason": "Fixed. A1: the /tmp class is home-independent and is now checked BEFORE the home guard, so an unset/relative $HOME no longer suppresses approved /tmp scratch. A2: input is collapse_double_slashes-normalized once up front so a doubled-slash memory path is approved like the /tmp class already accepts /tmp//x.md. A3: a trailing-slash $HOME is stripped before the prefix comparison so a legitimate MEMORY.md is not blocked. Guards added in tests/hooks/validate_worktree_paths.rs (approved_oop_tmp_allowed_with_empty_home, approved_oop_tmp_allowed_with_relative_home, approved_oop_memory_doubled_slash_is_allowed, approved_oop_memory_trailing_slash_home_is_allowed, validate_out_of_project_tmp_allowed_with_empty_home).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-24T21:52:57-07:00"
    },
    {
      "finding": "Reviewer R2: the memory class in is_approved_out_of_project_path admitted '.', '..', and empty path segments, approving a memory-rooted path that escapes via traversal.",
      "reason": "Fixed. After collapsing slashes and splitting the post-home tail, the helper now rejects the path when any segment is empty, '.', or '..' before the structural memory match — a '..' past memory/ is not a native single-segment match and would otherwise defer to a native prompt (hang) while also allowing traversal. Guards added in tests/hooks/validate_worktree_paths.rs: approved_oop_memory_parent_traversal_segment_is_blocked and approved_oop_memory_dot_segment_is_blocked.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-24T23:20:46-07:00"
    },
    {
      "finding": "Reviewer R1 + Documentation D1: the validate_worktree_paths.rs module doc and is_approved_out_of_project_path doc over-claimed the approved surface as 'everything native allows without a prompt' (memory/rules UNIVERSAL_ALLOW entries are Read-only; the gate is tool-agnostic), and used backward-facing prose ('the prior behavior').",
      "reason": "Fixed. The doc now describes the approved surface as a DELIBERATE SUBSET of UNIVERSAL_ALLOW's out-of-project entries (memory dir + /tmp scratch), states the check is path-shaped/tool-agnostic, notes a memory Edit/Write is left to the native system (the entry is Read-only), and explains over-blocking is the hang-safe direction. All forward-facing per forward-facing-authoring.md; the backward-facing '(the prior behavior)' sentence in the module doc is removed.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-24T23:20:53-07:00"
    },
    {
      "finding": "Reviewer R3: no subprocess test drove run_impl_main's $HOME resolution into the memory-allow path; the helper unit tests pass home directly, bypassing the env-var wiring.",
      "reason": "Fixed. Added validate_subprocess_memory_read_allowed_via_resolved_home in tests/hooks/validate_worktree_paths.rs: it spawns the hook with HOME pinned to a tempdir and an out-of-project memory file_path rooted at that HOME (memory dir under a separate tempdir from the worktree root), asserting exit 0. Guards against a change that drops or mis-resolves $HOME in run_impl_main.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-24T23:21:01-07:00"
    },
    {
      "finding": "Reviewer R4: the drift contract test's extraction marker '//tmp/*.' was shape-specific and would silently miss a /tmp entry added to UNIVERSAL_ALLOW in a single-slash shape.",
      "reason": "Fixed. Broadened the marker in approved_tmp_extensions_match_universal_allow (tests/hooks/validate_worktree_paths.rs) to '/tmp/*.', a substring of both 'Read(//tmp/*.md)' and a hypothetical 'Read(/tmp/*.md)', so a future /tmp entry in either shape is still extracted rather than silently missed.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-24T23:21:07-07:00"
    },
    {
      "finding": "Documentation D2: the 'Autonomous-flow-strict response shape' bullet in .claude/rules/hook-vs-instruction.md used backward-facing prose ('out-of-project paths are NO LONGER deferred', 'closing the prior residual gap').",
      "reason": "Fixed via bin/flow write-rule. The sentence now reads forward-facing: out-of-project paths are fail-closed except the approved surface (memory dir + /tmp scratch); a blocked path returns exit 2 with no native prompt so an unattended flow never hangs. git diff confirmed only that paragraph changed.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-24T23:21:13-07:00"
    },
    {
      "finding": "Documentation D3: the 'Residual gap' paragraph in .claude/rules/cognitive-isolation.md used backward-facing prose ('are now fail-closed', 'the earlier ... gap is closed for the active-flow case').",
      "reason": "Fixed via bin/flow write-rule. The paragraph now reads forward-facing: out-of-project paths are fail-closed during an active flow — allowed only for the approved memory + /tmp scratch surface and blocked (exit 2, no prompt) otherwise. git diff confirmed only that paragraph changed.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-24T23:21:18-07:00"
    },
    {
      "finding": "Documentation D4: the CLAUDE.md Key Files entry for agent_prompt_scan.rs was over-long, backward-facing ('now also fail-closes'), and described another file's mechanics (validate-worktree-paths).",
      "reason": "Fixed via bin/flow write-rule. The entry is trimmed to agent_prompt_scan.rs's own name + 1-line purpose per docs-with-behavior.md Key Files shape, removing the validate-worktree-paths parenthetical and the backward-facing 'now also fail-closes'. git diff confirmed only that bullet changed.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-24T23:37:06-07:00"
    },
    {
      "finding": "Infrastructure (discovered during Review Step 4 CI): bin/test's full-suite wall-clock gate used bash $SECONDS, which carried an inherited offset under the hours-old parent shell, reporting ~1956s for a run ci.rs's monotonic Instant measured at 116s — a FALSE suite-timeout failure (5187/5187 tests pass, 100/100/100 coverage).",
      "reason": "Fixed. Changed the full-suite gate timer in bin/test (the cargo llvm-cov nextest span) from $SECONDS to date +%s (absolute epoch, immune to inherited $SECONDS). The display-only timers in per-file/audit/meta modes are non-gating and intentionally left on $SECONDS. Pre-existing bug surfaced because this autonomous session is 5+ hours old; per fix-infrastructure-bugs.md the blocking infra bug was fixed in-flow rather than worked around. Re-running full CI to confirm green.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-25T02:49:39-07:00"
    },
    {
      "finding": "Missing discipline: subprocess-test-hygiene.md covered env-var neutralization but not working-directory isolation for spawned-binary tests; a hook subprocess test without .current_dir(fixture) resolves the real worktree branch+state and can false-fail on in-flight state fields.",
      "reason": "Surfaced by the learn-analyst from the Review-phase validate_skill false failure. Added a 'Working Directory Isolation' section to .claude/rules/subprocess-test-hygiene.md (the spawned-binary sibling of testing-gotchas Host Environment Leaks), requiring .current_dir(fixture_root) for FLOW-binary subprocess tests that read the state file, plus a hook table-row update. Forward-facing and generic; future hook subprocess tests now have explicit guidance.",
      "outcome": "rule_clarified",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-25T06:37:29-07:00",
      "path": ".claude/rules/subprocess-test-hygiene.md"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-25T06:45:12-07:00",
    "session_id": "31a6be86-f7f0-4f9e-a4bb-be9f0aac01d5",
    "model": "claude-opus-4-7",
    "five_hour_pct": 5,
    "seven_day_pct": 16,
    "session_input_tokens": 35964,
    "session_output_tokens": 1738230,
    "session_cache_creation_tokens": 9904442,
    "session_cache_read_tokens": 426527962,
    "session_cost_usd": 184.81722325,
    "by_model": {
      "claude-opus-4-7": {
        "input": 35964,
        "output": 1738230,
        "cache_create": 9904442,
        "cache_read": 426527962
      },
      "<synthetic>": {
        "input": 0,
        "output": 0,
        "cache_create": 0,
        "cache_read": 0
      }
    },
    "turn_count": 622,
    "tool_call_count": 274,
    "context_at_last_turn_tokens": 582345,
    "context_window_pct": 291.1725
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>