### PR TITLE
Use Semantic Commits Or Provide

### DIFF
--- a/.claude/rules/config-source-mapping.md
+++ b/.claude/rules/config-source-mapping.md
@@ -78,7 +78,7 @@ Modifications take effect immediately for the active session.
 
 Read at flow-start by `start-init`/`init_state` and copied into
 the per-flow state file. After `flow-start`, the running flow
-reads its preferences (`skills`, `commit_format`, etc.) from
+reads its preferences (`skills`, etc.) from
 `.flow-states/<branch>/state.json`, never from `.flow.json`
 directly.
 

--- a/.claude/rules/skill-authoring.md
+++ b/.claude/rules/skill-authoring.md
@@ -390,7 +390,7 @@ to confirm the identifier appears as a definition (e.g.
 
 The autonomy config chain is: prime presets → `.flow.json` → state file → skill reads.
 `/flow-prime` writes defaults to `.flow.json`. The user customizes `.flow.json`.
-`/flow-start` copies settings (`skills`, `commit_format`) from `.flow.json` into
+`/flow-start` copies settings (`skills`) from `.flow.json` into
 the state file. Phase skills read only from the state file — never `.flow.json`
 (which lives at the project root and is inaccessible from worktrees).
 When a phase skill's config is missing at runtime, the fix is always at the source

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Maintainer-only commands (private to this repo): `/flow-qa` files a pre-decompos
 - **TDD always** — test must fail before implementation is written; test must pass before commit.
 - **No lint suppression** — fix the code, not the linter. No exclusions, no suppression comments.
 - **Worktree isolation** — your team's trunk is never touched directly; multiple features run in parallel.
-- **Commit discipline** — imperative verb + tl;dr + per-file breakdown, every commit.
+- **Commit discipline** — Conventional Commits (`type(scope): description`) + body + per-file breakdown, every commit.
 
 ---
 

--- a/docs/reference/flow-state-schema.md
+++ b/docs/reference/flow-state-schema.md
@@ -113,7 +113,6 @@ The frozen phases file is a snapshot of `flow-phases.json` taken at start time. 
 | `session_id` | string / null | Claude Code session UUID — set by Stop hook from hook stdin |
 | `transcript_path` | string / null | Absolute path to session transcript .jsonl — set by Stop hook from hook stdin |
 | `skills` | object / absent | Per-skill autonomy settings copied from `.flow.json` by `/flow-start` — see [Skills Object](#skills-object) |
-| `commit_format` | string / absent | Commit message format: `"full"` or `"title-only"`. Copied from `.flow.json` by `/flow-start`. Absent when `.flow.json` has no `commit_format` key — skills default to `"full"` |
 | `start_step` | integer | Current Start phase step (0-5). Set by `init-state --start-step` at creation, then updated by `start-step` subcommand at each step boundary. Used by the TUI to show "step 3 of 5" in the Start phase annotation. Absent when Start is not in progress |
 | `start_steps_total` | integer | Total number of Start phase steps (hardcoded 5). Set by `init-state --start-steps-total` at creation. Used by the TUI for "step N of M" display |
 | `review_step` | integer | Last completed Review step (0-4). Set to 0 on phase entry, incremented after each step (1=Gather, 2=Launch, 3=Triage, 4=Fix). Used by the TUI and for resume after context compaction |

--- a/docs/skills/flow-commit.md
+++ b/docs/skills/flow-commit.md
@@ -18,38 +18,27 @@ Reviews all pending changes before committing. You see the full diff and propose
 
 1. Stages changes
 2. Shows `git status` and `git diff --cached` in parallel
-3. Proposes a commit message in the `tl;dr` format
+3. Proposes a commit message in the Conventional Commits format
 4. Commits, pulls, and pushes via `bin/flow finalize-commit` (which enforces CI internally and re-stages tracked-file modifications after CI so in-place auto-fixes are captured in the same commit)
 
 ---
 
 ## Commit Message Format
 
-The format is determined by the `commit_format` setting, copied from `.flow.json` into the state file by `/flow-start`. Defaults to `"full"` when no state file exists.
-
-**Full format** (`"full"`):
+FLOW commits follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) specification. There is a single always-on format — no per-project choice — so downstream CHANGELOG tooling matches every merge.
 
 ```text
-Full-sentence subject line (imperative verb + what + why, ends with a period.)
+type(scope): description
 
-tl;dr
-
-One or two sentences explaining the WHY.
+Free-form body paragraph explaining the WHY.
 
 - path/to/file.rb: What changed and why
 - path/to/other.rb: What changed and why
+
+BREAKING CHANGE: description of the incompatible change
 ```
 
-**Title-only format** (`"title-only"`):
-
-```text
-Full-sentence subject line (imperative verb + what + why, ends with a period.)
-
-- path/to/file.rb: What changed and why
-- path/to/other.rb: What changed and why
-```
-
-Subject starts with an imperative verb — Add, Fix, Update, Remove, Refactor. Includes the business reason. Ends with a period. No prefix jargon.
+The subject is `type(scope): description` — the `type` is required (`feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`), the `(scope)` is optional, and the lowercase imperative `description` has no trailing period. Append a `BREAKING CHANGE:` footer (or a `!` after the type) only when the change is backwards-incompatible.
 
 ---
 

--- a/docs/skills/flow-prime.md
+++ b/docs/skills/flow-prime.md
@@ -12,24 +12,23 @@ parent: Skills
 
 One-time project setup. Configures workspace permissions in `.claude/settings.json`, sets up git excludes, installs the `bin/{format,lint,build,test}` delegation stubs, and writes a version marker. Run once after installing FLOW and again after each upgrade.
 
-`--reprime` skips all questions and reuses the existing `.flow.json` config — same autonomy and commit format, just new artifacts installed. Use this for upgrades where your config hasn't changed.
+`--reprime` skips all questions and reuses the existing `.flow.json` config — same autonomy, just new artifacts installed. Use this for upgrades where your config hasn't changed.
 
 ---
 
 ## What It Does
 
 1. Asks the user for their primary role — PM, Tech Lead (recommended), or Founder / Solo Dev. The selection is recorded as the `role` field in `.flow.json` and sets a default planning persona for future planning conversations.
-2. Asks the user to choose a commit message format (full or title-only).
-3. Asks the user to choose an autonomy level (fully autonomous, fully manual, recommended, or customize per skill).
-4. Runs a single setup script that handles all configuration in one call:
+2. Asks the user to choose an autonomy level (fully autonomous, fully manual, recommended, or customize per skill).
+3. Runs a single setup script that handles all configuration in one call:
    - Reads or creates `.claude/settings.json` and merges FLOW universal allow/deny permissions
-   - Writes `.flow.json` with version, config hash, commit format, role (when set), and skills configuration
+   - Writes `.flow.json` with version, config hash, role (when set), and skills configuration
    - Adds `.flow-states/`, `.worktrees/`, `.flow.json`, `.claude/cost/`, `.claude/scheduled_tasks.lock`, `test_adversarial_flow.*`, `adversarial_flow_test.go`, `adversarial_flow_test.rb`, `adversarial_flow_spec.rb`, and `AdversarialFlowTests.swift` to `.git/info/exclude`
    - Installs a pre-commit hook that blocks direct `git commit` during active FLOW features and requires `/flow:flow-commit`
    - Installs a global launcher at `~/.local/bin/flow`
    - Installs `bin/{format,lint,build,test}` stubs from `assets/bin-stubs/<tool>.sh` into `<project_root>/bin/<tool>` when absent. Pre-existing `bin/*` scripts are never overwritten so users who already configured their own toolchain keep their work.
-5. Installs the `decompose` plugin from the `matt-k-wong/mkw-DAG-architect` marketplace
-6. Commits generated files (`.claude/settings.json` and any newly-installed `bin/<tool>` stubs) to version control
+4. Installs the `decompose` plugin from the `matt-k-wong/mkw-DAG-architect` marketplace
+5. Commits generated files (`.claude/settings.json` and any newly-installed `bin/<tool>` stubs) to version control
 
 After prime, the user is responsible for editing each `bin/<tool>` to wire it to their actual toolchain (cargo, pytest, go test, npm, etc.). The default stubs exit 0 with a stderr reminder so a fresh prime never blocks CI.
 

--- a/skills/flow-commit/SKILL.md
+++ b/skills/flow-commit/SKILL.md
@@ -27,16 +27,9 @@ whose path matches your current working directory — the
 
 Keep the project root and branch in context for the rest of this skill.
 
-## Round 2 — Banner and Format Detection
+## Round 2 — Banner Detection
 
-**Step 1.** Use the Glob tool: pattern `*.json`, path `<project_root>/.flow-states` — if any results, a FLOW phase is active (used for banner selection only).
-
-**Step 2.** If any `.flow-states/*.json` results exist, use the Read tool to read the state file for the current branch at `<project_root>/.flow-states/<branch>/state.json`.
-
-- Parse `commit_format`: `"title-only"` or `"full"`.
-- If no state file exists or the state file has no `commit_format` key → use `"full"`.
-
-Keep `commit_format` in context.
+Use the Glob tool: pattern `*.json`, path `<project_root>/.flow-states` — if any results, a FLOW phase is active (used for banner selection only).
 
 ## Announce
 
@@ -145,68 +138,60 @@ The `diff` code block renders red/green in most markdown environments.
 
 Write a commit message that a developer reading `git log` six months from now would find genuinely useful.
 
-Use the `commit_format` from Round 2 to determine the structure.
+FLOW commits follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) specification so downstream CHANGELOG tooling matches every merge. There is one format — no per-project choice.
 
-**If `commit_format` is `"full"`:**
+Structure:
 
 ```text
-Full-sentence subject line (imperative verb + what + why, ends with a period.)
+type(scope): description
 
-tl;dr
-
-One or two sentences explaining the WHY — what problem this solves,
+Free-form body paragraph explaining the WHY — what problem this solves,
 what behaviour changes, or what was wrong before.
 
 - path/to/file.rb: What changed and why
 - path/to/other.rb: What changed and why
 - path/to/another.rb: What changed and why
+
+BREAKING CHANGE: description of the incompatible change
 ```
+
+**Subject line.**
+
+- Shape: `type(scope): description`. The `type` is required; the `(scope)` is optional and omitted unless one obvious scope applies.
+- `description` is lowercase, imperative mood, and has no trailing period.
+- Infer `type` from the diff, using the standard set:
+  - `feat` — a new user-facing capability (minor version bump)
+  - `fix` — a bug fix (patch version bump)
+  - `docs` — documentation only
+  - `refactor` — a change that neither fixes a bug nor adds a feature
+  - `perf` — a performance improvement
+  - `test` — adding or correcting tests only
+  - `build` — build system or dependency changes
+  - `ci` — CI configuration changes
+  - `chore` — anything else that does not change src or test behaviour
+- Capture the business reason in the description or body — why this change matters, not just what changed.
+
+**Body.**
+
+- Blank line between the subject and the body.
+- A free-form paragraph explaining the motivation — what prompted this change.
+- A per-file bullet list: one bullet per changed file with a plain-English reason. Call out explicitly if the diff includes migrations, schema changes, or dependency-manifest changes.
+- Do not pad with obvious restatements of the diff.
+
+**Breaking changes.**
+
+- When the diff introduces a backwards-incompatible change, append a `BREAKING CHANGE: <description>` footer (or mark the type with `!`, e.g. `feat!: ...`). This drives the major-version bump in CHANGELOG tooling. Omit the footer entirely when nothing breaks.
 
 Before displaying your draft, verify it contains all of these in order:
 
-1. Subject line — imperative verb, what + why in one sentence, ends with a period
+1. Subject line — `type(scope): description`, lowercase imperative description, no trailing period
 2. Blank line
-3. The literal word `tl;dr` on its own line — no colon, no elaboration, just `tl;dr`
+3. Body paragraph — the WHY, not the what
 4. Blank line
-5. Explanation paragraph — the WHY, not the what
-6. Blank line
-7. File list — one bullet per changed file with reason
+5. File list — one bullet per changed file with reason
+6. A `BREAKING CHANGE:` footer ONLY when the diff is backwards-incompatible
 
 If any element is missing or out of order, rewrite before displaying.
-
-**If `commit_format` is `"title-only"`:**
-
-```text
-Full-sentence subject line (imperative verb + what + why, ends with a period.)
-
-- path/to/file.rb: What changed and why
-- path/to/other.rb: What changed and why
-- path/to/another.rb: What changed and why
-```
-
-Before displaying your draft, verify it contains all of these in order:
-
-1. Subject line — imperative verb, what + why in one sentence, ends with a period
-2. Blank line
-3. File list — one bullet per changed file with reason
-
-If any element is missing or out of order, rewrite before displaying.
-
-**Subject line rules (both formats):**
-- Start with an imperative verb: Add, Fix, Update, Remove, Refactor, Extract
-- Include the business reason — why this change matters, not just what changed. "Add Slack thread replies because operators want phase updates without polling the PR."
-- Describe the goal, not the mechanism — when a change has both, the subject says why it matters
-- No prefix jargon (no `feat:`, `chore:`, `fix:` — just the verb)
-- Ends with a period (it is a full sentence)
-
-**Body rules (both formats):**
-- Blank line between subject and body
-- List each meaningful change with its file and a plain-English reason
-- Call out explicitly if the diff includes migrations, schema changes, or Gemfile changes
-- Do not pad with obvious restatements of the diff
-
-**Additional body rules (full format only):**
-- Explain the motivation — what prompted this change?
 
 Display the full message under the heading **Commit Message**.
 

--- a/skills/flow-prime/SKILL.md
+++ b/skills/flow-prime/SKILL.md
@@ -14,7 +14,7 @@ description: "One-time project setup — configure and commit workspace permissi
 
 Run once after installing FLOW, and again after each FLOW upgrade. Configures workspace permissions, git excludes, installs the bin/* delegation stubs, and writes a version marker so `/flow:flow-start` knows the project is initialized.
 
-`--reprime` skips all questions and reuses the existing `.flow.json` config. Use this for upgrades where you want the same autonomy and commit format — just new artifacts installed.
+`--reprime` skips all questions and reuses the existing `.flow.json` config. Use this for upgrades where you want the same autonomy — just new artifacts installed.
 
 ## Announce
 
@@ -34,12 +34,12 @@ If `--reprime` was passed:
 
 1. Use the Read tool to read `.flow.json` from the project root.
    - If the file does not exist, stop with: "No existing config to reprime from. Run `/flow:flow-prime` instead."
-2. Extract `skills`, `commit_format`, and `role` from the JSON. The
+2. Extract `skills` and `role` from the JSON. The
    `role` field is optional — `.flow.json` files written before the
    role-selection step omit it, in which case treat it as unset and
    omit `--role` from the setup-script call.
-3. Run `claude plugin list` to check plugin state (needed for Step 5).
-4. Skip Steps 1–3 entirely. Jump to Step 4 with the extracted values.
+3. Run `claude plugin list` to check plugin state (needed for Step 4).
+4. Skip Steps 1–2 entirely. Jump to Step 3 with the extracted values.
 
 ## Steps
 
@@ -74,26 +74,7 @@ Store the result as `role_value`:
 - "PM" → `"pm"`
 - "Founder / Solo Dev" → `"founder-solo"`
 
-### Step 2 — Choose commit message format
-
-FLOW supports two commit message formats:
-
-- **Full** — subject + tl;dr + explanation + file list (detailed seven-element format)
-- **Title only** — subject line + file list (minimal, no tl;dr section)
-
-Ask the user which format to use with AskUserQuestion:
-
-> "What commit message format should FLOW use?"
->
-> - **Full format (Recommended)** — "Subject + tl;dr + explanation + file list (detailed)"
-> - **Title only** — "Subject line + file list, no tl;dr section"
-
-Store the result as `commit_format`:
-
-- "Full format" → `"full"`
-- "Title only" → `"title-only"`
-
-### Step 3 — Choose autonomy level
+### Step 2 — Choose autonomy level
 
 FLOW has two independent axes for skills that support them:
 
@@ -131,7 +112,7 @@ Ask the user how much autonomy FLOW should have using AskUserQuestion:
 
 **Customize** — ask per skill, in this order: code, review, learn, complete, abort.
 
-Start is exempt from the Customize loop because every preset fixes its continue mode to `auto` — Start has no useful interaction to gate on, so prompting for it would only add friction. Before asking the per-skill questions below, **seed `skills_dict` with `{"flow-start": {"continue": "auto"}}`** so the resulting JSON carries Start's continue mode through to Step 4.
+Start is exempt from the Customize loop because every preset fixes its continue mode to `auto` — Start has no useful interaction to gate on, so prompting for it would only add friction. Before asking the per-skill questions below, **seed `skills_dict` with `{"flow-start": {"continue": "auto"}}`** so the resulting JSON carries Start's continue mode through to Step 3.
 
 For each remaining skill, ask about only the applicable axes. List the recommended option first with "(Recommended)" in the label:
 
@@ -195,12 +176,11 @@ Store each answer as `{"continue": "<mode>"}` — the same object shape
 the presets use — so `flow-complete` and `flow-abort` carry a
 `continue` axis in `skills_dict`.
 
-Store the result as `skills_dict` for Step 4.
+Store the result as `skills_dict` for Step 3.
 
-### Step 4 — Run prime setup script
+### Step 3 — Run prime setup script
 
-Serialize `skills_dict` from Step 3 as a JSON string for the `--skills-json` argument.
-Pass the `commit_format` value from Step 2 via `--commit-format`.
+Serialize `skills_dict` from Step 2 as a JSON string for the `--skills-json` argument.
 Pass the concrete `role_value` from Step 1 via `--role`.
 
 **Do not pass the literal string `<role_value>` as the flag argument** —
@@ -208,7 +188,7 @@ the role-selection step yielded a concrete value (pm, tech-lead,
 founder-solo) that goes after `--role`.
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/bin/flow prime-setup <project_root> --skills-json '<skills_dict_json>' --commit-format <commit_format> --role <role_value> --plugin-root ${CLAUDE_PLUGIN_ROOT}
+${CLAUDE_PLUGIN_ROOT}/bin/flow prime-setup <project_root> --skills-json '<skills_dict_json>' --role <role_value> --plugin-root ${CLAUDE_PLUGIN_ROOT}
 ```
 
 When the Reprime path carries forward a legacy `.flow.json` that has
@@ -216,7 +196,7 @@ no `role` field (written before role selection existed), omit
 `--role` entirely:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/bin/flow prime-setup <project_root> --skills-json '<skills_dict_json>' --commit-format <commit_format> --plugin-root ${CLAUDE_PLUGIN_ROOT}
+${CLAUDE_PLUGIN_ROOT}/bin/flow prime-setup <project_root> --skills-json '<skills_dict_json>' --plugin-root ${CLAUDE_PLUGIN_ROOT}
 ```
 
 The script handles everything in a single call:
@@ -224,7 +204,7 @@ The script handles everything in a single call:
 - Reading or creating `.claude/settings.json`
 - Merging FLOW universal permissions (additive only — preserves existing entries)
 - Setting `defaultMode` to `acceptEdits` (overrides existing values — FLOW requires this for state file writes without prompts)
-- Writing `.flow.json` with version marker, config hash, skills config, and commit format
+- Writing `.flow.json` with version marker, config hash, and skills config
 - Adding `.flow-states/`, `.worktrees/`, `.flow.json`, `.claude/cost/`, `.claude/scheduled_tasks.lock`, `test_adversarial_flow.*`, `adversarial_flow_test.go`, `adversarial_flow_test.rb`, `adversarial_flow_spec.rb`, and `AdversarialFlowTests.swift` to `.git/info/exclude`
 - Installing a pre-commit hook at `.git/hooks/pre-commit` that blocks direct `git commit` during active FLOW features and requires commits to go through `/flow:flow-commit`
 - Installing a global `flow` launcher at `~/.local/bin/flow` that delegates to the plugin cache, and warning if `~/.local/bin` is not in PATH
@@ -500,7 +480,7 @@ All universal permissions written to `.claude/settings.json` for reference:
 }
 ```
 
-### Step 5 — Install plugins
+### Step 4 — Install plugins
 
 Run `claude plugin list` to check the current plugin state.
 
@@ -520,7 +500,7 @@ claude plugin install decompose@decompose-marketplace
 
 If all plugins are already present, skip silently.
 
-### Step 6 — Commit generated files
+### Step 5 — Commit generated files
 
 Check if the working tree has changes by running `git status`. If the output contains "working tree clean", skip to Done.
 
@@ -545,7 +525,7 @@ Report:
 - Git excludes configured for `.flow-states/`, `.worktrees/`, `.flow.json`, `.claude/cost/`, `.claude/scheduled_tasks.lock`, `test_adversarial_flow.*`, `adversarial_flow_test.go`, `adversarial_flow_test.rb`, `adversarial_flow_spec.rb`, and `AdversarialFlowTests.swift`
 - Pre-commit hook installed — blocks direct `git commit`, requires `/flow:flow-commit`
 - Global launcher installed at `~/.local/bin/flow` — run `flow tui` from any primed project
-- bin/* stubs installed (list whichever names appear in `stubs_installed` from Step 4); remind the user to edit each one to wire it to their actual toolchain
+- bin/* stubs installed (list whichever names appear in `stubs_installed` from Step 3); remind the user to edit each one to wire it to their actual toolchain
 - Decompose plugin installed (or already present) — DAG planning support from the `matt-k-wong/mkw-DAG-architect` marketplace
 - Generated files committed and pushed
 
@@ -562,4 +542,4 @@ Display the skills configuration as a pipe-delimited markdown table with exactly
 | abort       | manual | —        |
 ```
 
-Use the actual values from `skills_dict` (Step 3). The table above is just an example. Show `—` for axes that don't apply to a skill. The table must use pipe `|` delimiters — never render as a bullet list.
+Use the actual values from `skills_dict` (Step 2). The table above is just an example. Show `—` for axes that don't apply to a skill. The table must use pipe `|` delimiters — never render as a bullet list.

--- a/src/commands/init_state.rs
+++ b/src/commands/init_state.rs
@@ -67,10 +67,6 @@ fn seed_session_id_from_capture(project_root: &Path, branch: &str) {
 /// state files rely on the deterministic order. Writes to
 /// `.flow-states/<branch>.json`.
 ///
-/// `commit_format` — optional commit message format (`"full"` or `"title-only"`)
-/// extracted from `.flow.json` during prime. Written to state file when present;
-/// the commit skill reads it at runtime.
-///
 /// `relative_cwd` — relative path inside the worktree where the agent
 /// should operate. Empty string means worktree root. Captured by
 /// `start_init` from the user's cwd at flow-start time so mono-repo
@@ -83,7 +79,6 @@ pub fn create_state(
     branch: &str,
     skills: Option<&IndexMap<String, SkillConfig>>,
     prompt: &str,
-    commit_format: Option<&str>,
     start_step: Option<i64>,
     start_steps_total: Option<i64>,
     relative_cwd: &str,
@@ -129,9 +124,6 @@ pub fn create_state(
         // non-serializable fields. Always serializes.
         let skills_value = serde_json::to_value(s).expect("SkillConfig map always serializes");
         state.insert("skills".into(), skills_value);
-    }
-    if let Some(f) = commit_format {
-        state.insert("commit_format".into(), json!(f));
     }
     if let Some(step) = start_step {
         state.insert("start_step".into(), json!(step));
@@ -272,18 +264,11 @@ pub fn run(
         derived
     };
 
-    let commit_format_owned = flow_json
-        .get("commit_format")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
-    let commit_format = commit_format_owned.as_deref();
-
     if let Err(e) = create_state(
         &root,
         &branch,
         skills.as_ref(),
         &prompt,
-        commit_format,
         start_step,
         start_steps_total,
         relative_cwd,

--- a/src/prime_setup.rs
+++ b/src/prime_setup.rs
@@ -407,7 +407,6 @@ pub fn write_version_marker(
     version: &str,
     config_hash: Option<&str>,
     setup_hash: Option<&str>,
-    commit_format: Option<&str>,
     role: Option<&str>,
     plugin_root_path: Option<&str>,
     skills: Option<&Value>,
@@ -420,9 +419,6 @@ pub fn write_version_marker(
     }
     if let Some(h) = setup_hash {
         data["setup_hash"] = json!(h);
-    }
-    if let Some(f) = commit_format {
-        data["commit_format"] = json!(f);
     }
     if let Some(r) = role {
         data["role"] = json!(r);
@@ -579,10 +575,6 @@ pub struct Args {
     #[arg(long = "skills-json")]
     pub skills_json: Option<String>,
 
-    /// Commit message format (full or title-only)
-    #[arg(long = "commit-format")]
-    pub commit_format: Option<String>,
-
     /// User's primary role (pm, tech-lead, founder-solo)
     #[arg(long = "role")]
     pub role: Option<String>,
@@ -686,7 +678,6 @@ pub fn run_impl(args: &Args) -> Result<Value, Value> {
         &version,
         Some(&config_hash),
         Some(&setup_hash),
-        args.commit_format.as_deref(),
         normalized_role.as_deref(),
         args.plugin_root.as_deref(),
         skills.as_ref(),

--- a/tests/commands/init_state.rs
+++ b/tests/commands/init_state.rs
@@ -1133,7 +1133,6 @@ fn lib_create_state_slash_branch_returns_invalid_branch_error() {
         "test prompt",
         None,
         None,
-        None,
         "",
     );
     assert!(result.is_err(), "expected Err, got: {:?}", result);
@@ -1155,7 +1154,6 @@ fn lib_create_state_writes_valid_json() {
         "test prompt",
         None,
         None,
-        None,
         "",
     )
     .unwrap();
@@ -1175,17 +1173,7 @@ fn lib_create_state_session_tty_serializes_option_string() {
     // depends on whether the test harness inherits a TTY from its
     // parent process.
     let dir = tempfile::tempdir().unwrap();
-    create_state(
-        dir.path(),
-        "tty-present",
-        None,
-        "prompt",
-        None,
-        None,
-        None,
-        "",
-    )
-    .unwrap();
+    create_state(dir.path(), "tty-present", None, "prompt", None, None, "").unwrap();
     let state = read_state_direct(dir.path(), "tty-present");
     assert!(
         state.get("session_tty").is_some(),
@@ -1202,7 +1190,7 @@ fn lib_create_state_session_tty_serializes_option_string() {
 #[test]
 fn lib_create_state_null_pr_fields() {
     let dir = tempfile::tempdir().unwrap();
-    create_state(dir.path(), "pr-null-test", None, "", None, None, None, "").unwrap();
+    create_state(dir.path(), "pr-null-test", None, "", None, None, "").unwrap();
     let state = read_state_direct(dir.path(), "pr-null-test");
     assert!(state["pr_number"].is_null());
     assert!(state["pr_url"].is_null());
@@ -1212,7 +1200,7 @@ fn lib_create_state_null_pr_fields() {
 #[test]
 fn lib_create_state_has_six_phases() {
     let dir = tempfile::tempdir().unwrap();
-    create_state(dir.path(), "six-phases", None, "", None, None, None, "").unwrap();
+    create_state(dir.path(), "six-phases", None, "", None, None, "").unwrap();
     let state = read_state_direct(dir.path(), "six-phases");
     let phases = state["phases"].as_object().unwrap();
     assert_eq!(phases.len(), 5);
@@ -1226,7 +1214,7 @@ fn lib_create_state_has_six_phases() {
 #[test]
 fn lib_create_state_first_phase_in_progress() {
     let dir = tempfile::tempdir().unwrap();
-    create_state(dir.path(), "phase-status", None, "", None, None, None, "").unwrap();
+    create_state(dir.path(), "phase-status", None, "", None, None, "").unwrap();
     let state = read_state_direct(dir.path(), "phase-status");
     let start = &state["phases"]["flow-start"];
     assert_eq!(start["status"], "in_progress");
@@ -1238,7 +1226,7 @@ fn lib_create_state_first_phase_in_progress() {
 #[test]
 fn lib_create_state_other_phases_pending() {
     let dir = tempfile::tempdir().unwrap();
-    create_state(dir.path(), "pending-test", None, "", None, None, None, "").unwrap();
+    create_state(dir.path(), "pending-test", None, "", None, None, "").unwrap();
     let state = read_state_direct(dir.path(), "pending-test");
     for key in ["flow-code", "flow-review", "flow-learn", "flow-complete"] {
         let phase = &state["phases"][key];
@@ -1270,17 +1258,7 @@ fn lib_create_state_skills_included() {
         "flow-start".to_string(),
         SkillConfig::Detailed(start_config),
     );
-    create_state(
-        dir.path(),
-        "skills-test",
-        Some(&skills),
-        "",
-        None,
-        None,
-        None,
-        "",
-    )
-    .unwrap();
+    create_state(dir.path(), "skills-test", Some(&skills), "", None, None, "").unwrap();
     let state = read_state_direct(dir.path(), "skills-test");
     assert_eq!(state["skills"]["flow-start"]["continue"], "manual");
 }
@@ -1288,7 +1266,7 @@ fn lib_create_state_skills_included() {
 #[test]
 fn lib_create_state_skills_omitted_when_none() {
     let dir = tempfile::tempdir().unwrap();
-    create_state(dir.path(), "no-skills", None, "", None, None, None, "").unwrap();
+    create_state(dir.path(), "no-skills", None, "", None, None, "").unwrap();
     let state = read_state_direct(dir.path(), "no-skills");
     assert!(state.get("skills").is_none());
 }
@@ -1297,17 +1275,7 @@ fn lib_create_state_skills_omitted_when_none() {
 fn lib_create_state_writes_skills_map_verbatim() {
     let dir = tempfile::tempdir().unwrap();
     let skills = sample_skills();
-    create_state(
-        dir.path(),
-        "skills-test",
-        Some(&skills),
-        "",
-        None,
-        None,
-        None,
-        "",
-    )
-    .unwrap();
+    create_state(dir.path(), "skills-test", Some(&skills), "", None, None, "").unwrap();
     let state = read_state_direct(dir.path(), "skills-test");
     assert_eq!(state["skills"]["flow-start"]["continue"], "auto");
     assert_eq!(state["skills"]["flow-code"]["commit"], "auto");
@@ -1326,7 +1294,6 @@ fn lib_create_state_prompt_stored() {
         "fix issue #42 with special chars: && | ;",
         None,
         None,
-        None,
         "",
     )
     .unwrap();
@@ -1337,17 +1304,7 @@ fn lib_create_state_prompt_stored() {
 #[test]
 fn lib_create_state_start_step_fields() {
     let dir = tempfile::tempdir().unwrap();
-    create_state(
-        dir.path(),
-        "step-test",
-        None,
-        "",
-        None,
-        Some(3),
-        Some(11),
-        "",
-    )
-    .unwrap();
+    create_state(dir.path(), "step-test", None, "", Some(3), Some(11), "").unwrap();
     let state = read_state_direct(dir.path(), "step-test");
     assert_eq!(state["start_step"], 3);
     assert_eq!(state["start_steps_total"], 11);
@@ -1356,7 +1313,7 @@ fn lib_create_state_start_step_fields() {
 #[test]
 fn lib_create_state_start_step_absent_when_none() {
     let dir = tempfile::tempdir().unwrap();
-    create_state(dir.path(), "no-step", None, "", None, None, None, "").unwrap();
+    create_state(dir.path(), "no-step", None, "", None, None, "").unwrap();
     let state = read_state_direct(dir.path(), "no-step");
     assert!(state.get("start_step").is_none());
     assert!(state.get("start_steps_total").is_none());
@@ -1365,7 +1322,7 @@ fn lib_create_state_start_step_absent_when_none() {
 #[test]
 fn lib_create_state_files_block() {
     let dir = tempfile::tempdir().unwrap();
-    create_state(dir.path(), "files-test", None, "", None, None, None, "").unwrap();
+    create_state(dir.path(), "files-test", None, "", None, None, "").unwrap();
     let state = read_state_direct(dir.path(), "files-test");
     let files = &state["files"];
     assert!(files["plan"].is_null());
@@ -1377,17 +1334,7 @@ fn lib_create_state_files_block() {
 #[test]
 fn lib_create_state_required_fields() {
     let dir = tempfile::tempdir().unwrap();
-    create_state(
-        dir.path(),
-        "fields-test",
-        None,
-        "my prompt",
-        None,
-        None,
-        None,
-        "",
-    )
-    .unwrap();
+    create_state(dir.path(), "fields-test", None, "my prompt", None, None, "").unwrap();
     let state = read_state_direct(dir.path(), "fields-test");
     assert_eq!(state["schema_version"], 1);
     assert_eq!(state["branch"], "fields-test");
@@ -1409,7 +1356,6 @@ fn lib_create_state_key_order_matches_python() {
         "order-test",
         Some(&skills),
         "test",
-        Some("full"),
         Some(3),
         Some(11),
         "",
@@ -1437,7 +1383,6 @@ fn lib_create_state_key_order_matches_python() {
         "phases",
         "phase_transitions",
         "skills",
-        "commit_format",
         "start_step",
         "start_steps_total",
     ];
@@ -1451,35 +1396,9 @@ fn lib_create_state_key_order_matches_python() {
 fn lib_create_state_creates_flow_states_dir() {
     let dir = tempfile::tempdir().unwrap();
     assert!(!dir.path().join(".flow-states").exists());
-    create_state(dir.path(), "dir-test", None, "", None, None, None, "").unwrap();
+    create_state(dir.path(), "dir-test", None, "", None, None, "").unwrap();
     assert!(dir.path().join(".flow-states").is_dir());
     assert!(dir.path().join(".flow-states/dir-test/state.json").exists());
-}
-
-#[test]
-fn lib_create_state_commit_format_propagation() {
-    let dir = tempfile::tempdir().unwrap();
-    create_state(
-        dir.path(),
-        "cf-test",
-        None,
-        "",
-        Some("title-only"),
-        None,
-        None,
-        "",
-    )
-    .unwrap();
-    let state = read_state_direct(dir.path(), "cf-test");
-    assert_eq!(state["commit_format"], "title-only");
-}
-
-#[test]
-fn lib_create_state_commit_format_absent_when_none() {
-    let dir = tempfile::tempdir().unwrap();
-    create_state(dir.path(), "cf-none", None, "", None, None, None, "").unwrap();
-    let state = read_state_direct(dir.path(), "cf-none");
-    assert!(state.get("commit_format").is_none());
 }
 
 #[test]
@@ -1494,7 +1413,7 @@ fn lib_create_state_write_failure_returns_error() {
     fs::create_dir_all(&branch_dir).unwrap();
     fs::create_dir_all(branch_dir.join("state.json")).unwrap();
 
-    let err = create_state(dir.path(), branch, None, "", None, None, None, "").unwrap_err();
+    let err = create_state(dir.path(), branch, None, "", None, None, "").unwrap_err();
     assert!(err.contains("Cannot write state file"), "got: {}", err);
 }
 
@@ -1506,7 +1425,7 @@ fn lib_create_state_dir_failure_returns_error() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(dir.path().join(".flow-states"), "not a directory").unwrap();
 
-    let err = create_state(dir.path(), "dir-err", None, "", None, None, None, "").unwrap_err();
+    let err = create_state(dir.path(), "dir-err", None, "", None, None, "").unwrap_err();
     assert!(
         err.contains("Cannot create branch state directory"),
         "got: {}",
@@ -1533,27 +1452,4 @@ fn freeze_phases_failure_returns_error() {
     let data = parse_stdout(&output);
     assert_eq!(data["status"], "error");
     assert_eq!(data["step"], "freeze_phases");
-}
-
-#[test]
-fn run_reads_commit_format_from_flow_json() {
-    // Covers the .and_then + .map closures that extract `commit_format`
-    // from .flow.json in run().
-    let dir = tempfile::tempdir().unwrap();
-    setup_project(dir.path(), "rails", None);
-    // Re-write .flow.json with commit_format set.
-    fs::write(
-        dir.path().join(".flow.json"),
-        serde_json::to_string(&json!({
-            "flow_version": "1.1.0",
-            "commit_format": "title-only",
-        }))
-        .unwrap(),
-    )
-    .unwrap();
-
-    let output = run_init_state(dir.path(), &["commit-format-feature"]);
-    assert_eq!(output.status.code(), Some(0));
-    let state = read_state_file(dir.path(), "commit-format-feature");
-    assert_eq!(state["commit_format"], "title-only");
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -397,7 +397,7 @@ pub fn make_complete_state(
 /// Write .flow.json with version and optional skills config.
 ///
 /// `prime_setup` writes the file with these two keys (plus hashes,
-/// commit_format, and plugin_root when provided). Older callers that
+/// role, and plugin_root when provided). Older callers that
 /// passed a positional language name should drop the argument.
 pub fn write_flow_json(repo: &Path, version: &str, skills: Option<&Value>) {
     let mut data = json!({

--- a/tests/permissions.rs
+++ b/tests/permissions.rs
@@ -142,7 +142,6 @@ const PLACEHOLDER_SUBS: &[(&str, &str)] = &[
         "<skills_dict_json>",
         r#"{"flow-start":{"continue":"manual"}}"#,
     ),
-    ("<commit_format>", "full"),
     ("<role_value>", "pm"),
     ("<index>", "0"),
     ("<outcome>", "completed"),

--- a/tests/prime_setup.rs
+++ b/tests/prime_setup.rs
@@ -341,8 +341,7 @@ fn is_subsumed_skips_malformed_existing_entry() {
 #[test]
 fn version_marker_created() {
     let tmp = tempfile::tempdir().unwrap();
-    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None, None)
-        .unwrap();
+    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None).unwrap();
     assert!(tmp.path().join(".flow.json").exists());
     let data: Value =
         serde_json::from_str(&fs::read_to_string(tmp.path().join(".flow.json")).unwrap()).unwrap();
@@ -357,8 +356,7 @@ fn version_marker_writes_minimal_json() {
     // with the key still parse cleanly because every consumer ignores
     // unknown JSON fields.
     let tmp = tempfile::tempdir().unwrap();
-    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None, None)
-        .unwrap();
+    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None).unwrap();
     let data: Value =
         serde_json::from_str(&fs::read_to_string(tmp.path().join(".flow.json")).unwrap()).unwrap();
     assert!(
@@ -370,8 +368,7 @@ fn version_marker_writes_minimal_json() {
 #[test]
 fn version_marker_trailing_newline() {
     let tmp = tempfile::tempdir().unwrap();
-    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None, None)
-        .unwrap();
+    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None).unwrap();
     let content = fs::read_to_string(tmp.path().join(".flow.json")).unwrap();
     assert!(content.ends_with('\n'));
 }
@@ -387,7 +384,6 @@ fn version_marker_with_config_hash() {
         None,
         None,
         None,
-        None,
     )
     .unwrap();
     let data: Value =
@@ -398,8 +394,7 @@ fn version_marker_with_config_hash() {
 #[test]
 fn version_marker_without_config_hash() {
     let tmp = tempfile::tempdir().unwrap();
-    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None, None)
-        .unwrap();
+    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None).unwrap();
     let data: Value =
         serde_json::from_str(&fs::read_to_string(tmp.path().join(".flow.json")).unwrap()).unwrap();
     assert!(data.get("config_hash").is_none());
@@ -416,7 +411,6 @@ fn version_marker_with_setup_hash() {
         None,
         None,
         None,
-        None,
     )
     .unwrap();
     let data: Value =
@@ -428,17 +422,8 @@ fn version_marker_with_setup_hash() {
 fn version_marker_normalizes_bare_string_skills_to_block_shape() {
     let tmp = tempfile::tempdir().unwrap();
     let skills = json!({"flow-start": "manual", "flow-code": "auto"});
-    prime_setup::write_version_marker(
-        tmp.path(),
-        "1.0.0",
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(&skills),
-    )
-    .unwrap();
+    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, Some(&skills))
+        .unwrap();
     let data: Value =
         serde_json::from_str(&fs::read_to_string(tmp.path().join(".flow.json")).unwrap()).unwrap();
     assert_eq!(
@@ -458,17 +443,8 @@ fn version_marker_passes_through_object_skills() {
         "flow-code": {"commit": "auto", "continue": "manual"},
         "flow-complete": {"continue": "auto"}
     });
-    prime_setup::write_version_marker(
-        tmp.path(),
-        "1.0.0",
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(&skills),
-    )
-    .unwrap();
+    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, Some(&skills))
+        .unwrap();
     let data: Value =
         serde_json::from_str(&fs::read_to_string(tmp.path().join(".flow.json")).unwrap()).unwrap();
     assert_eq!(
@@ -484,17 +460,8 @@ fn version_marker_non_object_skills_passes_through() {
     // rewrites per-entry values inside an object.
     let tmp = tempfile::tempdir().unwrap();
     let skills = json!("auto");
-    prime_setup::write_version_marker(
-        tmp.path(),
-        "1.0.0",
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(&skills),
-    )
-    .unwrap();
+    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, Some(&skills))
+        .unwrap();
     let data: Value =
         serde_json::from_str(&fs::read_to_string(tmp.path().join(".flow.json")).unwrap()).unwrap();
     assert_eq!(data["skills"], json!("auto"));
@@ -503,30 +470,10 @@ fn version_marker_non_object_skills_passes_through() {
 #[test]
 fn version_marker_without_skills() {
     let tmp = tempfile::tempdir().unwrap();
-    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None, None)
-        .unwrap();
+    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None).unwrap();
     let data: Value =
         serde_json::from_str(&fs::read_to_string(tmp.path().join(".flow.json")).unwrap()).unwrap();
     assert!(data.get("skills").is_none());
-}
-
-#[test]
-fn version_marker_with_commit_format() {
-    let tmp = tempfile::tempdir().unwrap();
-    prime_setup::write_version_marker(
-        tmp.path(),
-        "1.0.0",
-        None,
-        None,
-        Some("full"),
-        None,
-        None,
-        None,
-    )
-    .unwrap();
-    let data: Value =
-        serde_json::from_str(&fs::read_to_string(tmp.path().join(".flow.json")).unwrap()).unwrap();
-    assert_eq!(data["commit_format"], "full");
 }
 
 #[test]
@@ -535,7 +482,6 @@ fn version_marker_with_plugin_root() {
     prime_setup::write_version_marker(
         tmp.path(),
         "1.0.0",
-        None,
         None,
         None,
         None,
@@ -551,17 +497,8 @@ fn version_marker_with_plugin_root() {
 #[test]
 fn write_version_marker_writes_role_when_provided() {
     let tmp = tempfile::tempdir().unwrap();
-    prime_setup::write_version_marker(
-        tmp.path(),
-        "1.0.0",
-        None,
-        None,
-        None,
-        Some("pm"),
-        None,
-        None,
-    )
-    .unwrap();
+    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, Some("pm"), None, None)
+        .unwrap();
     let data: Value =
         serde_json::from_str(&fs::read_to_string(tmp.path().join(".flow.json")).unwrap()).unwrap();
     assert_eq!(data["role"], "pm");
@@ -573,7 +510,6 @@ fn write_version_marker_writes_tech_lead_role() {
     prime_setup::write_version_marker(
         tmp.path(),
         "1.0.0",
-        None,
         None,
         None,
         Some("tech-lead"),
@@ -594,7 +530,6 @@ fn write_version_marker_writes_founder_solo_role() {
         "1.0.0",
         None,
         None,
-        None,
         Some("founder-solo"),
         None,
         None,
@@ -608,8 +543,7 @@ fn write_version_marker_writes_founder_solo_role() {
 #[test]
 fn write_version_marker_omits_role_when_none() {
     let tmp = tempfile::tempdir().unwrap();
-    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None, None)
-        .unwrap();
+    prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None).unwrap();
     let data: Value =
         serde_json::from_str(&fs::read_to_string(tmp.path().join(".flow.json")).unwrap()).unwrap();
     assert!(data.get("role").is_none());
@@ -767,7 +701,7 @@ fn version_marker_write_failure_returns_error() {
     let flow_json_as_dir = tmp.path().join(".flow.json");
     fs::create_dir(&flow_json_as_dir).unwrap();
     let result =
-        prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None, None);
+        prime_setup::write_version_marker(tmp.path(), "1.0.0", None, None, None, None, None);
     assert!(
         result.is_err(),
         "expected Err when .flow.json is a directory"
@@ -1023,24 +957,6 @@ fn cli_skills_json_written() {
         }),
         "prime-setup normalizes bare-string --skills-json entries to block shape"
     );
-}
-
-#[test]
-fn cli_commit_format_written() {
-    let tmp = tempfile::tempdir().unwrap();
-    make_git_repo(tmp.path());
-    let output = flow_rs()
-        .arg("prime-setup")
-        .arg(tmp.path())
-        .arg("--commit-format")
-        .arg("title-only")
-        .output()
-        .unwrap();
-    let data = parse_stdout(&output.stdout);
-    assert_eq!(data["status"], "ok");
-    let flow_data: Value =
-        serde_json::from_str(&fs::read_to_string(tmp.path().join(".flow.json")).unwrap()).unwrap();
-    assert_eq!(flow_data["commit_format"], "title-only");
 }
 
 #[test]
@@ -1675,7 +1591,6 @@ fn run_impl_library_happy_path_covers_all_callees() {
     let args = prime_setup::Args {
         project_root: project.to_string_lossy().to_string(),
         skills_json: None,
-        commit_format: Some("full".to_string()),
         role: None,
         plugin_root: None,
     };
@@ -1705,7 +1620,6 @@ fn run_impl_library_project_root_not_dir_errors() {
     let args = prime_setup::Args {
         project_root: missing.to_string_lossy().to_string(),
         skills_json: None,
-        commit_format: None,
         role: None,
         plugin_root: None,
     };
@@ -1726,7 +1640,6 @@ fn run_impl_library_invalid_skills_json_errors() {
     let args = prime_setup::Args {
         project_root: project.to_string_lossy().to_string(),
         skills_json: Some("not json {".to_string()),
-        commit_format: None,
         role: None,
         plugin_root: None,
     };
@@ -1748,7 +1661,6 @@ fn run_impl_library_invalid_role_errors() {
     let args = prime_setup::Args {
         project_root: project.to_string_lossy().to_string(),
         skills_json: None,
-        commit_format: None,
         role: Some("ic-engineer".to_string()),
         plugin_root: None,
     };
@@ -1812,7 +1724,6 @@ fn run_impl_library_merge_settings_err_path() {
     let args = prime_setup::Args {
         project_root: project.to_string_lossy().to_string(),
         skills_json: None,
-        commit_format: None,
         role: None,
         plugin_root: None,
     };
@@ -1839,7 +1750,6 @@ fn run_impl_library_write_version_marker_err_path() {
     let args = prime_setup::Args {
         project_root: project.to_string_lossy().to_string(),
         skills_json: None,
-        commit_format: None,
         role: None,
         plugin_root: None,
     };
@@ -1863,7 +1773,6 @@ fn run_impl_library_install_pre_commit_hook_err_path() {
     let args = prime_setup::Args {
         project_root: project.to_string_lossy().to_string(),
         skills_json: None,
-        commit_format: None,
         role: None,
         plugin_root: None,
     };

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -3206,15 +3206,6 @@ fn prime_step_6_commits_generated_files() {
 }
 
 #[test]
-fn prime_has_commit_format_prompt() {
-    let c = common::read_skill("flow-prime");
-    assert!(
-        c.contains("commit_format") || c.contains("commit format"),
-        "flow-prime must prompt for commit message format"
-    );
-}
-
-#[test]
 fn flow_prime_has_role_selection_step() {
     let c = common::read_skill("flow-prime");
     let role_marker = c
@@ -3262,7 +3253,7 @@ fn flow_prime_has_role_selection_step() {
 }
 
 #[test]
-fn flow_prime_step_headings_in_role_commit_autonomy_order() {
+fn flow_prime_step_headings_in_role_autonomy_setup_order() {
     let c = common::read_skill("flow-prime");
     let tail_at_steps = c
         .split_once("\n## Steps\n")
@@ -3294,13 +3285,13 @@ fn flow_prime_step_headings_in_role_commit_autonomy_order() {
         step1
     );
     assert!(
-        step2.contains("Choose commit message format"),
-        "Step 2 must be 'Choose commit message format'; got: {}",
+        step2.contains("Choose autonomy level"),
+        "Step 2 must be 'Choose autonomy level'; got: {}",
         step2
     );
     assert!(
-        step3.contains("Choose autonomy level"),
-        "Step 3 must be 'Choose autonomy level'; got: {}",
+        step3.contains("Run prime setup script"),
+        "Step 3 must be 'Run prime setup script'; got: {}",
         step3
     );
 }
@@ -3309,9 +3300,9 @@ fn flow_prime_step_headings_in_role_commit_autonomy_order() {
 fn flow_prime_recommended_preset_matches_new_shape() {
     let c = common::read_skill("flow-prime");
     let tail_at_step3 = c
-        .split_once("### Step 3 — Choose autonomy level")
+        .split_once("### Step 2 — Choose autonomy level")
         .map(|(_, tail)| tail)
-        .expect("flow-prime must declare a `### Step 3 — Choose autonomy level` heading");
+        .expect("flow-prime must declare a `### Step 2 — Choose autonomy level` heading");
     let step3_section = tail_at_step3
         .split_once("\n### ")
         .map(|(section, _)| section)
@@ -3320,7 +3311,7 @@ fn flow_prime_recommended_preset_matches_new_shape() {
         .split_once("**Recommended** — safe defaults:")
         .map(|(_, tail)| tail)
         .expect(
-            "Step 3 Autonomy section must label the Recommended preset \
+            "Step 2 Autonomy section must label the Recommended preset \
              with '**Recommended** — safe defaults:'",
         );
     let re = Regex::new(r"```json\n(\{[\s\S]*?\})\n```").unwrap();
@@ -3372,9 +3363,9 @@ fn flow_prime_recommended_preset_matches_new_shape() {
 fn flow_prime_fully_manual_preset_keeps_start_continue_auto() {
     let c = common::read_skill("flow-prime");
     let tail_at_step3 = c
-        .split_once("### Step 3 — Choose autonomy level")
+        .split_once("### Step 2 — Choose autonomy level")
         .map(|(_, tail)| tail)
-        .expect("flow-prime must declare a `### Step 3 — Choose autonomy level` heading");
+        .expect("flow-prime must declare a `### Step 2 — Choose autonomy level` heading");
     let step3_section = tail_at_step3
         .split_once("\n### ")
         .map(|(section, _)| section)
@@ -3383,7 +3374,7 @@ fn flow_prime_fully_manual_preset_keeps_start_continue_auto() {
         .split_once("**Fully manual** — all manual:")
         .map(|(_, tail)| tail)
         .expect(
-            "Step 3 Autonomy section must label the Fully manual preset \
+            "Step 2 Autonomy section must label the Fully manual preset \
              with '**Fully manual** — all manual:'",
         );
     let re = Regex::new(r"```json\n(\{[\s\S]*?\})\n```").unwrap();
@@ -3435,9 +3426,9 @@ fn flow_prime_fully_manual_preset_keeps_start_continue_auto() {
 fn flow_prime_customize_section_never_prompts_for_flow_start() {
     let c = common::read_skill("flow-prime");
     let tail_at_step3 = c
-        .split_once("### Step 3 — Choose autonomy level")
+        .split_once("### Step 2 — Choose autonomy level")
         .map(|(_, tail)| tail)
-        .expect("flow-prime must declare a `### Step 3 — Choose autonomy level` heading");
+        .expect("flow-prime must declare a `### Step 2 — Choose autonomy level` heading");
     let step3_section = tail_at_step3
         .split_once("\n### ")
         .map(|(section, _)| section)
@@ -3446,7 +3437,7 @@ fn flow_prime_customize_section_never_prompts_for_flow_start() {
         .split_once("**Customize** — ask per skill")
         .map(|(_, tail)| tail)
         .expect(
-            "Step 3 Autonomy section must declare the Customize branch \
+            "Step 2 Autonomy section must declare the Customize branch \
              with '**Customize** — ask per skill'",
         );
     let askuser_re = Regex::new(r#">[^\n]*"[^"\n]*/flow:flow-start[^"\n]*\?""#).unwrap();
@@ -3476,11 +3467,11 @@ fn flow_prime_reprime_extracts_role() {
         .unwrap_or(tail_at_heading);
     assert!(
         reprime.contains("role"),
-        "Reprime Check must mention extracting `role` alongside skills and commit_format"
+        "Reprime Check must mention extracting `role` alongside skills"
     );
     assert!(
-        reprime.contains("skills") && reprime.contains("commit_format"),
-        "Reprime Check still extracts skills and commit_format"
+        reprime.contains("skills"),
+        "Reprime Check still extracts skills"
     );
 }
 

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -2132,15 +2132,40 @@ fn commit_no_separate_ci_step() {
 }
 
 #[test]
-fn commit_has_commit_format_support() {
+fn commit_specifies_conventional_commits() {
     let c = common::read_skill("flow-commit");
     assert!(
-        c.contains("commit_format"),
-        "Commit must support commit_format"
+        c.contains("type(scope): description"),
+        "flow-commit must specify the Conventional Commits `type(scope): description` subject shape"
+    );
+    for ty in [
+        "`feat`",
+        "`fix`",
+        "`docs`",
+        "`refactor`",
+        "`perf`",
+        "`test`",
+        "`build`",
+        "`ci`",
+        "`chore`",
+    ] {
+        assert!(
+            c.contains(ty),
+            "flow-commit must enumerate the conventional type {}",
+            ty
+        );
+    }
+    assert!(
+        c.contains("no trailing period"),
+        "flow-commit must specify the no-trailing-period subject rule"
     );
     assert!(
-        c.contains("title-only") || c.contains("full"),
-        "Commit must support format options"
+        c.contains("BREAKING CHANGE"),
+        "flow-commit must document the BREAKING CHANGE footer for major bumps"
+    );
+    assert!(
+        !c.contains("title-only") && !c.contains("commit_format"),
+        "flow-commit must not branch on the removed commit_format axis"
     );
 }
 

--- a/tests/tombstones.rs
+++ b/tests/tombstones.rs
@@ -1081,6 +1081,79 @@ fn test_universal_allow_no_flow_bin_reset_wildcard() {
     );
 }
 
+/// Tombstone: removed in PR #1743. The `commit_format` configuration
+/// axis is gone — Conventional Commits is the single always-on commit
+/// format. `src/prime_setup.rs` must not re-introduce the
+/// `commit_format` field/key or the `--commit-format` CLI flag.
+///
+/// Protection target: the config-key literal `commit_format` and the
+/// CLI-flag literal `--commit-format` (whose `commit-format` substring
+/// the hyphen check catches). Assertion kind: literal byte-substring.
+/// Stability argument — the byte check holds because:
+///   1. `concat!` reassembly: a clap `#[arg]` flag name and a JSON key
+///      are written as plain string literals, never assembled from
+///      fragments by `concat!`.
+///   2. `format!` reassembly: a flag name / config key is matched where
+///      it appears verbatim in source, not produced by interpolation.
+///   3. Named constant reference: a `const` aliasing the value would
+///      still place the literal `commit_format` in source.
+///   4. `.arg()` split: N/A — the target is a struct field / flag name,
+///      not a value passed across multiple `.arg()` calls.
+///
+/// No file-resurrection pair: no source file was deleted (field/flag
+/// removal within `src/prime_setup.rs`).
+#[test]
+fn test_prime_setup_no_commit_format_flag() {
+    let root = common::repo_root();
+    let content =
+        fs::read_to_string(root.join("src/prime_setup.rs")).expect("src/prime_setup.rs must exist");
+    assert!(
+        !content.contains("commit_format"),
+        "src/prime_setup.rs must not contain `commit_format` — the \
+         configuration axis was removed; Conventional Commits is the \
+         single always-on commit format."
+    );
+    assert!(
+        !content.contains("commit-format"),
+        "src/prime_setup.rs must not contain the `--commit-format` CLI \
+         flag — the commit-format choice was removed."
+    );
+}
+
+/// Tombstone: removed in PR #1743. `skills/flow-prime/SKILL.md` no
+/// longer asks the commit-format question — the `commit_format`
+/// configuration axis was removed and Conventional Commits is the
+/// single always-on commit format. The prime skill must not
+/// re-introduce the prompt.
+///
+/// Protection target: the config-key literal `commit_format` and the
+/// CLI-flag literal `commit-format`. Assertion kind: literal
+/// byte-substring. Stability argument — the byte check holds because:
+///   1. `concat!` reassembly: a SKILL.md prose mention / bash flag is
+///      written verbatim in Markdown, never assembled by `concat!`.
+///   2. `format!` reassembly: Markdown prose is not produced by
+///      `format!` interpolation.
+///   3. Named constant reference: N/A for Markdown corpus.
+///   4. `.arg()` split: N/A for Markdown corpus.
+///
+/// No file-resurrection pair: `skills/flow-prime/SKILL.md` survives;
+/// only the commit-format prompt and the `--commit-format` invocation
+/// flag were removed from it.
+#[test]
+fn test_prime_no_commit_format_question() {
+    let c = common::read_skill("flow-prime");
+    assert!(
+        !c.contains("commit_format"),
+        "flow-prime SKILL must not contain `commit_format` — the \
+         commit-format choice was removed."
+    );
+    assert!(
+        !c.contains("commit-format"),
+        "flow-prime SKILL must not contain `--commit-format` — the \
+         prime-setup invocation no longer passes the flag."
+    );
+}
+
 // --- flow-decompose-project removal (issue #1590 AC#6) ---
 //
 // AC#6 of issue #1590 mandates the removal of the

--- a/tests/tombstones.rs
+++ b/tests/tombstones.rs
@@ -1154,6 +1154,39 @@ fn test_prime_no_commit_format_question() {
     );
 }
 
+/// Tombstone: removed in PR #1743. `skills/flow-commit/SKILL.md` no
+/// longer branches on the `commit_format` axis (`full` vs
+/// `title-only`) — Conventional Commits is the single always-on
+/// format. The commit skill must not re-introduce the format choice.
+///
+/// Protection target: the format-value literal `title-only` and the
+/// config-key literal `commit_format`. Assertion kind: literal
+/// byte-substring. Stability argument — the byte check holds because:
+///   1. `concat!` reassembly: a SKILL.md format-value mention is
+///      written verbatim in Markdown, never assembled by `concat!`.
+///   2. `format!` reassembly: Markdown prose is not produced by
+///      `format!` interpolation.
+///   3. Named constant reference: N/A for Markdown corpus.
+///   4. `.arg()` split: N/A for Markdown corpus.
+///
+/// No file-resurrection pair: `skills/flow-commit/SKILL.md` survives;
+/// only the per-project format branch was removed from it.
+#[test]
+fn test_commit_no_title_only_or_full_format() {
+    let c = common::read_skill("flow-commit");
+    assert!(
+        !c.contains("title-only"),
+        "flow-commit SKILL must not contain `title-only` — the \
+         per-project commit-format choice was removed in favor of \
+         Conventional Commits."
+    );
+    assert!(
+        !c.contains("commit_format"),
+        "flow-commit SKILL must not contain `commit_format` — the \
+         configuration axis was removed."
+    );
+}
+
 // --- flow-decompose-project removal (issue #1590 AC#6) ---
 //
 // AC#6 of issue #1590 mandates the removal of the


### PR DESCRIPTION
## What

/flow:flow-start #1716.

Closes #1716

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/use-semantic-commits-or-provide/log` |
| State | `.flow-states/use-semantic-commits-or-provide/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/f26f20c2-08a2-4294-9e9e-77ddbe5113da.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 37m |
| Review | 17m |
| Learn | 8m |
| Complete | <1m |
| **Total** | **1h 4m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 1.6M | $0.824 |
| Code | 110.9M | $62.564 |
| Review | 33.4M | $18.160 |
| Learn | 17.5M | $13.654 ↻ |
| Complete | 1.6M | $0.840 |
| **Total** | **165.0M** | **$96.042** |

*↻ rate-limit window reset observed mid-flow.*

<!-- end:Token Cost -->

## Review Findings

- ✓ **README.md:82 Commit discipline bullet described the removed tl;dr/full commit format**
  - Fixed — Group B changed the commit-message format to Conventional Commits and removed the tl;dr line; the README Guardrails bullet still described 'imperative verb + tl;dr + per-file breakdown'. Updated to 'Conventional Commits (type(scope): description) + body + per-file breakdown'. Documentation drift caused by this PR's own behavior change, fixed in-PR per review-scope.md.

<!-- end:Review Findings -->

## Learn Findings

- → **Agent-prompt path scan blocks the .flow-states diff-handoff path that flow-review/flow-learn skills and agent Input contracts instruct**
  - Filed — Forward-facing cross-flow Tenant 1 process gap: validate-pretool agent_prompt_scan rejects .flow-states/&lt;branch&gt;/\*.diff absolute paths because they sit outside the worktree, yet the Review/Learn skills and agent Input sections instruct passing exactly that path. Every Review and Learn phase launched from a worktree hits this by construction.

<!-- end:Learn Findings -->

## State File

<details>
<summary>.flow-states/use-semantic-commits-or-provide.json</summary>

```json
{
  "schema_version": 1,
  "branch": "use-semantic-commits-or-provide",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1743,
  "pr_url": "https://github.com/benkruger/flow/pull/1743",
  "started_at": "2026-05-29T14:27:43-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/use-semantic-commits-or-provide/log",
    "state": ".flow-states/use-semantic-commits-or-provide/state.json"
  },
  "session_tty": "/dev/ttys008",
  "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/f26f20c2-08a2-4294-9e9e-77ddbe5113da.jsonl",
  "notes": [],
  "prompt": "/flow:flow-start #1716",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-29T14:27:43-07:00",
      "completed_at": "2026-05-29T14:28:31-07:00",
      "session_started_at": null,
      "cumulative_seconds": 48,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-29T14:27:43-07:00",
        "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
        "model": "claude-opus-4-8",
        "five_hour_pct": 31,
        "seven_day_pct": 31,
        "session_input_tokens": 4641,
        "session_output_tokens": 1232,
        "session_cache_creation_tokens": 245939,
        "session_cache_read_tokens": 528347,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4641,
            "output": 1232,
            "cache_create": 245939,
            "cache_read": 528347
          }
        },
        "turn_count": 3,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 262450,
        "context_window_pct": 131.225
      },
      "window_at_complete": {
        "captured_at": "2026-05-29T14:28:31-07:00",
        "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
        "model": "claude-opus-4-8",
        "five_hour_pct": 31,
        "seven_day_pct": 31,
        "session_input_tokens": 4782,
        "session_output_tokens": 2166,
        "session_cache_creation_tokens": 247640,
        "session_cache_read_tokens": 2107264,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4782,
            "output": 2166,
            "cache_create": 247640,
            "cache_read": 2107264
          }
        },
        "turn_count": 9,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 264151,
        "context_window_pct": 132.0755
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-29T14:28:41-07:00",
      "completed_at": "2026-05-29T15:05:57-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2236,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-29T14:28:41-07:00",
        "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
        "model": "claude-opus-4-8",
        "five_hour_pct": 31,
        "seven_day_pct": 31,
        "session_input_tokens": 4786,
        "session_output_tokens": 2545,
        "session_cache_creation_tokens": 247962,
        "session_cache_read_tokens": 2635706,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4786,
            "output": 2545,
            "cache_create": 247962,
            "cache_read": 2635706
          }
        },
        "turn_count": 11,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 264473,
        "context_window_pct": 132.2365
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-29T14:49:29-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 36,
          "seven_day_pct": 31,
          "session_input_tokens": 234421,
          "session_output_tokens": 84030,
          "session_cache_creation_tokens": 697307,
          "session_cache_read_tokens": 69474998,
          "by_model": {
            "claude-opus-4-8": {
              "input": 234421,
              "output": 84030,
              "cache_create": 697307,
              "cache_read": 69474998
            }
          },
          "turn_count": 120,
          "tool_call_count": 38,
          "context_at_last_turn_tokens": 713818,
          "context_window_pct": 356.909
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-29T14:49:29-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 36,
          "seven_day_pct": 31,
          "session_input_tokens": 234421,
          "session_output_tokens": 84030,
          "session_cache_creation_tokens": 697307,
          "session_cache_read_tokens": 69474998,
          "by_model": {
            "claude-opus-4-8": {
              "input": 234421,
              "output": 84030,
              "cache_create": 697307,
              "cache_read": 69474998
            }
          },
          "turn_count": 120,
          "tool_call_count": 38,
          "context_at_last_turn_tokens": 713818,
          "context_window_pct": 356.909
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-29T15:00:23-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 37,
          "seven_day_pct": 32,
          "session_input_tokens": 239019,
          "session_output_tokens": 113723,
          "session_cache_creation_tokens": 752842,
          "session_cache_read_tokens": 95403155,
          "by_model": {
            "claude-opus-4-8": {
              "input": 239019,
              "output": 113723,
              "cache_create": 752842,
              "cache_read": 95403155
            }
          },
          "turn_count": 155,
          "tool_call_count": 49,
          "context_at_last_turn_tokens": 769353,
          "context_window_pct": 384.6765
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-29T15:00:23-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 37,
          "seven_day_pct": 32,
          "session_input_tokens": 239019,
          "session_output_tokens": 113723,
          "session_cache_creation_tokens": 752842,
          "session_cache_read_tokens": 95403155,
          "by_model": {
            "claude-opus-4-8": {
              "input": 239019,
              "output": 113723,
              "cache_create": 752842,
              "cache_read": 95403155
            }
          },
          "turn_count": 155,
          "tool_call_count": 49,
          "context_at_last_turn_tokens": 769353,
          "context_window_pct": 384.6765
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-29T15:05:03-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 37,
          "seven_day_pct": 32,
          "session_input_tokens": 239304,
          "session_output_tokens": 120325,
          "session_cache_creation_tokens": 775686,
          "session_cache_read_tokens": 106277416,
          "by_model": {
            "claude-opus-4-8": {
              "input": 239304,
              "output": 120325,
              "cache_create": 775686,
              "cache_read": 106277416
            }
          },
          "turn_count": 169,
          "tool_call_count": 54,
          "context_at_last_turn_tokens": 792197,
          "context_window_pct": 396.0985
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-29T15:05:57-07:00",
        "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
        "model": "claude-opus-4-8",
        "five_hour_pct": 37,
        "seven_day_pct": 32,
        "session_input_tokens": 239448,
        "session_output_tokens": 122322,
        "session_cache_creation_tokens": 791268,
        "session_cache_read_tokens": 112636113,
        "by_model": {
          "claude-opus-4-8": {
            "input": 239448,
            "output": 122322,
            "cache_create": 791268,
            "cache_read": 112636113
          }
        },
        "turn_count": 177,
        "tool_call_count": 58,
        "context_at_last_turn_tokens": 807779,
        "context_window_pct": 403.8895
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-29T15:06:10-07:00",
      "completed_at": "2026-05-29T15:23:38-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1048,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-29T15:06:10-07:00",
        "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
        "model": "claude-opus-4-8",
        "five_hour_pct": 37,
        "seven_day_pct": 32,
        "session_input_tokens": 239452,
        "session_output_tokens": 122855,
        "session_cache_creation_tokens": 791862,
        "session_cache_read_tokens": 114251976,
        "by_model": {
          "claude-opus-4-8": {
            "input": 239452,
            "output": 122855,
            "cache_create": 791862,
            "cache_read": 114251976
          }
        },
        "turn_count": 179,
        "tool_call_count": 58,
        "context_at_last_turn_tokens": 808373,
        "context_window_pct": 404.1865
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-29T15:07:11-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 37,
          "seven_day_pct": 32,
          "session_input_tokens": 239596,
          "session_output_tokens": 124749,
          "session_cache_creation_tokens": 810860,
          "session_cache_read_tokens": 120840507,
          "by_model": {
            "claude-opus-4-8": {
              "input": 239596,
              "output": 124749,
              "cache_create": 810860,
              "cache_read": 120840507
            }
          },
          "turn_count": 187,
          "tool_call_count": 62,
          "context_at_last_turn_tokens": 827371,
          "context_window_pct": 413.6855
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-29T15:18:48-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 46,
          "seven_day_pct": 34,
          "session_input_tokens": 239878,
          "session_output_tokens": 149225,
          "session_cache_creation_tokens": 862555,
          "session_cache_read_tokens": 131115820,
          "by_model": {
            "claude-opus-4-8": {
              "input": 239878,
              "output": 149225,
              "cache_create": 862555,
              "cache_read": 131115820
            }
          },
          "turn_count": 199,
          "tool_call_count": 66,
          "context_at_last_turn_tokens": 879066,
          "context_window_pct": 439.533
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-29T15:19:20-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 46,
          "seven_day_pct": 34,
          "session_input_tokens": 240011,
          "session_output_tokens": 149436,
          "session_cache_creation_tokens": 863026,
          "session_cache_read_tokens": 132874126,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240011,
              "output": 149436,
              "cache_create": 863026,
              "cache_read": 132874126
            }
          },
          "turn_count": 201,
          "tool_call_count": 67,
          "context_at_last_turn_tokens": 879537,
          "context_window_pct": 439.7685
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-29T15:23:25-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 47,
          "seven_day_pct": 34,
          "session_input_tokens": 240296,
          "session_output_tokens": 154685,
          "session_cache_creation_tokens": 906672,
          "session_cache_read_tokens": 145647183,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240296,
              "output": 154685,
              "cache_create": 906672,
              "cache_read": 145647183
            }
          },
          "turn_count": 215,
          "tool_call_count": 74,
          "context_at_last_turn_tokens": 923183,
          "context_window_pct": 461.5915
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-29T15:18:27-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-29T15:18:32-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-29T15:18:37-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-29T15:18:42-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-29T15:23:38-07:00",
        "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
        "model": "claude-opus-4-8",
        "five_hour_pct": 47,
        "seven_day_pct": 34,
        "session_input_tokens": 240300,
        "session_output_tokens": 155336,
        "session_cache_creation_tokens": 907523,
        "session_cache_read_tokens": 147493792,
        "by_model": {
          "claude-opus-4-8": {
            "input": 240300,
            "output": 155336,
            "cache_create": 907523,
            "cache_read": 147493792
          }
        },
        "turn_count": 217,
        "tool_call_count": 75,
        "context_at_last_turn_tokens": 924034,
        "context_window_pct": 462.017
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-29T15:23:51-07:00",
      "completed_at": "2026-05-29T15:32:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 532,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-29T15:23:51-07:00",
        "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
        "model": "claude-opus-4-8",
        "five_hour_pct": 38,
        "seven_day_pct": 32,
        "session_input_tokens": 240304,
        "session_output_tokens": 155878,
        "session_cache_creation_tokens": 924098,
        "session_cache_read_tokens": 149358156,
        "by_model": {
          "claude-opus-4-8": {
            "input": 240304,
            "output": 155878,
            "cache_create": 924098,
            "cache_read": 149358156
          }
        },
        "turn_count": 219,
        "tool_call_count": 75,
        "context_at_last_turn_tokens": 940609,
        "context_window_pct": 470.3045
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-29T15:28:26-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-29T15:28:37-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 50,
          "seven_day_pct": 34,
          "session_input_tokens": 240577,
          "session_output_tokens": 166005,
          "session_cache_creation_tokens": 959579,
          "session_cache_read_tokens": 157033477,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240577,
              "output": 166005,
              "cache_create": 959579,
              "cache_read": 157033477
            }
          },
          "turn_count": 227,
          "tool_call_count": 78,
          "context_at_last_turn_tokens": 976219,
          "context_window_pct": 488.1095
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-29T15:28:45-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 50,
          "seven_day_pct": 34,
          "session_input_tokens": 240579,
          "session_output_tokens": 166540,
          "session_cache_creation_tokens": 962552,
          "session_cache_read_tokens": 158009565,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240579,
              "output": 166540,
              "cache_create": 962552,
              "cache_read": 158009565
            }
          },
          "turn_count": 228,
          "tool_call_count": 78,
          "context_at_last_turn_tokens": 979063,
          "context_window_pct": 489.5315
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-29T15:29:13-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 50,
          "seven_day_pct": 34,
          "session_input_tokens": 240583,
          "session_output_tokens": 166980,
          "session_cache_creation_tokens": 963434,
          "session_cache_read_tokens": 159968255,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240583,
              "output": 166980,
              "cache_create": 963434,
              "cache_read": 159968255
            }
          },
          "turn_count": 230,
          "tool_call_count": 78,
          "context_at_last_turn_tokens": 979945,
          "context_window_pct": 489.9725
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-29T15:29:19-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 50,
          "seven_day_pct": 34,
          "session_input_tokens": 240585,
          "session_output_tokens": 168722,
          "session_cache_creation_tokens": 963618,
          "session_cache_read_tokens": 160948198,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240585,
              "output": 168722,
              "cache_create": 963618,
              "cache_read": 160948198
            }
          },
          "turn_count": 231,
          "tool_call_count": 78,
          "context_at_last_turn_tokens": 980129,
          "context_window_pct": 490.0645
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-29T15:32:24-07:00",
          "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
          "model": "claude-opus-4-8",
          "five_hour_pct": 52,
          "seven_day_pct": 35,
          "session_input_tokens": 503364,
          "session_output_tokens": 173808,
          "session_cache_creation_tokens": 1486978,
          "session_cache_read_tokens": 164980926,
          "by_model": {
            "claude-opus-4-8": {
              "input": 503364,
              "output": 173808,
              "cache_create": 1486978,
              "cache_read": 164980926
            }
          },
          "turn_count": 238,
          "tool_call_count": 80,
          "context_at_last_turn_tokens": 522064,
          "context_window_pct": 261.032
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-29T15:32:43-07:00",
        "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
        "model": "claude-opus-4-8",
        "five_hour_pct": 0,
        "seven_day_pct": 0,
        "session_input_tokens": 503497,
        "session_output_tokens": 175070,
        "session_cache_creation_tokens": 1488036,
        "session_cache_read_tokens": 166025723,
        "by_model": {
          "claude-opus-4-8": {
            "input": 503497,
            "output": 175070,
            "cache_create": 1488036,
            "cache_read": 166025723
          }
        },
        "turn_count": 240,
        "tool_call_count": 80,
        "context_at_last_turn_tokens": 523122,
        "context_window_pct": 261.561
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-29T15:33:04-07:00",
      "completed_at": "2026-05-29T15:33:33-07:00",
      "session_started_at": null,
      "cumulative_seconds": 29,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-29T15:33:04-07:00",
        "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
        "model": "claude-opus-4-8",
        "five_hour_pct": 52,
        "seven_day_pct": 35,
        "session_input_tokens": 503500,
        "session_output_tokens": 175577,
        "session_cache_creation_tokens": 1499198,
        "session_cache_read_tokens": 167073036,
        "by_model": {
          "claude-opus-4-8": {
            "input": 503500,
            "output": 175577,
            "cache_create": 1499198,
            "cache_read": 167073036
          }
        },
        "turn_count": 242,
        "tool_call_count": 80,
        "context_at_last_turn_tokens": 534283,
        "context_window_pct": 267.1415
      },
      "window_at_complete": {
        "captured_at": "2026-05-29T15:33:33-07:00",
        "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
        "model": "claude-opus-4-8",
        "five_hour_pct": 52,
        "seven_day_pct": 35,
        "session_input_tokens": 503635,
        "session_output_tokens": 176690,
        "session_cache_creation_tokens": 1500677,
        "session_cache_read_tokens": 168676911,
        "by_model": {
          "claude-opus-4-8": {
            "input": 503635,
            "output": 176690,
            "cache_create": 1500677,
            "cache_read": 168676911
          }
        },
        "turn_count": 245,
        "tool_call_count": 80,
        "context_at_last_turn_tokens": 535763,
        "context_window_pct": 267.8815
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-29T14:28:41-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-29T15:06:10-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-29T15:23:51-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-29T15:33:04-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "commit_format": "full",
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-29T14:27:43-07:00",
    "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
    "model": "claude-opus-4-8",
    "five_hour_pct": 31,
    "seven_day_pct": 31,
    "session_input_tokens": 4641,
    "session_output_tokens": 1232,
    "session_cache_creation_tokens": 245939,
    "session_cache_read_tokens": 528347,
    "by_model": {
      "claude-opus-4-8": {
        "input": 4641,
        "output": 1232,
        "cache_create": 245939,
        "cache_read": 528347
      }
    },
    "turn_count": 3,
    "tool_call_count": 0,
    "context_at_last_turn_tokens": 262450,
    "context_window_pct": 131.225
  },
  "code_tasks_total": 5,
  "code_task": 5,
  "code_task_name": "Verification: full CI 100/100/100 + classified supersession grep",
  "diff_stats": {
    "files_changed": 15,
    "insertions": 248,
    "deletions": 394,
    "captured_at": "2026-05-29T15:05:57-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "findings": [
    {
      "finding": "README.md:82 Commit discipline bullet described the removed tl;dr/full commit format",
      "reason": "Group B changed the commit-message format to Conventional Commits and removed the tl;dr line; the README Guardrails bullet still described 'imperative verb + tl;dr + per-file breakdown'. Updated to 'Conventional Commits (type(scope): description) + body + per-file breakdown'. Documentation drift caused by this PR's own behavior change, fixed in-PR per review-scope.md.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-29T15:19:42-07:00"
    },
    {
      "finding": "Agent-prompt path scan blocks the .flow-states diff-handoff path that flow-review/flow-learn skills and agent Input contracts instruct",
      "reason": "Forward-facing cross-flow Tenant 1 process gap: validate-pretool agent_prompt_scan rejects .flow-states/<branch>/*.diff absolute paths because they sit outside the worktree, yet the Review/Learn skills and agent Input sections instruct passing exactly that path. Every Review and Learn phase launched from a worktree hits this by construction.",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-29T15:32:18-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1745"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "compact_summary": "<analysis>\nThe conversation is an autonomous FLOW lifecycle execution for GitHub issue #1716, which removes the `commit_format` configuration axis from the FLOW plugin and rewrites the flow-commit skill to compose Conventional Commits. The flow ran in fully-autonomous mode (commit=auto, continue=auto for all phases).\n\nLet me reconstruct the state precisely:\n\n**Branch/PR:** `use-semantic-commits-or-provide`, PR #1743, worktree at `/Users/ben/code/flow/.worktrees/use-semantic-commits-or-provide`, project root `/Users/ben/code/flow`, base branch `main`.\n\n**Phases completed:**\n- Phase 1 (Start): complete (<1m)\n- Phase 2 (Code): complete (37m), 5 tasks across 2 atomic groups + verification. Commits: Group A `84edd0c`, Group B `d6d3439`.\n- Phase 3 (Review): complete (17m), 4 agents, 1 real finding (README.md:82) fixed as `d988c95`.\n- Phase 4 (Learn): IN PROGRESS — currently at Step 6 (learn_step=5).\n\n**Plan tasks (5):** Group A (Tasks 1+2, atomic): remove commit_format axis from Rust (src/prime_setup.rs, src/commands/init_state.rs), prime skill, schema doc, two .claude/rules files, tests, two tombstones. Group B (Tasks 3+4, atomic): rewrite flow-commit to Conventional Commits (SKILL.md, docs, contract test, tombstone). Task 5: verification.\n\n**Learn phase findings:** learn-analyst returned 1 Tenant 1 process-gap finding: the `agent_prompt_scan` hook blocks the `.flow-states/` diff-handoff path that the Review/Learn skills + agent Input contracts instruct (and the Learn skill prose falsely calls \"sanctioned\"). This recurs every flow. Tenants 2/3: no findings. No correction notes (notes: []).\n\n**Mechanical recoveries logged this session:**\n1. Group A commit's first finalize-commit failed clippy doc-lazy-continuation in tombstone doc blocks; fixed with blank line; restored `_continue_pending=commit` (cleared by failed finalize) and retried.\n2. Review agent_prompt_scan blocked .flow-states diff paths; recovery = agents run `git diff origin/main...HEAD` from cwd.\n\n**Errors hit:**\n- Grep/Glob tools NOT available in this session — used `grep` via Bash (no pipes/compound — those are blocked by validate-pretool).\n- Compound commands (pipes) blocked by hook.\n- `.claude/rules/` edits blocked by validate-claude-paths → must use `bin/flow write-rule` with full file content.\n- agent_prompt_scan blocks out-of-worktree paths in agent prompts (.flow-states diff paths, `/Users/ben/code/flow/bin/flow` absolute path, `/flow:flow-commit` slash-command leading-slash).\n- clippy doc-lazy-continuation lint on tombstone docs.\n\n**Current state at compaction:** Just self-invoked flow:flow-learn --continue-step with learn_step=5. The Resume Check maps learn_step=5 → Step 6 (File GitHub issues). The skill text was re-delivered. I now need to: file the Tenant 1 process-gap issue against benkruger/flow (Step 6), present the report (Step 7), then phase-finalize and (continue=auto) invoke flow:flow-complete.\n\nThis final message has CRITICAL instruction: respond with TEXT ONLY, no tools — it's a summarization request.\n\nLet me capture all the precise technical details for continuation.\n\nNote the learn-analyst's Tenant 1 finding wording for the issue I need to file: \"Agent-prompt path scan contradicts the diff-handoff path the Review/Learn skills and agent Input contracts instruct.\" Recommendation: either (a) extend agent_prompt_scan allow surface to permit `<project_root>/.flow-states/` path tokens, OR (b) change agent Input contract + skill invocation so agents obtain diff via git diff revision range as the documented primary path. File against benkruger/flow per filing-issues.md.\n\nState field reminders: state.json has `commit_format: \"full\"` (stale inert key from flow-start), code_task=5, review_step=4, learn_step=5, learn_steps_total=7. No slack_thread_ts (omit --thread-ts). repo is benkruger/flow.\n\nCommit-message constraints (global CLAUDE.md): no Co-Authored-By; use `git commit -F <file>` or `-m`; never heredoc. The flow-commit skill (cached version, still uses commit_format=full) composes full format (subject, tl;dr, explanation, file list).\n\nFiles modified across the flow (Group A + B + Review):\n- src/prime_setup.rs, src/commands/init_state.rs\n- skills/flow-prime/SKILL.md, skills/flow-commit/SKILL.md\n- docs/reference/flow-state-schema.md, docs/skills/flow-prime.md, docs/skills/flow-commit.md\n- .claude/rules/config-source-mapping.md, .claude/rules/skill-authoring.md\n- tests/prime_setup.rs, tests/commands/init_state.rs, tests/skill_contracts.rs, tests/permissions.rs, tests/common/mod.rs, tests/tombstones.rs\n- README.md (Review fix)\n\nTombstones added: test_prime_setup_no_commit_format_flag, test_prime_no_commit_format_question, test_commit_no_title_only_or_full_format. Contract test renamed: commit_has_commit_format_support → commit_specifies_conventional_commits.\n\nNow, the Step 6 issue filing process per the skill:\n1. Write issue body to `.flow-states/<branch>/issue-body-content.md`\n2. Route via `bin/flow write-rule --path <project_root>/.flow-issue-body --content-file ...`\n3. File: `bin/flow issue --repo benkruger/flow --title \"...\" --body-file .flow-issue-body`\n4. Record: `bin/flow add-issue --label \"Tech Debt\" --title \"...\" --url \"...\" --phase flow-learn`\n5. Record finding: `bin/flow add-finding --finding \"...\" --reason \"...\" --outcome \"filed\" --phase flow-learn --issue-url \"...\"`\n\nThen Step 7: set learn_step=6, present report. Then Done: phase-finalize --phase flow-learn --branch use-semantic-commits-or-provide, parse continue_action (auto → invoke flow:flow-complete).\n</analysis>\n\n<summary>\n\n1. Primary Request and Intent:\n   The user invoked `/flow:flow-start #1716` to run the full autonomous FLOW lifecycle on GitHub issue #1716. The issue (a pre-decomposed plan) requires: **Remove the `commit_format` configuration axis** (the `full` vs `title-only` commit-message-format choice) from the FLOW plugin end-to-end, and **rewrite the flow-commit skill to compose Conventional Commits** (`type(scope): description`) as the single always-on format, so a downstream CHANGELOG pipeline keyed off Conventional Commits matches every FLOW merge commit. The flow runs in fully autonomous mode (commit=auto, continue=auto for every phase). No additional user messages were sent after the initial `/flow:flow-start #1716` invocation — everything since has been autonomous skill execution.\n\n2. Key Technical Concepts:\n   - FLOW 5-phase lifecycle (Start, Code, Review, Learn, Complete), each a Skill the model executes via self-invocation with `--continue-step`.\n   - Atomic commit groups (tombstone co-commits with the removal it guards, per `.claude/rules/plan-commit-atomicity.md` + `skill-authoring.md` \"Contract Test Atomicity\").\n   - Tombstone tests with the five-item stability checklist (literal byte-substring, PR # marker, concat!/format!/constant keywords required when PR# ≥ STABILITY_DOCS_SENTINEL_PR=1397).\n   - Conventional Commits v1.0.0 (type set: feat/fix/docs/refactor/perf/test/build/ci/chore; no trailing period; BREAKING CHANGE footer).\n   - `bin/flow write-rule` for `.claude/` and managed-artifact writes (hook blocks Edit/Write on `.claude/`).\n   - agent_prompt_scan hook: blocks out-of-worktree path tokens in Agent prompts.\n   - Cognitive isolation: 4 Review agents (reviewer, pre-mortem, adversarial, documentation), 1 Learn agent (learn-analyst).\n   - Two-gate Learn filter (forward-facing + value test); correction notes are mandatory directives (none this flow).\n   - code_task counter (monotonic +1, batched for atomic groups); review_step/learn_step counters.\n\n3. Files and Code Sections:\n   - **src/prime_setup.rs**: Removed `commit_format: Option<&str>` param from `write_version_marker` (signature now `(project_root, version, config_hash, setup_hash, role, plugin_root_path, skills)`), the `data[\"commit_format\"]=json!(f)` write, the `commit_format` field + `--commit-format` clap arg on `Args`, and the `args.commit_format.as_deref()` passthrough in `run_impl`.\n   - **src/commands/init_state.rs**: Removed `commit_format` param from `create_state` (now `(project_root, branch, skills, prompt, start_step, start_steps_total, relative_cwd)`), its module doc, the `state.insert(\"commit_format\",...)` write, and the `.flow.json` extraction in `run()`.\n   - **skills/flow-prime/SKILL.md**: Deleted Step 2 \"Choose commit message format\"; renumbered to 5 steps (1 role, 2 autonomy, 3 run prime setup, 4 install plugins, 5 commit); removed `--commit-format` from both prime-setup invocations; dropped commit_format from Reprime Check extraction; updated all step cross-references.\n   - **skills/flow-commit/SKILL.md**: Renamed Round 2 to \"Banner Detection\" (kept the `.flow-states/*.json` Glob banner check, removed the commit_format read); rewrote Step 1 to a single Conventional Commits composition (`type(scope): description`, type set, no trailing period, BREAKING CHANGE footer; dropped tl;dr).\n   - **docs/reference/flow-state-schema.md**: Removed the `commit_format` field row.\n   - **docs/skills/flow-prime.md**: Removed commit-format step from numbered list, renumbered; dropped commit format from `.flow.json` write description.\n   - **docs/skills/flow-commit.md**: Rewrote format section to Conventional Commits.\n   - **.claude/rules/config-source-mapping.md**: `.flow.json` section now reads `preferences (\\`skills\\`, etc.)` (dropped commit_format) — written via write-rule.\n   - **.claude/rules/skill-authoring.md**: Config Chain Integrity now `copies settings (\\`skills\\`)` (dropped commit_format) — written via write-rule.\n   - **tests/prime_setup.rs**: Deleted version_marker_with_commit_format, cli_commit_format_written; dropped commit_format arg from all write_version_marker calls + Args literals.\n   - **tests/commands/init_state.rs**: Deleted lib_create_state_commit_format_propagation, lib_create_state_commit_format_absent_when_none, run_reads_commit_format_from_flow_json; dropped commit_format arg from all create_state calls; removed \"commit_format\" from key-order expected vec.\n   - **tests/skill_contracts.rs**: Deleted prime_has_commit_format_prompt; rewrote reprime-extraction test; rewrote `commit_has_commit_format_support`→`commit_specifies_conventional_commits`; renamed `flow_prime_step_headings_in_role_commit_autonomy_order`→`flow_prime_step_headings_in_role_autonomy_setup_order`; retargeted \"Step 3 — Choose autonomy level\"→\"Step 2\".\n   - **tests/permissions.rs**: Removed `(\"<commit_format>\", \"full\")` placeholder row.\n   - **tests/common/mod.rs**: Updated write_flow_json doc comment (commit_format→role).\n   - **tests/tombstones.rs**: Added `test_prime_setup_no_commit_format_flag`, `test_prime_no_commit_format_question` (Group A), `test_commit_no_title_only_or_full_format` (Group B) — all PR #1743, full stability checklist, with a blank `///` line before the \"No file-resurrection pair\" paragraph (clippy fix).\n   - **README.md**: Line 82 Guardrails bullet changed from \"imperative verb + tl;dr + per-file breakdown\" to \"Conventional Commits (`type(scope): description`) + body + per-file breakdown\" (Review fix).\n   - **.flow-states/use-semantic-commits-or-provide/state.json**: code_task=5, review_step=4, learn_step=5, learn_steps_total=7, repo=benkruger/flow, no slack_thread_ts, still has inert `commit_format: \"full\"` key. 1 Review finding recorded (README fixed).\n\n4. Errors and fixes:\n   - **Grep/Glob tools unavailable** in this session (ToolSearch found neither): used `grep` via Bash without pipes/compound operators.\n   - **Compound commands blocked** by validate-pretool: split into separate Bash calls.\n   - **Edit on `.claude/rules/` blocked** by validate-claude-paths: used `bin/flow write-rule --path <worktree-abs> --content-file <.flow-states content file>` with full reproduced file content; verified via `git diff --stat` that exactly 1 line changed per file.\n   - **clippy doc-lazy-continuation** on tombstone doc blocks (Group A first finalize-commit failed at lint): added blank `///` line before the \"No file-resurrection pair\" paragraph in both tombstones. The failed finalize-commit had cleared `_continue_pending`; restored `_continue_pending=commit` before retry. Logged as mechanical recovery.\n   - **agent_prompt_scan blocked .flow-states diff-file paths** in Review agent prompts: recovery = instruct agents to obtain diff via `git diff origin/main...HEAD` (full) / `git diff -w origin/main...HEAD` (substantive) from their cwd. Logged.\n   - **agent_prompt_scan blocked `/Users/ben/code/flow/bin/flow`** absolute path in adversarial agent prompt: changed to relative `bin/flow ci --test --file tests/test_adversarial_flow.rs` (worktree cwd; Review phase so Layer 11 doesn't block).\n   - **agent_prompt_scan blocked `/flow`** extracted from `/flow:flow-commit` slash-command references in learn-analyst prompt: removed all leading-slash skill names (used bare `flow-commit`, etc.).\n   - **Process note:** Review agents launched in multiple batches (2 then blocked-then-relaunched) rather than the HARD-GATE's preferred single concurrent batch — cognitive isolation preserved (independent prompts).\n\n5. Problem Solving:\n   Completed Code (5 tasks, 2 atomic groups + verification, all CI 100/100/100), Review (4 agents, README drift fixed), and most of Learn (learn-analyst returned 1 process-gap finding). The recurring agent_prompt_scan-vs-.flow-states-path contradiction was identified by learn-analyst as a genuine forward-facing cross-flow Tenant 1 process gap to file against benkruger/flow.\n\n6. All user messages:\n   - `/flow:flow-start #1716` (the only real user message — all else is autonomous skill execution and tool results). Security/operational constraints in effect (from global + project CLAUDE.md/rules): never add Co-Authored-By; use `git commit -m` or `-F <file>`, never heredoc; never `git checkout/reset/stash`; bash shell only; never invoke cargo directly; all `.claude/` writes via `bin/flow write-rule`; `.claude/rules` writes target project repo only (never `~/.claude/`); process-gap issues file to `benkruger/flow`.\n\n7. Pending Tasks:\n   - Complete Learn Step 6: file the Tenant 1 process-gap issue against `benkruger/flow`.\n   - Learn Step 7: present report; then phase-finalize flow-learn; then (continue=auto) invoke flow:flow-complete.\n   - Phase 5 Complete: merge PR #1743, remove worktree, delete state file.\n\n8. Current Work:\n   Just self-invoked `flow:flow-learn --continue-step` with `learn_step=5`, which resumes at **Step 6 — File GitHub issues**. One Tenant 1 finding must be filed against benkruger/flow: the learn-analyst's \"Agent-prompt path scan contradicts the diff-handoff path the Review/Learn skills and agent Input contracts instruct\" — the `agent_prompt_scan` hook (src/hooks/agent_prompt_scan.rs) rejects `.flow-states/<branch>/*.diff` absolute paths in agent prompts because they sit outside the worktree, yet `skills/flow-review/SKILL.md` Step 1, `skills/flow-learn/SKILL.md` Step 1, and `agents/learn-analyst.md:55-58` (plus the four Review agent Input sections) instruct passing exactly that path; the Learn skill prose even falsely claims \".flow-states/<branch>/, the sanctioned agent-prompt path surface, so embedding it in the agent prompt does not trip the validate-pretool Agent-prompt path scan.\" Recommendation: either extend agent_prompt_scan's allow surface to permit `<project_root>/.flow-states/` tokens, OR change the agent Input contract + skill invocation to make `git diff origin/main...HEAD` the documented primary diff-handoff. The final message is a TEXT-ONLY summarization request (no tools permitted).\n\n9. Optional Next Step:\n   File the process-gap issue per Learn Step 6. The skill instructs: \"For each process gap finding from Step 2, file a GitHub issue on the plugin repo... Write the issue body to `.flow-states/<branch>/issue-body-content.md`... route it to `.flow-issue-body`... via `bin/flow write-rule`... Then file: `bin/flow issue --repo benkruger/flow --title \"<issue_title>\" --body-file .flow-issue-body`... After each successful issue, record it [add-issue --label \"Tech Debt\"]... also record the finding [add-finding --outcome \"filed\" --issue-url].\" Then Step 7 (set learn_step=6, present the Learn — Report with the Process gaps and Issues filed sections), then Done (`bin/flow phase-finalize --phase flow-learn --branch use-semantic-commits-or-provide`, omit --thread-ts; continue_action will be \"invoke\" → invoke `flow:flow-complete`). NOTE: the immediate response must be text-only (the current turn forbids tool calls); resume tool use on the next turn.\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/use-semantic-commits-or-provide",
  "compact_count": 1,
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "Review/Learn diff handoff via .flow-states/ path is blocked by the validate-pretool agent-prompt scan",
      "url": "https://github.com/benkruger/flow/issues/1745",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-05-29T15:32:16-07:00"
    }
  ],
  "complete_steps_total": 5,
  "complete_step": 5,
  "window_at_complete": {
    "captured_at": "2026-05-29T15:33:33-07:00",
    "session_id": "f26f20c2-08a2-4294-9e9e-77ddbe5113da",
    "model": "claude-opus-4-8",
    "five_hour_pct": 52,
    "seven_day_pct": 35,
    "session_input_tokens": 503635,
    "session_output_tokens": 176690,
    "session_cache_creation_tokens": 1500677,
    "session_cache_read_tokens": 168676911,
    "by_model": {
      "claude-opus-4-8": {
        "input": 503635,
        "output": 176690,
        "cache_create": 1500677,
        "cache_read": 168676911
      }
    },
    "turn_count": 245,
    "tool_call_count": 80,
    "context_at_last_turn_tokens": 535763,
    "context_window_pct": 267.8815
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | Review/Learn diff handoff via .flow-states/ path is blocked by the validate-pretool agent-prompt scan | Learn | #1745 |

<!-- end:Issues Filed -->