### PR TITLE
Remove Redundant Json Serialize

### DIFF
--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -493,27 +493,26 @@ pub fn run_impl_main(args: &Args) -> (Value, i32) {
     let root = Path::new(&args.project_root);
     if !root.is_dir() {
         let msg = format!("Project root not found: {}", args.project_root);
-        let err_str = crate::output::json_error_string(&msg, &[]);
-        return (serde_json::from_str(&err_str).unwrap(), 1);
+        return (crate::output::json_error_value(&msg, &[]), 1);
     }
 
     // Per-branch mode: --branch and --worktree are required.
     let branch = match args.branch.as_deref() {
         Some(b) => b,
         None => {
-            let err_str =
-                crate::output::json_error_string("--branch (with --worktree) is required", &[]);
-            return (serde_json::from_str(&err_str).unwrap(), 1);
+            return (
+                crate::output::json_error_value("--branch (with --worktree) is required", &[]),
+                1,
+            );
         }
     };
     let worktree = match args.worktree.as_deref() {
         Some(w) => w,
         None => {
-            let err_str = crate::output::json_error_string(
-                "--worktree is required when --branch is set",
-                &[],
+            return (
+                crate::output::json_error_value("--worktree is required when --branch is set", &[]),
+                1,
             );
-            return (serde_json::from_str(&err_str).unwrap(), 1);
         }
     };
 
@@ -541,12 +540,15 @@ pub fn run_impl_main(args: &Args) -> (Value, i32) {
             format!("failed: cannot resolve integration branch — {}", msg),
         );
     }
-    let steps = steps;
-    let steps_map: IndexMap<String, Value> = steps
-        .into_iter()
-        .map(|(k, v)| (k, Value::String(v)))
-        .collect();
-    let steps_value = serde_json::to_value(steps_map).unwrap();
-    let ok_str = crate::output::json_ok_string(&[("steps", steps_value)]);
-    (serde_json::from_str(&ok_str).unwrap(), 0)
+    // Build the steps object directly as a `serde_json::Map`
+    // (`preserve_order` keeps the insertion order from the
+    // order-preserving `steps` IndexMap), so the success arm returns
+    // the Value with no serialize/reparse round-trip.
+    let steps_value = Value::Object(
+        steps
+            .into_iter()
+            .map(|(k, v)| (k, Value::String(v)))
+            .collect(),
+    );
+    (crate::output::json_ok_value(&[("steps", steps_value)]), 0)
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -20,23 +20,50 @@ pub fn json_error(message: &str, fields: &[(&str, Value)]) {
     println!("{}", json_error_string(message, fields));
 }
 
-/// Build a JSON success response as a String (for testing or capture).
-pub fn json_ok_string(fields: &[(&str, Value)]) -> String {
+/// Build a JSON success response as a `Value`.
+///
+/// Produces a status-first `Value::Object` — `{"status": "ok",
+/// ...extra_fields}`. Callers that return `(Value, i32)` use this
+/// directly instead of reparsing the `*_string` form. `serde_json::Map`
+/// preserves insertion order (`preserve_order` feature), so `status`
+/// is always the first key.
+pub fn json_ok_value(fields: &[(&str, Value)]) -> Value {
     let mut map = serde_json::Map::new();
     map.insert("status".to_string(), Value::String("ok".to_string()));
     for (key, value) in fields {
         map.insert((*key).to_string(), value.clone());
     }
-    Value::Object(map).to_string()
+    Value::Object(map)
 }
 
-/// Build a JSON error response as a String (for testing or capture).
-pub fn json_error_string(message: &str, fields: &[(&str, Value)]) -> String {
+/// Build a JSON error response as a `Value`.
+///
+/// Produces a status-first `Value::Object` — `{"status": "error",
+/// "message": "...", ...extra_fields}`. Callers that return
+/// `(Value, i32)` use this directly instead of reparsing the
+/// `*_string` form.
+pub fn json_error_value(message: &str, fields: &[(&str, Value)]) -> Value {
     let mut map = serde_json::Map::new();
     map.insert("status".to_string(), Value::String("error".to_string()));
     map.insert("message".to_string(), Value::String(message.to_string()));
     for (key, value) in fields {
         map.insert((*key).to_string(), value.clone());
     }
-    Value::Object(map).to_string()
+    Value::Object(map)
+}
+
+/// Build a JSON success response as a String (for testing or capture).
+///
+/// Delegates to `json_ok_value` and serializes — byte-identical to
+/// the `Value` form's `.to_string()`.
+pub fn json_ok_string(fields: &[(&str, Value)]) -> String {
+    json_ok_value(fields).to_string()
+}
+
+/// Build a JSON error response as a String (for testing or capture).
+///
+/// Delegates to `json_error_value` and serializes — byte-identical to
+/// the `Value` form's `.to_string()`.
+pub fn json_error_string(message: &str, fields: &[(&str, Value)]) -> String {
+    json_error_value(message, fields).to_string()
 }

--- a/src/phase_transition.rs
+++ b/src/phase_transition.rs
@@ -24,7 +24,7 @@ use crate::cwd_scope;
 use crate::flow_paths::FlowPaths;
 use crate::git::resolve_branch;
 use crate::lock::mutate_state;
-use crate::output::json_error_string;
+use crate::output::json_error_value;
 use crate::phase_config::{self, load_phase_config, phase_number, PHASE_ORDER};
 use crate::utils::{elapsed_since, format_time, now, tolerant_i64};
 
@@ -293,22 +293,25 @@ pub fn run_impl_main(
             phase,
             PHASE_ORDER.join(", ")
         );
-        return (json_error_value(&msg), 1);
+        return (json_error_value(&msg, &[]), 1);
     }
 
     if action != "enter" && action != "complete" {
         let msg = format!("Invalid action: {}. Must be 'enter' or 'complete'", action);
-        return (json_error_value(&msg), 1);
+        return (json_error_value(&msg, &[]), 1);
     }
 
     if let Err(msg) = cwd_scope::enforce(cwd, root) {
-        return (json_error_value(&msg), 1);
+        return (json_error_value(&msg, &[]), 1);
     }
 
     let branch = match resolve_branch(branch_override, root) {
         Some(b) => b,
         None => {
-            return (json_error_value("Could not determine current branch"), 1);
+            return (
+                json_error_value("Could not determine current branch", &[]),
+                1,
+            );
         }
     };
     // `resolve_branch` may return a raw git ref (slash-containing,
@@ -319,10 +322,13 @@ pub fn run_impl_main(
         Some(p) => p,
         None => {
             return (
-                json_error_value(&format!(
-                    "Invalid branch name: \"{}\" (contains '/' or is empty)",
-                    branch
-                )),
+                json_error_value(
+                    &format!(
+                        "Invalid branch name: \"{}\" (contains '/' or is empty)",
+                        branch
+                    ),
+                    &[],
+                ),
                 1,
             );
         }
@@ -331,7 +337,10 @@ pub fn run_impl_main(
 
     if !state_path.exists() {
         return (
-            json_error_value(&format!("No state file found: {}", state_path.display())),
+            json_error_value(
+                &format!("No state file found: {}", state_path.display()),
+                &[],
+            ),
             1,
         );
     }
@@ -340,7 +349,7 @@ pub fn run_impl_main(
         Ok(c) => c,
         Err(e) => {
             return (
-                json_error_value(&format!("Could not read state file: {}", e)),
+                json_error_value(&format!("Could not read state file: {}", e), &[]),
                 1,
             );
         }
@@ -350,7 +359,7 @@ pub fn run_impl_main(
         Ok(v) => v,
         Err(e) => {
             return (
-                json_error_value(&format!("Could not read state file: {}", e)),
+                json_error_value(&format!("Could not read state file: {}", e), &[]),
                 1,
             );
         }
@@ -358,7 +367,7 @@ pub fn run_impl_main(
 
     if state.get("phases").is_none() || state["phases"].get(phase).is_none() {
         return (
-            json_error_value(&format!("Phase {} not found in state file", phase)),
+            json_error_value(&format!("Phase {} not found in state file", phase), &[]),
             1,
         );
     }
@@ -437,20 +446,9 @@ pub fn run_impl_main(
                 ),
             );
             (
-                json_error_value(&format!("State mutation failed: {}", e)),
+                json_error_value(&format!("State mutation failed: {}", e), &[]),
                 1,
             )
         }
     }
-}
-
-/// Build a `json_error`-shaped Value (parsed from `json_error_string`)
-/// so `run_impl_main` can return `(Value, i32)` while matching the
-/// pre-extraction `json_error` output contract exactly. The parse
-/// cannot fail — `json_error_string` constructs the JSON from a valid
-/// serde_json::Map — so `.expect` is correct per
-/// `.claude/rules/testability-means-simplicity.md`.
-fn json_error_value(message: &str) -> Value {
-    serde_json::from_str::<Value>(&json_error_string(message, &[]))
-        .expect("json_error_string produces valid JSON")
 }

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -596,6 +596,95 @@ fn step_key_order_with_pull() {
     );
 }
 
+// --- run_impl_main top-level return-arm shape ---
+//
+// Pin the top-level `Value` shape of every `run_impl_main` return arm
+// — status-first key order, exact error messages, and the success
+// arm's `[status, steps]` ordering. These guard the rewrite of the
+// three error arms from `from_str(&json_error_string(...)).unwrap()`
+// to `json_error_value(...)` and the success arm from
+// `json_ok_string` + reparse to `json_ok_value`: the output must stay
+// byte-identical, so a key-order or message regression in that
+// rewrite trips here. Named consumer: the JSON the `flow-complete`
+// skill parses from `cleanup` stdout.
+
+fn top_level_keys(value: &Value) -> Vec<String> {
+    value
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(|k| k.to_string())
+        .collect()
+}
+
+#[test]
+fn run_impl_main_nonexistent_root_is_status_first_error() {
+    let args = Args {
+        project_root: "/nonexistent/path/does/not/exist".to_string(),
+        branch: Some("test-branch".to_string()),
+        worktree: Some(".worktrees/test-branch".to_string()),
+        pr: None,
+        pull: false,
+    };
+    let (value, code) = run_impl_main(&args);
+    assert_eq!(code, 1);
+    assert_eq!(value["status"], "error");
+    assert!(value["message"]
+        .as_str()
+        .unwrap()
+        .contains("Project root not found"));
+    assert_eq!(top_level_keys(&value), vec!["status", "message"]);
+}
+
+#[test]
+fn run_impl_main_missing_branch_is_status_first_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let args = Args {
+        project_root: dir.path().to_string_lossy().to_string(),
+        branch: None,
+        worktree: Some(".worktrees/x".to_string()),
+        pr: None,
+        pull: false,
+    };
+    let (value, code) = run_impl_main(&args);
+    assert_eq!(code, 1);
+    assert_eq!(value["status"], "error");
+    assert_eq!(value["message"], "--branch (with --worktree) is required");
+    assert_eq!(top_level_keys(&value), vec!["status", "message"]);
+}
+
+#[test]
+fn run_impl_main_missing_worktree_is_status_first_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let args = Args {
+        project_root: dir.path().to_string_lossy().to_string(),
+        branch: Some("test-branch".to_string()),
+        worktree: None,
+        pr: None,
+        pull: false,
+    };
+    let (value, code) = run_impl_main(&args);
+    assert_eq!(code, 1);
+    assert_eq!(value["status"], "error");
+    assert_eq!(
+        value["message"],
+        "--worktree is required when --branch is set"
+    );
+    assert_eq!(top_level_keys(&value), vec!["status", "message"]);
+}
+
+#[test]
+fn run_impl_main_success_is_status_then_steps() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_git_repo(dir.path());
+    let wt_rel = setup_feature(dir.path(), "test-feature");
+
+    let (value, code) = run_impl_main(&args_for(dir.path(), "test-feature", &wt_rel, None, false));
+    assert_eq!(code, 0);
+    assert_eq!(value["status"], "ok");
+    assert_eq!(top_level_keys(&value), vec!["status", "steps"]);
+}
+
 // --- queue_entry step ---
 
 #[test]

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -600,13 +600,11 @@ fn step_key_order_with_pull() {
 //
 // Pin the top-level `Value` shape of every `run_impl_main` return arm
 // — status-first key order, exact error messages, and the success
-// arm's `[status, steps]` ordering. These guard the rewrite of the
-// three error arms from `from_str(&json_error_string(...)).unwrap()`
-// to `json_error_value(...)` and the success arm from
-// `json_ok_string` + reparse to `json_ok_value`: the output must stay
-// byte-identical, so a key-order or message regression in that
-// rewrite trips here. Named consumer: the JSON the `flow-complete`
-// skill parses from `cleanup` stdout.
+// arm's `[status, steps]` ordering. The JSON the `flow-complete`
+// skill parses from `cleanup` stdout depends on this exact shape, so
+// any key-order shift or message change in the output helpers trips
+// these tests. Named consumer: the `flow-complete` skill's parse of
+// `cleanup` stdout.
 
 fn top_level_keys(value: &Value) -> Vec<String> {
     value

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -8,7 +8,9 @@
 //! println branches. Captured stdout during tests is suppressed by
 //! the Rust test harness unless the test fails.
 
-use flow_rs::output::{json_error, json_error_string, json_ok, json_ok_string};
+use flow_rs::output::{
+    json_error, json_error_string, json_error_value, json_ok, json_ok_string, json_ok_value,
+};
 use serde_json::{json, Value};
 
 // --- json_ok_string ---
@@ -108,4 +110,63 @@ fn json_error_prints_without_panicking() {
 #[test]
 fn json_error_prints_with_fields_without_panicking() {
     json_error("test", &[("field", json!("value"))]);
+}
+
+// --- json_ok_value / json_error_value ---
+//
+// The `*_value` helpers build the `Value::Object` directly; the
+// `*_string` variants delegate to them and `.to_string()`. The
+// status-first ordering and the delegation equivalence are the
+// invariants callers (`cleanup`, `phase_transition`) depend on:
+// they return the Value directly and never reparse a String.
+
+#[test]
+fn json_ok_value_is_status_first_object() {
+    let v = json_ok_value(&[("branch", json!("my-feature")), ("pr_number", json!(42))]);
+    assert!(v.is_object());
+    let keys: Vec<&str> = v.as_object().unwrap().keys().map(|k| k.as_str()).collect();
+    assert_eq!(keys.first(), Some(&"status"));
+    assert_eq!(v["status"], "ok");
+    assert_eq!(v["branch"], "my-feature");
+    assert_eq!(v["pr_number"], 42);
+}
+
+#[test]
+fn json_error_value_is_status_first_then_message() {
+    let v = json_error_value("boom", &[("phase", json!("flow-code"))]);
+    assert!(v.is_object());
+    let keys: Vec<&str> = v.as_object().unwrap().keys().map(|k| k.as_str()).collect();
+    assert_eq!(keys.first(), Some(&"status"));
+    assert_eq!(keys.get(1), Some(&"message"));
+    assert_eq!(v["status"], "error");
+    assert_eq!(v["message"], "boom");
+    assert_eq!(v["phase"], "flow-code");
+}
+
+#[test]
+fn json_ok_string_equals_value_to_string() {
+    let fields = [("branch", json!("my-feature")), ("pr_number", json!(42))];
+    assert_eq!(json_ok_string(&fields), json_ok_value(&fields).to_string());
+}
+
+#[test]
+fn json_ok_string_equals_value_to_string_empty() {
+    assert_eq!(json_ok_string(&[]), json_ok_value(&[]).to_string());
+}
+
+#[test]
+fn json_error_string_equals_value_to_string() {
+    let fields = [("phase", json!("flow-code"))];
+    assert_eq!(
+        json_error_string("boom", &fields),
+        json_error_value("boom", &fields).to_string()
+    );
+}
+
+#[test]
+fn json_error_string_equals_value_to_string_empty() {
+    assert_eq!(
+        json_error_string("boom", &[]),
+        json_error_value("boom", &[]).to_string()
+    );
 }


### PR DESCRIPTION
## What

#1774.

Closes #1774

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/remove-redundant-json-serialize/log` |
| State | `.flow-states/remove-redundant-json-serialize/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 40m |
| Review | 8h 21m |
| Learn | 8m |
| Complete | 6m |
| **Total** | **9h 18m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 2.2M | $1.194 |
| Code | 33.2M | $20.824 |
| Review | 22.2M | $0.000* |
| Learn | 23.6M | — |
| Complete | 5.4M | — |
| **Total** | **86.6M** | **$22.018**\* |

| Model | Tokens |
|-------|--------|
| claude-opus-4-8 | 86.6M |
| <synthetic> | 0 |

*Partial: some phases had no cost data.*

<!-- end:Token Cost -->

## Review Findings

- ✓ **tests/cleanup.rs run_impl_main arm-shape section comment described refactor history (guard the rewrite from from_str/json_error_string to json_error_value) instead of the forward-facing guarded invariant**
  - Fixed — Backward-facing comment per comment-quality.md and forward-facing-authoring.md; rewrote to describe the status-first Value shape the flow-complete consumer depends on, dropping the rewrite-history sentence

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/remove-redundant-json-serialize.json</summary>

```json
{
  "schema_version": 1,
  "branch": "remove-redundant-json-serialize",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1780,
  "pr_url": "https://github.com/benkruger/flow/pull/1780",
  "started_at": "2026-05-31T08:55:10-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/remove-redundant-json-serialize/log",
    "state": ".flow-states/remove-redundant-json-serialize/state.json"
  },
  "session_tty": "/dev/ttys014",
  "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4.jsonl",
  "notes": [],
  "prompt": "#1774",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-31T08:55:10-07:00",
      "completed_at": "2026-05-31T08:55:52-07:00",
      "session_started_at": null,
      "cumulative_seconds": 42,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-31T08:55:10-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 71,
        "seven_day_pct": 60,
        "session_input_tokens": 4647,
        "session_output_tokens": 1946,
        "session_cache_creation_tokens": 250177,
        "session_cache_read_tokens": 1339821,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4647,
            "output": 1946,
            "cache_create": 250177,
            "cache_read": 1339821
          }
        },
        "turn_count": 6,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 266688,
        "context_window_pct": 133.344
      },
      "window_at_complete": {
        "captured_at": "2026-05-31T08:55:52-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 71,
        "seven_day_pct": 61,
        "session_input_tokens": 4920,
        "session_output_tokens": 3480,
        "session_cache_creation_tokens": 261420,
        "session_cache_read_tokens": 3507780,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4920,
            "output": 3480,
            "cache_create": 261420,
            "cache_read": 3507780
          }
        },
        "turn_count": 14,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 277931,
        "context_window_pct": 138.9655
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-31T08:56:05-07:00",
      "completed_at": "2026-05-31T09:36:35-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2430,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-31T08:56:05-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 71,
        "seven_day_pct": 61,
        "session_input_tokens": 4922,
        "session_output_tokens": 3912,
        "session_cache_creation_tokens": 266419,
        "session_cache_read_tokens": 3785709,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4922,
            "output": 3912,
            "cache_create": 266419,
            "cache_read": 3785709
          }
        },
        "turn_count": 15,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 282930,
        "context_window_pct": 141.465
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-31T09:00:32-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 75,
          "seven_day_pct": 61,
          "session_input_tokens": 236050,
          "session_output_tokens": 18611,
          "session_cache_creation_tokens": 553414,
          "session_cache_read_tokens": 16488752,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236050,
              "output": 18611,
              "cache_create": 553414,
              "cache_read": 16488752
            }
          },
          "turn_count": 39,
          "tool_call_count": 11,
          "context_at_last_turn_tokens": 569925,
          "context_window_pct": 284.9625
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-31T09:00:32-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 75,
          "seven_day_pct": 61,
          "session_input_tokens": 236050,
          "session_output_tokens": 18611,
          "session_cache_creation_tokens": 553414,
          "session_cache_read_tokens": 16488752,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236050,
              "output": 18611,
              "cache_create": 553414,
              "cache_read": 16488752
            }
          },
          "turn_count": 39,
          "tool_call_count": 11,
          "context_at_last_turn_tokens": 569925,
          "context_window_pct": 284.9625
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-31T09:09:07-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 79,
          "seven_day_pct": 62,
          "session_input_tokens": 236626,
          "session_output_tokens": 49916,
          "session_cache_creation_tokens": 591158,
          "session_cache_read_tokens": 33927273,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236626,
              "output": 49916,
              "cache_create": 591158,
              "cache_read": 33927273
            }
          },
          "turn_count": 69,
          "tool_call_count": 19,
          "context_at_last_turn_tokens": 607669,
          "context_window_pct": 303.8345
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-31T09:16:22-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 84,
          "seven_day_pct": 63,
          "session_input_tokens": 236634,
          "session_output_tokens": 55727,
          "session_cache_creation_tokens": 598816,
          "session_cache_read_tokens": 36370576,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236634,
              "output": 55727,
              "cache_create": 598816,
              "cache_read": 36370576
            }
          },
          "turn_count": 73,
          "tool_call_count": 19,
          "context_at_last_turn_tokens": 615327,
          "context_window_pct": 307.6635
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-31T09:26:13-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 86,
          "seven_day_pct": 63,
          "session_input_tokens": 236634,
          "session_output_tokens": 55727,
          "session_cache_creation_tokens": 598816,
          "session_cache_read_tokens": 36370576,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236634,
              "output": 55727,
              "cache_create": 598816,
              "cache_read": 36370576
            }
          },
          "turn_count": 73,
          "tool_call_count": 19,
          "context_at_last_turn_tokens": 615327,
          "context_window_pct": 307.6635
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-05-31T09:33:28-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 94,
          "seven_day_pct": 65,
          "session_input_tokens": 236634,
          "session_output_tokens": 55727,
          "session_cache_creation_tokens": 598816,
          "session_cache_read_tokens": 36370576,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236634,
              "output": 55727,
              "cache_create": 598816,
              "cache_read": 36370576
            }
          },
          "turn_count": 73,
          "tool_call_count": 19,
          "context_at_last_turn_tokens": 615327,
          "context_window_pct": 307.6635
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-05-31T09:35:38-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 94,
          "seven_day_pct": 65,
          "session_input_tokens": 236634,
          "session_output_tokens": 55727,
          "session_cache_creation_tokens": 598816,
          "session_cache_read_tokens": 36370576,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236634,
              "output": 55727,
              "cache_create": 598816,
              "cache_read": 36370576
            }
          },
          "turn_count": 73,
          "tool_call_count": 19,
          "context_at_last_turn_tokens": 615327,
          "context_window_pct": 307.6635
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-31T09:36:35-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 94,
        "seven_day_pct": 65,
        "session_input_tokens": 236634,
        "session_output_tokens": 55727,
        "session_cache_creation_tokens": 598816,
        "session_cache_read_tokens": 36370576,
        "by_model": {
          "claude-opus-4-8": {
            "input": 236634,
            "output": 55727,
            "cache_create": 598816,
            "cache_read": 36370576
          }
        },
        "turn_count": 73,
        "tool_call_count": 19,
        "context_at_last_turn_tokens": 615327,
        "context_window_pct": 307.6635
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-31T09:36:45-07:00",
      "completed_at": "2026-05-31T17:58:44-07:00",
      "session_started_at": null,
      "cumulative_seconds": 30119,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-31T09:36:45-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 94,
        "seven_day_pct": 65,
        "session_input_tokens": 236634,
        "session_output_tokens": 55727,
        "session_cache_creation_tokens": 598816,
        "session_cache_read_tokens": 36370576,
        "by_model": {
          "claude-opus-4-8": {
            "input": 236634,
            "output": 55727,
            "cache_create": 598816,
            "cache_read": 36370576
          }
        },
        "turn_count": 73,
        "tool_call_count": 19,
        "context_at_last_turn_tokens": 615327,
        "context_window_pct": 307.6635
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-31T09:37:44-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 94,
          "seven_day_pct": 65,
          "session_input_tokens": 236634,
          "session_output_tokens": 55727,
          "session_cache_creation_tokens": 598816,
          "session_cache_read_tokens": 36370576,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236634,
              "output": 55727,
              "cache_create": 598816,
              "cache_read": 36370576
            }
          },
          "turn_count": 73,
          "tool_call_count": 19,
          "context_at_last_turn_tokens": 615327,
          "context_window_pct": 307.6635
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-31T17:52:23-07:00",
          "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
          "model": "claude-opus-4-8",
          "five_hour_pct": 61,
          "seven_day_pct": 78,
          "session_input_tokens": 245424,
          "session_output_tokens": 115122,
          "session_cache_creation_tokens": 2357085,
          "session_cache_read_tokens": 114319994,
          "by_model": {
            "claude-opus-4-8": {
              "input": 245424,
              "output": 115122,
              "cache_create": 2357085,
              "cache_read": 114319994
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 193,
          "tool_call_count": 75,
          "context_at_last_turn_tokens": 814201,
          "context_window_pct": 407.1005
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-31T17:53:16-07:00",
          "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
          "model": "claude-opus-4-8",
          "five_hour_pct": 61,
          "seven_day_pct": 78,
          "session_input_tokens": 245561,
          "session_output_tokens": 116654,
          "session_cache_creation_tokens": 2376660,
          "session_cache_read_tokens": 117597535,
          "by_model": {
            "claude-opus-4-8": {
              "input": 245561,
              "output": 116654,
              "cache_create": 2376660,
              "cache_read": 117597535
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 197,
          "tool_call_count": 77,
          "context_at_last_turn_tokens": 833776,
          "context_window_pct": 416.888
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-31T17:58:17-07:00",
          "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
          "model": "claude-opus-4-8",
          "five_hour_pct": 65,
          "seven_day_pct": 79,
          "session_input_tokens": 245853,
          "session_output_tokens": 123313,
          "session_cache_creation_tokens": 2407402,
          "session_cache_read_tokens": 132114554,
          "by_model": {
            "claude-opus-4-8": {
              "input": 245853,
              "output": 123313,
              "cache_create": 2407402,
              "cache_read": 132114554
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 214,
          "tool_call_count": 84,
          "context_at_last_turn_tokens": 864518,
          "context_window_pct": 432.259
        }
      ],
      "agents_returned": [
        {
          "agent": "documentation",
          "timestamp": "2026-05-31T17:51:28-07:00"
        },
        {
          "agent": "reviewer",
          "timestamp": "2026-05-31T17:51:45-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-31T17:51:51-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-31T17:51:57-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-31T17:58:44-07:00",
        "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
        "model": "claude-opus-4-8",
        "five_hour_pct": 66,
        "seven_day_pct": 79,
        "session_input_tokens": 245992,
        "session_output_tokens": 124492,
        "session_cache_creation_tokens": 2425901,
        "session_cache_read_tokens": 136474644,
        "by_model": {
          "claude-opus-4-8": {
            "input": 245992,
            "output": 124492,
            "cache_create": 2425901,
            "cache_read": 136474644
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 219,
        "tool_call_count": 86,
        "context_at_last_turn_tokens": 883017,
        "context_window_pct": 441.5085
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-31T17:58:59-07:00",
      "completed_at": "2026-05-31T18:07:36-07:00",
      "session_started_at": null,
      "cumulative_seconds": 517,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-31T17:58:59-07:00",
        "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
        "model": "claude-opus-4-8",
        "five_hour_pct": 66,
        "seven_day_pct": 79,
        "session_input_tokens": 245996,
        "session_output_tokens": 124994,
        "session_cache_creation_tokens": 2426209,
        "session_cache_read_tokens": 138240824,
        "by_model": {
          "claude-opus-4-8": {
            "input": 245996,
            "output": 124994,
            "cache_create": 2426209,
            "cache_read": 138240824
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 221,
        "tool_call_count": 87,
        "context_at_last_turn_tokens": 883325,
        "context_window_pct": 441.6625
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-31T18:02:00-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-31T18:03:17-07:00",
          "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
          "model": "claude-opus-4-8",
          "five_hour_pct": 69,
          "seven_day_pct": 80,
          "session_input_tokens": 246269,
          "session_output_tokens": 133176,
          "session_cache_creation_tokens": 2463948,
          "session_cache_read_tokens": 145471262,
          "by_model": {
            "claude-opus-4-8": {
              "input": 246269,
              "output": 133176,
              "cache_create": 2463948,
              "cache_read": 145471262
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 229,
          "tool_call_count": 90,
          "context_at_last_turn_tokens": 921193,
          "context_window_pct": 460.5965
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-31T18:03:44-07:00",
          "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
          "model": "claude-opus-4-8",
          "five_hour_pct": 69,
          "seven_day_pct": 80,
          "session_input_tokens": 246277,
          "session_output_tokens": 139178,
          "session_cache_creation_tokens": 2487302,
          "session_cache_read_tokens": 149185147,
          "by_model": {
            "claude-opus-4-8": {
              "input": 246277,
              "output": 139178,
              "cache_create": 2487302,
              "cache_read": 149185147
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 233,
          "tool_call_count": 92,
          "context_at_last_turn_tokens": 944418,
          "context_window_pct": 472.209
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-31T18:04:13-07:00",
          "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
          "model": "claude-opus-4-8",
          "five_hour_pct": 69,
          "seven_day_pct": 80,
          "session_input_tokens": 246412,
          "session_output_tokens": 139886,
          "session_cache_creation_tokens": 2504731,
          "session_cache_read_tokens": 152019072,
          "by_model": {
            "claude-opus-4-8": {
              "input": 246412,
              "output": 139886,
              "cache_create": 2504731,
              "cache_read": 152019072
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 236,
          "tool_call_count": 93,
          "context_at_last_turn_tokens": 961847,
          "context_window_pct": 480.9235
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-31T18:04:40-07:00",
          "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
          "model": "claude-opus-4-8",
          "five_hour_pct": 69,
          "seven_day_pct": 80,
          "session_input_tokens": 246422,
          "session_output_tokens": 140755,
          "session_cache_creation_tokens": 2522515,
          "session_cache_read_tokens": 156864089,
          "by_model": {
            "claude-opus-4-8": {
              "input": 246422,
              "output": 140755,
              "cache_create": 2522515,
              "cache_read": 156864089
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 241,
          "tool_call_count": 95,
          "context_at_last_turn_tokens": 979631,
          "context_window_pct": 489.8155
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-31T18:05:00-07:00",
          "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
          "model": "claude-opus-4-8",
          "five_hour_pct": 69,
          "seven_day_pct": 80,
          "session_input_tokens": 246555,
          "session_output_tokens": 141138,
          "session_cache_creation_tokens": 2539634,
          "session_cache_read_tokens": 158823562,
          "by_model": {
            "claude-opus-4-8": {
              "input": 246555,
              "output": 141138,
              "cache_create": 2539634,
              "cache_read": 158823562
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 243,
          "tool_call_count": 96,
          "context_at_last_turn_tokens": 996750,
          "context_window_pct": 498.375
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-31T18:07:20-07:00",
          "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
          "model": "claude-opus-4-8",
          "five_hour_pct": 70,
          "seven_day_pct": 80,
          "session_input_tokens": 289088,
          "session_output_tokens": 142361,
          "session_cache_creation_tokens": 2817197,
          "session_cache_read_tokens": 160833898,
          "by_model": {
            "claude-opus-4-8": {
              "input": 289088,
              "output": 142361,
              "cache_create": 2817197,
              "cache_read": 160833898
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 246,
          "tool_call_count": 97,
          "context_at_last_turn_tokens": 336061,
          "context_window_pct": 168.0305
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-31T18:07:36-07:00",
        "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
        "model": "claude-opus-4-8",
        "five_hour_pct": 71,
        "seven_day_pct": 80,
        "session_input_tokens": 507653,
        "session_output_tokens": 142838,
        "session_cache_creation_tokens": 2861015,
        "session_cache_read_tokens": 161127430,
        "by_model": {
          "claude-opus-4-8": {
            "input": 507653,
            "output": 142838,
            "cache_create": 2861015,
            "cache_read": 161127430
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 247,
        "tool_call_count": 97,
        "context_at_last_turn_tokens": 555915,
        "context_window_pct": 277.9575
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-31T18:08:04-07:00",
      "completed_at": "2026-05-31T18:14:55-07:00",
      "session_started_at": null,
      "cumulative_seconds": 411,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-31T18:08:04-07:00",
        "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
        "model": "claude-opus-4-8",
        "five_hour_pct": 71,
        "seven_day_pct": 80,
        "session_input_tokens": 507789,
        "session_output_tokens": 144470,
        "session_cache_creation_tokens": 3091333,
        "session_cache_read_tokens": 163146000,
        "by_model": {
          "claude-opus-4-8": {
            "input": 507789,
            "output": 144470,
            "cache_create": 3091333,
            "cache_read": 163146000
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 251,
        "tool_call_count": 97,
        "context_at_last_turn_tokens": 567670,
        "context_window_pct": 283.835
      },
      "step_snapshots": [
        {
          "step": 2,
          "field": "complete_step",
          "captured_at": "2026-05-31T18:08:14-07:00",
          "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
          "model": "claude-opus-4-8",
          "five_hour_pct": 71,
          "seven_day_pct": 80,
          "session_input_tokens": 507791,
          "session_output_tokens": 144929,
          "session_cache_creation_tokens": 3112864,
          "session_cache_read_tokens": 163713668,
          "by_model": {
            "claude-opus-4-8": {
              "input": 507791,
              "output": 144929,
              "cache_create": 3112864,
              "cache_read": 163713668
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 252,
          "tool_call_count": 97,
          "context_at_last_turn_tokens": 589201,
          "context_window_pct": 294.6005
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-31T18:14:55-07:00",
        "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
        "model": "claude-opus-4-8",
        "five_hour_pct": 74,
        "seven_day_pct": 81,
        "session_input_tokens": 512007,
        "session_output_tokens": 147058,
        "session_cache_creation_tokens": 3130743,
        "session_cache_read_tokens": 168514164,
        "by_model": {
          "claude-opus-4-8": {
            "input": 512007,
            "output": 147058,
            "cache_create": 3130743,
            "cache_read": 168514164
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 260,
        "tool_call_count": 99,
        "context_at_last_turn_tokens": 607080,
        "context_window_pct": 303.54
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-31T08:56:05-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-31T09:36:45-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-31T17:58:59-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-31T18:08:04-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-31T08:55:10-07:00",
    "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
    "model": "claude-opus-4-8",
    "five_hour_pct": 71,
    "seven_day_pct": 60,
    "session_input_tokens": 4647,
    "session_output_tokens": 1946,
    "session_cache_creation_tokens": 250177,
    "session_cache_read_tokens": 1339821,
    "by_model": {
      "claude-opus-4-8": {
        "input": 4647,
        "output": 1946,
        "cache_create": 250177,
        "cache_read": 1339821
      }
    },
    "turn_count": 6,
    "tool_call_count": 2,
    "context_at_last_turn_tokens": 266688,
    "context_window_pct": 133.344
  },
  "code_tasks_total": 7,
  "code_task_name": "Validate byte-identity + 100% coverage",
  "code_task": 7,
  "diff_stats": {
    "files_changed": 5,
    "insertions": 226,
    "deletions": 49,
    "captured_at": "2026-05-31T09:36:35-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "findings": [
    {
      "finding": "tests/cleanup.rs run_impl_main arm-shape section comment described refactor history (guard the rewrite from from_str/json_error_string to json_error_value) instead of the forward-facing guarded invariant",
      "reason": "Backward-facing comment per comment-quality.md and forward-facing-authoring.md; rewrote to describe the status-first Value shape the flow-complete consumer depends on, dropping the rewrite-history sentence",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-31T17:54:10-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "compact_summary": "<analysis>\nThis conversation is an autonomous FLOW lifecycle run on the FLOW plugin repository itself, triggered by `/flow:flow-start #1774`. Let me chronologically reconstruct it.\n\n**Phase 1 (Start):** `/flow:flow-start #1774` — initialized the flow. `start-init 1774` returned branch `remove-redundant-json-serialize`. start-gate clean. start-workspace created worktree `/Users/ben/code/flow/.worktrees/remove-redundant-json-serialize`, PR #1780. plan-from-issue extracted a 7-task plan. phase-finalize → continue_action=invoke (auto). All modes are auto/auto throughout.\n\n**The task (issue #1774):** A pure internal refactor of `src/output.rs`, `src/cleanup.rs`, `src/phase_transition.rs` to add value-returning JSON helpers (`json_ok_value`/`json_error_value`) and eliminate serialize-then-reparse round-trips, keeping output byte-identical.\n\n**Phase 2 (Code):** Executed 7 tasks across 4 commits:\n- Tasks 1-2 (commit f0ba050): Added `json_ok_value`/`json_error_value` to output.rs, refactored `_string` to delegate; added delegation-equivalence tests to tests/output.rs.\n- Task 3 (commit 2c514c5): Added safety-net arm-shape tests to tests/cleanup.rs.\n- Task 4 (commit 1299435): Rewrote cleanup run_impl_main 5 sites to return Values directly. Hit PHANTOM MISSES (stale instrumented binaries, \"112 functions mismatched data\") → ran `bin/flow ci --clean` → re-measured 100/100/100.\n- Task 5 (commit 13effd1): Deleted private json_error_value from phase_transition.rs, re-pointed 10 callsites. Hit PHANTOM MISSES again → `ci --clean` → 100/100/100.\n- Task 6 (verification, no commit), Task 7 (validation, no commit).\n- phase-finalize flow-code → invoke.\n\n**Phase 3 (Review):** Four agents launched. First launch: reviewer BLOCKED (prompt had `...` ellipsis tokens parsed as path traversal); adversarial BLOCKED (out-of-worktree `/Users/ben/code/flow/bin/flow` path). Pre-mortem and documentation returned. Re-launched reviewer (scrubbed `...`) and adversarial (relative `bin/flow`). Final results: reviewer/pre-mortem/adversarial = no findings; documentation = 1 finding (backward-facing comment in tests/cleanup.rs).\n\n**CRITICAL EVENT — record-agent-return failure and user intervention:** When recording agent returns, `record-agent-return` failed with `phase_marker_not_found` for reviewer AND pre-mortem. I diagnosed this as a possible environmental/transcript issue (also noting resume-anchor was returning foreign `/tmp/.../counter-learn` paths throughout the flow). I STOPPED and surfaced a 3-option decision to the user (investigate infra / authorize finalize-past-gate / something else). \n\nThe user responded by typing `/flow:flow-continue` TWICE. The first cleared the halt. After clearing, I retried `record-agent-return` for documentation → it SUCCEEDED. The earlier failure was transient transcript-flush timing. I then recorded all 4 agents successfully. I logged both anomalies (resume-anchor foreign paths, record-agent-return transient failure) for Learn via `bin/flow log`. I owned that my earlier \"environmental/unrecoverable\" diagnosis was wrong (a retry fixed it).\n\nReview Step 3 triage: 1 real finding (documentation T6 backward-facing comment). Step 4: fixed the comment in tests/cleanup.rs (rewrote the \"guard the rewrite from X to Y\" sentence to forward-facing), recorded add-finding fixed, ran `bin/flow ci` (green 100/100/100), committed 79d5c81. phase-finalize flow-review → invoke (formatted_time \"8h 21m\" — inflated by the pause).\n\n**Phase 4 (Learn) — CURRENT:** \n- Step 1: read state (notes empty, code_task 7/7 no drift), captured diff, launched learn-analyst. First launch BLOCKED (`/flow:flow-note` in prompt parsed as `/flow` path). Re-launched scrubbed → returned END-OF-FINDINGS with ZERO findings all tenants. Recorded learn-analyst return (succeeded immediately this time). learn_step=1.\n- Step 2: synthesis — no correction notes, zero findings → zero artifacts. learn_step=2.\n- Step 3: route — nothing to route. learn_step=3.\n- Step 4: promote-permissions → skipped (no_local_file). learn_step=4 just recorded.\n\nImmediately before this summary request, I had just run `bin/flow set-timestamp --set learn_step=4` (success). The next action per the skill is to self-invoke `flow:flow-learn --continue-step` to reach Step 5 (Commit — conditional; since no changes were made in Steps 3-4, it skips the commit and advances).\n\nSecurity/constraint notes: many from CLAUDE.md/rules. Key behavioral constraints observed throughout: never raw git commit (use /flow:flow-commit), commit-msg via write-rule, 10-min Bash timeout on CI commands, `.flow-states/` lives at main repo root not worktree, agent prompts must not contain out-of-worktree paths or `...`/`/flow` tokens, cognitive isolation (never fabricate agent findings), verify-before-filing issues.\n\nI must also surface the two logged infra anomalies in the Step 7 Learn report (I committed to this): resume-anchor foreign-path returns and the transient record-agent-return failure.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user invoked `/flow:flow-start #1774`, launching an autonomous FLOW lifecycle (Start → Code → Review → Learn → Complete) on the FLOW plugin repo itself. Issue #1774 is a pre-decomposed 7-task plan: a **pure internal refactor** to add value-returning JSON helpers (`json_ok_value` / `json_error_value`) to `src/output.rs`, refactor the existing `json_ok_string` / `json_error_string` to delegate to them, rewrite `src/cleanup.rs::run_impl_main`'s five return arms to return `Value` directly (eliminating `serde_json::from_str(...).unwrap()` reparse round-trips), and delete the private `json_error_value` in `src/phase_transition.rs` (re-pointing its 10 callsites to `crate::output::json_error_value(&msg, &[])`). The invariant: output must stay **byte-identical** (status-first key order, identical messages). All skill modes are commit=auto / continue=auto (fully autonomous). Mid-flow, the user's only direct messages were two `/flow:flow-continue` invocations (resume directives).\n\n2. Key Technical Concepts:\n   - FLOW 5-phase lifecycle plugin; `bin/flow` Rust subcommands; self-invocation via `--continue-step`; phase-enter/phase-finalize/resolve-skill-mode/set-timestamp state mutations.\n   - serde_json `preserve_order` feature → `serde_json::Map` is insertion-order-preserving (backed by IndexMap); `Value::Object`.\n   - Per-file coverage gate `bin/test tests/<name>.rs` (100/100/100); phantom misses from stale instrumented binaries (`ci --clean` recovery, the only Layer 11 carve-out during Code phase).\n   - Cognitive isolation: 4 Review agents (reviewer/pre-mortem/adversarial/documentation), END-OF-FINDINGS marker, record-agent-return transcript verification, never fabricate agent findings.\n   - comment-quality.md / forward-facing-authoring.md (forbid backward-facing \"rewrite from X to Y\" comments).\n   - Agent-prompt path scan (`validate-pretool`): blocks out-of-worktree paths and `...`/`/flow` tokens in Agent prompts; `.flow-states/<branch>/` is carved out.\n   - Two-exit halt model; `/flow:flow-continue` clears `_halt_pending`.\n\n3. Files and Code Sections:\n   - `src/output.rs` (committed f0ba050): Added `json_ok_value(fields: &[(&str, Value)]) -> Value` and `json_error_value(message: &str, fields: &[(&str, Value)]) -> Value` building `Value::Object(map)` with ordered Map; refactored `json_ok_string`/`json_error_string` to `json_*_value(...).to_string()`.\n   - `tests/output.rs` (f0ba050): Added status-first ordering tests + `json_*_string == json_*_value().to_string()` delegation-equivalence tests (with empty-field variants). Import line: `use flow_rs::output::{json_error, json_error_string, json_error_value, json_ok, json_ok_string, json_ok_value};`\n   - `tests/cleanup.rs` (committed 2c514c5, then comment fixed in 79d5c81): Added `top_level_keys` helper + 4 `run_impl_main_*` arm-shape tests (`run_impl_main_nonexistent_root_is_status_first_error`, `_missing_branch_`, `_missing_worktree_`, `_success_is_status_then_steps`). In Review, rewrote the section comment from backward-facing (\"These guard the rewrite of the three error arms from `from_str(&json_error_string(...)).unwrap()` to `json_error_value(...)`...\") to forward-facing (\"The JSON the `flow-complete` skill parses from `cleanup` stdout depends on this exact shape...\").\n   - `src/cleanup.rs` (committed 1299435): Rewrote 3 error arms → `crate::output::json_error_value(...)`; success arm → `let steps_value = Value::Object(steps.into_iter().map(|(k,v)| (k, Value::String(v))).collect()); (crate::output::json_ok_value(&[(\"steps\", steps_value)]), 0)`. Zero reparse `.unwrap()` remain.\n   - `src/phase_transition.rs` (committed 13effd1): Import changed to `use crate::output::json_error_value;`; private `fn json_error_value(message: &str)` deleted; 10 callsites re-pointed to `json_error_value(&msg, &[])`.\n   - `.flow-states/remove-redundant-json-serialize/state.json`: `notes: []`, `code_task: 7`, `code_tasks_total: 7`, `review_step: 4`, `learn_step: 4`, `files.plan: null` (minor anomaly — plan.md exists at `.flow-states/<branch>/plan.md`). All 4 review agents in `agents_returned`. 1 finding (documentation, fixed).\n\n4. Errors and fixes:\n   - **Phantom misses (Tasks 4 and 5):** Per-file coverage dropped (e.g. 94.74%/91.67%/99.58%) due to stale instrumented binaries (\"mismatched data\" / duplicate crate hashes Cs1s5hr3kGH2u vs Cs8Vnou6xwcBw confirmed via `bin/test --funcs`). Fixed with `bin/flow ci --clean` then re-measure → 100/100/100. (Diagnosed properly via `--show`/`--funcs` per coverage-gap-diagnosis.md, not speculation.)\n   - **Agent launch blocks (Review):** reviewer blocked on `...` ellipsis in PLAN text (parsed as path traversal); adversarial blocked on out-of-worktree `/Users/ben/code/flow/bin/flow`. Fixed by scrubbing `...` and using worktree-relative `bin/flow`. In Learn, learn-analyst blocked on `/flow:flow-note` (parsed as `/flow` path) → scrubbed to \"flow-note\".\n   - **record-agent-return `phase_marker_not_found` (Review):** Failed for reviewer + pre-mortem immediately after agents returned. I initially diagnosed it as possibly environmental/unrecoverable (citing recurrent resume-anchor foreign `/tmp/.../counter-learn` returns) and STOPPED to surface a decision to the user. User typed `/flow:flow-continue`. On retry after the pause, it SUCCEEDED — root cause was transient transcript-flush timing. I OWNED that my earlier \"environmental/unrecoverable\" lean was the wrong call (a retry fixed it). Recorded all 4 agents, logged both anomalies for Learn.\n   - **resume-anchor foreign paths:** `bin/flow resume-anchor` returned `/private/tmp/.../counter-learn` (a different flow) on most `--continue-step` calls; cwd persisted correctly so no harm. Logged for Learn review.\n\n5. Problem Solving:\n   Completed Code phase (4 commits, 100/100/100 throughout), Review phase (1 finding fixed, all agents recorded), and Learn Steps 1-4. The transient record-agent-return failure resolved on retry. The two infra anomalies (resume-anchor foreign paths; record-agent-return flush timing) are logged but NOT filed as issues — I decided per `filing-issues.md` \"Verify Before Filing\" not to autonomously file half-diagnosed issues, and per cognitive-isolation not to inject them as agent findings; I committed to surfacing them in the Step 7 Learn report for the user to decide on filing.\n\n6. All user messages:\n   - `/flow:flow-start` with `ARGUMENTS: #1774` (initial invocation).\n   - `/flow:flow-continue` (Stop-hook refused my pause; user typed this to clear halt and resume).\n   - `/flow:flow-continue` (second invocation, immediately after — reinforcing \"proceed\").\n   (No other non-tool-result user messages. No security constraints stated beyond the standing CLAUDE.md/rules corpus: never raw git commit / always /flow:flow-commit; commit messages via `bin/flow write-rule`; 10-min Bash timeout on CI commands; `.flow-states/` at main-repo root not worktree; agent prompts must avoid out-of-worktree paths; never fabricate agent findings.)\n\n7. Pending Tasks:\n   - Complete Learn phase Steps 5, 6, 7 and Done (phase-finalize flow-learn).\n   - Surface the two logged infra anomalies (resume-anchor foreign-path returns; transient record-agent-return failure) in the Step 7 Learn report.\n   - Phase 5 (Complete): merge PR #1780, remove worktree, delete state file (auto-advances since continue=auto).\n\n8. Current Work:\n   In Phase 4 (Learn), I had just completed Step 4 (Promote permissions → `{\"status\":\"skipped\",\"reason\":\"no_local_file\"}`) and recorded `bin/flow set-timestamp --set learn_step=4` (returned `{\"status\":\"ok\",\"updates\":[{\"path\":\"learn_step\",\"value\":4}]}`). The Learn phase has produced ZERO artifacts (no correction notes, learn-analyst found nothing — clean refactor). Per the skill, the next action is to self-invoke `flow:flow-learn --continue-step` to enter Step 5 (Commit — conditional): since no changes were made in Steps 3-4, Step 5 records `learn_step=5` and self-invokes to skip the commit, advancing toward Step 6 (no issues to file) and Step 7 (report). In Step 7 I must include the two logged infra anomalies as observed-but-not-filed notes.\n\n9. Optional Next Step:\n   Self-invoke `flow:flow-learn --continue-step` to proceed to Step 5. The skill states: \"If no changes were made in Steps 3-4, record step completion and self-invoke to skip the commit: `bin/flow set-timestamp --set learn_step=5` Then invoke `flow:flow-learn --continue-step`.\" Steps 3-4 produced no changes (zero findings, no permission promotion), so Step 5 skips the commit. Continue through Step 6 (skip — no findings to file), Step 7 (present the Learn report — including the two logged infra anomalies: resume-anchor foreign-path returns and the transient `record-agent-return` `phase_marker_not_found`), and Done (`bin/flow phase-finalize --phase flow-learn --branch remove-redundant-json-serialize`), which with continue=auto invokes `flow:flow-complete`.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user invoked `/flow:flow-start #1774` to run an autonomous FLOW lifecycle on the FLOW plugin repo. Issue #1774 is a pre-decomposed 7-task pure-refactor: add value-returning JSON helpers `json_ok_value`/`json_error_value` to `src/output.rs`, make `json_ok_string`/`json_error_string` delegate to them, rewrite `src/cleanup.rs::run_impl_main`'s five return arms to return `Value` directly (removing `serde_json::from_str(...).unwrap()` reparse round-trips), and delete the private `json_error_value` in `src/phase_transition.rs` (re-pointing 10 callsites to `crate::output::json_error_value(&msg, &[])`). Invariant: byte-identical output (status-first key order, identical messages). All modes auto/auto.\n\n2. Key Technical Concepts:\n   - FLOW phases (Start/Code/Review/Learn/Complete), `bin/flow` subcommands, `--continue-step` self-invocation, phase-enter/phase-finalize/resolve-skill-mode/set-timestamp.\n   - serde_json `preserve_order` → order-preserving `Map`; `Value::Object`.\n   - 100/100/100 per-file coverage gate (`bin/test tests/<name>.rs`); phantom misses (stale instrumented binaries) fixed via `bin/flow ci --clean`.\n   - Cognitive isolation; 4 Review agents; END-OF-FINDINGS marker; record-agent-return transcript verification; never fabricate agent findings.\n   - comment-quality.md / forward-facing-authoring.md; agent-prompt path scanner (blocks out-of-worktree paths and `...`/`/flow` tokens; `.flow-states/<branch>/` carved out).\n   - Two-exit halt model; `/flow:flow-continue` clears `_halt_pending`.\n\n3. Files and Code Sections:\n   - `src/output.rs` (commit f0ba050): new `json_ok_value`/`json_error_value` returning `Value::Object`; `_string` variants delegate via `.to_string()`.\n   - `tests/output.rs` (f0ba050): status-first ordering + delegation-equivalence tests.\n   - `tests/cleanup.rs` (commit 2c514c5; comment fixed in 79d5c81): `top_level_keys` helper + 4 `run_impl_main_*` arm-shape tests. Review rewrote the section comment to forward-facing.\n   - `src/cleanup.rs` (commit 1299435): 3 error arms → `crate::output::json_error_value(...)`; success arm builds steps `Value::Object` inline and returns `crate::output::json_ok_value(&[(\"steps\", steps_value)])`.\n   - `src/phase_transition.rs` (commit 13effd1): import → `json_error_value`; private helper deleted; 10 callsites → `json_error_value(&msg, &[])`.\n   - `.flow-states/remove-redundant-json-serialize/state.json`: notes empty, code_task 7/7, review_step 4, learn_step 4, all 4 review agents recorded, 1 finding fixed.\n\n4. Errors and fixes:\n   - Phantom misses (Tasks 4, 5): coverage dropped due to stale instrumented binaries; diagnosed via `--show`/`--funcs`; fixed with `bin/flow ci --clean` → 100/100/100.\n   - Agent prompt blocks: reviewer (`...` ellipsis), adversarial (out-of-worktree `bin/flow` path), learn-analyst (`/flow:flow-note` → `/flow`). Fixed by scrubbing tokens / using worktree-relative paths.\n   - record-agent-return `phase_marker_not_found` (Review): failed initially, I surfaced a decision to the user; user typed `/flow:flow-continue`; retry SUCCEEDED (transient transcript-flush timing). I owned the wrong initial \"environmental\" diagnosis. User feedback: the two `/flow:flow-continue` invocations = \"proceed.\"\n   - resume-anchor returned foreign `/tmp/.../counter-learn` paths repeatedly; cwd persisted so no harm; logged.\n\n5. Problem Solving:\n   Code + Review phases completed; Learn Steps 1-4 done with zero findings. Two infra anomalies logged (not filed — per Verify-Before-Filing and cognitive isolation) to be surfaced in the Step 7 report.\n\n6. All user messages:\n   - `/flow:flow-start` `ARGUMENTS: #1774`\n   - `/flow:flow-continue` (clear halt, resume)\n   - `/flow:flow-continue` (second, reinforcing proceed)\n   No additional security constraints beyond the standing CLAUDE.md/rules (never raw git commit / always /flow:flow-commit; commit-msg via write-rule; never fabricate agent findings; `.flow-states/` at main-repo root).\n\n7. Pending Tasks:\n   - Finish Learn Steps 5-7 and Done (phase-finalize flow-learn).\n   - Surface the two infra anomalies in the Step 7 Learn report.\n   - Phase 5 Complete (merge PR #1780, remove worktree, delete state) — auto-advances.\n\n8. Current Work:\n   Just completed Learn Step 4 (promote-permissions skipped, no_local_file) and recorded `learn_step=4`. Learn produced zero artifacts (no correction notes, learn-analyst zero findings). Next is to self-invoke `flow:flow-learn --continue-step` → Step 5 (conditional commit), which skips the commit because Steps 3-4 made no changes.\n\n9. Optional Next Step:\n   Run `bin/flow set-timestamp --set learn_step=5` then invoke `flow:flow-learn --continue-step` (Step 5 conditional-commit skip path, since no changes were made). Per the skill: \"If no changes were made in Steps 3-4, record step completion and self-invoke to skip the commit: `bin/flow set-timestamp --set learn_step=5` Then invoke `flow:flow-learn --continue-step`.\" Then proceed through Step 6 (no issues to file), Step 7 (Learn report — including the resume-anchor foreign-path and transient record-agent-return anomalies I logged), and Done (`bin/flow phase-finalize --phase flow-learn --branch remove-redundant-json-serialize`), which auto-invokes `flow:flow-complete`.\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/remove-redundant-json-serialize",
  "compact_count": 1,
  "complete_steps_total": 5,
  "complete_step": 5,
  "_continue_context": "Self-invoke flow:flow-complete --continue-step.",
  "window_at_complete": {
    "captured_at": "2026-05-31T18:14:55-07:00",
    "session_id": "7e3c9311-2e66-4975-bdb2-7b6fc14d2dc4",
    "model": "claude-opus-4-8",
    "five_hour_pct": 74,
    "seven_day_pct": 81,
    "session_input_tokens": 512007,
    "session_output_tokens": 147058,
    "session_cache_creation_tokens": 3130743,
    "session_cache_read_tokens": 168514164,
    "by_model": {
      "claude-opus-4-8": {
        "input": 512007,
        "output": 147058,
        "cache_create": 3130743,
        "cache_read": 168514164
      },
      "<synthetic>": {
        "input": 0,
        "output": 0,
        "cache_create": 0,
        "cache_read": 0
      }
    },
    "turn_count": 260,
    "tool_call_count": 99,
    "context_at_last_turn_tokens": 607080,
    "context_window_pct": 303.54
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>