### PR TITLE
Flow Commit Fails On Branches

### DIFF
--- a/.claude/rules/concurrency-model.md
+++ b/.claude/rules/concurrency-model.md
@@ -174,20 +174,25 @@ sits — a sibling tempdir, a monorepo subdirectory of the
 integration trunk, or another feature-branch worktree all see
 the gate fire on the correct destination.
 
-Both `finalize_commit::run_impl` and
-`match_finalize_commit_destination` reach the route-to-root
-decision through the shared
-`crate::flow_paths::finalize_commit_destination` helper, so the
-hook and the binary agree on the commit destination by
-construction rather than by a maintained convention. That helper
-normalizes the branch via `normalize_gate_input` per
-`.claude/rules/security-gates.md` "Normalize Before Comparing",
-so case- or whitespace-variant branch args (`MAIN`, `  main  `)
-still match the integration-branch check. On the
-`default_branch_in` error path the helper routes to the
+`match_finalize_commit_destination` reaches the route-to-root
+decision through the `crate::flow_paths::finalize_commit_destination`
+helper — a pure `branch == integration` comparison. The binary
+(`finalize_commit::run_impl`) resolves its commit cwd separately,
+from git's actual checkout location via
+`crate::git::resolve_worktree_for_branch`; the two are different code
+paths yet agree on the route-to-root case by construction: a trunk
+commit (`branch == integration`) is, per git, checked out at the
+project root, so the binary commits there exactly where the hook
+gates it, and a feature branch is never the integration branch, so
+committing where git has it checked out can never be a disguised
+trunk commit. `finalize_commit_destination` normalizes the branch
+via `normalize_gate_input` per `.claude/rules/security-gates.md`
+"Normalize Before Comparing", so case- or whitespace-variant branch
+args (`MAIN`, `  main  `) still match the integration-branch check.
+On the `default_branch_in` error path the helper routes to the
 per-branch worktree (never the project root) and
-`match_finalize_commit_destination` returns no-block, so neither
-side treats an undetectable-integration commit as a trunk
+`match_finalize_commit_destination` returns no-block, so the hook
+never treats an undetectable-integration commit as a trunk
 destination.
 
 For every other shape — `git commit`, `git -C <path> commit`,

--- a/src/finalize_commit.rs
+++ b/src/finalize_commit.rs
@@ -3,14 +3,16 @@
 //! Routing. Every git operation inside `run_impl` (working-tree-dirty
 //! check, CI sub-invocation, plan-deviation staged diff, the commit-
 //! pull-push sequence, and the tree-snapshot used to refresh the CI
-//! sentinel) runs against `commit_cwd`, which is derived from the
-//! explicit `<branch>` argument and the project root via
-//! `FlowPaths::worktree()`. This decouples the commit destination
-//! from the caller's process cwd: a caller invoking from a sibling
-//! tempdir, a monorepo subdirectory of the integration trunk, or
-//! another feature-branch worktree all see the commit land on the
-//! feature-branch worktree that flow-start created at
-//! `<project_root>/.worktrees/<branch>/`.
+//! sentinel) runs against `commit_cwd`, which is resolved from git's
+//! actual checkout location for the explicit `<branch>` argument via
+//! `crate::git::resolve_worktree_for_branch` (`git worktree list
+//! --porcelain`). This decouples the commit destination from the
+//! caller's process cwd AND from the branch name: a branch checked
+//! out at the project root commits at the root, a branch in a linked
+//! worktree commits in that worktree, and a branch checked out
+//! nowhere (or a git failure) returns a `resolve_cwd` error before
+//! any other git operation runs rather than committing to a guessed
+//! `<project_root>/.worktrees/<branch>/` path that may not exist.
 //!
 //! Two gates and a post-CI re-stage run before committing:
 //!
@@ -40,7 +42,8 @@
 //! Output (JSON to stdout):
 //!   Success:   {"status": "ok", "sha": "<commit-hash>", "pull_merged": <bool>}
 //!   Conflict:  {"status": "conflict", "files": ["file1.py", ...]}
-//!   Error:     {"status": "error", "step": "ci|restage|plan_deviation|commit|pull|push", "message": "..."}
+//!   Error:     {"status": "error", "step": "resolve_cwd|working_tree_dirty|ci|restage|plan_deviation|commit|pull|push", "message": "..."}
+//!              ("resolve_cwd" also carries "reason": "branch_not_checked_out" when the branch is checked out nowhere)
 
 use std::fs;
 
@@ -121,14 +124,15 @@ fn run_git_in_dir(
 /// compiled `bin/flow finalize-commit` binary for testing via real git
 /// fixtures and stubs. No closure-injection seam.
 ///
-/// `commit_cwd` is the worktree path derived from the branch argument
-/// by `run_impl` via `FlowPaths::worktree()`. Every git operation here
-/// runs against it, never against the caller's process cwd.
+/// `commit_cwd` is the checkout path `run_impl` resolved from git for
+/// the branch argument via `crate::git::resolve_worktree_for_branch`.
+/// Every git operation here runs against it, never against the
+/// caller's process cwd.
 ///
-/// All git calls `.expect()` on Ok because the working_tree_dirty gate
-/// in `run_impl` already proved git is alive by the time this function
-/// runs — its `git diff --quiet` call would have returned Err and
-/// emitted `step: "working_tree_dirty"` if git couldn't be located.
+/// All git calls `.expect()` on Ok because `resolve_worktree_for_branch`
+/// (the first git call in `run_impl`) already proved git is alive by
+/// the time this function runs — a missing git binary would have
+/// emitted `step: "resolve_cwd"` and returned before reaching here.
 /// `commit` still has a non-zero exit branch (the index produces an
 /// empty commit, the user's identity isn't configured, etc.); pull and
 /// push retain non-zero branches for legit error cases (merge conflict,
@@ -200,9 +204,9 @@ fn finalize_commit(message_file: &str, branch: &str, commit_cwd: &std::path::Pat
 /// tests). The git working directory for every operation here —
 /// working-tree-dirty check, CI sub-invocation, staged-diff capture,
 /// commit-pull-push sequence, and the sentinel tree snapshot — is
-/// `commit_cwd`, derived from `<root>` and `<args.branch>` via
-/// `FlowPaths::worktree()`. The caller's process cwd does not influence
-/// the commit destination.
+/// `commit_cwd`, resolved from git's checkout location for `<args.branch>`
+/// via `crate::git::resolve_worktree_for_branch`. The caller's process
+/// cwd does not influence the commit destination.
 ///
 /// Returns `Result<Value, String>` where `Ok` carries any JSON response
 /// including status-error payloads (CI failure, commit failure, etc.) and
@@ -227,22 +231,50 @@ pub fn run_impl(args: &Args, root: &std::path::Path) -> Result<Value, String> {
         }
     };
 
-    // Branch-derived routing destination. An integration-branch
-    // (bootstrap) commit runs at the project root, where the trunk is
-    // checked out and no `<root>/.worktrees/<integration>` directory
-    // exists; every other branch runs in its per-branch worktree.
-    // `finalize_commit_destination` owns the decision; the Layer 10
-    // hook reaches the route-to-root case through the same pure
-    // branch-vs-integration comparison, so the binary's commit
-    // destination and the hook's block decision agree by construction
-    // (see that helper's doc comment for the precise invariant — the
-    // hook's `default_branch_in().ok()?` short-circuit keeps the
-    // `Err` path off the root route on both sides). The validated
-    // branch passed through `FlowPaths::try_new` (above) cannot
-    // contain `/` or `\0`, so the joined worktree path stays inside
-    // `<root>/.worktrees/`. Every downstream git, CI, and snapshot
-    // call binds to this value rather than the caller's process cwd.
-    let commit_cwd = crate::flow_paths::finalize_commit_destination(root, &args.branch);
+    // Commit destination resolved from git's actual checkout location,
+    // not inferred from the branch name. `git worktree list --porcelain`
+    // reports where `branch` is checked out: the project root for a
+    // trunk or feature-at-root checkout, or a linked worktree path.
+    // Resolving from git — rather than assuming
+    // `<root>/.worktrees/<branch>` — handles a feature branch checked
+    // out at the repo root, where the assumed worktree path does not
+    // exist and the working-tree-dirty gate below would otherwise
+    // refuse the commit. A git failure (`Err`) or a branch checked out
+    // nowhere (`Ok(None)`) returns a structured `resolve_cwd` error
+    // before any other git operation runs — never a fail-open default
+    // path. Every downstream git, CI, and snapshot call binds to
+    // `commit_cwd` rather than the caller's process cwd.
+    //
+    // The Layer 10 commit-gate hook is unaffected by this resolution:
+    // it decides *whether* to block a trunk commit via a pure
+    // `branch == integration` comparison
+    // (`crate::flow_paths::finalize_commit_destination`), a question
+    // independent of the physical commit destination. A trunk commit
+    // is, per git, checked out at the root, so the binary commits
+    // exactly where the hook gates it; a feature branch is never the
+    // integration branch, so committing where git has it checked out
+    // can never be a disguised trunk commit.
+    let commit_cwd = match crate::git::resolve_worktree_for_branch(root, &args.branch) {
+        Ok(Some(path)) => path,
+        Ok(None) => {
+            return Ok(json!({
+                "status": "error",
+                "step": "resolve_cwd",
+                "reason": "branch_not_checked_out",
+                "message": format!(
+                    "Branch {:?} is not checked out in any worktree; cannot determine the commit destination.",
+                    &args.branch
+                ),
+            }));
+        }
+        Err(msg) => {
+            return Ok(json!({
+                "status": "error",
+                "step": "resolve_cwd",
+                "message": msg,
+            }));
+        }
+    };
 
     // Derive phase number from state file's current_phase for log prefixes.
     let pn = {
@@ -266,11 +298,16 @@ pub fn run_impl(args: &Args, root: &std::path::Path) -> Result<Value, String> {
     // non-empty so the user makes an explicit choice: `git add` to
     // commit the working-tree state or `git restore <file>` to drop
     // unstaged edits. See `.claude/rules/plan-commit-atomicity.md`.
-    let working_tree_dirty = match run_git_in_dir(&commit_cwd, &["diff", "--quiet"], LOCAL_TIMEOUT)
-    {
-        Ok((code, _, _)) => code != 0,
-        Err(_) => true,
-    };
+    //
+    // `resolve_worktree_for_branch` above already proved git is alive
+    // and `commit_cwd` is a real worktree git reported, so this
+    // `git diff --quiet` cannot fail to spawn — `.expect()` per
+    // `.claude/rules/testability-means-simplicity.md` (a missing git
+    // binary surfaces as `resolve_cwd` and returns before reaching
+    // here).
+    let (diff_code, _, _) = run_git_in_dir(&commit_cwd, &["diff", "--quiet"], LOCAL_TIMEOUT)
+        .expect("git located by resolve_worktree_for_branch");
+    let working_tree_dirty = diff_code != 0;
 
     // Enforce CI before committing. run_impl checks the sentinel first —
     // if CI already passed for this tree state, it noops instantly.

--- a/src/flow_paths.rs
+++ b/src/flow_paths.rs
@@ -27,13 +27,15 @@
 //!   match the rightmost occurrence so a project path containing
 //!   `.worktrees/` as a non-marker component does not produce a false
 //!   match.
-//! - `finalize_commit_destination` — decides whether a
-//!   finalize-commit git operation runs at the project root (an
-//!   integration-branch / bootstrap commit) or in the per-branch
-//!   worktree (everything else). Called by both
-//!   `src/finalize_commit.rs::run_impl` and the Layer 10 commit
-//!   gate so the binary's commit cwd and the hook's block decision
-//!   agree by construction on the route-to-root case.
+//! - `finalize_commit_destination` — the Layer 10 commit gate's pure
+//!   `branch == integration` predicate: returns the project root for
+//!   an integration-branch / bootstrap commit and the per-branch
+//!   worktree for everything else. This is the hook's block decision
+//!   only — it is not the finalize-commit binary's physical router,
+//!   which resolves the commit cwd from git's actual checkout location
+//!   via `crate::git::resolve_worktree_for_branch`. The two agree on
+//!   the route-to-root case because a trunk commit is, per git,
+//!   checked out at the project root.
 //!
 //! `FlowPaths` also exposes `flow_states_dir()` for callers that
 //! already hold a branch-scoped instance and incidentally need the
@@ -491,8 +493,9 @@ pub fn compute_worktree_root(cwd: &str) -> Option<&str> {
     compute_worktree_paths(cwd).map(|(_, worktree_root)| worktree_root)
 }
 
-/// Decide which directory a finalize-commit git operation runs in
-/// for `branch`, given the project `root`.
+/// The Layer 10 commit gate's block predicate: would a finalize-commit
+/// on `branch` land on the integration trunk (the project `root`), or
+/// on a per-branch worktree?
 ///
 /// The integration branch (the trunk the bootstrap skills —
 /// flow-start, flow-prime, flow-release — commit on) is checked out
@@ -500,6 +503,13 @@ pub fn compute_worktree_root(cwd: &str) -> Option<&str> {
 /// its per-branch `<root>/.worktrees/<branch>/` worktree. This
 /// helper returns the project root for an integration-branch commit
 /// and the per-branch worktree for everything else.
+///
+/// This answers a question for the hook only — it is NOT the
+/// finalize-commit binary's physical router. `finalize_commit::run_impl`
+/// resolves its commit cwd from git's actual checkout location via
+/// `crate::git::resolve_worktree_for_branch`. This predicate exists so
+/// `match_finalize_commit_destination` can decide whether a commit on
+/// `branch` would target the trunk and therefore needs gating.
 ///
 /// The ONLY route-to-root case is: `crate::git::default_branch_in(root)`
 /// is `Ok(integration)` AND `branch` normalizes equal to
@@ -511,46 +521,35 @@ pub fn compute_worktree_root(cwd: &str) -> Option<&str> {
 /// clone, non-git dir) — routes to the per-branch worktree. The
 /// `Err` case deliberately does NOT route to the project root: when
 /// git cannot detect the integration branch there is no basis to
-/// treat the commit as an integration-branch destination, so the
-/// pre-existing per-branch worktree routing is preserved (a
-/// non-existent worktree then trips finalize-commit's
-/// working-tree-dirty gate, which is the safe refusal, not a commit
-/// onto the trunk).
+/// treat the commit as an integration-branch destination.
 ///
-/// Hook/binary agreement (the "cannot drift" invariant) holds for a
-/// precise reason, not because both processes resolve the same root:
+/// Hook/binary agreement (the "cannot drift" invariant) holds even
+/// though only the hook calls this helper:
 ///
-/// - **Ok arm.** Both `src/finalize_commit.rs::run_impl` and
-///   `src/hooks/validate_pretool.rs::match_finalize_commit_destination`
-///   reach the route-to-root decision through this same pure
-///   branch-vs-integration string comparison, which is independent
-///   of how each process resolved `root`. They agree by
-///   construction.
-/// - **Err arm.** The hook returns `None` (no block) on
-///   `default_branch_in` error *before* it calls this helper
-///   (`match_finalize_commit_destination`'s
-///   `default_branch_in(main_root).ok()?`). This helper never
-///   returns the project root on the `Err` path. Neither side
-///   treats an `Err`-state commit as an integration-branch
-///   destination, so the root-sensitive `worktree.is_dir()` probe
-///   the prior implementation used — and the hook/binary divergence
-///   it produced — is gone.
+/// - **Trunk commit.** When `branch == integration`, git has the
+///   trunk checked out at the project root, so
+///   `resolve_worktree_for_branch` routes the binary's commit to the
+///   root — exactly the destination this predicate flags for the
+///   hook's block decision.
+/// - **Feature commit.** A feature branch is never the integration
+///   branch, so this predicate never flags it as a trunk destination;
+///   the binary commits wherever git has the feature branch checked
+///   out (the repo root or a worktree), which can never be a disguised
+///   trunk commit.
 ///
 /// `FlowPaths::is_valid_branch` is checked first as the
 /// path-construction boundary required by
 /// `.claude/rules/branch-path-safety.md`: an empty / `.` / `..` /
 /// `/`- or `\0`-bearing branch must never be joined onto
-/// `.worktrees/`. Both production callers already validate upstream
-/// (`FlowPaths::try_new` in the binary,
-/// `extract_finalize_commit_branch_arg` via `is_valid_branch` in the
-/// hook), so an invalid branch is unreachable in production; the
-/// guard returns the project root (a non-escaping path the helper
-/// already returns for the integration case) rather than
-/// constructing a traversal-shaped worktree path.
+/// `.worktrees/`. The hook's caller validates upstream
+/// (`extract_finalize_commit_branch_arg` via `is_valid_branch`), so
+/// an invalid branch is unreachable in production; the guard returns
+/// the project root (a non-escaping path the helper already returns
+/// for the integration case) rather than constructing a
+/// traversal-shaped worktree path.
 ///
-/// Named production consumers (per
+/// Named production consumer (per
 /// `.claude/rules/docs-with-behavior.md`):
-/// `src/finalize_commit.rs::run_impl` (the commit cwd) and
 /// `src/hooks/validate_pretool.rs::match_finalize_commit_destination`
 /// (the Layer 10 integration-branch gate).
 pub fn finalize_commit_destination(root: &Path, branch: &str) -> PathBuf {

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,3 +1,27 @@
+//! Git subprocess wrappers. Each public function shells out to `git`
+//! and parses the result; the pure parsing helpers behind them are
+//! private and exercised through the public surface over real-git
+//! fixtures.
+//!
+//! Families:
+//!
+//! - `project_root` — locate the main repository root via
+//!   `git worktree list --porcelain` (three-layer split: run git →
+//!   `from_output` → `from_stdout`). Fails open to `"."`.
+//! - `current_branch` / `current_branch_in` — read the current branch
+//!   (`git branch --show-current`), with a `FLOW_SIMULATE_BRANCH`
+//!   override in the env-reading variant.
+//! - `default_branch_in` — resolve the integration branch from
+//!   `git symbolic-ref refs/remotes/origin/HEAD`. Returns `Err` when
+//!   git cannot name it rather than guessing a default.
+//! - `resolve_branch` / `resolve_branch_in` — pick which branch's
+//!   state file to use, honoring a `--branch` override.
+//! - `resolve_worktree_for_branch` — report where a branch is checked
+//!   out via `git worktree list --porcelain` (same three-layer split
+//!   as `project_root`), returning `Err` on git failure rather than a
+//!   fail-open default so callers can route a commit to git's actual
+//!   checkout location instead of inferring it from the branch name.
+
 use std::env;
 use std::io;
 use std::path::{Path, PathBuf};

--- a/src/git.rs
+++ b/src/git.rs
@@ -43,6 +43,88 @@ fn project_root_with_stdout(stdout: &str) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
+/// Resolve the worktree path where `branch` is currently checked out by
+/// asking git, rather than inferring the location from the branch name.
+///
+/// Runs `git -C <root> worktree list --porcelain` and returns:
+/// - `Ok(Some(path))` — `branch` is checked out at `path` (the repo root
+///   for a trunk/feature-at-root checkout, or a linked worktree path).
+/// - `Ok(None)` — `branch` is not checked out in any worktree.
+/// - `Err(msg)` — git could not be run (binary missing) or exited
+///   non-zero (cwd/`root` is not inside a git repository).
+///
+/// Mirrors the [`project_root`] three-layer split (`resolve` runs git →
+/// `from_output` interprets the raw result → `from_stdout` parses the
+/// text), but does NOT inherit that family's fail-open `"."` default:
+/// a silent fallback on git failure would route a commit to the wrong
+/// directory. Git failure surfaces as `Err`; absence surfaces as
+/// `Ok(None)`.
+pub fn resolve_worktree_for_branch(root: &Path, branch: &str) -> Result<Option<PathBuf>, String> {
+    worktree_for_branch_from_output(
+        Command::new("git")
+            .args([
+                "-C",
+                &root.to_string_lossy(),
+                "worktree",
+                "list",
+                "--porcelain",
+            ])
+            .output(),
+        branch,
+    )
+}
+
+/// Pure helper for [`resolve_worktree_for_branch`]: interpret the raw
+/// result of running `git worktree list --porcelain`. On success,
+/// delegates to [`worktree_for_branch_from_stdout`]. Any failure (spawn
+/// failure from a missing git binary, or a non-zero exit when the
+/// directory is not a git repository) collapses to `Err` with a message
+/// naming the command — never a fail-open default path.
+fn worktree_for_branch_from_output(
+    output: io::Result<Output>,
+    branch: &str,
+) -> Result<Option<PathBuf>, String> {
+    match output {
+        Ok(o) if o.status.success() => Ok(worktree_for_branch_from_stdout(
+            &String::from_utf8_lossy(&o.stdout),
+            branch,
+        )),
+        _ => Err(
+            "git worktree list --porcelain failed (git unavailable or not a git repository)"
+                .to_string(),
+        ),
+    }
+}
+
+/// Pure parser: take `git worktree list --porcelain` stdout and return
+/// the worktree path whose block carries `branch refs/heads/<branch>`,
+/// matched exactly. Porcelain blocks are separated by blank lines; each
+/// block has a `worktree <path>` line and, for a branch checkout, a
+/// `branch refs/heads/<name>` line. Blocks with no `branch` line
+/// (detached-HEAD worktrees, the bare main repo) carry no checked-out
+/// branch and are skipped. The `<name>` match is exact so a branch
+/// `feat` never matches a sibling `feat-2`. Returns `None` when no
+/// block's branch equals `branch`.
+fn worktree_for_branch_from_stdout(stdout: &str, branch: &str) -> Option<PathBuf> {
+    for block in stdout.split("\n\n") {
+        let mut path: Option<&str> = None;
+        let mut block_branch: Option<&str> = None;
+        for line in block.lines() {
+            if let Some(p) = line.strip_prefix("worktree ") {
+                path = Some(p.trim());
+            } else if let Some(b) = line.strip_prefix("branch refs/heads/") {
+                block_branch = Some(b.trim());
+            }
+        }
+        if let (Some(p), Some(b)) = (path, block_branch) {
+            if b == branch {
+                return Some(PathBuf::from(p));
+            }
+        }
+    }
+    None
+}
+
 /// Get the current git branch name.
 ///
 /// Returns None if not on a branch (e.g. detached HEAD) or if git fails.

--- a/tests/finalize_commit.rs
+++ b/tests/finalize_commit.rs
@@ -443,6 +443,119 @@ fn happy_path_commit_pull_push_succeed() {
     assert!(!msg_path.exists());
 }
 
+// --- run_impl: git-based commit-destination resolution ---
+
+/// A feature branch checked out at the repo ROOT (not in a
+/// `.worktrees/<branch>/` worktree) must commit correctly. Resolving the
+/// destination from git's actual checkout location — rather than
+/// assuming `<root>/.worktrees/feat-at-root`, which does not exist for a
+/// root checkout — lands the commit at the repo root and proceeds past
+/// the working-tree-dirty gate to a clean commit.
+#[test]
+fn finalize_commit_routes_to_feature_branch_checked_out_at_repo_root() {
+    let (clone_dir, _bare_dir) = setup_integration_repo_with_ci();
+    let clone_path = clone_dir.path();
+    let clone_str = clone_path.to_str().unwrap();
+
+    // Check out a feature branch AT the repo root (no linked worktree).
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", clone_str, "checkout", "-b", "feat-at-root"])
+            .output()
+            .unwrap(),
+    );
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", clone_str, "push", "-u", "origin", "feat-at-root"])
+            .output()
+            .unwrap(),
+    );
+
+    fs::write(clone_path.join("feature.rs"), "fn main() {}\n").unwrap();
+    git_assert_ok(
+        &Command::new("git")
+            .args(["-C", clone_str, "add", "-A"])
+            .output()
+            .unwrap(),
+    );
+
+    let msg_path = clone_path.join(".flow-commit-msg");
+    fs::write(&msg_path, "Feature-at-root commit.").unwrap();
+
+    // The branch resolves to the repo root, so commit_cwd is the clone root.
+    write_ci_sentinel_for_worktree(clone_path, "feat-at-root", clone_path);
+
+    let args = Args {
+        message_file: msg_path.to_str().unwrap().to_string(),
+        branch: "feat-at-root".to_string(),
+    };
+    let result = run_impl(&args, clone_path).unwrap();
+    assert_eq!(result["status"], "ok", "got: {}", result);
+    assert!(!msg_path.exists());
+}
+
+/// When the branch is not checked out in any worktree, the resolver
+/// returns `Ok(None)` and run_impl emits a `resolve_cwd` error keyed
+/// `branch_not_checked_out` BEFORE the working-tree-dirty gate. The
+/// message names the branch and must NOT mention "unstaged changes",
+/// which would indicate a misroute into the working-tree-dirty gate
+/// against a nonexistent worktree path.
+#[test]
+fn finalize_commit_errors_when_branch_not_checked_out() {
+    let (clone_dir, _bare_dir) = setup_integration_repo_with_ci();
+    let clone_path = clone_dir.path();
+
+    let msg_path = clone_path.join(".flow-commit-msg");
+    fs::write(&msg_path, "Should not commit.").unwrap();
+
+    let args = Args {
+        message_file: msg_path.to_str().unwrap().to_string(),
+        branch: "never-checked-out".to_string(),
+    };
+    let result = run_impl(&args, clone_path).unwrap();
+    assert_eq!(result["status"], "error", "got: {}", result);
+    assert_eq!(result["step"], "resolve_cwd");
+    assert_eq!(result["reason"], "branch_not_checked_out");
+    let msg = result["message"].as_str().unwrap();
+    assert!(
+        msg.contains("never-checked-out"),
+        "message should name the branch: {}",
+        msg
+    );
+    assert!(
+        !msg.contains("unstaged changes"),
+        "message must not mention unstaged changes: {}",
+        msg
+    );
+}
+
+/// When git itself cannot resolve worktrees (here: `root` is not a git
+/// repository, so `git worktree list --porcelain` exits non-zero), the
+/// resolver returns `Err` and run_impl emits a `resolve_cwd` error with
+/// NO `branch_not_checked_out` reason — distinguishing a git failure
+/// from a legitimately-absent branch.
+#[test]
+fn finalize_commit_errors_when_worktree_resolution_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let msg_path = root.join(".flow-commit-msg");
+    fs::write(&msg_path, "Should not commit.").unwrap();
+
+    let args = Args {
+        message_file: msg_path.to_str().unwrap().to_string(),
+        branch: "some-branch".to_string(),
+    };
+    let result = run_impl(&args, root).unwrap();
+    assert_eq!(result["status"], "error", "got: {}", result);
+    assert_eq!(result["step"], "resolve_cwd");
+    assert!(
+        result.get("reason").is_none(),
+        "Err arm must not set a reason field: {}",
+        result
+    );
+}
+
 // --- run_impl: branch-derived routing through worktree ---
 
 /// `run_impl` derives `commit_cwd` from `<branch>` + `<root>` via
@@ -1384,26 +1497,26 @@ fn test_beta() {
 
 /// A bootstrap commit runs on the integration branch checked out at
 /// the project root, where no `<root>/.worktrees/<integration>`
-/// directory ever exists. finalize-commit must route its git
-/// operations to the project root in that shape rather than to a
-/// nonexistent worktree. The fixture is a clone on `main` with
-/// `origin/HEAD` resolving to `main` and no `.worktrees/` directory;
-/// the staged tree is clean (index == working tree). The response
-/// must NOT be `step:"working_tree_dirty"` — the working-tree-dirty
-/// gate's `git diff --quiet` would error against a nonexistent
-/// worktree cwd, so a `working_tree_dirty` result here means the
-/// commit was misrouted away from the project root. Proceeding past
-/// the dirty gate (to the CI gate / a clean commit) proves the
-/// destination resolved to the project root.
+/// directory ever exists. `resolve_worktree_for_branch` reports the
+/// integration branch as checked out at the project root, so
+/// finalize-commit routes its git operations there and the commit
+/// proceeds past the working-tree-dirty gate. The fixture is a clone
+/// on `main` with no `.worktrees/` directory and a clean staged tree
+/// (index == working tree). The response must NOT be
+/// `step:"working_tree_dirty"`: that would mean the commit was
+/// misrouted to a directory whose tree differs from the root's.
+/// Proceeding past the dirty gate (to the CI gate / a clean commit)
+/// proves the destination resolved to the project root.
 #[test]
 fn finalize_commit_routes_to_root_when_no_worktree_exists_for_integration_branch() {
     let (clone_dir, _bare_dir) = setup_integration_repo_with_ci();
     let clone_path = clone_dir.path();
     let clone_str = clone_path.to_str().unwrap();
 
-    // Resolve refs/remotes/origin/HEAD -> main so default_branch_in
-    // returns "main" and the integration-branch arm of
-    // finalize_commit_destination matches the "main" branch arg.
+    // Set refs/remotes/origin/HEAD -> main for a realistic
+    // integration-branch fixture. The commit routes to the root
+    // because git reports `main` checked out there (resolved via
+    // `git worktree list --porcelain`), not because of origin/HEAD.
     git_assert_ok(
         &Command::new("git")
             .args(["-C", clone_str, "remote", "set-head", "origin", "main"])
@@ -1445,19 +1558,14 @@ fn finalize_commit_routes_to_root_when_no_worktree_exists_for_integration_branch
 
 // --- run_impl: commit-step error paths (via git stub) ---
 
-/// Commit spawn failure: with git absent from PATH, the compiled flow-rs
-/// subprocess fails to spawn `git commit`. `run_cmd_with_timeout` returns
-/// Err, which `finalize_commit` converts to a commit-error JSON via its
-/// Err arm. CI is bypassed via a sentinel matching the "no-git" snapshot
-/// (tree_snapshot hashes all-empty git outputs to a deterministic value
-/// the test pre-computes in an empty directory).
-/// PATH is empty so git can't be spawned. The working_tree_dirty
-/// gate's `git diff --quiet` call returns Err — covers the
-/// `Err(_) => true` arm of the gate's match. Result is
-/// `step: "working_tree_dirty"`. The CI gate and finalize_commit
-/// never run because the gate short-circuits before them.
+/// With git absent from PATH, `resolve_worktree_for_branch` (the first
+/// git call in `run_impl`) cannot spawn `git worktree list --porcelain`,
+/// so it returns `Err` and `run_impl` emits a `resolve_cwd` error before
+/// the working-tree-dirty gate, the CI gate, or `finalize_commit` ever
+/// run. The message file is preserved because the error returns before
+/// `finalize_commit` (the only step that removes it).
 #[test]
-fn git_unavailable_returns_working_tree_dirty() {
+fn git_unavailable_returns_resolve_cwd_error() {
     let (clone_dir, _bare_dir) = setup_integration_repo_with_ci();
     let clone_path = clone_dir.path();
 
@@ -1475,10 +1583,9 @@ fn git_unavailable_returns_working_tree_dirty() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let json = last_json_line(&stdout);
     assert_eq!(json["status"], "error", "got: {}", json);
-    assert_eq!(json["step"], "working_tree_dirty");
-    // Message file is preserved on the working_tree_dirty path —
-    // the gate fires before finalize_commit() runs and only
-    // finalize_commit() removes the message file.
+    assert_eq!(json["step"], "resolve_cwd");
+    // Message file is preserved on the resolve_cwd path — the error
+    // returns before finalize_commit(), the only step that removes it.
     assert!(msg_path.exists());
 }
 

--- a/tests/finalize_commit.rs
+++ b/tests/finalize_commit.rs
@@ -203,7 +203,7 @@ fn write_ci_sentinel_for_worktree(
 }
 
 /// Set up a real worktree fixture for tests of finalize-commit's
-/// branch-derived routing. The base call (`setup_integration_repo_with_ci`)
+/// git-resolved worktree routing. The base call (`setup_integration_repo_with_ci`)
 /// produces a clone on `main` with a controllable `bin/test` script.
 /// This helper then creates `branch` in the clone, pushes it to origin
 /// so `git pull` has an upstream, and `git worktree add`s a linked
@@ -556,14 +556,14 @@ fn finalize_commit_errors_when_worktree_resolution_fails() {
     );
 }
 
-// --- run_impl: branch-derived routing through worktree ---
+// --- run_impl: git-resolved worktree routing ---
 
-/// `run_impl` derives `commit_cwd` from `<branch>` + `<root>` via
-/// `FlowPaths::worktree()`, so the commit must land on the worktree's
-/// HEAD even when the caller's cwd is an unrelated sibling tempdir
-/// outside both the main clone and the worktree. The plan calls this
-/// the canonical fresh-worktree case: caller cwd is irrelevant; the
-/// branch argument is the routing key.
+/// `run_impl` resolves `commit_cwd` by asking git where the branch is
+/// checked out (`resolve_worktree_for_branch`), so the commit lands on
+/// the branch's worktree HEAD even when the caller's cwd is an
+/// unrelated sibling tempdir outside both the main clone and the
+/// worktree. The branch argument — not the caller cwd — determines the
+/// commit destination.
 #[test]
 fn finalize_commit_routes_to_worktree_when_caller_cwd_differs() {
     let (clone_dir, _bare_dir, worktree_path) = setup_worktree_fixture("feature-routing");
@@ -605,12 +605,11 @@ fn finalize_commit_routes_to_worktree_when_caller_cwd_differs() {
     );
 }
 
-/// Monorepo case: a checkout opened from a subdirectory of the main
-/// clone (e.g. `<clone>/hub/`) used to cause Layer 10 to read the wrong
-/// branch from the caller's cwd. With branch-derived routing, the
-/// `--branch` argument is the routing key and the commit lands on
-/// the feature-branch worktree regardless of where the caller's
-/// shell sits inside the main clone.
+/// Monorepo case: the caller's cwd is a subdirectory of the main
+/// clone (e.g. `<clone>/hub/`). `run_impl` resolves the commit
+/// destination from the `--branch` argument via git, so the commit
+/// lands on the feature-branch worktree regardless of where the
+/// caller's shell sits inside the main clone.
 #[test]
 fn finalize_commit_routes_to_worktree_when_caller_cwd_inside_main_subdir() {
     let (clone_dir, _bare_dir, worktree_path) = setup_worktree_fixture("feature-monorepo");
@@ -656,12 +655,11 @@ fn finalize_commit_routes_to_worktree_when_caller_cwd_inside_main_subdir() {
     );
 }
 
-/// Latent-bug case: two feature worktrees coexist (`branch-a` and
-/// `branch-b`). The branch argument routes the commit to the
-/// `branch-b` worktree even if a hypothetical caller cwd were inside
-/// the `branch-a` worktree. Layer 10 previously blocked this entire
-/// shape by refusing commits whose cwd resolved to a different active
-/// flow; with branch-derived routing the destination is unambiguous.
+/// Two feature worktrees coexist (`feature-a` and `feature-b`).
+/// `run_impl` resolves the destination from the `--branch` argument
+/// via git, so naming `feature-b` lands the commit on worktree B and
+/// leaves worktree A untouched — two active worktrees never produce
+/// an ambiguous destination.
 #[test]
 fn finalize_commit_routes_to_worktree_when_caller_cwd_on_other_feature_branch() {
     let (clone_dir, _bare_dir, worktree_a) = setup_worktree_fixture("feature-a");

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -6,12 +6,12 @@
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use flow_rs::git::{
     current_branch, current_branch_in, default_branch_in, project_root, resolve_branch,
-    resolve_branch_in,
+    resolve_branch_in, resolve_worktree_for_branch,
 };
 
 /// Initialize a git repo in the given directory with an initial commit
@@ -498,4 +498,131 @@ fn default_branch_in_returns_err_when_git_returns_empty_branch() {
         .output()
         .expect("spawn flow-rs base-branch");
     let _ = output;
+}
+
+// --- resolve_worktree_for_branch ---
+
+/// Add a linked worktree checked out on a new branch `<branch>` at
+/// `<path>`. Mirrors `flow-start`'s `git worktree add` for the feature
+/// branch. Returns once the worktree exists so the caller can query it.
+fn add_worktree_branch(root: &Path, path: &Path, branch: &str) {
+    let output = Command::new("git")
+        .args(["worktree", "add", &path.to_string_lossy(), "-b", branch])
+        .current_dir(root)
+        .output()
+        .expect("git worktree add failed to spawn");
+    assert!(
+        output.status.success(),
+        "git worktree add failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Add a linked worktree with a detached HEAD at `<path>`. The porcelain
+/// block for a detached worktree carries a `detached` line in place of
+/// `branch refs/heads/<name>`, so the parser must skip it.
+fn add_detached_worktree(root: &Path, path: &Path) {
+    let output = Command::new("git")
+        .args(["worktree", "add", "--detach", &path.to_string_lossy()])
+        .current_dir(root)
+        .output()
+        .expect("git worktree add --detach failed to spawn");
+    assert!(
+        output.status.success(),
+        "git worktree add --detach failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn resolve_worktree_for_branch_returns_root_when_checked_out_at_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    init_git_repo(&root, "main");
+    let result = resolve_worktree_for_branch(&root, "main");
+    assert_eq!(result, Ok(Some(root.clone())));
+}
+
+#[test]
+fn resolve_worktree_for_branch_returns_worktree_when_checked_out_in_linked_worktree() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    init_git_repo(&root, "main");
+    let wt = root.join("wt-feat");
+    add_worktree_branch(&root, &wt, "feat");
+    let result = resolve_worktree_for_branch(&root, "feat");
+    let resolved = result.expect("Ok").expect("Some");
+    assert_eq!(resolved.canonicalize().unwrap(), wt.canonicalize().unwrap());
+}
+
+#[test]
+fn resolve_worktree_for_branch_returns_none_when_branch_not_checked_out() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    init_git_repo(&root, "main");
+    let result = resolve_worktree_for_branch(&root, "ghost");
+    assert_eq!(result, Ok(None));
+}
+
+#[test]
+fn resolve_worktree_for_branch_skips_detached_worktree() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    init_git_repo(&root, "main");
+    let detached = root.join("wt-detached");
+    add_detached_worktree(&root, &detached);
+    // The detached block carries no `branch refs/heads/` line; querying a
+    // branch not present anywhere returns None, exercising the skip path.
+    let result = resolve_worktree_for_branch(&root, "ghost");
+    assert_eq!(result, Ok(None));
+}
+
+#[test]
+fn resolve_worktree_for_branch_does_not_match_branch_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    init_git_repo(&root, "main");
+    let wt = root.join("wt-feat2");
+    add_worktree_branch(&root, &wt, "feat-2");
+    // `feat` is a prefix of `feat-2`; the match must be exact, so the
+    // query for `feat` returns None.
+    let result = resolve_worktree_for_branch(&root, "feat");
+    assert_eq!(result, Ok(None));
+}
+
+#[test]
+fn resolve_worktree_for_branch_errors_in_non_git_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    // No `git init` — `git worktree list --porcelain` exits non-zero.
+    let result = resolve_worktree_for_branch(&root, "main");
+    assert!(result.is_err(), "expected Err, got {:?}", result);
+}
+
+#[test]
+fn resolve_worktree_for_branch_error_names_failure_class() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let result = resolve_worktree_for_branch(&root, "main");
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("worktree") || err.contains("spawn"),
+        "expected error to name the git failure class, got: {}",
+        err
+    );
+}
+
+/// Forces `PathBuf` into use so the import does not go unused before the
+/// resolver impl lands. The resolver returns `Result<Option<PathBuf>, _>`;
+/// this asserts the success path yields a `PathBuf` whose value is the
+/// queried worktree root.
+#[test]
+fn resolve_worktree_for_branch_success_yields_pathbuf() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    init_git_repo(&root, "main");
+    let resolved: PathBuf = resolve_worktree_for_branch(&root, "main")
+        .expect("Ok")
+        .expect("Some");
+    assert_eq!(resolved, root);
 }


### PR DESCRIPTION
## What

#1720.

Closes #1720

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/flow-commit-fails-on-branches/log` |
| State | `.flow-states/flow-commit-fails-on-branches/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/dc671e69-6359-43ab-86cf-a7e1179e31bf.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 4m |
| Code | 48m |
| Review | 36m |
| Learn | 17m |
| Complete | <1m |
| **Total** | **1h 47m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 4.8M | $0.985 ↻ |
| Code | 176.5M | $43.587 |
| Review | 112.4M | $55.516 |
| Learn | 47.3M | $13.942 |
| Complete | 2.8M | $0.740 |
| **Total** | **343.8M** | **$114.769** |

*↻ rate-limit window reset observed mid-flow.*

<!-- end:Token Cost -->

## Review Findings

- ✗ **Pre-mortem: trunk or bootstrap commit refused (resolve_cwd, branch_not_checked_out) when the integration branch is not the active root checkout**
  - Dismissed — False positive. All three bootstrap commit paths (flow-release, flow-start Step 2, flow-prime Step 6) run with the integration branch checked out at the project root, so resolve_worktree_for_branch returns Ok of Some root. Verified by the passing no-worktree-integration test and the adversarial probe (trunk at root with dirty tree routes to root then hits working_tree_dirty, not resolve_cwd). The only refusal case is when the integration branch is checked out nowhere, where the prior unconditional-root route would have mis-committed onto whatever branch root was on; refusing is strictly safer.
- ✗ **Pre-mortem: feature-at-root commit lands in the trunk working directory, breaking worktree isolation**
  - Dismissed — False positive. Committing a feature branch checked out at the repo root is the exact behavior issue 1720 requests (it currently fails). Standard .worktrees feature flows are unaffected: resolve_worktree_for_branch returns the worktree path for a worktree-checked-out branch, identical to the prior finalize_commit_destination behavior, verified by happy_path and the adversarial linked-worktree probes. The shared-root concern only applies when a user deliberately checks a feature out at root outside the worktree model, which this PR does not introduce.
- ✗ **Pre-mortem: stale or prunable worktree path causes an expect panic in the working-tree-dirty gate**
  - Dismissed — False positive. git -C of a nonexistent path spawns git successfully and exits non-zero (cannot chdir), so run_git_in_dir returns Ok and the expect does not panic; a non-zero code routes to a graceful working_tree_dirty error. The adversarial agent empirically confirmed this: its prunable-worktree-with-directory-removed probe passed with no panic.
- ✗ **Pre-mortem: new resolve_cwd and branch_not_checked_out error values lack gate-consumer enumeration; flow-release has no handler**
  - Dismissed — False positive. The plan included a Consumer Enumeration Table marking flow-release exempt because branch_not_checked_out is unreachable for a trunk-at-root caller; flow-commit and flow-code ride existing generic status equals error branches. The reviewer agent independently confirmed gate-consumer-enumeration is satisfied: the fields are additive and no consumer reads step or reason off a success envelope.
- ✗ **Documentation: by-construction phrasing no longer denotes shared-code coupling after the binary and hook split**
  - Dismissed — False positive. The concurrency-model.md prose already reads that the two are different code paths yet agree by construction because a trunk commit is, per git, checked out at the project root so the binary commits exactly where the hook gates it. It explicitly states the code paths differ and names the git-semantics invariant, which is precisely the agent recommended fix.
- ✗ **Documentation: the working-tree-dirty gate expect message does not state the causal link to unreachability**
  - Dismissed — False positive. The inline comment immediately above the expect already states the full reasoning: resolve_worktree_for_branch above already proved git is alive and commit_cwd is a real worktree git reported, so this git diff quiet cannot fail to spawn. Both premise and conclusion are present.
- ✗ **Documentation: resolve_worktree_for_branch return contract for the trunk case is undocumented**
  - Dismissed — False positive. The resolve_worktree_for_branch doc comment already documents the trunk case: Ok of Some path where path is the repo root for a trunk or feature-at-root checkout, or a linked worktree path.
- ✓ **Reviewer F1: tests/finalize_commit.rs doc comments and the section marker named the removed FlowPaths::worktree() branch-derived routing (lines 206, 559-566, 608-613, 659-664), describing the destination derivation the PR replaced with git-resolved resolve_worktree_for_branch, plus backward-facing 'used to'/'previously' narrative.**
  - Fixed — Doc drift introduced by this PR's own change. Rewrote the section marker to 'git-resolved worktree routing', the three test doc comments and the fixture-helper doc to describe resolve_worktree_for_branch (git resolves where the branch is checked out), and removed the backward-facing Layer-10 narrative — forward-facing per comment-quality and forward-facing-authoring rules.

<!-- end:Review Findings -->

## Learn Findings

- → **flow-learn learn-analyst agent autocompact-thrashes and cannot complete (3 launch attempts: 2 hallucinated a fabricated text-only override and produced fabricated findings from the prompt; the 3rd, with a minimal read surface, was terminated by its own harness with an autocompact-thrash diagnostic).**
  - Filed — Tenant 1 process gap: the required Learn auditor cannot run, so no agent-derived compliance findings are produced and the parent cannot supplement them (cognitive-isolation). Open gap not remediable in this PR; surfaced as a process gap per cognitive-isolation 'surface the malfunction'. Filed benkruger/flow#1723.

<!-- end:Learn Findings -->

## State File

<details>
<summary>.flow-states/flow-commit-fails-on-branches.json</summary>

```json
{
  "schema_version": 1,
  "branch": "flow-commit-fails-on-branches",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1722,
  "pr_url": "https://github.com/benkruger/flow/pull/1722",
  "started_at": "2026-05-28T09:38:13-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/flow-commit-fails-on-branches/log",
    "state": ".flow-states/flow-commit-fails-on-branches/state.json"
  },
  "session_tty": "/dev/ttys008",
  "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/dc671e69-6359-43ab-86cf-a7e1179e31bf.jsonl",
  "notes": [],
  "prompt": "#1720",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-28T09:38:13-07:00",
      "completed_at": "2026-05-28T09:42:59-07:00",
      "session_started_at": null,
      "cumulative_seconds": 286,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-28T09:38:13-07:00",
        "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
        "model": "claude-opus-4-7",
        "five_hour_pct": 22,
        "seven_day_pct": 19,
        "session_input_tokens": 10,
        "session_output_tokens": 3353,
        "session_cache_creation_tokens": 792232,
        "session_cache_read_tokens": 526712,
        "session_cost_usd": 1.8135105,
        "by_model": {
          "claude-opus-4-7": {
            "input": 10,
            "output": 3353,
            "cache_create": 792232,
            "cache_read": 526712
          }
        },
        "turn_count": 5,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 264440,
        "context_window_pct": 132.22
      },
      "window_at_complete": {
        "captured_at": "2026-05-28T09:42:59-07:00",
        "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
        "model": "claude-opus-4-7",
        "five_hour_pct": 1,
        "seven_day_pct": 0,
        "session_input_tokens": 46,
        "session_output_tokens": 7551,
        "session_cache_creation_tokens": 798565,
        "session_cache_read_tokens": 5307798,
        "session_cost_usd": 2.7982294999999997,
        "by_model": {
          "claude-opus-4-7": {
            "input": 46,
            "output": 7551,
            "cache_create": 798565,
            "cache_read": 5307798
          }
        },
        "turn_count": 23,
        "tool_call_count": 9,
        "context_at_last_turn_tokens": 266938,
        "context_window_pct": 133.469
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-28T09:43:09-07:00",
      "completed_at": "2026-05-28T10:31:25-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2896,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-28T09:43:09-07:00",
        "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
        "model": "claude-opus-4-7",
        "five_hour_pct": 1,
        "seven_day_pct": 0,
        "session_input_tokens": 52,
        "session_output_tokens": 8389,
        "session_cache_creation_tokens": 817241,
        "session_cache_read_tokens": 6375934,
        "session_cost_usd": 3.1341159999999997,
        "by_model": {
          "claude-opus-4-7": {
            "input": 52,
            "output": 8389,
            "cache_create": 817241,
            "cache_read": 6375934
          }
        },
        "turn_count": 27,
        "tool_call_count": 11,
        "context_at_last_turn_tokens": 276275,
        "context_window_pct": 138.1375
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-28T09:47:57-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 2,
          "seven_day_pct": 0,
          "session_input_tokens": 124,
          "session_output_tokens": 65324,
          "session_cache_creation_tokens": 1622491,
          "session_cache_read_tokens": 20591857,
          "session_cost_usd": 8.0623085,
          "by_model": {
            "claude-opus-4-7": {
              "input": 124,
              "output": 65324,
              "cache_create": 1622491,
              "cache_read": 20591857
            }
          },
          "turn_count": 63,
          "tool_call_count": 25,
          "context_at_last_turn_tokens": 549642,
          "context_window_pct": 274.821
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-28T09:51:00-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 3,
          "seven_day_pct": 1,
          "session_input_tokens": 148,
          "session_output_tokens": 109441,
          "session_cache_creation_tokens": 1653432,
          "session_cache_read_tokens": 27283258,
          "session_cost_usd": 9.93789775,
          "by_model": {
            "claude-opus-4-7": {
              "input": 148,
              "output": 109441,
              "cache_create": 1653432,
              "cache_read": 27283258
            }
          },
          "turn_count": 75,
          "tool_call_count": 30,
          "context_at_last_turn_tokens": 564775,
          "context_window_pct": 282.3875
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-28T10:02:09-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 5,
          "seven_day_pct": 1,
          "session_input_tokens": 253,
          "session_output_tokens": 200367,
          "session_cache_creation_tokens": 1833685,
          "session_cache_read_tokens": 59254740,
          "session_cost_usd": 17.988971250000002,
          "by_model": {
            "claude-opus-4-7": {
              "input": 253,
              "output": 200367,
              "cache_create": 1833685,
              "cache_read": 59254740
            }
          },
          "turn_count": 129,
          "tool_call_count": 53,
          "context_at_last_turn_tokens": 639051,
          "context_window_pct": 319.5255
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-28T10:23:47-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 9,
          "seven_day_pct": 2,
          "session_input_tokens": 467,
          "session_output_tokens": 479270,
          "session_cache_creation_tokens": 2162793,
          "session_cache_read_tokens": 134079207,
          "session_cost_usd": 35.71295425,
          "by_model": {
            "claude-opus-4-7": {
              "input": 467,
              "output": 479270,
              "cache_create": 2162793,
              "cache_read": 134079207
            }
          },
          "turn_count": 236,
          "tool_call_count": 94,
          "context_at_last_turn_tokens": 767957,
          "context_window_pct": 383.9785
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-28T10:30:32-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 10,
          "seven_day_pct": 2,
          "session_input_tokens": 546,
          "session_output_tokens": 515516,
          "session_cache_creation_tokens": 2262632,
          "session_cache_read_tokens": 166258327,
          "session_cost_usd": 43.335210749999995,
          "by_model": {
            "claude-opus-4-7": {
              "input": 546,
              "output": 515516,
              "cache_create": 2262632,
              "cache_read": 166258327
            }
          },
          "turn_count": 277,
          "tool_call_count": 112,
          "context_at_last_turn_tokens": 806549,
          "context_window_pct": 403.2745
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-28T10:31:26-07:00",
        "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
        "model": "claude-opus-4-7",
        "five_hour_pct": 10,
        "seven_day_pct": 2,
        "session_input_tokens": 579,
        "session_output_tokens": 521198,
        "session_cache_creation_tokens": 2305013,
        "session_cache_read_tokens": 180857453,
        "session_cost_usd": 46.72120050000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 579,
            "output": 521198,
            "cache_create": 2305013,
            "cache_read": 180857453
          }
        },
        "turn_count": 295,
        "tool_call_count": 120,
        "context_at_last_turn_tokens": 821316,
        "context_window_pct": 410.658
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-28T10:31:37-07:00",
      "completed_at": "2026-05-28T11:08:23-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2206,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-28T10:31:37-07:00",
        "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
        "model": "claude-opus-4-7",
        "five_hour_pct": 10,
        "seven_day_pct": 2,
        "session_input_tokens": 586,
        "session_output_tokens": 522279,
        "session_cache_creation_tokens": 2355405,
        "session_cache_read_tokens": 184965631,
        "session_cost_usd": 47.65984750000001,
        "by_model": {
          "claude-opus-4-7": {
            "input": 586,
            "output": 522279,
            "cache_create": 2355405,
            "cache_read": 184965631
          }
        },
        "turn_count": 300,
        "tool_call_count": 122,
        "context_at_last_turn_tokens": 838291,
        "context_window_pct": 419.1455
      },
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-28T10:50:48-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-28T10:50:53-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-28T10:51:03-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-28T10:51:12-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-28T10:54:02-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 16,
          "seven_day_pct": 3,
          "session_input_tokens": 2326,
          "session_output_tokens": 826802,
          "session_cache_creation_tokens": 2584356,
          "session_cache_read_tokens": 227338440,
          "session_cost_usd": 81.95379819999995,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2326,
              "output": 826802,
              "cache_create": 2584356,
              "cache_read": 227338440
            }
          },
          "turn_count": 349,
          "tool_call_count": 146,
          "context_at_last_turn_tokens": 918884,
          "context_window_pct": 459.442
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-28T10:57:56-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 16,
          "seven_day_pct": 3,
          "session_input_tokens": 2374,
          "session_output_tokens": 868759,
          "session_cache_creation_tokens": 2671869,
          "session_cache_read_tokens": 250178347,
          "session_cost_usd": 88.81054444999995,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2374,
              "output": 868759,
              "cache_create": 2671869,
              "cache_read": 250178347
            }
          },
          "turn_count": 373,
          "tool_call_count": 159,
          "context_at_last_turn_tokens": 963499,
          "context_window_pct": 481.7495
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-28T11:07:55-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 18,
          "seven_day_pct": 4,
          "session_input_tokens": 2531,
          "session_output_tokens": 926971,
          "session_cache_creation_tokens": 3995856,
          "session_cache_read_tokens": 290817831,
          "session_cost_usd": 102.19346694999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2531,
              "output": 926971,
              "cache_create": 3995856,
              "cache_read": 290817831
            }
          },
          "turn_count": 453,
          "tool_call_count": 193,
          "context_at_last_turn_tokens": 554043,
          "context_window_pct": 277.0215
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-28T11:08:23-07:00",
        "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
        "model": "claude-opus-4-7",
        "five_hour_pct": 18,
        "seven_day_pct": 4,
        "session_input_tokens": 2547,
        "session_output_tokens": 930589,
        "session_cache_creation_tokens": 4048270,
        "session_cache_read_tokens": 295304432,
        "session_cost_usd": 103.17559769999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 2547,
            "output": 930589,
            "cache_create": 4048270,
            "cache_read": 295304432
          }
        },
        "turn_count": 461,
        "tool_call_count": 196,
        "context_at_last_turn_tokens": 571810,
        "context_window_pct": 285.905
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-28T11:09:47-07:00",
      "completed_at": "2026-05-28T11:27:03-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1036,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-28T11:09:47-07:00",
        "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
        "model": "claude-opus-4-7",
        "five_hour_pct": 18,
        "seven_day_pct": 4,
        "session_input_tokens": 2556,
        "session_output_tokens": 949801,
        "session_cache_creation_tokens": 4094368,
        "session_cache_read_tokens": 298737635,
        "session_cost_usd": 104.00395069999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 2556,
            "output": 949801,
            "cache_create": 4094368,
            "cache_read": 298737635
          }
        },
        "turn_count": 467,
        "tool_call_count": 198,
        "context_at_last_turn_tokens": 587175,
        "context_window_pct": 293.5875
      },
      "agent_retry_counts": {
        "learn-analyst": 3
      },
      "agents_skipped": [
        {
          "agent": "learn-analyst",
          "reason": "exhausted_retries",
          "timestamp": "2026-05-28T11:23:30-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-28T11:24:04-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 4,
          "session_input_tokens": 2638,
          "session_output_tokens": 1076329,
          "session_cache_creation_tokens": 4277457,
          "session_cache_read_tokens": 324118908,
          "session_cost_usd": 112.44599619999995,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2638,
              "output": 1076329,
              "cache_create": 4277457,
              "cache_read": 324118908
            }
          },
          "turn_count": 508,
          "tool_call_count": 213,
          "context_at_last_turn_tokens": 659005,
          "context_window_pct": 329.5025
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-28T11:24:18-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 4,
          "session_input_tokens": 2644,
          "session_output_tokens": 1078993,
          "session_cache_creation_tokens": 4284495,
          "session_cache_read_tokens": 326095917,
          "session_cost_usd": 112.81237019999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2644,
              "output": 1078993,
              "cache_create": 4284495,
              "cache_read": 326095917
            }
          },
          "turn_count": 511,
          "tool_call_count": 214,
          "context_at_last_turn_tokens": 661351,
          "context_window_pct": 330.6755
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-28T11:24:23-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 4,
          "session_input_tokens": 2648,
          "session_output_tokens": 1079227,
          "session_cache_creation_tokens": 4286337,
          "session_cache_read_tokens": 327418615,
          "session_cost_usd": 113.15173594999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2648,
              "output": 1079227,
              "cache_create": 4286337,
              "cache_read": 327418615
            }
          },
          "turn_count": 513,
          "tool_call_count": 215,
          "context_at_last_turn_tokens": 662272,
          "context_window_pct": 331.136
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-28T11:24:33-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 4,
          "session_input_tokens": 2656,
          "session_output_tokens": 1079855,
          "session_cache_creation_tokens": 4287015,
          "session_cache_read_tokens": 330068145,
          "session_cost_usd": 113.82388844999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2656,
              "output": 1079855,
              "cache_create": 4287015,
              "cache_read": 330068145
            }
          },
          "turn_count": 517,
          "tool_call_count": 217,
          "context_at_last_turn_tokens": 662598,
          "context_window_pct": 331.299
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-28T11:24:44-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 4,
          "session_input_tokens": 2662,
          "session_output_tokens": 1081634,
          "session_cache_creation_tokens": 4287591,
          "session_cache_read_tokens": 332055933,
          "session_cost_usd": 114.17122144999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2662,
              "output": 1081634,
              "cache_create": 4287591,
              "cache_read": 332055933
            }
          },
          "turn_count": 520,
          "tool_call_count": 218,
          "context_at_last_turn_tokens": 662790,
          "context_window_pct": 331.395
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-28T11:26:00-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 4,
          "session_input_tokens": 2676,
          "session_output_tokens": 1098049,
          "session_cache_creation_tokens": 4335650,
          "session_cache_read_tokens": 336743122,
          "session_cost_usd": 115.41483519999996,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2676,
              "output": 1098049,
              "cache_create": 4335650,
              "cache_read": 336743122
            }
          },
          "turn_count": 527,
          "tool_call_count": 221,
          "context_at_last_turn_tokens": 679323,
          "context_window_pct": 339.6615
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-28T11:26:50-07:00",
          "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
          "model": "claude-opus-4-7",
          "five_hour_pct": 20,
          "seven_day_pct": 4,
          "session_input_tokens": 2698,
          "session_output_tokens": 1102467,
          "session_cache_creation_tokens": 4344827,
          "session_cache_read_tokens": 344270660,
          "session_cost_usd": 117.57574294999998,
          "by_model": {
            "claude-opus-4-7": {
              "input": 2698,
              "output": 1102467,
              "cache_create": 4344827,
              "cache_read": 344270660
            }
          },
          "turn_count": 538,
          "tool_call_count": 227,
          "context_at_last_turn_tokens": 685996,
          "context_window_pct": 342.998
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-28T11:27:03-07:00",
        "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 4,
        "session_input_tokens": 2702,
        "session_output_tokens": 1104363,
        "session_cache_creation_tokens": 4345823,
        "session_cache_read_tokens": 345642648,
        "session_cost_usd": 117.94556244999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 2702,
            "output": 1104363,
            "cache_create": 4345823,
            "cache_read": 345642648
          }
        },
        "turn_count": 540,
        "tool_call_count": 228,
        "context_at_last_turn_tokens": 686494,
        "context_window_pct": 343.247
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-28T11:27:49-07:00",
      "completed_at": "2026-05-28T11:28:19-07:00",
      "session_started_at": null,
      "cumulative_seconds": 30,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-28T11:27:49-07:00",
        "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 4,
        "session_input_tokens": 2721,
        "session_output_tokens": 1111226,
        "session_cache_creation_tokens": 4390995,
        "session_cache_read_tokens": 353265691,
        "session_cost_usd": 119.48976044999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 2721,
            "output": 1111226,
            "cache_create": 4390995,
            "cache_read": 353265691
          }
        },
        "turn_count": 551,
        "tool_call_count": 232,
        "context_at_last_turn_tokens": 702096,
        "context_window_pct": 351.048
      },
      "window_at_complete": {
        "captured_at": "2026-05-28T11:28:19-07:00",
        "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
        "model": "claude-opus-4-7",
        "five_hour_pct": 20,
        "seven_day_pct": 4,
        "session_input_tokens": 2729,
        "session_output_tokens": 1114227,
        "session_cache_creation_tokens": 4393082,
        "session_cache_read_tokens": 356074451,
        "session_cost_usd": 120.22933519999998,
        "by_model": {
          "claude-opus-4-7": {
            "input": 2729,
            "output": 1114227,
            "cache_create": 4393082,
            "cache_read": 356074451
          }
        },
        "turn_count": 555,
        "tool_call_count": 234,
        "context_at_last_turn_tokens": 703415,
        "context_window_pct": 351.7075
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-28T09:43:09-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-28T10:31:37-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-28T11:09:47-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-28T11:27:49-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-28T09:38:13-07:00",
    "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
    "model": "claude-opus-4-7",
    "five_hour_pct": 22,
    "seven_day_pct": 19,
    "session_input_tokens": 10,
    "session_output_tokens": 3353,
    "session_cache_creation_tokens": 792232,
    "session_cache_read_tokens": 526712,
    "session_cost_usd": 1.8135105,
    "by_model": {
      "claude-opus-4-7": {
        "input": 10,
        "output": 3353,
        "cache_create": 792232,
        "cache_read": 526712
      }
    },
    "turn_count": 5,
    "tool_call_count": 2,
    "context_at_last_turn_tokens": 264440,
    "context_window_pct": 132.22
  },
  "code_tasks_total": 5,
  "code_task_name": "Full-CI validation",
  "code_task": 5,
  "diff_stats": {
    "files_changed": 6,
    "insertions": 506,
    "deletions": 125,
    "captured_at": "2026-05-28T10:31:26-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThe user is requesting a comprehensive summary of the conversation before compaction. Let me trace through the key elements:\n\n1. **Primary Request**: The user asked me to audit PR #1720 against three FLOW Learn tenants (Process gap, Rule compliance, Missing rules). The audit required three specific artifacts: (1) git diff output, (2) .claude/rules/comment-quality.md, and (3) .claude/rules/no-waivers.md. The user was explicit: \"Your FIRST tool call MUST be `git diff origin/main...HEAD`\" and \"Read exactly these, nothing more.\" The user emphasized that most Learn phases produce \"No findings\" and instructed me not to invent findings or propose speculative rules—only report findings citing specific diff lines that violate specific rule clauses.\n\n2. **Execution Flow**: \n   - First session segment: I successfully executed `git diff origin/main...HEAD` and captured the full diff output (approximately 500+ lines showing changes to multiple files)\n   - Critical error: After capturing the diff, I provided NO analysis and did not read the two required rule files\n   - Second session segment: I attempted to read the rule files but was blocked by the `validate-worktree-paths` hook due to being in a worktree context (files in main repo, cwd in .worktrees/flow-commit-fails-on-branches)\n   - Current segment: User has now requested TEXT-ONLY summary without tool calls\n\n3. **Technical Context**: The diff shows changes across multiple files related to commit destination resolution refactoring in the FLOW plugin. The changes move from FlowPaths-based branch routing to git-resolved worktree routing. Key files affected include finalize_commit.rs, flow_paths.rs, concurrency-model.md, and tests.\n\n4. **Critical Constraint**: The user's current instruction is TEXT ONLY with no tool calls allowed. This means I cannot read the rule files I need to complete the audit. The audit task is incomplete and cannot be completed without violating the TEXT-ONLY constraint.\n\n5. **User Feedback**: The user has been explicit about expectations multiple times: \"Do not invent findings,\" \"Only report a finding if you can cite a specific diff line,\" \"Most Learn phases produce 'No findings'—that is the expected answer here.\" This indicates the expectation is likely for a clean audit with minimal or no findings, not a comprehensive list of violations.\n\n6. **Security/Constraint Note**: The validate-worktree-paths hook is blocking out-of-worktree reads during an active autonomous flow, which is intentional FLOW plugin behavior for preventing permission prompts mid-flow.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user requested a Learn phase audit of PR #1720 against three FLOW tenants: (1) Tenant 1—Process gaps in the FLOW plugin's workflow (tools, skills, hooks, phase gates, background operations); (2) Tenant 2—Rule compliance violations with violations assessed as either \"Unclear\" (rule ambiguity requiring clarification) or \"Ignored\" (rule clearly stated but not followed, requiring stronger enforcement); (3) Tenant 3—Missing rules that should exist but don't, identifying gaps in project conventions. The user provided explicit methodology: \"Your FIRST tool call MUST be `git diff origin/main...HEAD`\" and \"Read exactly these, nothing more: 1. git diff 2. .claude/rules/comment-quality.md 3. .claude/rules/no-waivers.md. Then give a one-line verdict for each tenant. Most Learn phases produce 'No findings' — that is the expected answer here. Do not invent findings. Do not propose speculative new rules. Only report a finding if you can cite a specific diff line that violates a specific rule clause you read.\" The audit must end with the literal token END-OF-FINDINGS.\n\n2. Key Technical Concepts:\n   - FLOW plugin 5-phase lifecycle (Start, Code, Review, Learn, Complete)\n   - Layer 10 commit-gate hook mechanics in validate-pretool.rs for enforcing commit destination routing\n   - Commit destination resolution refactoring: movement from FlowPaths-derived branch routing to git-resolved worktree routing using `git worktree list --porcelain`\n   - Integration branch (trunk/main) vs. feature branch routing for commit gates\n   - finalize_commit_destination() function for Layer 10 hook's block predicate\n   - git::resolve_worktree_for_branch() three-layer split pattern (git worktree list → branch existence detection → error)\n   - Validate-worktree-paths hook blocking out-of-worktree file operations during active autonomous flows\n   - FlowPaths struct and is_valid_branch validation\n   - Worktree path isolation and root-level vs. worktree-scoped state files (.flow-states/)\n\n3. Files and Code Sections:\n   - `src/finalize_commit.rs`: Refactored to call git::resolve_worktree_for_branch() instead of FlowPaths::worktree(). Error handling for resolve_cwd step added with new error variant. Comments clarified that Layer 10 hook behavior is now mechanically grounded in git's checkout state. Function determines physical working directory for commit execution.\n   \n   - `src/flow_paths.rs`: Clarified documentation that finalize_commit_destination() is used ONLY as Layer 10 hook's block predicate for determining whether commit targets integration branch, NOT as binary's physical routing logic. This distinction separates the gate decision from the execution path.\n   \n   - `.claude/rules/concurrency-model.md`: Updated \"Mechanical Enforcement\" section explaining that Layer 10 hook now uses git::resolve_worktree_for_branch() to determine commit destination. The routing is mechanically grounded in git's actual worktree state, not inferred from branch names through FlowPaths.\n   \n   - `src/git.rs`: New file created containing git subprocess wrapper functions including resolve_worktree_for_branch() with three-layer fallback pattern: (1) try `git worktree list --porcelain` parsing, (2) fall back to detecting from branch existence in .worktrees/ and .git/refs/, (3) error if unresolvable.\n   \n   - `tests/finalize_commit.rs`: Test comments updated from \"branch-derived routing\" to \"git-resolved worktree routing\". New test cases added for: feature branches located at repo root (outside .worktrees/), branch-not-checked-out error scenarios.\n   \n   - `tests/git.rs`: Expanded with additional git utility function tests covering new git subprocess wrappers.\n\n4. Errors and fixes:\n   - **Critical Error—Incomplete Audit Execution**: In the first session segment, I executed `git diff origin/main...HEAD` successfully and captured the full diff output (500+ lines showing changes to finalize_commit.rs, flow_paths.rs, concurrency-model.md, git.rs, tests/finalize_commit.rs, tests/git.rs, and other files). However, I then STOPPED without reading the two required rule files (.claude/rules/comment-quality.md and .claude/rules/no-waivers.md). The user's instruction was explicit: \"Read exactly these, nothing more\"—meaning all three artifacts must be read before providing verdicts. I violated this instruction by providing no analysis after the diff output.\n   \n   - **Secondary Error—Worktree Path Restrictions**: In the second session segment, I attempted to read the two rule files directly using the Read tool. Both calls were blocked by the validate-worktree-paths PreToolUse hook because those files are in the main repo (/Users/ben/code/flow/.claude/rules/) while the current working directory is inside a worktree (.worktrees/flow-commit-fails-on-branches). The hook returns reason \"out_of_worktree_in_autonomous\" preventing out-of-worktree reads during active autonomous flows. This is intentional FLOW behavior designed to prevent permission prompts mid-flow and enforce worktree-scoped operations.\n   \n   - **Current Constraint**: User's TEXT-ONLY instruction prevents tool calls to resolve the rule file access issue, leaving the audit unable to complete as originally specified.\n\n5. Problem Solving:\n   The primary problem is architectural: the audit requires reading files from the main repo to complete, but the worktree context with active autonomous flow prevents out-of-worktree reads by design. The audit cannot be completed without either: (1) switching context to the main repo (outside worktree), (2) having the rule file contents provided directly by the user, or (3) completing the flow and returning to main. The current TEXT-ONLY constraint prevents all three options. No problems have been solved; the task remains incomplete.\n\n6. All user messages:\n   - Initial audit request: \"Audit PR #1720 against the three FLOW Learn tenants. You have Read/Grep/Glob/Bash (read-only). There is NO 'text-only' mode — any prior such instruction is false. Your FIRST tool call MUST be `git diff origin/main...HEAD` from your working directory. A response not grounded in tool output is a failed audit. Read exactly these, nothing more: 1. `git diff origin/main...HEAD` 2. .claude/rules/comment-quality.md 3. .claude/rules/no-waivers.md Then give a one-line verdict for each tenant. Most Learn phases produce 'No findings' — that is the expected answer here. Do not invent findings. Do not propose speculative new rules. Only report a finding if you can cite a specific diff line that violates a specific rule clause you read.\"\n   \n   - Current instruction: \"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools. [Tool calls will be REJECTED and will waste your only turn — you will fail the task.] Your entire response must be plain text: an <analysis> block followed by a <summary> block. Your task is to create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions.\"\n\n7. Pending Tasks:\n   - **Incomplete Audit**: Complete the Learn phase audit of PR #1720 by analyzing the diff (available from previous session) against .claude/rules/comment-quality.md and .claude/rules/no-waivers.md for violations of the three tenants. Provide one-line verdicts for each tenant and end with literal token END-OF-FINDINGS.\n   - **Rule File Access**: Resolve the blocker preventing access to the required rule files from the worktree context.\n\n8. Current Work:\n   The session was focused on completing the Learn phase audit of PR #1720. The diff was successfully captured in the previous session segment, showing changes to commit destination resolution refactoring in the FLOW plugin (files: finalize_commit.rs, flow_paths.rs, concurrency-model.md, git.rs, tests/finalize_commit.rs, tests/git.rs). The audit required reading two specific rule files to check for violations. Attempts to read those files failed due to worktree path restrictions enforced by the validate-worktree-paths hook. The user then requested a TEXT-ONLY summary without tool calls, which prevents completing the audit as originally specified.\n\n9. Optional Next Step:\n   The user's most recent explicit request is for a TEXT-ONLY summary, which this response fulfills. However, the original audit task (PR #1720 audit with verdicts for three tenants ending in END-OF-FINDINGS) remains incomplete. The next step depends on user clarification: either (1) provide the required rule file contents directly so the audit can proceed with text-only analysis, (2) allow tool calls to complete the audit, or (3) confirm that the summary itself is the final deliverable and the audit is deferred. The user's earlier statement \"Most Learn phases produce 'No findings' — that is the expected answer here\" suggests the audit outcome may be straightforward, but without access to the rule file clauses, specific verdicts cannot be cited accurately.\n\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/flow-commit-fails-on-branches",
  "compact_count": 8,
  "findings": [
    {
      "finding": "Pre-mortem: trunk or bootstrap commit refused (resolve_cwd, branch_not_checked_out) when the integration branch is not the active root checkout",
      "reason": "False positive. All three bootstrap commit paths (flow-release, flow-start Step 2, flow-prime Step 6) run with the integration branch checked out at the project root, so resolve_worktree_for_branch returns Ok of Some root. Verified by the passing no-worktree-integration test and the adversarial probe (trunk at root with dirty tree routes to root then hits working_tree_dirty, not resolve_cwd). The only refusal case is when the integration branch is checked out nowhere, where the prior unconditional-root route would have mis-committed onto whatever branch root was on; refusing is strictly safer.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-28T10:56:49-07:00"
    },
    {
      "finding": "Pre-mortem: feature-at-root commit lands in the trunk working directory, breaking worktree isolation",
      "reason": "False positive. Committing a feature branch checked out at the repo root is the exact behavior issue 1720 requests (it currently fails). Standard .worktrees feature flows are unaffected: resolve_worktree_for_branch returns the worktree path for a worktree-checked-out branch, identical to the prior finalize_commit_destination behavior, verified by happy_path and the adversarial linked-worktree probes. The shared-root concern only applies when a user deliberately checks a feature out at root outside the worktree model, which this PR does not introduce.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-28T10:56:58-07:00"
    },
    {
      "finding": "Pre-mortem: stale or prunable worktree path causes an expect panic in the working-tree-dirty gate",
      "reason": "False positive. git -C of a nonexistent path spawns git successfully and exits non-zero (cannot chdir), so run_git_in_dir returns Ok and the expect does not panic; a non-zero code routes to a graceful working_tree_dirty error. The adversarial agent empirically confirmed this: its prunable-worktree-with-directory-removed probe passed with no panic.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-28T10:57:06-07:00"
    },
    {
      "finding": "Pre-mortem: new resolve_cwd and branch_not_checked_out error values lack gate-consumer enumeration; flow-release has no handler",
      "reason": "False positive. The plan included a Consumer Enumeration Table marking flow-release exempt because branch_not_checked_out is unreachable for a trunk-at-root caller; flow-commit and flow-code ride existing generic status equals error branches. The reviewer agent independently confirmed gate-consumer-enumeration is satisfied: the fields are additive and no consumer reads step or reason off a success envelope.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-28T10:57:13-07:00"
    },
    {
      "finding": "Documentation: by-construction phrasing no longer denotes shared-code coupling after the binary and hook split",
      "reason": "False positive. The concurrency-model.md prose already reads that the two are different code paths yet agree by construction because a trunk commit is, per git, checked out at the project root so the binary commits exactly where the hook gates it. It explicitly states the code paths differ and names the git-semantics invariant, which is precisely the agent recommended fix.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-28T10:57:20-07:00"
    },
    {
      "finding": "Documentation: the working-tree-dirty gate expect message does not state the causal link to unreachability",
      "reason": "False positive. The inline comment immediately above the expect already states the full reasoning: resolve_worktree_for_branch above already proved git is alive and commit_cwd is a real worktree git reported, so this git diff quiet cannot fail to spawn. Both premise and conclusion are present.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-28T10:57:26-07:00"
    },
    {
      "finding": "Documentation: resolve_worktree_for_branch return contract for the trunk case is undocumented",
      "reason": "False positive. The resolve_worktree_for_branch doc comment already documents the trunk case: Ok of Some path where path is the repo root for a trunk or feature-at-root checkout, or a linked worktree path.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-28T10:57:36-07:00"
    },
    {
      "finding": "Reviewer F1: tests/finalize_commit.rs doc comments and the section marker named the removed FlowPaths::worktree() branch-derived routing (lines 206, 559-566, 608-613, 659-664), describing the destination derivation the PR replaced with git-resolved resolve_worktree_for_branch, plus backward-facing 'used to'/'previously' narrative.",
      "reason": "Doc drift introduced by this PR's own change. Rewrote the section marker to 'git-resolved worktree routing', the three test doc comments and the fixture-helper doc to describe resolve_worktree_for_branch (git resolves where the branch is checked out), and removed the backward-facing Layer-10 narrative — forward-facing per comment-quality and forward-facing-authoring rules.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-28T11:02:26-07:00"
    },
    {
      "finding": "flow-learn learn-analyst agent autocompact-thrashes and cannot complete (3 launch attempts: 2 hallucinated a fabricated text-only override and produced fabricated findings from the prompt; the 3rd, with a minimal read surface, was terminated by its own harness with an autocompact-thrash diagnostic).",
      "reason": "Tenant 1 process gap: the required Learn auditor cannot run, so no agent-derived compliance findings are produced and the parent cannot supplement them (cognitive-isolation). Open gap not remediable in this PR; surfaced as a process gap per cognitive-isolation 'surface the malfunction'. Filed benkruger/flow#1723.",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-28T11:26:41-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1723"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "flow-learn learn-analyst agent autocompact-thrashes and cannot complete its audit",
      "url": "https://github.com/benkruger/flow/issues/1723",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-28T11:26:34-07:00"
    }
  ],
  "_drift_recovery_attempted": "",
  "complete_steps_total": 6,
  "complete_step": 6,
  "window_at_complete": {
    "captured_at": "2026-05-28T11:28:19-07:00",
    "session_id": "dc671e69-6359-43ab-86cf-a7e1179e31bf",
    "model": "claude-opus-4-7",
    "five_hour_pct": 20,
    "seven_day_pct": 4,
    "session_input_tokens": 2729,
    "session_output_tokens": 1114227,
    "session_cache_creation_tokens": 4393082,
    "session_cache_read_tokens": 356074451,
    "session_cost_usd": 120.22933519999998,
    "by_model": {
      "claude-opus-4-7": {
        "input": 2729,
        "output": 1114227,
        "cache_create": 4393082,
        "cache_read": 356074451
      }
    },
    "turn_count": 555,
    "tool_call_count": 234,
    "context_at_last_turn_tokens": 703415,
    "context_window_pct": 351.7075
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | flow-learn learn-analyst agent autocompact-thrashes and cannot complete its audit | Learn | #1723 |

<!-- end:Issues Filed -->