### PR TITLE
Review Phase Agents Trigger

### DIFF
--- a/.claude/rules/cognitive-isolation.md
+++ b/.claude/rules/cognitive-isolation.md
@@ -212,10 +212,17 @@ retry-prompt HARD-GATE is the upstream defense — drop the
 requirement from the prompt rather than redirecting toward a
 different out-of-worktree path.
 
-When in doubt, drop the path from the retry prompt entirely.
-The agent's investigation can succeed by reading in-worktree
-files alone; out-of-worktree references are almost always
-incidental to the actual review task.
+The one sanctioned exception is a path under this flow's own
+`<project_root>/.flow-states/<branch>/` subtree: `agent_prompt_scan`
+carves that subtree out (see `.claude/rules/hook-cwd-resolution.md`
+"agent_prompt_scan `.flow-states/` Carve-Out"), so a Review retry
+prompt carrying the substantive-diff path there need not drop it —
+the scan allows it even though it sits outside the worktree.
+
+When in doubt about any OTHER out-of-worktree path, drop it from the
+retry prompt entirely. The agent's investigation can succeed by
+reading in-worktree files alone; out-of-worktree references are
+almost always incidental to the actual review task.
 
 ## Never Supplement Agent Work From the Parent Session
 

--- a/.claude/rules/hook-cwd-resolution.md
+++ b/.claude/rules/hook-cwd-resolution.md
@@ -1,0 +1,97 @@
+# Hook cwd Resolution
+
+PreToolUse enforcement hooks must resolve the working directory they
+reason about from the hook payload's `cwd` field — via
+`crate::hooks::resolve_hook_cwd` — not from the hook subprocess's own
+`std::env::current_dir()`.
+
+## Why
+
+Claude Code spawns each PreToolUse hook as a subprocess and supplies
+the session's (and a sub-agent's) working directory in the payload
+`cwd` field. During an active flow that directory is the worktree.
+The hook subprocess's own `std::env::current_dir()`, by contrast, can
+resolve to the main repo root (the directory the session was started
+in) rather than the worktree. When a hook reads `env::current_dir()`
+and it points at the main repo root, every worktree-derived gate sees
+the wrong directory:
+
+- `validate-worktree-paths` — `compute_worktree_paths` returns `None`,
+  the gate self-disables, and an out-of-worktree tool call falls
+  through to a native permission prompt that hangs an autonomous flow.
+- `validate-claude-paths` — `flow_active` stays false and the
+  `.claude/` redirect silently disables.
+- `validate-skill` — the state file (and thus the halt gate) does not
+  resolve.
+- `validate-pretool` — the five cwd consumers (branch detection,
+  `main_root`, `flow_active`, the agent-prompt `worktree_root`, and
+  the Layer 10/11 + halt gates) all see the wrong directory; most
+  visibly the agent-prompt scan resolves no worktree and skips,
+  letting an out-of-worktree path reach a sub-agent.
+
+## The Rule
+
+`resolve_hook_cwd(hook_input: &Value) -> Option<String>` returns the
+payload `cwd` when present and non-empty, else falls back to
+`std::env::current_dir()`. Every hook `run()` wrapper resolves cwd
+through it:
+
+```rust
+let cwd = hook_input.as_ref().and_then(crate::hooks::resolve_hook_cwd);
+```
+
+A new PreToolUse hook that reasons about the worktree, branch, state
+file, or `.flow-states/` paths MUST resolve its cwd through
+`resolve_hook_cwd`, never directly from `env::current_dir()`. The
+fallback preserves behavior when no payload `cwd` is supplied; an
+empty `cwd` string is treated as absent so a degenerate payload falls
+back rather than producing an empty path.
+
+## agent_prompt_scan `.flow-states/` Carve-Out
+
+Once the worktree gate resolves correctly from the payload cwd, the
+parent-side Agent prompt scan (`validate_agent_prompt`) engages on
+every Review sub-agent launch. The reviewer launch's prompt carries
+the substantive-diff path under `<project_root>/.flow-states/`, which
+is outside the worktree. Without a carve-out, engaging the gate would
+hard-block every Review sub-agent launch — trading the native-prompt
+failure for a hard-block failure.
+
+`validate_agent_prompt` therefore allows candidates that normalize
+under `<project_root>/.flow-states/`. project_root is derived by
+reusing `compute_worktree_paths` on the `worktree_root` (no disk
+access); its rightmost-occurrence `rfind` resolves a project_root
+that itself contains `.worktrees/`. When `worktree_root` lacks the
+`/.worktrees/` anchor the derivation yields `None` and the carve-out
+does not apply — the candidate stays blocked.
+
+## How to Apply
+
+When authoring or modifying a PreToolUse hook:
+
+1. Resolve cwd in the `run()` wrapper via `resolve_hook_cwd`, then
+   thread the single resolved value to every cwd consumer so they
+   cannot diverge.
+2. Never call `env::current_dir()` directly for the gate cwd.
+3. When the hook scans Agent prompts for out-of-worktree paths, allow
+   `<project_root>/.flow-states/` so legitimate sub-agent launches
+   (which carry the diff path there) are not hard-blocked.
+
+## Cross-References
+
+- `src/hooks/mod.rs` — `resolve_hook_cwd` and its doc comment.
+- `src/hooks/agent_prompt_scan.rs` — the `.flow-states/` carve-out in
+  `validate_agent_prompt`.
+- `.claude/rules/cognitive-isolation.md` "Retry-prompt path-scoping
+  constraint" — the retry-prompt discipline the carve-out interacts
+  with: a `.flow-states/` diff path need not be dropped from a retry
+  prompt because the scan now allows it.
+- `.claude/rules/hook-state-timing.md` — the sibling discipline for
+  WHEN hooks read state fields; this rule covers WHICH directory the
+  reads resolve against.
+- `.claude/rules/config-source-mapping.md` — the sibling discipline
+  for config-file-to-reader mappings; the hook payload `cwd` is a
+  runtime input (not a config file), so its source mapping is recorded
+  here rather than there.
+- `.claude/rules/external-input-path-construction.md` — the byte-cap
+  and validation discipline the resolved cwd flows into.

--- a/.claude/rules/hook-cwd-resolution.md
+++ b/.claude/rules/hook-cwd-resolution.md
@@ -52,18 +52,26 @@ back rather than producing an empty path.
 Once the worktree gate resolves correctly from the payload cwd, the
 parent-side Agent prompt scan (`validate_agent_prompt`) engages on
 every Review sub-agent launch. The reviewer launch's prompt carries
-the substantive-diff path under `<project_root>/.flow-states/`, which
-is outside the worktree. Without a carve-out, engaging the gate would
-hard-block every Review sub-agent launch — trading the native-prompt
-failure for a hard-block failure.
+the substantive-diff path under `<project_root>/.flow-states/<branch>/`,
+which is outside the worktree. Without a carve-out, engaging the gate
+would hard-block every Review sub-agent launch — trading the
+native-prompt failure for a hard-block failure.
 
 `validate_agent_prompt` therefore allows candidates that normalize
-under `<project_root>/.flow-states/`. project_root is derived by
-reusing `compute_worktree_paths` on the `worktree_root` (no disk
-access); its rightmost-occurrence `rfind` resolves a project_root
-that itself contains `.worktrees/`. When `worktree_root` lacks the
-`/.worktrees/` anchor the derivation yields `None` and the carve-out
-does not apply — the candidate stays blocked.
+under this flow's own `<project_root>/.flow-states/<branch>/` subtree
+— scoped to the current branch, NOT the whole `.flow-states/` root
+that every concurrent flow shares, so a sub-agent prompt cannot be
+pointed at another concurrent flow's per-branch state. project_root
+and the branch are derived by reusing `compute_worktree_paths` on the
+`worktree_root` (no disk access): it returns
+`(project_root, <project_root>/.worktrees/<branch>)`, and the branch
+is the tail after the `/.worktrees/` anchor (sliced, not via
+`Path::file_name`, so the derivation is branchless and the 100%
+coverage gate has no unreachable arm). Its rightmost-occurrence
+`rfind` resolves a project_root that itself contains `.worktrees/`.
+When `worktree_root` lacks the `/.worktrees/` anchor the derivation
+yields `None` and the carve-out does not apply — the candidate stays
+blocked.
 
 ## How to Apply
 
@@ -74,8 +82,10 @@ When authoring or modifying a PreToolUse hook:
    cannot diverge.
 2. Never call `env::current_dir()` directly for the gate cwd.
 3. When the hook scans Agent prompts for out-of-worktree paths, allow
-   `<project_root>/.flow-states/` so legitimate sub-agent launches
-   (which carry the diff path there) are not hard-blocked.
+   the current flow's own `<project_root>/.flow-states/<branch>/`
+   subtree so legitimate sub-agent launches (which carry the diff
+   path there) are not hard-blocked — scoped to the branch, not the
+   whole `.flow-states/` root.
 
 ## Cross-References
 
@@ -84,8 +94,8 @@ When authoring or modifying a PreToolUse hook:
   `validate_agent_prompt`.
 - `.claude/rules/cognitive-isolation.md` "Retry-prompt path-scoping
   constraint" — the retry-prompt discipline the carve-out interacts
-  with: a `.flow-states/` diff path need not be dropped from a retry
-  prompt because the scan now allows it.
+  with: a `.flow-states/<branch>/` diff path need not be dropped from
+  a retry prompt because the scan now allows it.
 - `.claude/rules/hook-state-timing.md` — the sibling discipline for
   WHEN hooks read state fields; this rule covers WHICH directory the
   reads resolve against.

--- a/src/hooks/agent_prompt_scan.rs
+++ b/src/hooks/agent_prompt_scan.rs
@@ -26,7 +26,11 @@
 //!   Composes the helpers, applies the byte cap, resolves
 //!   relative candidates against the worktree root, lexically
 //!   normalizes the result (no disk touch), and prefix-compares
-//!   against the worktree root.
+//!   against the worktree root. Candidates under
+//!   `<project_root>/.flow-states/` are carved out (allowed) so
+//!   engaging the worktree gate does not hard-block the Review
+//!   sub-agent launch, whose prompt carries the substantive-diff
+//!   path outside the worktree.
 //!
 //! The `Constructor Invariant Audit` for this module per
 //! `.claude/rules/extract-helper-refactor.md`:
@@ -150,10 +154,18 @@ fn normalize_path_lexical(p: &Path) -> PathBuf {
 /// Otherwise extracts path candidates, runs the safety validator
 /// on each, resolves relative candidates against `worktree_root`,
 /// lexically normalizes the result, and rejects any candidate
-/// whose normalized form does not start with `worktree_root`. The
-/// `prompt` is sliced at `AGENT_PROMPT_BYTE_CAP` along a UTF-8
-/// char boundary BEFORE the regex sweep so unbounded input cannot
-/// produce unbounded I/O.
+/// whose normalized form does not start with `worktree_root` —
+/// EXCEPT candidates that normalize under
+/// `<project_root>/.flow-states/`, which are allowed via the
+/// `.flow-states/` carve-out. project_root is derived by reusing
+/// `compute_worktree_paths` on `worktree_root` (no disk touch); the
+/// carve-out exists so engaging the worktree gate (the hook now
+/// resolves the worktree from the payload cwd) does not hard-block
+/// the Review sub-agent launch, whose prompt carries the
+/// substantive-diff path under `.flow-states/`. The `prompt` is
+/// sliced at `AGENT_PROMPT_BYTE_CAP` along a UTF-8 char boundary
+/// BEFORE the regex sweep so unbounded input cannot produce
+/// unbounded I/O.
 pub fn validate_agent_prompt(
     prompt: Option<&str>,
     worktree_root: &Path,
@@ -198,6 +210,28 @@ pub fn validate_agent_prompt(
         };
         let resolved_norm = normalize_path_lexical(&resolved);
         if !resolved_norm.starts_with(&worktree_norm) {
+            // `.flow-states/` carve-out: the reviewer launch passes
+            // the substantive-diff path (under
+            // `<project_root>/.flow-states/`, outside the worktree) in
+            // the agent prompt. Once the hook resolves the worktree
+            // from the payload cwd, engaging the gate would otherwise
+            // hard-block every Review sub-agent launch. Allow
+            // candidates that normalize under
+            // `<project_root>/.flow-states/`. project_root is derived
+            // by reusing `compute_worktree_paths` on the worktree_root
+            // (no disk touch); its rightmost-occurrence `rfind` means a
+            // project_root that itself contains `.worktrees/` resolves
+            // correctly. When worktree_root lacks the `/.worktrees/`
+            // anchor the derivation yields `None` and the carve-out
+            // does not apply — the candidate stays blocked.
+            let wt_str = worktree_root.to_string_lossy();
+            if let Some((project_root, _)) = crate::flow_paths::compute_worktree_paths(&wt_str) {
+                let flow_states =
+                    normalize_path_lexical(&Path::new(project_root).join(".flow-states"));
+                if resolved_norm.starts_with(&flow_states) {
+                    continue;
+                }
+            }
             return (
                 false,
                 format!(

--- a/src/hooks/agent_prompt_scan.rs
+++ b/src/hooks/agent_prompt_scan.rs
@@ -26,11 +26,13 @@
 //!   Composes the helpers, applies the byte cap, resolves
 //!   relative candidates against the worktree root, lexically
 //!   normalizes the result (no disk touch), and prefix-compares
-//!   against the worktree root. Candidates under
-//!   `<project_root>/.flow-states/` are carved out (allowed) so
-//!   engaging the worktree gate does not hard-block the Review
-//!   sub-agent launch, whose prompt carries the substantive-diff
-//!   path outside the worktree.
+//!   against the worktree root. Candidates under this flow's own
+//!   `<project_root>/.flow-states/<branch>/` subtree are carved out
+//!   (allowed) so engaging the worktree gate does not hard-block the
+//!   Review sub-agent launch, whose prompt carries the
+//!   substantive-diff path there. The carve-out is scoped to the
+//!   current flow's branch subdirectory, NOT the whole
+//!   `.flow-states/` root that every concurrent flow shares.
 //!
 //! The `Constructor Invariant Audit` for this module per
 //! `.claude/rules/extract-helper-refactor.md`:
@@ -155,15 +157,17 @@ fn normalize_path_lexical(p: &Path) -> PathBuf {
 /// on each, resolves relative candidates against `worktree_root`,
 /// lexically normalizes the result, and rejects any candidate
 /// whose normalized form does not start with `worktree_root` —
-/// EXCEPT candidates that normalize under
-/// `<project_root>/.flow-states/`, which are allowed via the
-/// `.flow-states/` carve-out. project_root is derived by reusing
-/// `compute_worktree_paths` on `worktree_root` (no disk touch); the
-/// carve-out exists so engaging the worktree gate (the hook now
-/// resolves the worktree from the payload cwd) does not hard-block
-/// the Review sub-agent launch, whose prompt carries the
-/// substantive-diff path under `.flow-states/`. The `prompt` is
-/// sliced at `AGENT_PROMPT_BYTE_CAP` along a UTF-8 char boundary
+/// EXCEPT candidates that normalize under this flow's own
+/// `<project_root>/.flow-states/<branch>/` subtree, which are allowed
+/// via the `.flow-states/` carve-out. project_root and branch are
+/// derived by reusing `compute_worktree_paths` on `worktree_root` (no
+/// disk touch); the carve-out is scoped to the current flow's branch
+/// subdirectory — not the whole `.flow-states/` root, which every
+/// concurrent flow shares — so engaging the worktree gate (the hook
+/// now resolves the worktree from the payload cwd) does not
+/// hard-block the Review sub-agent launch, whose prompt carries the
+/// substantive-diff path under `.flow-states/<branch>/`. The `prompt`
+/// is sliced at `AGENT_PROMPT_BYTE_CAP` along a UTF-8 char boundary
 /// BEFORE the regex sweep so unbounded input cannot produce
 /// unbounded I/O.
 pub fn validate_agent_prompt(
@@ -212,23 +216,36 @@ pub fn validate_agent_prompt(
         if !resolved_norm.starts_with(&worktree_norm) {
             // `.flow-states/` carve-out: the reviewer launch passes
             // the substantive-diff path (under
-            // `<project_root>/.flow-states/`, outside the worktree) in
-            // the agent prompt. Once the hook resolves the worktree
-            // from the payload cwd, engaging the gate would otherwise
-            // hard-block every Review sub-agent launch. Allow
-            // candidates that normalize under
-            // `<project_root>/.flow-states/`. project_root is derived
-            // by reusing `compute_worktree_paths` on the worktree_root
-            // (no disk touch); its rightmost-occurrence `rfind` means a
-            // project_root that itself contains `.worktrees/` resolves
-            // correctly. When worktree_root lacks the `/.worktrees/`
-            // anchor the derivation yields `None` and the carve-out
-            // does not apply — the candidate stays blocked.
+            // `<project_root>/.flow-states/<branch>/`, outside the
+            // worktree) in the agent prompt. Once the hook resolves the
+            // worktree from the payload cwd, engaging the gate would
+            // otherwise hard-block every Review sub-agent launch. Allow
+            // candidates that normalize under THIS flow's own
+            // `<project_root>/.flow-states/<branch>/` subtree — scoped
+            // to the current branch, NOT the whole `.flow-states/` root
+            // that every concurrent flow shares. project_root and the
+            // branch are derived by reusing `compute_worktree_paths` on
+            // the worktree_root (no disk touch); its rightmost-occurrence
+            // `rfind` means a project_root that itself contains
+            // `.worktrees/` resolves correctly. When worktree_root lacks
+            // the `/.worktrees/` anchor the derivation yields `None` and
+            // the carve-out does not apply — the candidate stays blocked.
             let wt_str = worktree_root.to_string_lossy();
-            if let Some((project_root, _)) = crate::flow_paths::compute_worktree_paths(&wt_str) {
-                let flow_states =
-                    normalize_path_lexical(&Path::new(project_root).join(".flow-states"));
-                if resolved_norm.starts_with(&flow_states) {
+            if let Some((project_root, wt_root)) =
+                crate::flow_paths::compute_worktree_paths(&wt_str)
+            {
+                // `wt_root` is `<project_root>/.worktrees/<branch>`; the
+                // branch is the tail after the anchor. Slicing (not
+                // `Path::file_name`) keeps the derivation branchless so
+                // the 100% coverage gate has no unreachable arm.
+                let branch = wt_root
+                    .strip_prefix(project_root)
+                    .and_then(|rest| rest.strip_prefix("/.worktrees/"))
+                    .unwrap_or("");
+                let flow_states_branch = normalize_path_lexical(
+                    &Path::new(project_root).join(".flow-states").join(branch),
+                );
+                if resolved_norm.starts_with(&flow_states_branch) {
                     continue;
                 }
             }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -169,6 +169,37 @@ pub fn read_hook_input() -> Option<Value> {
     serde_json::from_str(&input).ok()
 }
 
+/// Resolve the working directory a hook should reason about.
+///
+/// Returns the payload `cwd` field when present and non-empty, else
+/// falls back to `std::env::current_dir()`.
+///
+/// The payload `cwd` is the authoritative source: Claude Code sends
+/// the session's (and a sub-agent's) working directory in the hook
+/// payload, which during an active flow is the worktree. The hook
+/// subprocess's own `std::env::current_dir()` is the directory Claude
+/// Code spawned the hook in, which can resolve to the main repo root
+/// rather than the worktree — when it does, worktree-derived gates
+/// (`compute_worktree_paths` and branch detection) silently see the
+/// wrong directory and self-disable. Reading the payload `cwd` first
+/// keeps those gates anchored to the worktree; the `env::current_dir()`
+/// fallback preserves behavior when no payload `cwd` is supplied.
+///
+/// An empty `cwd` string is treated as absent (filtered) so a
+/// degenerate payload falls back rather than producing an empty path.
+pub fn resolve_hook_cwd(hook_input: &Value) -> Option<String> {
+    hook_input
+        .get("cwd")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            std::env::current_dir()
+                .ok()
+                .map(|p| p.to_string_lossy().into_owned())
+        })
+}
+
 pub mod agent_prompt_scan;
 pub mod capture_session;
 pub mod post_compact;

--- a/src/hooks/validate_claude_paths.rs
+++ b/src/hooks/validate_claude_paths.rs
@@ -322,12 +322,20 @@ pub fn run_impl_main(
 
 /// Run the validate-claude-paths hook (entry point from CLI).
 ///
-/// Thin wrapper: reads stdin, resolves `std::env::current_dir()`,
+/// Thin wrapper: reads stdin, resolves the cwd from the payload `cwd`
+/// field via `resolve_hook_cwd` (fallback `std::env::current_dir()`),
 /// calls `run_impl_main`, writes any block message to stderr, and
-/// exits with the returned code.
+/// exits with the returned code. The payload `cwd` is the
+/// session/sub-agent worktree; the hook subprocess's own
+/// `env::current_dir()` can resolve to the main repo root, where
+/// `flow_active` would stay false and the `.claude/` redirect would
+/// silently disable mid-flow.
 pub fn run() {
     let input = read_hook_input();
-    let cwd = std::env::current_dir().ok();
+    let cwd: Option<std::path::PathBuf> = input
+        .as_ref()
+        .and_then(crate::hooks::resolve_hook_cwd)
+        .map(std::path::PathBuf::from);
     let (code, message) = run_impl_main(input, cwd.as_deref());
     if let Some(m) = message {
         eprintln!("{}", m);

--- a/src/hooks/validate_pretool.rs
+++ b/src/hooks/validate_pretool.rs
@@ -2079,14 +2079,22 @@ fn run_impl_main(hook_input: Option<Value>, cwd: Option<String>) -> (i32, Option
 
 /// Run the validate-pretool hook (entry point from CLI). Thin wrapper
 /// around `run_impl_main` that resolves the cwd and translates the
-/// decision into stderr + exit-code side effects. The cwd is read from
-/// `std::env::current_dir()`; the `.ok()` None arm (cwd inode unlinked)
-/// is covered by the stale-cwd subprocess test.
+/// decision into stderr + exit-code side effects.
+///
+/// The cwd is resolved from the hook payload's `cwd` field via
+/// `resolve_hook_cwd`, with `std::env::current_dir()` as fallback. The
+/// payload `cwd` is the session/sub-agent worktree; the hook
+/// subprocess's own `env::current_dir()` can resolve to the main repo
+/// root, where the five cwd consumers (branch detection, `main_root`,
+/// `flow_active`, the agent-prompt `worktree_root`, and the
+/// Layer 10/11 and halt gates) would all see the wrong directory —
+/// most visibly the agent-prompt scan would resolve no worktree and
+/// skip, letting an out-of-worktree path reach a sub-agent. The
+/// fallback's `.ok()` None arm (cwd inode unlinked) is covered by the
+/// stale-cwd subprocess test.
 pub fn run() {
     let hook_input = read_hook_input();
-    let cwd = std::env::current_dir()
-        .ok()
-        .map(|p| p.to_string_lossy().to_string());
+    let cwd = hook_input.as_ref().and_then(crate::hooks::resolve_hook_cwd);
     let (code, message) = run_impl_main(hook_input, cwd);
     if let Some(msg) = message {
         eprintln!("{}", msg);

--- a/src/hooks/validate_pretool.rs
+++ b/src/hooks/validate_pretool.rs
@@ -1895,23 +1895,34 @@ fn is_flow_advancing_bash_command(cmd: &str) -> bool {
     }
 }
 
-/// Run the validate-pretool hook (entry point from CLI).
-pub fn run() {
-    let hook_input = match read_hook_input() {
+/// Decision core for the validate-pretool hook. Returns
+/// `(exit_code, Option<stderr_message>)` so `run()` can translate the
+/// decision into `eprintln!` + `process::exit` side effects.
+///
+/// `cwd` is the resolved working directory the hook reasons about —
+/// `run()` supplies it. Every cwd-derived consumer (settings/project
+/// root discovery, branch detection, `main_root`, the agent-prompt
+/// `worktree_root`, and the Layer 10/11 + halt gates) reads the single
+/// `cwd` value threaded here so they cannot diverge. A `None` cwd
+/// (env::current_dir() failed upstream) makes each consumer fall
+/// through to its no-flow default. Integration tests drive every
+/// branch through the hook subprocess with fixture stdin payloads.
+fn run_impl_main(hook_input: Option<Value>, cwd: Option<String>) -> (i32, Option<String>) {
+    let hook_input = match hook_input {
         Some(input) => input,
-        None => std::process::exit(0),
+        None => return (0, None),
     };
 
-    // Resolve cwd ONCE and reuse for both settings discovery and
-    // branch detection. env::current_dir() can fail when the cwd
-    // inode has been unlinked (e.g. the stale-cwd adversarial path);
-    // in that case both settings and branch fall through to None.
-    // Per `.claude/rules/testability-means-simplicity.md` the prior
-    // `find_settings_and_root`/`detect_branch_from_cwd` generic seams
-    // have been removed because their per-monomorphization Err arms
-    // were unreachable through any production callsite — the
+    // Resolve cwd-derived inputs ONCE from the single threaded `cwd`
+    // value and reuse for settings discovery and branch detection. A
+    // `None` cwd (env::current_dir() failed upstream, e.g. the
+    // stale-cwd adversarial path) makes both settings and branch fall
+    // through to None. Per `.claude/rules/testability-means-simplicity.md`
+    // the prior `find_settings_and_root`/`detect_branch_from_cwd`
+    // generic seams have been removed because their per-monomorphization
+    // Err arms were unreachable through any production callsite — the
     // stale-cwd subprocess test covers the failure path here instead.
-    let cwd = std::env::current_dir().ok();
+    let cwd: Option<PathBuf> = cwd.map(PathBuf::from);
     let (settings, project_root) = cwd
         .as_deref()
         .map(find_settings_and_root_from)
@@ -1951,8 +1962,7 @@ pub fn run() {
     if let Some(bg) = tool_input.get("run_in_background") {
         if is_bg_truthy(bg) {
             if let Some(msg) = should_block_background(command, flow_active) {
-                eprintln!("{}", msg);
-                std::process::exit(2);
+                return (2, Some(msg));
             }
         }
     }
@@ -1967,8 +1977,7 @@ pub fn run() {
         let subagent_type = tool_input.get("subagent_type").and_then(|v| v.as_str());
         let (allowed, message) = validate_agent(subagent_type, flow_active);
         if !allowed {
-            eprintln!("{}", message);
-            std::process::exit(2);
+            return (2, Some(message));
         }
         let prompt_field = tool_input.get("prompt").and_then(|v| v.as_str());
         let worktree_root = cwd.as_deref().and_then(|c| {
@@ -1982,17 +1991,15 @@ pub fn run() {
                     flow_active,
                 );
             if !prompt_allowed {
-                eprintln!("{}", prompt_message);
-                std::process::exit(2);
+                return (2, Some(prompt_message));
             }
         }
-        std::process::exit(0);
+        return (0, None);
     }
 
     let (allowed, message) = validate(command, settings.as_ref(), flow_active);
     if !allowed {
-        eprintln!("{}", message);
-        std::process::exit(2);
+        return (2, Some(message));
     }
 
     // Layer 10: block direct commit invocations when the hook's
@@ -2010,8 +2017,7 @@ pub fn run() {
         if let Some(msg) =
             check_commit_during_flow(command, cwd_path, transcript_path.as_deref(), &home)
         {
-            eprintln!("{}", msg);
-            std::process::exit(2);
+            return (2, Some(msg));
         }
     }
 
@@ -2025,8 +2031,7 @@ pub fn run() {
     // unaffected. See `.claude/rules/per-file-coverage-iteration.md`.
     if let Some(cwd_path) = cwd.as_deref() {
         if let Some(msg) = check_ci_during_code_phase(command, cwd_path) {
-            eprintln!("{}", msg);
-            std::process::exit(2);
+            return (2, Some(msg));
         }
     }
 
@@ -2053,18 +2058,38 @@ pub fn run() {
                 .map(|paths| is_halt_set(&paths.state_file()))
                 .unwrap_or(false);
             if halt {
-                eprintln!(
-                    "BLOCKED: this flow is halted. The autonomous flow paused after a user \
-                     message and stays paused until the user explicitly resumes or aborts. \
-                     The model cannot advance the flow (counter, phase, commit, marker) \
-                     while halted. Two exits are available — only the user can take them: \
-                     type `/flow:flow-continue` to resume, or `/flow:flow-abort` to close \
-                     the flow. See .claude/rules/autonomous-phase-discipline.md."
+                return (
+                    2,
+                    Some(
+                        "BLOCKED: this flow is halted. The autonomous flow paused after a user \
+                         message and stays paused until the user explicitly resumes or aborts. \
+                         The model cannot advance the flow (counter, phase, commit, marker) \
+                         while halted. Two exits are available — only the user can take them: \
+                         type `/flow:flow-continue` to resume, or `/flow:flow-abort` to close \
+                         the flow. See .claude/rules/autonomous-phase-discipline.md."
+                            .to_string(),
+                    ),
                 );
-                std::process::exit(2);
             }
         }
     }
 
-    std::process::exit(0);
+    (0, None)
+}
+
+/// Run the validate-pretool hook (entry point from CLI). Thin wrapper
+/// around `run_impl_main` that resolves the cwd and translates the
+/// decision into stderr + exit-code side effects. The cwd is read from
+/// `std::env::current_dir()`; the `.ok()` None arm (cwd inode unlinked)
+/// is covered by the stale-cwd subprocess test.
+pub fn run() {
+    let hook_input = read_hook_input();
+    let cwd = std::env::current_dir()
+        .ok()
+        .map(|p| p.to_string_lossy().to_string());
+    let (code, message) = run_impl_main(hook_input, cwd);
+    if let Some(msg) = message {
+        eprintln!("{}", msg);
+    }
+    std::process::exit(code);
 }

--- a/src/hooks/validate_skill.rs
+++ b/src/hooks/validate_skill.rs
@@ -218,14 +218,21 @@ pub fn run_impl_main(
 }
 
 /// Run the validate-skill hook (entry point from CLI). Reads stdin,
-/// resolves `$HOME` via `home_dir_or_empty()` and the current
-/// working directory via `std::env::current_dir()`, calls
-/// `run_impl_main`, writes any block message to stderr, and exits
-/// with the returned code.
+/// resolves `$HOME` via `home_dir_or_empty()` and the working
+/// directory from the payload `cwd` field via `resolve_hook_cwd`
+/// (fallback `std::env::current_dir()`), calls `run_impl_main`, writes
+/// any block message to stderr, and exits with the returned code. The
+/// payload `cwd` is the session/sub-agent worktree; the hook
+/// subprocess's own `env::current_dir()` can resolve to the main repo
+/// root, where the state file (and thus the halt gate) would not
+/// resolve mid-flow.
 pub fn run() {
     let input = read_hook_input();
     let home = home_dir_or_empty();
-    let cwd = std::env::current_dir().ok();
+    let cwd: Option<PathBuf> = input
+        .as_ref()
+        .and_then(crate::hooks::resolve_hook_cwd)
+        .map(PathBuf::from);
     let (code, message) = run_impl_main(input, cwd.as_deref(), &home);
     if let Some(m) = message {
         eprintln!("{}", m);

--- a/src/hooks/validate_worktree_paths.rs
+++ b/src/hooks/validate_worktree_paths.rs
@@ -657,11 +657,17 @@ fn run_impl_main(hook_input: Option<Value>, cwd: Option<String>) -> (i32, Option
 /// Run the validate-worktree-paths hook (entry point from CLI). Thin
 /// wrapper around `run_impl_main` that translates decisions into
 /// stderr + exit code side effects.
+///
+/// The cwd is resolved from the hook payload's `cwd` field via
+/// `resolve_hook_cwd` (with `std::env::current_dir()` as fallback),
+/// not directly from `env::current_dir()`. The payload `cwd` is the
+/// session/sub-agent worktree; the hook subprocess's own
+/// `env::current_dir()` can resolve to the main repo root, which would
+/// make `compute_worktree_paths` self-disable and let out-of-worktree
+/// tool calls fall through to a native permission prompt mid-flow.
 pub fn run() {
     let hook_input = read_hook_input();
-    let cwd = std::env::current_dir()
-        .ok()
-        .map(|p| p.to_string_lossy().to_string());
+    let cwd = hook_input.as_ref().and_then(crate::hooks::resolve_hook_cwd);
     let (code, message) = run_impl_main(hook_input, cwd);
     if let Some(msg) = message {
         eprintln!("{}", msg);

--- a/tests/hooks/agent_prompt_scan.rs
+++ b/tests/hooks/agent_prompt_scan.rs
@@ -271,3 +271,64 @@ fn validate_agent_prompt_blocks_absolute_with_trailing_parentdir() {
     let (allowed, _) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
     assert!(!allowed);
 }
+
+// --- .flow-states/ carve-out (Task 10 Branch Enumeration Table) ---
+
+#[test]
+fn agent_prompt_allows_flow_states_diff_path() {
+    // Branch A: the reviewer launch passes the substantive-diff path
+    // (under <project_root>/.flow-states/, outside the worktree) in
+    // the agent prompt. The carve-out derives project_root from the
+    // worktree_root (/Users/alice) and allows the .flow-states/
+    // candidate so engaging the worktree gate does not hard-block
+    // Review sub-agent launches.
+    let prompt = "Read the substantive diff at \
+                  /Users/alice/.flow-states/feat/full-diff.diff and review it.";
+    let (allowed, msg) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
+    assert!(allowed, "flow-states diff path must be allowed; msg={msg}");
+}
+
+#[test]
+fn agent_prompt_blocks_arbitrary_out_of_worktree_path() {
+    // Branch B: a candidate that is outside the worktree AND outside
+    // <project_root>/.flow-states/ is still blocked. The carve-out is
+    // scoped to .flow-states/ only — it does not widen to the whole
+    // project root.
+    let prompt = "Read /Users/alice/src/other.rs and report.";
+    let (allowed, _) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
+    assert!(!allowed, "non-.flow-states out-of-worktree path must block");
+}
+
+#[test]
+fn agent_prompt_flow_states_derive_handles_no_worktrees_segment() {
+    // Branch C: when worktree_root lacks the /.worktrees/ anchor,
+    // compute_worktree_paths returns None, so project_root cannot be
+    // derived and the carve-out does not apply — the out-of-worktree
+    // candidate (even a .flow-states/-shaped one) is blocked rather
+    // than crashing.
+    let worktree_root = Path::new("/Users/alice/plainroot");
+    let prompt = "Read /Users/alice/elsewhere/.flow-states/x and report.";
+    let (allowed, _) = validate_agent_prompt(Some(prompt), worktree_root, true);
+    assert!(
+        !allowed,
+        "no-/.worktrees/ worktree_root yields no project_root → block"
+    );
+}
+
+#[test]
+fn agent_prompt_flow_states_derive_uses_rightmost_worktrees() {
+    // Branch D: a worktree_root whose project_root itself contains a
+    // `/.worktrees/` directory must resolve project_root at the
+    // RIGHTMOST anchor (via compute_worktree_paths' rfind). The
+    // carve-out's .flow-states/ root is therefore
+    // /home/dev/.worktrees/outer/.flow-states, not /home/dev/.flow-states.
+    // A diff path under the rightmost project_root's .flow-states/ is
+    // allowed; a leftmost derivation would have blocked it.
+    let worktree_root = Path::new("/home/dev/.worktrees/outer/.worktrees/feat");
+    let prompt = "Review /home/dev/.worktrees/outer/.flow-states/feat/full-diff.diff now.";
+    let (allowed, msg) = validate_agent_prompt(Some(prompt), worktree_root, true);
+    assert!(
+        allowed,
+        "rightmost project_root .flow-states/ must be allowed; msg={msg}"
+    );
+}

--- a/tests/hooks/agent_prompt_scan.rs
+++ b/tests/hooks/agent_prompt_scan.rs
@@ -277,11 +277,12 @@ fn validate_agent_prompt_blocks_absolute_with_trailing_parentdir() {
 #[test]
 fn agent_prompt_allows_flow_states_diff_path() {
     // Branch A: the reviewer launch passes the substantive-diff path
-    // (under <project_root>/.flow-states/, outside the worktree) in
-    // the agent prompt. The carve-out derives project_root from the
-    // worktree_root (/Users/alice) and allows the .flow-states/
-    // candidate so engaging the worktree gate does not hard-block
-    // Review sub-agent launches.
+    // (under this flow's own <project_root>/.flow-states/<branch>/,
+    // outside the worktree) in the agent prompt. The carve-out derives
+    // project_root (/Users/alice) and branch (feat) from the
+    // worktree_root and allows the .flow-states/feat/ candidate so
+    // engaging the worktree gate does not hard-block Review sub-agent
+    // launches.
     let prompt = "Read the substantive diff at \
                   /Users/alice/.flow-states/feat/full-diff.diff and review it.";
     let (allowed, msg) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
@@ -291,9 +292,9 @@ fn agent_prompt_allows_flow_states_diff_path() {
 #[test]
 fn agent_prompt_blocks_arbitrary_out_of_worktree_path() {
     // Branch B: a candidate that is outside the worktree AND outside
-    // <project_root>/.flow-states/ is still blocked. The carve-out is
-    // scoped to .flow-states/ only — it does not widen to the whole
-    // project root.
+    // this flow's <project_root>/.flow-states/<branch>/ subtree is
+    // still blocked. The carve-out is scoped to the branch subtree
+    // only — it does not widen to the whole project root.
     let prompt = "Read /Users/alice/src/other.rs and report.";
     let (allowed, _) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
     assert!(!allowed, "non-.flow-states out-of-worktree path must block");
@@ -320,15 +321,35 @@ fn agent_prompt_flow_states_derive_uses_rightmost_worktrees() {
     // Branch D: a worktree_root whose project_root itself contains a
     // `/.worktrees/` directory must resolve project_root at the
     // RIGHTMOST anchor (via compute_worktree_paths' rfind). The
-    // carve-out's .flow-states/ root is therefore
-    // /home/dev/.worktrees/outer/.flow-states, not /home/dev/.flow-states.
-    // A diff path under the rightmost project_root's .flow-states/ is
-    // allowed; a leftmost derivation would have blocked it.
+    // carve-out's branch subtree is therefore
+    // /home/dev/.worktrees/outer/.flow-states/feat, not
+    // /home/dev/.flow-states/feat. A diff path under the rightmost
+    // project_root's .flow-states/<branch>/ is allowed; a leftmost
+    // derivation would have blocked it.
     let worktree_root = Path::new("/home/dev/.worktrees/outer/.worktrees/feat");
     let prompt = "Review /home/dev/.worktrees/outer/.flow-states/feat/full-diff.diff now.";
     let (allowed, msg) = validate_agent_prompt(Some(prompt), worktree_root, true);
     assert!(
         allowed,
-        "rightmost project_root .flow-states/ must be allowed; msg={msg}"
+        "rightmost project_root .flow-states/<branch>/ must be allowed; msg={msg}"
+    );
+}
+
+#[test]
+fn agent_prompt_blocks_other_branch_flow_states() {
+    // Branch-scope regression guard: a `.flow-states/` candidate under
+    // a DIFFERENT branch than the current worktree (worktree_root =
+    // /Users/alice/.worktrees/feat → branch `feat`) must be blocked.
+    // `/Users/alice/.flow-states/other-branch/state.json` is under the
+    // shared `.flow-states/` root but NOT under `.flow-states/feat/`,
+    // so the branch-scoped carve-out does not admit it — preventing a
+    // sub-agent prompt from being pointed at another concurrent flow's
+    // per-branch state. A whole-`.flow-states/`-root carve-out would
+    // have allowed it.
+    let prompt = "Read /Users/alice/.flow-states/other-branch/state.json and report.";
+    let (allowed, _) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
+    assert!(
+        !allowed,
+        "a .flow-states/ path under a different branch must be blocked"
     );
 }

--- a/tests/hooks/shared.rs
+++ b/tests/hooks/shared.rs
@@ -276,6 +276,43 @@ fn test_build_permission_regexes_missing_key() {
     assert!(regexes.is_empty());
 }
 
+// === resolve_hook_cwd ===
+
+#[test]
+fn resolve_hook_cwd_returns_payload_cwd_when_present() {
+    // A non-empty payload `cwd` is the authoritative source — it reflects
+    // the session/sub-agent worktree, whereas env::current_dir() is the
+    // hook spawn cwd and can drift to the main repo root.
+    let input = json!({"cwd": "/Users/dev/project/.worktrees/feat"});
+    assert_eq!(
+        hooks::resolve_hook_cwd(&input),
+        Some("/Users/dev/project/.worktrees/feat".to_string())
+    );
+}
+
+#[test]
+fn resolve_hook_cwd_falls_back_when_absent() {
+    // No `cwd` field — falls back to std::env::current_dir(). Capture the
+    // same syscall at the same instant; no env-var mutation, so the two
+    // adjacent reads agree (no chdir occurs in this test binary).
+    let input = json!({"tool_input": {"file_path": "/x"}});
+    let expected = std::env::current_dir()
+        .ok()
+        .map(|p| p.to_string_lossy().to_string());
+    assert_eq!(hooks::resolve_hook_cwd(&input), expected);
+}
+
+#[test]
+fn resolve_hook_cwd_falls_back_when_empty() {
+    // An empty `cwd` string is treated as absent (filtered) — falls back
+    // to env::current_dir() rather than returning Some("").
+    let input = json!({"cwd": ""});
+    let expected = std::env::current_dir()
+        .ok()
+        .map(|p| p.to_string_lossy().to_string());
+    assert_eq!(hooks::resolve_hook_cwd(&input), expected);
+}
+
 // --- Library-level tests (migrated from src/hooks/mod.rs) ---
 
 use flow_rs::flow_paths::FlowPaths;

--- a/tests/hooks/validate_claude_paths.rs
+++ b/tests/hooks/validate_claude_paths.rs
@@ -529,6 +529,33 @@ fn run_hook_subprocess(cwd: &Path, stdin_input: &str) -> (i32, String, String) {
     )
 }
 
+#[test]
+fn validate_claude_paths_reads_payload_cwd_engages_gate() {
+    // The `.claude/` redirect must resolve flow_active from the
+    // payload `cwd` field, not env::current_dir(). Real cwd is the
+    // project root (non-worktree): branch detection fails there,
+    // flow_active stays false, and the redirect self-disables. The
+    // payload cwd points at the active-flow worktree where flow_active
+    // is true. With the payload honored, editing a protected .claude/
+    // path blocks (exit 2). Reading env::current_dir() (the project
+    // root) would allow (exit 0).
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let worktree = seed_active_flow_fixture(&root, "feat");
+    let target = worktree.join(".claude/rules/foo.md");
+    let input = format!(
+        r#"{{"cwd":"{}","tool_name":"Edit","tool_input":{{"file_path":"{}"}}}}"#,
+        worktree.to_string_lossy(),
+        target.to_string_lossy()
+    );
+    let (code, _stdout, stderr) = run_hook_subprocess(&root, &input);
+    assert_eq!(
+        code, 2,
+        "payload cwd must engage the .claude/ redirect; stderr={stderr}"
+    );
+    assert!(stderr.contains("BLOCKED"));
+}
+
 /// `run()` with no active flow silently allows (exit 0, no stderr).
 #[test]
 fn run_subprocess_exits_0_when_no_flow_active() {

--- a/tests/hooks/validate_pretool.rs
+++ b/tests/hooks/validate_pretool.rs
@@ -2250,6 +2250,34 @@ fn validate_pretool_run_impl_main_accepts_cwd() {
 }
 
 #[test]
+fn validate_pretool_reads_payload_cwd_engages_gate() {
+    // validate_pretool must resolve its cwd from the payload `cwd`
+    // field, not env::current_dir(). The single resolved cwd feeds all
+    // five cwd consumers documented on run_impl_main (branch detection,
+    // main_root, flow_active, the agent-prompt worktree_root, and the
+    // Layer 10/11 + halt gates); they read one `cwd` binding so a
+    // payload cwd reaching any one reaches all. Layer 10 is the
+    // observable witness here: the payload cwd points at a git repo on
+    // the integration branch while the process's real cwd is a non-git
+    // tempdir. With the payload honored, the git-commit invocation
+    // engages Layer 10 (exit 2). Reading env::current_dir() (the
+    // non-git real cwd) would resolve no branch and allow (exit 0).
+    let (_dir_repo, repo) = setup_repo_on_branch("main");
+    let other = tempfile::tempdir().expect("real cwd tempdir");
+    let real_cwd = other.path().canonicalize().expect("canonicalize");
+    let input = format!(
+        r#"{{"cwd":"{}","tool_input":{{"command":"git commit -m \"x\""}}}}"#,
+        repo.to_string_lossy()
+    );
+    let (code, _stdout, stderr) = run_hook_with_input(&input, Some(&real_cwd));
+    assert_eq!(
+        code, 2,
+        "payload cwd on the integration branch must engage Layer 10; stderr={stderr}"
+    );
+    assert!(stderr.contains("BLOCKED"));
+}
+
+#[test]
 fn t1_bare_git_commit_on_main_blocks() {
     let (_dir, root) = setup_repo_on_branch("main");
     let input = r#"{"tool_input": {"command": "git commit -m \"x\""}}"#;

--- a/tests/hooks/validate_pretool.rs
+++ b/tests/hooks/validate_pretool.rs
@@ -2209,6 +2209,46 @@ fn setup_repo_on_branch(branch: &str) -> (tempfile::TempDir, std::path::PathBuf)
     (dir, root)
 }
 
+// --- run_impl_main cwd-seam contract (Task 4) ---
+
+/// The validate-pretool decision logic lives in a private
+/// `run_impl_main(hook_input, cwd)` core; `run()` resolves the cwd and
+/// delegates. This guards the delegation contract: the core's outcome
+/// is a function of the cwd it receives. A regression that dropped the
+/// cwd thread (run_impl_main ignoring its cwd parameter) would make the
+/// Layer 10 commit gate stop depending on the working directory's
+/// branch — this test trips on that by asserting the same input
+/// produces opposite outcomes under two different cwds.
+///
+/// This is a delegation-contract test for a behavior-preserving
+/// extraction, so it passes both before and after the refactor (per
+/// `.claude/rules/skill-authoring.md` "Delegation Path Tests Need No
+/// Migration"). It is not a TDD-red test — there is no new behavior to
+/// red, only a preserved delegation path.
+#[test]
+fn validate_pretool_run_impl_main_accepts_cwd() {
+    let input = r#"{"tool_input": {"command": "git commit -m \"x\""}}"#;
+
+    // cwd on the integration branch → Layer 10 commit gate fires.
+    let (_dir_main, root_main) = setup_repo_on_branch("main");
+    let (code_main, _o, stderr_main) = run_hook_with_input(input, Some(&root_main));
+    assert_eq!(
+        code_main, 2,
+        "core must consume cwd: git commit with cwd on main blocks; stderr={stderr_main}"
+    );
+    assert!(stderr_main.contains("BLOCKED"));
+
+    // Same input, cwd on a feature branch → Layer 10 does not fire.
+    // Opposite outcome under a different cwd proves the threaded cwd is
+    // the discriminator the core acts on.
+    let (_dir_feat, root_feat) = setup_repo_on_branch("feat-x");
+    let (code_feat, _o2, stderr_feat) = run_hook_with_input(input, Some(&root_feat));
+    assert_eq!(
+        code_feat, 0,
+        "core must consume cwd: git commit with cwd on feature branch allows; stderr={stderr_feat}"
+    );
+}
+
 #[test]
 fn t1_bare_git_commit_on_main_blocks() {
     let (_dir, root) = setup_repo_on_branch("main");

--- a/tests/hooks/validate_skill.rs
+++ b/tests/hooks/validate_skill.rs
@@ -499,6 +499,71 @@ fn write_jsonl_fixture(home: &Path, jsonl: &str) -> std::path::PathBuf {
     crate::common::transcript_fixture(home, "p", jsonl)
 }
 
+/// Spawn validate-skill with an explicit payload `cwd` field while the
+/// process's real cwd (`.current_dir`) is a DIFFERENT directory.
+/// Proves `run()` resolves the state file's worktree from the payload
+/// `cwd`, not env::current_dir(). HOME is pinned to `real_cwd` per
+/// `.claude/rules/subprocess-test-hygiene.md`. Returns (exit, stderr).
+fn spawn_skill_with_payload_cwd(real_cwd: &Path, stdin_input: &str) -> (i32, String) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["hook", "validate-skill"])
+        .env_remove("FLOW_CI_RUNNING")
+        .env("HOME", real_cwd)
+        .current_dir(real_cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn flow-rs");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(stdin_input.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().expect("wait");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+#[test]
+fn validate_skill_reads_payload_cwd_engages_gate() {
+    // The halt gate must resolve the state file's worktree from the
+    // payload `cwd` field, not env::current_dir(). Real cwd is the
+    // project root (non-worktree): branch detection fails there,
+    // state_path stays None, and the halt gate passes through. The
+    // payload cwd points at the worktree whose flow has
+    // `_halt_pending=true`. With the payload honored, a non-user-only
+    // Skill call is blocked (exit 2). Reading env::current_dir() (the
+    // project root) would allow (exit 0).
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    std::fs::create_dir_all(root.join(".claude")).unwrap();
+    std::fs::write(root.join(".claude").join("settings.json"), "{}").unwrap();
+    let worktree = root.join(".worktrees").join("feat");
+    std::fs::create_dir_all(&worktree).unwrap();
+    std::fs::write(worktree.join(".git"), "gitdir: fake\n").unwrap();
+    let branch_dir = root.join(".flow-states").join("feat");
+    std::fs::create_dir_all(&branch_dir).unwrap();
+    std::fs::write(
+        branch_dir.join("state.json"),
+        json!({"_halt_pending": true}).to_string(),
+    )
+    .unwrap();
+    let input = format!(
+        r#"{{"cwd":"{}","tool_input":{{"skill":"flow:flow-status"}}}}"#,
+        worktree.to_string_lossy()
+    );
+    let (code, stderr) = spawn_skill_with_payload_cwd(&root, &input);
+    assert_eq!(
+        code, 2,
+        "payload cwd must engage the halt gate; stderr={stderr}"
+    );
+    assert!(stderr.contains("BLOCKED"));
+}
+
 #[test]
 fn subprocess_validate_skill_blocks_user_only_invocation_without_user_command() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -1451,6 +1451,73 @@ fn worktree_fixture(tmp: &tempfile::TempDir) -> (std::path::PathBuf, std::path::
     (root, worktree_cwd)
 }
 
+// --- payload-cwd gate engagement (Task 6) ---
+
+/// Spawn validate-worktree-paths with an explicit payload `cwd` field
+/// while the process's real cwd (`.current_dir`) is a DIFFERENT
+/// directory. Proves `run()` resolves the worktree from the payload
+/// `cwd`, not `std::env::current_dir()`. Returns `(exit_code, stderr)`.
+///
+/// Env hygiene per `.claude/rules/subprocess-test-hygiene.md`: removes
+/// `FLOW_CI_RUNNING` and pins `HOME` to `real_cwd` so the child reads
+/// no user dotfiles.
+fn spawn_with_payload_cwd(
+    real_cwd: &std::path::Path,
+    payload_cwd: &str,
+    file_path: &str,
+) -> (i32, String) {
+    let stdin_input = format!(
+        r#"{{"cwd":"{}","tool_name":"Read","tool_input":{{"file_path":"{}"}}}}"#,
+        payload_cwd, file_path
+    );
+    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
+        .args(["hook", "validate-worktree-paths"])
+        .env_remove("FLOW_CI_RUNNING")
+        .env("HOME", real_cwd)
+        .current_dir(real_cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn flow-rs");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(stdin_input.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().expect("wait");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+#[test]
+fn validate_worktree_paths_reads_payload_cwd_engages_gate() {
+    // The worktree gate must resolve the worktree from the payload
+    // `cwd` field, not the hook's env::current_dir(). Real cwd is the
+    // (non-worktree) project root where compute_worktree_paths returns
+    // None and the gate self-disables; the payload cwd points at the
+    // worktree. With the payload cwd honored, an out-of-worktree
+    // file_path engages the gate (exit 2). If the hook read
+    // env::current_dir() instead, the gate would self-disable and
+    // allow (exit 0) — the Review-phase halt this fix targets.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (root, worktree_cwd) = worktree_fixture(&tmp);
+    let file_path = root.join("Cargo.toml");
+    let (code, stderr) = spawn_with_payload_cwd(
+        &root,                           // real cwd: non-worktree project root
+        &worktree_cwd.to_string_lossy(), // payload cwd: the worktree
+        &file_path.to_string_lossy(),    // out-of-worktree, in-project target
+    );
+    assert_eq!(
+        code, 2,
+        "payload cwd must engage the worktree gate on an out-of-worktree \
+         path; stderr={stderr}"
+    );
+}
+
 /// R3: drive run_impl_main's $HOME resolution into the memory-allow
 /// path. The helper unit tests pass `home` directly; only a subprocess
 /// test proves run_impl_main reads $HOME from the environment and


### PR DESCRIPTION
## What

#1746.

Closes #1746

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/review-phase-agents-trigger/log` |
| State | `.flow-states/review-phase-agents-trigger/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/3393017e-8d43-4bfb-a9e3-def85c09eb90.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 9m |
| Code | 1h 12m |
| Review | 55m |
| Learn | 5m |
| Complete | <1m |
| **Total** | **2h 23m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 3.0M | $1.817 |
| Code | 113.3M | $67.600 |
| Review | 47.7M | $35.691 |
| Learn | 5.6M | $3.637 |
| Complete | 1.9M | $1.132 |
| **Total** | **171.6M** | **$109.878** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **pre-mortem: resolve_hook_cwd returns the payload cwd with no NUL/absolute/anchor/is_valid_branch validation before it flows into worktree/state path construction**
  - Dismissed — False positive: the reviewer's execution trace and the adversarial agent's passing probes confirm the cwd flows only into non-I/O string analysis (compute_worktree_paths: rfind+slice, no filesystem touch) and the try_new/is_valid_branch-validated branch machinery — there is no unvalidated path-construction-to-I/O sink. Null/non-string/whitespace cwd falls back without panic; traversal is closed upstream by is_safe_path_candidate + normalize_path_lexical. A resolve_hook_cwd-level validator would be an unreachable defensive branch the project's no-waivers/tests-guard-real-regressions rules forbid.
- ✗ **pre-mortem: four PreToolUse gates now engage/disable keyed to the payload cwd's branch with no cwd-vs-session mismatch detection (halt gate, .claude redirect, worktree gate evaluate a cwd-selected branch)**
  - Dismissed — False positive: the payload cwd IS the action's real working directory supplied by Claude Code, so each gate evaluates the flow that owns the directory the action actually runs in — by construction the correct branch. The mismatch scenario assumes a model-controlled/diverging payload cwd, which contradicts the PR's verified premise (Task 1 spike) that the payload cwd is the trusted session/sub-agent worktree. Outside FLOW's threat model (accidental model behavior, not harness compromise).
- ✗ **pre-mortem: Layer 10 commit gate binds to the payload cwd while git commit executes in the process cwd, a gate-action divergence surface**
  - Dismissed — False positive: Claude Code runs the Bash tool command in the directory named by the payload cwd field, so git commit executes in the same directory the gate evaluates — gate and action consume one cwd value, no divergence in production. The validate_pretool_reads_payload_cwd_engages_gate test separates payload cwd from the process real cwd only to prove which source the hook reads, not because they diverge at runtime.
- ✗ **documentation: CLAUDE.md Architecture-References lacks a one-line pointer to the new .claude/rules/hook-cwd-resolution.md rule**
  - Dismissed — False positive (value test, review-scope.md): not PR-caused drift of existing content but an optional new index entry. The reviewer agent (context-rich, had CLAUDE.md inline) judged it optional/not-required; the rule is discoverable by globbing .claude/rules/; CLAUDE.md's Architecture References index is non-exhaustive (peer rules such as security-gates.md and external-input-path-construction.md carry no individual pointer); and per persistence-routing.md obey-vs-describe the rule is largely descriptive (hook-authoring mechanics) rather than an obey-every-session behavioral pointer. Adding it duplicates glob-discoverable information.
- ✓ **pre-mortem: the agent_prompt_scan .flow-states/ carve-out was scoped to the whole &lt;project_root&gt;/.flow-states/ subtree (shared by every concurrent flow), not this flow's own branch subdir**
  - Fixed — Real (Tenant 1/4, defense-in-depth, broader than documented intent): narrowed the carve-out in validate_agent_prompt to &lt;project_root&gt;/.flow-states/&lt;branch&gt;/ — branch derived by slicing wt_root after the /.worktrees/ anchor (branchless, so the 100% gate has no unreachable arm). Added regression test agent_prompt_blocks_other_branch_flow_states proving a different branch's .flow-states/ path is now blocked; updated the module/function/carve-out doc comments in agent_prompt_scan.rs and the carve-out section + How-to-Apply item 3 in .claude/rules/hook-cwd-resolution.md (same commit, docs-with-behavior). A sub-agent prompt can no longer be pointed at another concurrent flow's per-branch state.
- ✓ **documentation: cognitive-isolation.md 'Retry-prompt path-scoping constraint' advised 'drop the path' without noting the new .flow-states/&lt;branch&gt;/ carve-out exception**
  - Fixed — Real (Tenant 6, PR-caused drift per docs-with-behavior): before this PR there was no carve-out so 'drop the path' was complete; the PR's carve-out makes it incomplete for the substantive-diff path. Added a sanctioned-exception paragraph to the Retry-prompt path-scoping constraint section stating a .flow-states/&lt;branch&gt;/ diff path need not be dropped (agent_prompt_scan carves it out), cross-referencing hook-cwd-resolution.md. git diff --stat confirms only the intended 15-line change to the file.

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/review-phase-agents-trigger.json</summary>

````json
{
  "schema_version": 1,
  "branch": "review-phase-agents-trigger",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1748,
  "pr_url": "https://github.com/benkruger/flow/pull/1748",
  "started_at": "2026-05-30T06:26:22-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/review-phase-agents-trigger/log",
    "state": ".flow-states/review-phase-agents-trigger/state.json"
  },
  "session_tty": "/dev/ttys012",
  "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/3393017e-8d43-4bfb-a9e3-def85c09eb90.jsonl",
  "notes": [],
  "prompt": "#1746",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-30T06:26:22-07:00",
      "completed_at": "2026-05-30T06:36:05-07:00",
      "session_started_at": null,
      "cumulative_seconds": 583,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-30T06:26:22-07:00",
        "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
        "model": "claude-opus-4-8",
        "five_hour_pct": 1,
        "seven_day_pct": 39,
        "session_input_tokens": 2,
        "session_output_tokens": 958,
        "session_cache_creation_tokens": 245477,
        "session_cache_read_tokens": 16509,
        "by_model": {
          "claude-opus-4-8": {
            "input": 2,
            "output": 958,
            "cache_create": 245477,
            "cache_read": 16509
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 261988,
        "context_window_pct": 130.994
      },
      "window_at_complete": {
        "captured_at": "2026-05-30T06:36:05-07:00",
        "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
        "model": "claude-opus-4-8",
        "five_hour_pct": 3,
        "seven_day_pct": 39,
        "session_input_tokens": 282,
        "session_output_tokens": 9921,
        "session_cache_creation_tokens": 263377,
        "session_cache_read_tokens": 2976314,
        "by_model": {
          "claude-opus-4-8": {
            "input": 282,
            "output": 9921,
            "cache_create": 263377,
            "cache_read": 2976314
          }
        },
        "turn_count": 12,
        "tool_call_count": 1,
        "context_at_last_turn_tokens": 275382,
        "context_window_pct": 137.691
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-30T06:36:15-07:00",
      "completed_at": "2026-05-30T07:48:34-07:00",
      "session_started_at": null,
      "cumulative_seconds": 4339,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-30T06:36:15-07:00",
        "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
        "model": "claude-opus-4-8",
        "five_hour_pct": 3,
        "seven_day_pct": 39,
        "session_input_tokens": 286,
        "session_output_tokens": 10420,
        "session_cache_creation_tokens": 263908,
        "session_cache_read_tokens": 3527150,
        "by_model": {
          "claude-opus-4-8": {
            "input": 286,
            "output": 10420,
            "cache_create": 263908,
            "cache_read": 3527150
          }
        },
        "turn_count": 14,
        "tool_call_count": 1,
        "context_at_last_turn_tokens": 275784,
        "context_window_pct": 137.892
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-30T06:44:37-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 5,
          "seven_day_pct": 40,
          "session_input_tokens": 228397,
          "session_output_tokens": 45361,
          "session_cache_creation_tokens": 551078,
          "session_cache_read_tokens": 8243573,
          "by_model": {
            "claude-opus-4-8": {
              "input": 228397,
              "output": 45361,
              "cache_create": 551078,
              "cache_read": 8243573
            }
          },
          "turn_count": 26,
          "tool_call_count": 3,
          "context_at_last_turn_tokens": 562954,
          "context_window_pct": 281.477
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-30T06:48:48-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 5,
          "seven_day_pct": 40,
          "session_input_tokens": 228687,
          "session_output_tokens": 56428,
          "session_cache_creation_tokens": 577629,
          "session_cache_read_tokens": 17390879,
          "by_model": {
            "claude-opus-4-8": {
              "input": 228687,
              "output": 56428,
              "cache_create": 577629,
              "cache_read": 17390879
            }
          },
          "turn_count": 42,
          "tool_call_count": 8,
          "context_at_last_turn_tokens": 589505,
          "context_window_pct": 294.7525
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-30T06:48:48-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 5,
          "seven_day_pct": 40,
          "session_input_tokens": 228687,
          "session_output_tokens": 56428,
          "session_cache_creation_tokens": 577629,
          "session_cache_read_tokens": 17390879,
          "by_model": {
            "claude-opus-4-8": {
              "input": 228687,
              "output": 56428,
              "cache_create": 577629,
              "cache_read": 17390879
            }
          },
          "turn_count": 42,
          "tool_call_count": 8,
          "context_at_last_turn_tokens": 589505,
          "context_window_pct": 294.7525
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-30T07:04:15-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 7,
          "seven_day_pct": 40,
          "session_input_tokens": 229387,
          "session_output_tokens": 110188,
          "session_cache_creation_tokens": 667716,
          "session_cache_read_tokens": 34807418,
          "by_model": {
            "claude-opus-4-8": {
              "input": 229387,
              "output": 110188,
              "cache_create": 667716,
              "cache_read": 34807418
            }
          },
          "turn_count": 70,
          "tool_call_count": 15,
          "context_at_last_turn_tokens": 679592,
          "context_window_pct": 339.796
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-30T07:04:15-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 7,
          "seven_day_pct": 40,
          "session_input_tokens": 229387,
          "session_output_tokens": 110188,
          "session_cache_creation_tokens": 667716,
          "session_cache_read_tokens": 34807418,
          "by_model": {
            "claude-opus-4-8": {
              "input": 229387,
              "output": 110188,
              "cache_create": 667716,
              "cache_read": 34807418
            }
          },
          "turn_count": 70,
          "tool_call_count": 15,
          "context_at_last_turn_tokens": 679592,
          "context_window_pct": 339.796
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-30T07:29:42-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 9,
          "seven_day_pct": 41,
          "session_input_tokens": 230804,
          "session_output_tokens": 200399,
          "session_cache_creation_tokens": 819200,
          "session_cache_read_tokens": 83242921,
          "by_model": {
            "claude-opus-4-8": {
              "input": 230804,
              "output": 200399,
              "cache_create": 819200,
              "cache_read": 83242921
            }
          },
          "turn_count": 134,
          "tool_call_count": 27,
          "context_at_last_turn_tokens": 831076,
          "context_window_pct": 415.538
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-30T07:29:42-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 9,
          "seven_day_pct": 41,
          "session_input_tokens": 230804,
          "session_output_tokens": 200399,
          "session_cache_creation_tokens": 819200,
          "session_cache_read_tokens": 83242921,
          "by_model": {
            "claude-opus-4-8": {
              "input": 230804,
              "output": 200399,
              "cache_create": 819200,
              "cache_read": 83242921
            }
          },
          "turn_count": 134,
          "tool_call_count": 27,
          "context_at_last_turn_tokens": 831076,
          "context_window_pct": 415.538
        },
        {
          "step": 8,
          "field": "code_task",
          "captured_at": "2026-05-30T07:29:42-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 9,
          "seven_day_pct": 41,
          "session_input_tokens": 230804,
          "session_output_tokens": 200399,
          "session_cache_creation_tokens": 819200,
          "session_cache_read_tokens": 83242921,
          "by_model": {
            "claude-opus-4-8": {
              "input": 230804,
              "output": 200399,
              "cache_create": 819200,
              "cache_read": 83242921
            }
          },
          "turn_count": 134,
          "tool_call_count": 27,
          "context_at_last_turn_tokens": 831076,
          "context_window_pct": 415.538
        },
        {
          "step": 9,
          "field": "code_task",
          "captured_at": "2026-05-30T07:29:42-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 9,
          "seven_day_pct": 41,
          "session_input_tokens": 230804,
          "session_output_tokens": 200399,
          "session_cache_creation_tokens": 819200,
          "session_cache_read_tokens": 83242921,
          "by_model": {
            "claude-opus-4-8": {
              "input": 230804,
              "output": 200399,
              "cache_create": 819200,
              "cache_read": 83242921
            }
          },
          "turn_count": 134,
          "tool_call_count": 27,
          "context_at_last_turn_tokens": 831076,
          "context_window_pct": 415.538
        },
        {
          "step": 10,
          "field": "code_task",
          "captured_at": "2026-05-30T07:29:42-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 9,
          "seven_day_pct": 41,
          "session_input_tokens": 230804,
          "session_output_tokens": 200399,
          "session_cache_creation_tokens": 819200,
          "session_cache_read_tokens": 83242921,
          "by_model": {
            "claude-opus-4-8": {
              "input": 230804,
              "output": 200399,
              "cache_create": 819200,
              "cache_read": 83242921
            }
          },
          "turn_count": 134,
          "tool_call_count": 27,
          "context_at_last_turn_tokens": 831076,
          "context_window_pct": 415.538
        },
        {
          "step": 11,
          "field": "code_task",
          "captured_at": "2026-05-30T07:45:08-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 11,
          "seven_day_pct": 41,
          "session_input_tokens": 231369,
          "session_output_tokens": 255393,
          "session_cache_creation_tokens": 900399,
          "session_cache_read_tokens": 104707056,
          "by_model": {
            "claude-opus-4-8": {
              "input": 231369,
              "output": 255393,
              "cache_create": 900399,
              "cache_read": 104707056
            }
          },
          "turn_count": 159,
          "tool_call_count": 36,
          "context_at_last_turn_tokens": 912275,
          "context_window_pct": 456.1375
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-30T07:48:34-07:00",
        "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
        "model": "claude-opus-4-8",
        "five_hour_pct": 11,
        "seven_day_pct": 41,
        "session_input_tokens": 231650,
        "session_output_tokens": 259280,
        "session_cache_creation_tokens": 922837,
        "session_cache_read_tokens": 115734656,
        "by_model": {
          "claude-opus-4-8": {
            "input": 231650,
            "output": 259280,
            "cache_create": 922837,
            "cache_read": 115734656
          }
        },
        "turn_count": 171,
        "tool_call_count": 42,
        "context_at_last_turn_tokens": 934713,
        "context_window_pct": 467.3565
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-30T07:48:46-07:00",
      "completed_at": "2026-05-30T08:44:29-07:00",
      "session_started_at": null,
      "cumulative_seconds": 3343,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-30T07:48:46-07:00",
        "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
        "model": "claude-opus-4-8",
        "five_hour_pct": 11,
        "seven_day_pct": 41,
        "session_input_tokens": 231654,
        "session_output_tokens": 259978,
        "session_cache_creation_tokens": 923512,
        "session_cache_read_tokens": 117604326,
        "by_model": {
          "claude-opus-4-8": {
            "input": 231654,
            "output": 259978,
            "cache_create": 923512,
            "cache_read": 117604326
          }
        },
        "turn_count": 173,
        "tool_call_count": 42,
        "context_at_last_turn_tokens": 935388,
        "context_window_pct": 467.694
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-30T07:49:54-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 12,
          "seven_day_pct": 41,
          "session_input_tokens": 231798,
          "session_output_tokens": 262339,
          "session_cache_creation_tokens": 943013,
          "session_cache_read_tokens": 125210250,
          "by_model": {
            "claude-opus-4-8": {
              "input": 231798,
              "output": 262339,
              "cache_create": 943013,
              "cache_read": 125210250
            }
          },
          "turn_count": 181,
          "tool_call_count": 45,
          "context_at_last_turn_tokens": 954889,
          "context_window_pct": 477.4445
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-30T08:17:44-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 22,
          "seven_day_pct": 43,
          "session_input_tokens": 496285,
          "session_output_tokens": 364343,
          "session_cache_creation_tokens": 1646386,
          "session_cache_read_tokens": 133614055,
          "by_model": {
            "claude-opus-4-8": {
              "input": 496285,
              "output": 364343,
              "cache_create": 1646386,
              "cache_read": 133614055
            }
          },
          "turn_count": 194,
          "tool_call_count": 46,
          "context_at_last_turn_tokens": 685071,
          "context_window_pct": 342.5355
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-30T08:22:16-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 22,
          "seven_day_pct": 43,
          "session_input_tokens": 496422,
          "session_output_tokens": 389350,
          "session_cache_creation_tokens": 1695641,
          "session_cache_read_tokens": 136406708,
          "by_model": {
            "claude-opus-4-8": {
              "input": 496422,
              "output": 389350,
              "cache_create": 1695641,
              "cache_read": 136406708
            }
          },
          "turn_count": 198,
          "tool_call_count": 46,
          "context_at_last_turn_tokens": 734326,
          "context_window_pct": 367.163
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-30T08:44:02-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 24,
          "seven_day_pct": 43,
          "session_input_tokens": 497130,
          "session_output_tokens": 479125,
          "session_cache_creation_tokens": 1831202,
          "session_cache_read_tokens": 162146622,
          "by_model": {
            "claude-opus-4-8": {
              "input": 497130,
              "output": 479125,
              "cache_create": 1831202,
              "cache_read": 162146622
            }
          },
          "turn_count": 230,
          "tool_call_count": 55,
          "context_at_last_turn_tokens": 869758,
          "context_window_pct": 434.879
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-30T08:13:00-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-30T08:13:01-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-30T08:17:42-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-30T08:17:43-07:00"
        }
      ],
      "agent_retry_counts": {
        "pre-mortem": 1,
        "adversarial": 1
      },
      "window_at_complete": {
        "captured_at": "2026-05-30T08:44:29-07:00",
        "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
        "model": "claude-opus-4-8",
        "five_hour_pct": 24,
        "seven_day_pct": 44,
        "session_input_tokens": 497263,
        "session_output_tokens": 480901,
        "session_cache_creation_tokens": 1835215,
        "session_cache_read_tokens": 163888289,
        "by_model": {
          "claude-opus-4-8": {
            "input": 497263,
            "output": 480901,
            "cache_create": 1835215,
            "cache_read": 163888289
          }
        },
        "turn_count": 232,
        "tool_call_count": 56,
        "context_at_last_turn_tokens": 873771,
        "context_window_pct": 436.8855
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-30T08:45:41-07:00",
      "completed_at": "2026-05-30T08:50:45-07:00",
      "session_started_at": null,
      "cumulative_seconds": 304,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-30T08:45:41-07:00",
        "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
        "model": "claude-opus-4-8",
        "five_hour_pct": 24,
        "seven_day_pct": 44,
        "session_input_tokens": 497267,
        "session_output_tokens": 483258,
        "session_cache_creation_tokens": 1853118,
        "session_cache_read_tokens": 165652127,
        "by_model": {
          "claude-opus-4-8": {
            "input": 497267,
            "output": 483258,
            "cache_create": 1853118,
            "cache_read": 165652127
          }
        },
        "turn_count": 234,
        "tool_call_count": 56,
        "context_at_last_turn_tokens": 891674,
        "context_window_pct": 445.837
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-30T08:49:51-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-30T08:50:28-07:00",
          "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
          "model": "claude-opus-4-8",
          "five_hour_pct": 27,
          "seven_day_pct": 44,
          "session_input_tokens": 497405,
          "session_output_tokens": 501077,
          "session_cache_creation_tokens": 1905095,
          "session_cache_read_tokens": 170237269,
          "by_model": {
            "claude-opus-4-8": {
              "input": 497405,
              "output": 501077,
              "cache_create": 1905095,
              "cache_read": 170237269
            }
          },
          "turn_count": 239,
          "tool_call_count": 56,
          "context_at_last_turn_tokens": 943651,
          "context_window_pct": 471.8255
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-30T08:50:45-07:00",
        "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
        "model": "claude-opus-4-8",
        "five_hour_pct": 27,
        "seven_day_pct": 44,
        "session_input_tokens": 497407,
        "session_output_tokens": 503569,
        "session_cache_creation_tokens": 1911438,
        "session_cache_read_tokens": 171180918,
        "by_model": {
          "claude-opus-4-8": {
            "input": 497407,
            "output": 503569,
            "cache_create": 1911438,
            "cache_read": 171180918
          }
        },
        "turn_count": 240,
        "tool_call_count": 56,
        "context_at_last_turn_tokens": 949994,
        "context_window_pct": 474.997
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-30T08:51:18-07:00",
      "completed_at": "2026-05-30T08:51:59-07:00",
      "session_started_at": null,
      "cumulative_seconds": 41,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-30T08:51:18-07:00",
        "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
        "model": "claude-opus-4-8",
        "five_hour_pct": 27,
        "seven_day_pct": 44,
        "session_input_tokens": 497540,
        "session_output_tokens": 504858,
        "session_cache_creation_tokens": 1914970,
        "session_cache_read_tokens": 173083427,
        "by_model": {
          "claude-opus-4-8": {
            "input": 497540,
            "output": 504858,
            "cache_create": 1914970,
            "cache_read": 173083427
          }
        },
        "turn_count": 242,
        "tool_call_count": 56,
        "context_at_last_turn_tokens": 953655,
        "context_window_pct": 476.8275
      },
      "window_at_complete": {
        "captured_at": "2026-05-30T08:51:59-07:00",
        "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
        "model": "claude-opus-4-8",
        "five_hour_pct": 27,
        "seven_day_pct": 44,
        "session_input_tokens": 497543,
        "session_output_tokens": 508691,
        "session_cache_creation_tokens": 1927322,
        "session_cache_read_tokens": 175000772,
        "by_model": {
          "claude-opus-4-8": {
            "input": 497543,
            "output": 508691,
            "cache_create": 1927322,
            "cache_read": 175000772
          }
        },
        "turn_count": 244,
        "tool_call_count": 56,
        "context_at_last_turn_tokens": 965878,
        "context_window_pct": 482.939
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-30T06:36:15-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-30T07:48:46-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-30T08:45:41-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-30T08:51:18-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-30T06:26:22-07:00",
    "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
    "model": "claude-opus-4-8",
    "five_hour_pct": 1,
    "seven_day_pct": 39,
    "session_input_tokens": 2,
    "session_output_tokens": 958,
    "session_cache_creation_tokens": 245477,
    "session_cache_read_tokens": 16509,
    "by_model": {
      "claude-opus-4-8": {
        "input": 2,
        "output": 958,
        "cache_create": 245477,
        "cache_read": 16509
      }
    },
    "turn_count": 1,
    "tool_call_count": 0,
    "context_at_last_turn_tokens": 261988,
    "context_window_pct": 130.994
  },
  "code_tasks_total": 11,
  "code_task": 11,
  "code_task_name": "docs + rule sync (rule-file portion)",
  "diff_stats": {
    "files_changed": 13,
    "insertions": 592,
    "deletions": 51,
    "captured_at": "2026-05-30T07:48:34-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThis is a FLOW plugin development session. The user invoked `/flow:flow-start #1746` to begin an autonomous flow on GitHub issue #1746. The flow is `continue: auto` and `commit: auto` (streamline mode), running unattended. The repository is the FLOW Claude Code plugin (Rust + Markdown skills) at `/Users/ben/code/flow`, working in worktree `/Users/ben/code/flow/.worktrees/review-phase-agents-trigger`.\n\nLet me trace the work chronologically:\n\n1. **flow-start**: Issue #1746 → branch `review-phase-agents-trigger`. CI gate (`start-gate`) initially failed with `ci_failed` showing 3 files at ~50% coverage — diagnosed as phantom misses (4 stale crate hashes via `bin/test --funcs`). Ran `bin/flow ci --clean`, re-ran start-gate → `clean`. Created worktree, PR #1748. Extracted plan (11 tasks) from issue. Advanced to Code.\n\n2. **The bug/plan**: Review phase halts autonomous flows because PreToolUse hooks read `std::env::current_dir()` (can resolve to main repo root) instead of the payload `cwd` field (the worktree). Fix: introduce `resolve_hook_cwd` resolver, thread it through 4 hooks, add a `.flow-states/` carve-out in `agent_prompt_scan`.\n\n3. **Task 1 (spike)**: Verified payload-cwd assumption empirically. Found the parent gate already engages correctly (blocked Read of out-of-worktree Cargo.toml). Sub-agent pwd = worktree. Concluded Arm A (payload cwd = worktree). Logged that the plan's eprintln mechanic wasn't executable (live hook builds from main-repo src). code_task=1.\n\n4. **Tasks 2-3 (commit d9759ac)**: Added `resolve_hook_cwd` to `src/hooks/mod.rs` + 3 tests in `tests/hooks/shared.rs`. 100% covered. Committed.\n\n5. **Tasks 4-5 (commit 1476039)**: Extracted `run_impl_main(hook_input, cwd) -> (i32, Option<String>)` from `validate_pretool::run()` (behavior-preserving, run() still uses env::current_dir). Added delegation-contract test `validate_pretool_run_impl_main_accepts_cwd`. Committed (aggregate 100%, per-file 86% explained as subprocess-covered).\n\n6. **Tasks 6-10 atomic group (commit 5fc5d3af)**: Threaded `resolve_hook_cwd` through validate_worktree_paths, validate_claude_paths, validate_skill, validate_pretool run() wrappers. Added `.flow-states/` carve-out to `validate_agent_prompt`. Added 4 engagement tests (3 thin-wrapper + 1 pretool) + 4 carve-out branch tests. Updated module doc comments. Hit a clippy `doc_lazy_continuation` lint failure (line-initial `+` in doc comment) — fixed by rewording. Then hit Layer 10 block on retry because finalize-commit had consumed `_continue_pending` — re-set it and retried. Committed (5245 tests, 100%).\n\n7. **Task 11 (commit 2aa08af)**: Deviated from plan — instead of 3 in-place rule edits (risky full-file overwrite via write-rule), created ONE new rule `.claude/rules/hook-cwd-resolution.md`. Logged deviation. Committed.\n\n8. **Code phase complete** (1h 12m). Advanced to Review.\n\n9. **Review phase (current)**: phase-enter, re-anchored cwd, resolved mode (auto/auto). Step 1 (Gather): base=main, captured diffs, derived doc_paths, adversarial path `tests/test_adversarial_flow.rs`, no stale tombstones. Just ran `set-timestamp --set review_step=1`. \n\nThe summary request came right after `review_step=1` was recorded. Next action would be to self-invoke `flow:flow-review --continue-step` to proceed to Step 2 (Launch agents).\n\nKey recurring patterns: per-file gates show <100% for subprocess-heavy/multi-binary files (aggregate is the real gate at commit time); phantom misses cleared with `bin/flow ci --clean`; commit-msg via Write to `.flow-states/<branch>/commit-msg-content.txt` → `bin/flow write-rule` → `finalize-commit`; mechanical recovery on `.flow-states/` path block (canonical path is main repo, not worktree).\n\nSecurity/process constraints observed: never raw git commit; route through /flow:flow-commit; .claude/ edits blocked → use write-rule; no compound bash commands/pipes; no shell redirects; cwd-canonicalize in subprocess tests; subprocess-test-hygiene (env_remove FLOW_CI_RUNNING, HOME, .current_dir to fixture).\n\nLet me capture all values needed to continue Review Step 2.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   - The user invoked `/flow:flow-start #1746` — an autonomous (`continue: auto`, `commit: auto`/streamline) FLOW lifecycle on GitHub issue #1746 in the FLOW plugin repo. The flow runs unattended through Start → Code → Review → Learn → Complete.\n   - Issue #1746 (\"Review Phase Agents Trigger\"): The Review phase halts autonomous flows because PreToolUse enforcement hooks resolve the worktree from the hook subprocess's own `std::env::current_dir()` (which can resolve to the main repo root) rather than the payload `cwd` field (the active flow's worktree). When that happens, `compute_worktree_paths` returns `None`, worktree-derived gates self-disable, and tool calls fall through to native permission prompts that hang the autonomous flow. The fix: a shared `resolve_hook_cwd` resolver (payload cwd, env::current_dir fallback) threaded through all four enforcement hooks, plus a `.flow-states/` carve-out in `agent_prompt_scan` so engaging the gate does not hard-block the Review sub-agent launch (whose prompt carries the diff path under `.flow-states/`, outside the worktree).\n   - The implicit intent is to execute the 11-task plan from the issue through the full FLOW lifecycle, honoring all `.claude/rules/` and CLAUDE.md conventions.\n\n2. Key Technical Concepts:\n   - FLOW 5-phase lifecycle (Start/Code/Review/Learn/Complete), each a SKILL.md the model follows; phase gates via `bin/flow` subcommands and PreToolUse hooks.\n   - PreToolUse hooks: `validate-worktree-paths`, `validate-claude-paths`, `validate-skill`, `validate-pretool`, `validate-ask-user`; the `run()` thin-wrapper + `run_impl_main(...) -> (i32, Option<String>)` pattern.\n   - `resolve_hook_cwd(hook_input: &Value) -> Option<String>` — payload `cwd` (non-empty) else `std::env::current_dir()` fallback.\n   - `compute_worktree_paths(cwd: &str) -> Option<(&str project_root, &str worktree_root)>` — rightmost-occurrence `rfind` on `/.worktrees/`.\n   - `agent_prompt_scan::validate_agent_prompt` — parent-side Agent prompt out-of-worktree path scan, with the new `.flow-states/` carve-out.\n   - Per-file coverage gate `bin/test tests/<name>.rs` (100/100/100 against mirrored src) vs aggregate full-CI gate (commit-time `finalize-commit` → `ci::run_impl()`).\n   - Phantom misses (stale instrumented binaries → `bin/test --funcs` shows duplicate crate hashes / \"Unexecuted instantiation\"; fix via `bin/flow ci --clean`).\n   - Subprocess test hygiene: `.current_dir(fixture)`, `env_remove(\"FLOW_CI_RUNNING\")`, `HOME` pinned, macOS path canonicalization.\n   - Layer 10 commit gate + active-flow skill-commit carve-out (`_continue_pending=commit` marker + transcript walker `flow:flow-commit`).\n   - code_task counter (one increment per plan task); deviation logging via `bin/flow log`.\n   - Commit choreography: Write to `.flow-states/<branch>/commit-msg-content.txt` → `bin/flow write-rule --path .../commit-msg.txt --content-file ...` → `bin/flow finalize-commit <msg-path> <branch>`.\n\n3. Files and Code Sections:\n   - `src/hooks/mod.rs` — Added `pub fn resolve_hook_cwd(hook_input: &Value) -> Option<String>` (before `pub mod agent_prompt_scan;`):\n     ```rust\n     pub fn resolve_hook_cwd(hook_input: &Value) -> Option<String> {\n         hook_input.get(\"cwd\").and_then(|v| v.as_str()).filter(|s| !s.is_empty()).map(str::to_string)\n             .or_else(|| std::env::current_dir().ok().map(|p| p.to_string_lossy().into_owned()))\n     }\n     ```\n     Shared hook helpers live here; tests in `tests/hooks/shared.rs`. 100% covered.\n   - `src/hooks/validate_pretool.rs` — Extracted `fn run_impl_main(hook_input: Option<Value>, cwd: Option<String>) -> (i32, Option<String>)` (1:1 exit→return mapping, halt message verbatim, 5 cwd consumers). `run()` now: `let cwd = hook_input.as_ref().and_then(crate::hooks::resolve_hook_cwd);`. Doc comment fixed for clippy (reworded \"Layer 10/11 + halt gates\" → \"Layer 10/11 and halt gates\" to avoid line-initial `+`).\n   - `src/hooks/validate_worktree_paths.rs` — `run()`: `let cwd = hook_input.as_ref().and_then(crate::hooks::resolve_hook_cwd);`.\n   - `src/hooks/validate_claude_paths.rs` — `run()`: `let cwd: Option<std::path::PathBuf> = input.as_ref().and_then(crate::hooks::resolve_hook_cwd).map(std::path::PathBuf::from);` (PathBuf not imported, fully-qualified).\n   - `src/hooks/validate_skill.rs` — `run()`: `let cwd: Option<PathBuf> = input.as_ref().and_then(crate::hooks::resolve_hook_cwd).map(PathBuf::from);` (PathBuf imported).\n   - `src/hooks/agent_prompt_scan.rs` — In `validate_agent_prompt`, inside the `if !resolved_norm.starts_with(&worktree_norm)` block, added carve-out before the block-return:\n     ```rust\n     let wt_str = worktree_root.to_string_lossy();\n     if let Some((project_root, _)) = crate::flow_paths::compute_worktree_paths(&wt_str) {\n         let flow_states = normalize_path_lexical(&Path::new(project_root).join(\".flow-states\"));\n         if resolved_norm.starts_with(&flow_states) { continue; }\n     }\n     ```\n     Module + function doc comments updated.\n   - `tests/hooks/shared.rs` — 3 tests: `resolve_hook_cwd_returns_payload_cwd_when_present`, `resolve_hook_cwd_falls_back_when_absent`, `resolve_hook_cwd_falls_back_when_empty`.\n   - `tests/hooks/validate_pretool.rs` — `validate_pretool_run_impl_main_accepts_cwd` (delegation contract) + `validate_pretool_reads_payload_cwd_engages_gate` (Layer 10 witness via payload cwd = git repo on main, real cwd = non-git tempdir). Uses `setup_repo_on_branch(\"main\")` + `run_hook_with_input(input, Some(&real_cwd))`.\n   - `tests/hooks/validate_worktree_paths.rs` — helper `spawn_with_payload_cwd(real_cwd, payload_cwd, file_path)` + test `validate_worktree_paths_reads_payload_cwd_engages_gate` (uses `worktree_fixture`).\n   - `tests/hooks/validate_claude_paths.rs` — `validate_claude_paths_reads_payload_cwd_engages_gate` (uses `seed_active_flow_fixture` + `run_hook_subprocess(&root, &input)` with payload cwd field).\n   - `tests/hooks/validate_skill.rs` — helper `spawn_skill_with_payload_cwd(real_cwd, stdin_input)` + test `validate_skill_reads_payload_cwd_engages_gate` (`_halt_pending=true` fixture, `.claude/settings.json` + `.worktrees/feat/.git` + `.flow-states/feat/state.json`).\n   - `tests/hooks/agent_prompt_scan.rs` — 4 carve-out tests: `agent_prompt_allows_flow_states_diff_path`, `agent_prompt_blocks_arbitrary_out_of_worktree_path`, `agent_prompt_flow_states_derive_handles_no_worktrees_segment`, `agent_prompt_flow_states_derive_uses_rightmost_worktrees`. `WORKTREE = \"/Users/alice/.worktrees/feat\"`.\n   - `.claude/rules/hook-cwd-resolution.md` — NEW rule (Task 11) documenting the cwd-source invariant + `.flow-states/` carve-out + cross-refs.\n\n4. Errors and fixes:\n   - **start-gate `ci_failed` (3 files ~50%)**: Diagnosed via `bin/test --funcs commands/init_state.rs` showing 4 crate hashes (phantom misses). Fixed with `bin/flow ci --clean` then re-ran start-gate → clean.\n   - **agent_prompt_scan per-file 73%**: `bin/test --show` showed \"110 functions mismatched data\" / \"Unexecuted instantiation\" (phantom misses); my carve-out lines had counts >0. Fixed with `bin/flow ci --clean`, re-ran → 100%.\n   - **validate_pretool per-file 86%/99%**: Confirmed sibling-binary-covered (scan_unquoted State::Double + agent-prompt block lines 1987-1995), not new gaps. Aggregate 100% at commit confirmed.\n   - **clippy `doc_lazy_continuation` (validate_pretool.rs run() doc)**: A doc line wrapped so `+ halt gates)` started a line. Fixed by rewording to \"the Layer 10/11 and halt gates\" and reflowing.\n   - **Layer 10 block on finalize-commit retry**: After the first finalize-commit (atomic group) failed at lint, it had consumed `_continue_pending` (now `\"\"`). Re-set `_continue_pending=commit` (model-writable belt-and-suspenders marker; load-bearing walker `flow:flow-commit` still held) and retried. Logged as possible ergonomic gap.\n   - **`.flow-states/` Write block**: Writing commit-msg-content to `.worktrees/.../.flow-states/...` blocked; hook named canonical path `/Users/ben/code/flow/.flow-states/review-phase-agents-trigger/...`. Mechanical recovery — reissued against canonical main-repo path.\n\n5. Problem Solving:\n   - Empirically verified the payload-cwd assumption (Task 1 spike) when the plan's literal eprintln mechanic was not executable (live hook builds from main-repo src via CLAUDE_PLUGIN_ROOT). Used a gate-engagement probe (blocked Read) + Explore sub-agent pwd probe instead. Concluded the fix is safe-by-construction (worst case no-op).\n   - Distinguished per-file gate (single binary) from aggregate gate (commit-time full CI); relied on commit-time internal CI for cross-binary coverage verification.\n   - Consolidated Task 11's three planned rule edits into one new rule file to avoid corruption risk of `write-rule` wholesale overwrite on large existing files (Edit is blocked under `.claude/` during a flow).\n\n6. All user messages:\n   - `/flow:flow-start #1746` (the only substantive user message; the rest are skill prompts injected by the harness or tool results). The argument `#1746` is workflow input, not conversation.\n   - (Final message) Instruction to produce this conversation summary as text only, no tool calls.\n   - Security/process constraints in effect (from CLAUDE.md + rules, must persist): never raw `git commit` — route through `/flow:flow-commit`; never edit `.claude/` directly during a flow — use `bin/flow write-rule`; no compound bash commands or pipes or shell redirects; never run `bin/flow` in background; never invoke cargo directly; 100% coverage gate, no waivers; never invoke user-only skills (flow-abort/reset/prime/continue/release/qa); subprocess tests must set `.current_dir(fixture)` + `env_remove(\"FLOW_CI_RUNNING\")` + pin HOME; commit-msg via write-rule, never heredoc/`-m`; use 10-min Bash timeout for CI-running `bin/flow` subcommands.\n\n7. Pending Tasks:\n   - Complete Phase 3 Review (currently at Step 1 done → Step 2 Launch agents). Steps: 2 Launch (4 isolated agents in ONE response), 3 Triage, 4 Fix, Done → phase-finalize → invoke flow-learn.\n   - Phase 4 Learn, Phase 5 Complete.\n   - A deferred item flagged for Review's documentation agent: `cognitive-isolation.md`'s retry-prompt section still gives conservative-but-safe \"drop out-of-worktree paths\" advice without a forward-ref to the `.flow-states/` carve-out — left for Review Step 4 to assess.\n\n8. Current Work:\n   In Review Step 1 (Gather), just completed. All artifacts captured: base=`main`; `<full_diff_file>` = `/Users/ben/code/flow/.flow-states/review-phase-agents-trigger/full-diff.diff`; `<substantive_diff_file>` = `/Users/ben/code/flow/.flow-states/review-phase-agents-trigger/substantive-diff.diff`; `<doc_paths>` = [`/Users/ben/code/flow/.worktrees/review-phase-agents-trigger/.claude/rules/hook-cwd-resolution.md`, `/Users/ben/code/flow/.worktrees/review-phase-agents-trigger/CLAUDE.md`]; `<temp_test_file>` = `tests/test_adversarial_flow.rs`; `<test_command>` = `/Users/ben/code/flow/bin/flow ci --test --file tests/test_adversarial_flow.rs`; tombstone audit `stale: []` (nothing to remove). Just ran `bin/flow set-timestamp --set review_step=1` (returned ok). cwd is the worktree. commit=auto, continue=auto. PR #1748. The plan file is at `.flow-states/review-phase-agents-trigger/plan.md` (read earlier, 11 tasks). CLAUDE.md and all `.claude/rules/*.md` were read earlier this session (available in context).\n\n9. Optional Next Step:\n   Per flow-review Step 1: \"To continue to Step 2, invoke `flow:flow-review --continue-step` using the Skill tool as your final action. Do not output anything else after this invocation.\" Next step: invoke the Skill tool with `flow:flow-review` and args `--continue-step`. On re-entry (review_step=1), re-run Mode Resolution, then proceed to Step 2 — launch all four agents (reviewer with `DIFF_FILE: <full_diff_file>` + plan + CLAUDE.md + rules; pre-mortem, adversarial, documentation with `SUBSTANTIVE_DIFF_FILE: <substantive_diff_file>`; adversarial also gets `<temp_test_file>`/`<test_command>`; documentation gets `DOC_PATHS:` list) in a SINGLE response with four `Agent` tool calls and nothing else between them (cognitive-isolation HARD-GATE).\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/review-phase-agents-trigger",
  "compact_count": 1,
  "findings": [
    {
      "finding": "pre-mortem: resolve_hook_cwd returns the payload cwd with no NUL/absolute/anchor/is_valid_branch validation before it flows into worktree/state path construction",
      "reason": "False positive: the reviewer's execution trace and the adversarial agent's passing probes confirm the cwd flows only into non-I/O string analysis (compute_worktree_paths: rfind+slice, no filesystem touch) and the try_new/is_valid_branch-validated branch machinery — there is no unvalidated path-construction-to-I/O sink. Null/non-string/whitespace cwd falls back without panic; traversal is closed upstream by is_safe_path_candidate + normalize_path_lexical. A resolve_hook_cwd-level validator would be an unreachable defensive branch the project's no-waivers/tests-guard-real-regressions rules forbid.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-30T08:21:43-07:00"
    },
    {
      "finding": "pre-mortem: four PreToolUse gates now engage/disable keyed to the payload cwd's branch with no cwd-vs-session mismatch detection (halt gate, .claude redirect, worktree gate evaluate a cwd-selected branch)",
      "reason": "False positive: the payload cwd IS the action's real working directory supplied by Claude Code, so each gate evaluates the flow that owns the directory the action actually runs in — by construction the correct branch. The mismatch scenario assumes a model-controlled/diverging payload cwd, which contradicts the PR's verified premise (Task 1 spike) that the payload cwd is the trusted session/sub-agent worktree. Outside FLOW's threat model (accidental model behavior, not harness compromise).",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-30T08:21:46-07:00"
    },
    {
      "finding": "pre-mortem: Layer 10 commit gate binds to the payload cwd while git commit executes in the process cwd, a gate-action divergence surface",
      "reason": "False positive: Claude Code runs the Bash tool command in the directory named by the payload cwd field, so git commit executes in the same directory the gate evaluates — gate and action consume one cwd value, no divergence in production. The validate_pretool_reads_payload_cwd_engages_gate test separates payload cwd from the process real cwd only to prove which source the hook reads, not because they diverge at runtime.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-30T08:21:49-07:00"
    },
    {
      "finding": "documentation: CLAUDE.md Architecture-References lacks a one-line pointer to the new .claude/rules/hook-cwd-resolution.md rule",
      "reason": "False positive (value test, review-scope.md): not PR-caused drift of existing content but an optional new index entry. The reviewer agent (context-rich, had CLAUDE.md inline) judged it optional/not-required; the rule is discoverable by globbing .claude/rules/; CLAUDE.md's Architecture References index is non-exhaustive (peer rules such as security-gates.md and external-input-path-construction.md carry no individual pointer); and per persistence-routing.md obey-vs-describe the rule is largely descriptive (hook-authoring mechanics) rather than an obey-every-session behavioral pointer. Adding it duplicates glob-discoverable information.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-30T08:34:34-07:00"
    },
    {
      "finding": "pre-mortem: the agent_prompt_scan .flow-states/ carve-out was scoped to the whole <project_root>/.flow-states/ subtree (shared by every concurrent flow), not this flow's own branch subdir",
      "reason": "Real (Tenant 1/4, defense-in-depth, broader than documented intent): narrowed the carve-out in validate_agent_prompt to <project_root>/.flow-states/<branch>/ — branch derived by slicing wt_root after the /.worktrees/ anchor (branchless, so the 100% gate has no unreachable arm). Added regression test agent_prompt_blocks_other_branch_flow_states proving a different branch's .flow-states/ path is now blocked; updated the module/function/carve-out doc comments in agent_prompt_scan.rs and the carve-out section + How-to-Apply item 3 in .claude/rules/hook-cwd-resolution.md (same commit, docs-with-behavior). A sub-agent prompt can no longer be pointed at another concurrent flow's per-branch state.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-30T08:37:55-07:00"
    },
    {
      "finding": "documentation: cognitive-isolation.md 'Retry-prompt path-scoping constraint' advised 'drop the path' without noting the new .flow-states/<branch>/ carve-out exception",
      "reason": "Real (Tenant 6, PR-caused drift per docs-with-behavior): before this PR there was no carve-out so 'drop the path' was complete; the PR's carve-out makes it incomplete for the substantive-diff path. Added a sanctioned-exception paragraph to the Retry-prompt path-scoping constraint section stating a .flow-states/<branch>/ diff path need not be dropped (agent_prompt_scan carves it out), cross-referencing hook-cwd-resolution.md. git diff --stat confirms only the intended 15-line change to the file.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-30T08:38:00-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 5,
  "complete_step": 5,
  "window_at_complete": {
    "captured_at": "2026-05-30T08:51:59-07:00",
    "session_id": "3393017e-8d43-4bfb-a9e3-def85c09eb90",
    "model": "claude-opus-4-8",
    "five_hour_pct": 27,
    "seven_day_pct": 44,
    "session_input_tokens": 497543,
    "session_output_tokens": 508691,
    "session_cache_creation_tokens": 1927322,
    "session_cache_read_tokens": 175000772,
    "by_model": {
      "claude-opus-4-8": {
        "input": 497543,
        "output": 508691,
        "cache_create": 1927322,
        "cache_read": 175000772
      }
    },
    "turn_count": 244,
    "tool_call_count": 56,
    "context_at_last_turn_tokens": 965878,
    "context_window_pct": 482.939
  },
  "_auto_continue": "/flow:flow-complete"
}
````

</details>