### PR TITLE
Consolidate Duplicated Hook Test

### DIFF
--- a/.claude/rules/subprocess-test-hygiene.md
+++ b/.claude/rules/subprocess-test-hygiene.md
@@ -107,8 +107,9 @@ field is set; the fix is to add `.current_dir(fixture_root)`.
 
 ## Canonical Helper Pattern
 
-Every test file that spawns the binary should define a
-no-recursion helper at the top and go through it exclusively:
+Subprocess tests that are NOT hook invocations should define a
+no-recursion helper at the top of the test file and go through it
+exclusively:
 
 ```rust
 fn flow_rs_no_recursion() -> Command {
@@ -134,6 +135,28 @@ let output = flow_rs_no_recursion()
     .expect("spawn flow-rs issue");
 ```
 
+### Hook Subprocess Tests Route Through the Shared Helper
+
+Tests that spawn the `bin/flow hook <name>` subcommand go through
+the shared `crate::common::spawn_hook(hook_name, cwd, stdin, env)`
+helper in `tests/common/mod.rs` rather than a per-file
+`flow_rs_no_recursion`. The shared helper centralizes the recursion
+guard plus the worktree-isolation surface this rule mandates: it
+removes `FLOW_CI_RUNNING`, `FLOW_SIMULATE_BRANCH`, and `HOME`, sets
+`.current_dir(cwd)`, pipes all three stdio streams, then applies the
+caller-supplied `env` pairs last (last-write-wins, so a test that
+needs a specific `HOME` or `FLOW_SIMULATE_BRANCH` passes it
+explicitly via the `env` slice). `stdin` is `&[u8]` so a non-UTF-8
+robustness payload stays expressible, and the helper returns the
+child's `Output`.
+
+The per-file `flow_rs_no_recursion` pattern above remains correct
+for subprocess tests that are NOT hook invocations: non-hook
+subcommands, BrokenPipe-tolerant stdin probes, and spawns that need
+a `pre_exec` hook (`setsid`, `rmdir`) the shared helper does not
+expose. For those, define the per-file helper and pass the
+neutralizers at the call site.
+
 ## When to Apply Which Neutralizers
 
 Map the subcommand the test invokes to the services its module
@@ -144,7 +167,7 @@ reaches, and neutralize exactly those:
 | `bin/flow issue`, `close-issue`, `close-issues`, `link-blocked-by`, `auto-close-parent`, `label-issues` | `gh` CLI → GitHub API | `GH_TOKEN=invalid`, `HOME=<tempdir>` |
 | `bin/flow notify-slack` | Slack webhook POST | `env_remove("SLACK_WEBHOOK_URL")`, `env_remove("SLACK_BOT_TOKEN")` |
 | `bin/flow ci`, `build`, `test`, `lint`, `format` | recursion guard | `env_remove("FLOW_CI_RUNNING")` |
-| `bin/flow hook <name>` | state file reads, stdin | `HOME=<tempdir>` if the hook might read ~/.config; `.current_dir(fixture)` so the hook resolves a fixture branch/state, not the real worktree (see "Working Directory Isolation") |
+| `bin/flow hook <name>` | state file reads, stdin | routed through `crate::common::spawn_hook`, which removes `HOME` and sets `.current_dir(fixture)` so the hook resolves a fixture branch/state, not the real worktree (see "Working Directory Isolation"); pass a specific `HOME` via the `env` slice when the hook must read one |
 
 ## Plan-Phase Trigger
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -452,27 +452,33 @@ pub fn parse_output(output: &Output) -> Value {
 ///   re-sets it (e.g. dispatcher's `run_hook` passes
 ///   `("FLOW_SIMULATE_BRANCH", branch)`).
 /// - `HOME` — the ambient-config home; removed so the child reads no
-///   user dotfiles. Callers that need a specific home pass it through
-///   `env` (e.g. `("HOME", fixture)` for transcript fixtures); callers
-///   that want it unset (e.g. capture-session's non-absolute-home test)
-///   pass an empty slice.
+///   user dotfiles. The removal is UNCONDITIONAL: a caller that needs
+///   a specific home re-adds it by passing `("HOME", fixture)` in
+///   `env` (e.g. for transcript fixtures), which sets HOME to that
+///   fixture value. There is no way to inherit the parent process's
+///   real HOME — that is deliberate, per the rule's Working Directory
+///   Isolation: a hook test must never resolve against the runner's
+///   real home. Omitting the key from `env` is not a request to
+///   inherit; it simply leaves the unconditional removal in place.
 ///
 /// `env` pairs are applied AFTER the three removals, so passing
 /// `("HOME", fixture)` or `("FLOW_SIMULATE_BRANCH", "feature/x")`
-/// re-sets the removed var to the fixture value (last-write-wins on
-/// `Command`). A caller needing an extra var removed instead of set
-/// expresses it as the absence of that key from `env` when the var is
-/// one of the three above, or builds its own `Command` for any other
-/// var the slice cannot express.
+/// re-adds the removed var with the fixture value (last-write-wins on
+/// `Command`). A var that must stay removed is simply left out of
+/// `env`; a var the slice cannot express (e.g. a removal of some
+/// fourth var, or a `pre_exec` closure) means the caller builds its
+/// own `Command`.
 ///
 /// # Parameters
 /// - `hook_name`: the hook subcommand (e.g. `"post-compact"`).
 /// - `cwd`: the child's working directory (a fixture git repo or
 ///   tempdir).
-/// - `stdin`: bytes written to the child's stdin, as a `&str` (every
-///   hook payload is UTF-8 JSON or deliberately-malformed UTF-8 text).
+/// - `stdin`: raw bytes written to the child's stdin. Bytes (not
+///   `&str`) so byte-origin callers pass their payload directly and a
+///   probe can feed deliberately-malformed non-UTF-8 input to exercise
+///   the production hooks' raw-stdin reads.
 /// - `env`: `(key, value)` pairs set on the child after the removals.
-pub fn spawn_hook(hook_name: &str, cwd: &Path, stdin: &str, env: &[(&str, &str)]) -> Output {
+pub fn spawn_hook(hook_name: &str, cwd: &Path, stdin: &[u8], env: &[(&str, &str)]) -> Output {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_flow-rs"));
     cmd.args(["hook", hook_name])
         .env_remove("FLOW_CI_RUNNING")
@@ -490,7 +496,7 @@ pub fn spawn_hook(hook_name: &str, cwd: &Path, stdin: &str, env: &[(&str, &str)]
         .stdin
         .as_mut()
         .expect("piped stdin")
-        .write_all(stdin.as_bytes())
+        .write_all(stdin)
         .expect("write stdin to flow-rs hook");
     child.wait_with_output().expect("wait for flow-rs hook")
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,9 +9,10 @@
 
 use std::collections::HashMap;
 use std::fs;
+use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::sync::{Mutex, OnceLock};
 
 use flow_rs::flow_paths::FlowStatesDir;
@@ -425,6 +426,73 @@ pub fn parse_output(output: &Output) -> Value {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let last_line = stdout.trim().lines().last().unwrap_or("");
     serde_json::from_str(last_line).unwrap_or_else(|_| json!({"raw": stdout.trim()}))
+}
+
+// --- Hook subprocess spawning ---
+
+/// Spawn `flow-rs hook <hook_name>`, write `stdin` to the child, and
+/// return its full [`std::process::Output`].
+///
+/// Builds the command with `current_dir(cwd)` and all three stdio
+/// streams piped, writes `stdin` to the child's stdin, and waits for
+/// completion. Returning the full `Output` lets every caller
+/// destructure the field it needs — exit code, stdout, or stderr — so
+/// one helper serves both the `(exit, stderr)` and full-`Output`
+/// consumers across the hook test files.
+///
+/// **Environment contract** (per
+/// `.claude/rules/subprocess-test-hygiene.md`): three host env vars are
+/// always `env_remove`d BEFORE the `env` overrides apply, so the child
+/// inherits none of them unless the caller re-sets them through `env`:
+///
+/// - `FLOW_CI_RUNNING` — the recursion guard; a fresh hook invocation
+///   must not look like a nested CI run.
+/// - `FLOW_SIMULATE_BRANCH` — the branch-detection override; removed so
+///   branch resolution comes from the `cwd` git fixture unless a caller
+///   re-sets it (e.g. dispatcher's `run_hook` passes
+///   `("FLOW_SIMULATE_BRANCH", branch)`).
+/// - `HOME` — the ambient-config home; removed so the child reads no
+///   user dotfiles. Callers that need a specific home pass it through
+///   `env` (e.g. `("HOME", fixture)` for transcript fixtures); callers
+///   that want it unset (e.g. capture-session's non-absolute-home test)
+///   pass an empty slice.
+///
+/// `env` pairs are applied AFTER the three removals, so passing
+/// `("HOME", fixture)` or `("FLOW_SIMULATE_BRANCH", "feature/x")`
+/// re-sets the removed var to the fixture value (last-write-wins on
+/// `Command`). A caller needing an extra var removed instead of set
+/// expresses it as the absence of that key from `env` when the var is
+/// one of the three above, or builds its own `Command` for any other
+/// var the slice cannot express.
+///
+/// # Parameters
+/// - `hook_name`: the hook subcommand (e.g. `"post-compact"`).
+/// - `cwd`: the child's working directory (a fixture git repo or
+///   tempdir).
+/// - `stdin`: bytes written to the child's stdin, as a `&str` (every
+///   hook payload is UTF-8 JSON or deliberately-malformed UTF-8 text).
+/// - `env`: `(key, value)` pairs set on the child after the removals.
+pub fn spawn_hook(hook_name: &str, cwd: &Path, stdin: &str, env: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_flow-rs"));
+    cmd.args(["hook", hook_name])
+        .env_remove("FLOW_CI_RUNNING")
+        .env_remove("FLOW_SIMULATE_BRANCH")
+        .env_remove("HOME")
+        .current_dir(cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+    let mut child = cmd.spawn().expect("spawn flow-rs hook");
+    child
+        .stdin
+        .as_mut()
+        .expect("piped stdin")
+        .write_all(stdin.as_bytes())
+        .expect("write stdin to flow-rs hook");
+    child.wait_with_output().expect("wait for flow-rs hook")
 }
 
 /// Build a `WindowSnapshot`-shaped JSON Value for fixtures.

--- a/tests/hooks/capture_session.rs
+++ b/tests/hooks/capture_session.rs
@@ -38,12 +38,7 @@ fn run_capture_session(home_env: Option<&Path>, stdin_bytes: &[u8]) -> Option<i3
         Some(h) => vec![("HOME", h)],
         None => vec![],
     };
-    let output = crate::common::spawn_hook(
-        "capture-session",
-        dir.path(),
-        std::str::from_utf8(stdin_bytes).expect("capture-session stdin is UTF-8"),
-        &env,
-    );
+    let output = crate::common::spawn_hook("capture-session", dir.path(), stdin_bytes, &env);
     output.status.code()
 }
 
@@ -138,7 +133,7 @@ fn capture_session_skips_when_home_is_relative() {
     let output = crate::common::spawn_hook(
         "capture-session",
         dir.path(),
-        r#"{"session_id":"valid-sid"}"#,
+        br#"{"session_id":"valid-sid"}"#,
         &[("HOME", "relative-home")],
     );
     assert_eq!(output.status.code(), Some(0));

--- a/tests/hooks/capture_session.rs
+++ b/tests/hooks/capture_session.rs
@@ -24,30 +24,26 @@ fn capture_file(home: &Path) -> PathBuf {
 }
 
 /// Spawn `flow-rs hook capture-session`, pipe `stdin_bytes`, wait for
-/// exit. Returns the child's exit code. Wraps the verbose stdin/stdout
-/// boilerplate so individual tests stay focused on assertions.
+/// exit. Returns the child's exit code. Delegates to
+/// [`crate::common::spawn_hook`], whose universal `env_remove("HOME")`
+/// covers the `home_env: None` case (capture-session resolves its
+/// capture-file location from `HOME`, so an unset `HOME` exercises the
+/// fail-open path); `Some(h)` re-sets `HOME` via the `env` slice. The
+/// `cwd` is an inert tempdir because capture-session reads `HOME`, not
+/// the working directory.
 fn run_capture_session(home_env: Option<&Path>, stdin_bytes: &[u8]) -> Option<i32> {
-    let mut cmd = flow_rs_no_recursion();
-    cmd.args(["hook", "capture-session"])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    match home_env {
-        Some(h) => {
-            cmd.env("HOME", h);
-        }
-        None => {
-            cmd.env_remove("HOME");
-        }
-    }
-    let mut child = cmd.spawn().expect("spawn capture-session");
-    child
-        .stdin
-        .as_mut()
-        .expect("piped stdin")
-        .write_all(stdin_bytes)
-        .expect("write stdin");
-    let output = child.wait_with_output().expect("wait capture-session");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = home_env.map(|h| h.to_str().expect("HOME path is UTF-8"));
+    let env: Vec<(&str, &str)> = match home {
+        Some(h) => vec![("HOME", h)],
+        None => vec![],
+    };
+    let output = crate::common::spawn_hook(
+        "capture-session",
+        dir.path(),
+        std::str::from_utf8(stdin_bytes).expect("capture-session stdin is UTF-8"),
+        &env,
+    );
     output.status.code()
 }
 
@@ -138,20 +134,13 @@ fn capture_session_skips_when_home_is_relative() {
     // resolve against the worktree's cwd — exactly the
     // hostile-config trap `.claude/rules/external-input-path-construction.md`
     // "Validate env-var-derived paths as absolute" defends against.
-    let mut cmd = flow_rs_no_recursion();
-    cmd.args(["hook", "capture-session"])
-        .env("HOME", "relative-home")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let mut child = cmd.spawn().expect("spawn capture-session");
-    child
-        .stdin
-        .as_mut()
-        .expect("piped stdin")
-        .write_all(br#"{"session_id":"valid-sid"}"#)
-        .expect("write stdin");
-    let output = child.wait_with_output().expect("wait capture-session");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = crate::common::spawn_hook(
+        "capture-session",
+        dir.path(),
+        r#"{"session_id":"valid-sid"}"#,
+        &[("HOME", "relative-home")],
+    );
     assert_eq!(output.status.code(), Some(0));
 }
 

--- a/tests/hooks/dispatcher.rs
+++ b/tests/hooks/dispatcher.rs
@@ -62,13 +62,11 @@ fn read_state(dir: &Path, branch: &str) -> Value {
 /// - `dir` is the child's `current_dir`, scoping `project_root()`
 ///   discovery to the tempdir so the child reads and mutates only the
 ///   fixture's `.flow-states/` directory.
+/// - `spawn_hook` also unconditionally removes `FLOW_CI_RUNNING` and
+///   `HOME`; these hooks resolve from cwd and branch (not HOME), so the
+///   `HOME` removal is inert here.
 fn run_hook(hook: &str, dir: &Path, branch: &str, stdin_data: &[u8]) -> Output {
-    crate::common::spawn_hook(
-        hook,
-        dir,
-        std::str::from_utf8(stdin_data).expect("hook stdin is UTF-8"),
-        &[("FLOW_SIMULATE_BRANCH", branch)],
-    )
+    crate::common::spawn_hook(hook, dir, stdin_data, &[("FLOW_SIMULATE_BRANCH", branch)])
 }
 
 /// Initialize a git repo in `dir` with an initial commit on `branch_name`.
@@ -105,14 +103,11 @@ fn setup_git_repo_on_branch(dir: &Path, branch_name: &str) {
 ///
 /// Callers must use [`setup_git_repo_on_branch`] (not
 /// [`setup_git_and_state`]) so the fixture repo has a deterministic
-/// HEAD branch and an initial commit.
+/// HEAD branch and an initial commit. `spawn_hook` also unconditionally
+/// removes `FLOW_CI_RUNNING` and `HOME` (inert for these cwd- and
+/// branch-resolving hooks).
 fn run_hook_no_simulate(hook: &str, dir: &Path, stdin_data: &[u8]) -> Output {
-    crate::common::spawn_hook(
-        hook,
-        dir,
-        std::str::from_utf8(stdin_data).expect("hook stdin is UTF-8"),
-        &[],
-    )
+    crate::common::spawn_hook(hook, dir, stdin_data, &[])
 }
 
 // ---------------------------------------------------------------------------
@@ -804,13 +799,18 @@ fn setup_worktree_fixture(dir: &Path, branch: &str, with_state_file: bool) -> st
     worktree
 }
 
+/// Spawn `flow-rs hook <hook>` in an explicit `cwd` and return the
+/// captured `Output`. Delegates to [`crate::common::spawn_hook`] with an
+/// empty `env` slice, so no `FLOW_SIMULATE_BRANCH` is set and the hook's
+/// branch/flow detection resolves from `cwd` itself — the fixture signal
+/// these `validate-pretool`/`validate-claude-paths`/`validate-worktree-paths`
+/// tests rely on. Unlike [`run_hook`] it sets no simulated branch, and
+/// unlike [`run_hook_no_simulate`] the cwd is the fixture under test
+/// rather than a git repo on a deterministic branch. `spawn_hook`'s
+/// universal removals (`FLOW_CI_RUNNING`, `FLOW_SIMULATE_BRANCH`, `HOME`)
+/// apply.
 fn run_hook_in(cwd: &Path, hook: &str, stdin_data: &[u8]) -> Output {
-    crate::common::spawn_hook(
-        hook,
-        cwd,
-        std::str::from_utf8(stdin_data).expect("hook stdin is UTF-8"),
-        &[],
-    )
+    crate::common::spawn_hook(hook, cwd, stdin_data, &[])
 }
 
 #[test]

--- a/tests/hooks/dispatcher.rs
+++ b/tests/hooks/dispatcher.rs
@@ -9,22 +9,12 @@
 //! that bypassed the clap wiring, stdin reading, and branch resolution layers.
 
 use std::fs;
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Output, Stdio};
+use std::process::{Command, Output};
 
 use crate::common::flow_states_dir;
 
 use serde_json::{json, Value};
-
-/// Build a `Command` targeting the compiled `flow-rs` test binary.
-///
-/// `CARGO_BIN_EXE_flow-rs` is set by Cargo's integration test harness to the
-/// absolute path of the just-built binary, so this is hermetic — it never
-/// depends on `$PATH` or an installed `bin/flow` dispatcher.
-fn flow_rs() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-}
 
 /// Initialize a bare git repo at `dir` and write `state` to
 /// `<dir>/.flow-states/<branch>.json`.
@@ -59,40 +49,26 @@ fn read_state(dir: &Path, branch: &str) -> Value {
     serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
 }
 
-/// Spawn `flow-rs hook <hook>` with simulated branch resolution, pipe
-/// `stdin_data` to the child, and return the captured `Output`.
+/// Spawn `flow-rs hook <hook>` with simulated branch resolution and
+/// return the captured `Output`. Delegates the command construction,
+/// stdin write, and `wait_with_output` to [`crate::common::spawn_hook`].
 ///
-/// - `FLOW_SIMULATE_BRANCH` is set on the child `Command` only (not the
-///   test process) so parallel Cargo tests cannot race on it — this
-///   satisfies `.claude/rules/testing-gotchas.md` Rust Parallel Test Env
-///   Var Races. All three hooks use `resolve_branch()` (which delegates
-///   to `current_branch()` internally), and both functions honor the
-///   env var, so one helper serves all three hooks.
-/// - `current_dir(dir)` scopes `project_root()` discovery to the tempdir
-///   so the child reads and mutates only the fixture's `.flow-states/`
-///   directory — prevents host environment leaks (see testing-gotchas.md).
-/// - All three stdio streams must be piped explicitly. `Command::spawn`
-///   defaults to inheriting stdout/stderr, which means `wait_with_output`
-///   would return empty buffers while the child's output leaks directly
-///   to the test harness terminal.
-///   Piping stdout and stderr lets `wait_with_output` capture them for
-///   assertion AND keeps cargo test output clean.
+/// - `FLOW_SIMULATE_BRANCH` is passed in the `env` slice so it is set on
+///   the child only (not the test process) — parallel Cargo tests cannot
+///   race on it, satisfying `.claude/rules/testing-gotchas.md` Rust
+///   Parallel Test Env Var Races. All three hooks use `resolve_branch()`
+///   (which delegates to `current_branch()` internally) and honor the env
+///   var, so one helper serves all three hooks.
+/// - `dir` is the child's `current_dir`, scoping `project_root()`
+///   discovery to the tempdir so the child reads and mutates only the
+///   fixture's `.flow-states/` directory.
 fn run_hook(hook: &str, dir: &Path, branch: &str, stdin_data: &[u8]) -> Output {
-    let mut cmd = flow_rs();
-    cmd.arg("hook")
-        .arg(hook)
-        .env("FLOW_SIMULATE_BRANCH", branch)
-        .current_dir(dir)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    let mut child = cmd.spawn().unwrap();
-    {
-        let stdin = child.stdin.as_mut().unwrap();
-        stdin.write_all(stdin_data).unwrap();
-    }
-    child.wait_with_output().unwrap()
+    crate::common::spawn_hook(
+        hook,
+        dir,
+        std::str::from_utf8(stdin_data).expect("hook stdin is UTF-8"),
+        &[("FLOW_SIMULATE_BRANCH", branch)],
+    )
 }
 
 /// Initialize a git repo in `dir` with an initial commit on `branch_name`.
@@ -117,13 +93,13 @@ fn setup_git_repo_on_branch(dir: &Path, branch_name: &str) {
     run(&["commit", "--allow-empty", "-m", "init"]);
 }
 
-/// Spawn `flow-rs hook <hook>` WITHOUT `FLOW_SIMULATE_BRANCH`, pipe
-/// `stdin_data` to the child, and return the captured `Output`.
+/// Spawn `flow-rs hook <hook>` WITHOUT `FLOW_SIMULATE_BRANCH` and return
+/// the captured `Output`. Delegates to [`crate::common::spawn_hook`].
 ///
-/// Unlike [`run_hook`], this helper does NOT set `FLOW_SIMULATE_BRANCH`
-/// on the child process, and explicitly removes it from the inherited
-/// environment via `env_remove`. This forces the hook to resolve the
-/// branch via real git (`git branch --show-current`) and the
+/// Unlike [`run_hook`], this helper passes an empty `env` slice, so
+/// `spawn_hook`'s universal `env_remove("FLOW_SIMULATE_BRANCH")` is the
+/// effective behavior and nothing re-sets it. This forces the hook to
+/// resolve the branch via real git (`git branch --show-current`) and the
 /// `resolve_branch` state-file-scan fallback — exercising the exact
 /// production code path that `FLOW_SIMULATE_BRANCH` short-circuits.
 ///
@@ -131,21 +107,12 @@ fn setup_git_repo_on_branch(dir: &Path, branch_name: &str) {
 /// [`setup_git_and_state`]) so the fixture repo has a deterministic
 /// HEAD branch and an initial commit.
 fn run_hook_no_simulate(hook: &str, dir: &Path, stdin_data: &[u8]) -> Output {
-    let mut cmd = flow_rs();
-    cmd.arg("hook")
-        .arg(hook)
-        .env_remove("FLOW_SIMULATE_BRANCH")
-        .current_dir(dir)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    let mut child = cmd.spawn().unwrap();
-    {
-        let stdin = child.stdin.as_mut().unwrap();
-        stdin.write_all(stdin_data).unwrap();
-    }
-    child.wait_with_output().unwrap()
+    crate::common::spawn_hook(
+        hook,
+        dir,
+        std::str::from_utf8(stdin_data).expect("hook stdin is UTF-8"),
+        &[],
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -838,21 +805,12 @@ fn setup_worktree_fixture(dir: &Path, branch: &str, with_state_file: bool) -> st
 }
 
 fn run_hook_in(cwd: &Path, hook: &str, stdin_data: &[u8]) -> Output {
-    let mut cmd = flow_rs();
-    cmd.arg("hook")
-        .arg(hook)
-        .env_remove("FLOW_SIMULATE_BRANCH")
-        .env_remove("FLOW_CI_RUNNING")
-        .current_dir(cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let mut child = cmd.spawn().unwrap();
-    {
-        let stdin = child.stdin.as_mut().unwrap();
-        stdin.write_all(stdin_data).unwrap();
-    }
-    child.wait_with_output().unwrap()
+    crate::common::spawn_hook(
+        hook,
+        cwd,
+        std::str::from_utf8(stdin_data).expect("hook stdin is UTF-8"),
+        &[],
+    )
 }
 
 #[test]

--- a/tests/hooks/post_compact.rs
+++ b/tests/hooks/post_compact.rs
@@ -13,12 +13,7 @@ use flow_rs::hooks::post_compact::capture_compact_data;
 use serde_json::{json, Value};
 
 fn run_post_compact(cwd: &Path, stdin: &[u8]) -> std::process::Output {
-    crate::common::spawn_hook(
-        "post-compact",
-        cwd,
-        std::str::from_utf8(stdin).expect("post-compact stdin is UTF-8"),
-        &[],
-    )
+    crate::common::spawn_hook("post-compact", cwd, stdin, &[])
 }
 
 fn init_git(dir: &Path, branch: &str) {

--- a/tests/hooks/post_compact.rs
+++ b/tests/hooks/post_compact.rs
@@ -6,31 +6,19 @@
 //! covered by the per-file gate.
 
 use std::fs;
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use flow_rs::hooks::post_compact::capture_compact_data;
 use serde_json::{json, Value};
 
-fn flow_rs_no_recursion() -> Command {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_flow-rs"));
-    cmd.env_remove("FLOW_CI_RUNNING")
-        .env_remove("FLOW_SIMULATE_BRANCH");
-    cmd
-}
-
 fn run_post_compact(cwd: &Path, stdin: &[u8]) -> std::process::Output {
-    let mut child = flow_rs_no_recursion()
-        .args(["hook", "post-compact"])
-        .current_dir(cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs hook post-compact");
-    child.stdin.as_mut().unwrap().write_all(stdin).unwrap();
-    child.wait_with_output().expect("wait")
+    crate::common::spawn_hook(
+        "post-compact",
+        cwd,
+        std::str::from_utf8(stdin).expect("post-compact stdin is UTF-8"),
+        &[],
+    )
 }
 
 fn init_git(dir: &Path, branch: &str) {

--- a/tests/hooks/stop_failure.rs
+++ b/tests/hooks/stop_failure.rs
@@ -13,12 +13,7 @@ use flow_rs::hooks::stop_failure::capture_failure_data;
 use serde_json::{json, Value};
 
 fn run_stop_failure(cwd: &Path, stdin: &[u8]) -> std::process::Output {
-    crate::common::spawn_hook(
-        "stop-failure",
-        cwd,
-        std::str::from_utf8(stdin).expect("stop-failure stdin is UTF-8"),
-        &[],
-    )
+    crate::common::spawn_hook("stop-failure", cwd, stdin, &[])
 }
 
 fn init_git(dir: &Path, branch: &str) {

--- a/tests/hooks/stop_failure.rs
+++ b/tests/hooks/stop_failure.rs
@@ -6,31 +6,19 @@
 //! per-file gate.
 
 use std::fs;
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use flow_rs::hooks::stop_failure::capture_failure_data;
 use serde_json::{json, Value};
 
-fn flow_rs_no_recursion() -> Command {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_flow-rs"));
-    cmd.env_remove("FLOW_CI_RUNNING")
-        .env_remove("FLOW_SIMULATE_BRANCH");
-    cmd
-}
-
 fn run_stop_failure(cwd: &Path, stdin: &[u8]) -> std::process::Output {
-    let mut child = flow_rs_no_recursion()
-        .args(["hook", "stop-failure"])
-        .current_dir(cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs hook stop-failure");
-    child.stdin.as_mut().unwrap().write_all(stdin).unwrap();
-    child.wait_with_output().expect("wait")
+    crate::common::spawn_hook(
+        "stop-failure",
+        cwd,
+        std::str::from_utf8(stdin).expect("stop-failure stdin is UTF-8"),
+        &[],
+    )
 }
 
 fn init_git(dir: &Path, branch: &str) {

--- a/tests/hooks/validate_ask_user.rs
+++ b/tests/hooks/validate_ask_user.rs
@@ -435,7 +435,7 @@ fn test_set_blocked_preserves_other_fields() {
 // --- run() subprocess test ---
 
 fn run_hook(cwd: &Path, stdin_input: &str) -> (i32, String, String) {
-    let output = crate::common::spawn_hook("validate-ask-user", cwd, stdin_input, &[]);
+    let output = crate::common::spawn_hook("validate-ask-user", cwd, stdin_input.as_bytes(), &[]);
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stdout).to_string(),
@@ -765,7 +765,7 @@ fn validate_ask_user_carve_out_subprocess_allows_during_in_progress_auto() {
     let output = crate::common::spawn_hook(
         "validate-ask-user",
         &root,
-        &payload.to_string(),
+        payload.to_string().as_bytes(),
         &[("HOME", root.to_str().unwrap())],
     );
     // Without the carve-out the in_progress + auto block would
@@ -820,7 +820,7 @@ fn validate_ask_user_block_persists_when_no_carve_out_during_in_progress_auto() 
     let output = crate::common::spawn_hook(
         "validate-ask-user",
         &root,
-        &payload.to_string(),
+        payload.to_string().as_bytes(),
         &[("HOME", root.to_str().unwrap())],
     );
     assert_eq!(output.status.code().unwrap_or(-1), 2);
@@ -883,7 +883,7 @@ fn run_validate_ask_user(root: &Path, payload: &Value) -> (i32, String, String) 
     let output = crate::common::spawn_hook(
         "validate-ask-user",
         root,
-        &payload.to_string(),
+        payload.to_string().as_bytes(),
         &[("HOME", root.to_str().unwrap())],
     );
     (

--- a/tests/hooks/validate_ask_user.rs
+++ b/tests/hooks/validate_ask_user.rs
@@ -1,9 +1,8 @@
 //! Integration tests for `src/hooks/validate_ask_user.rs`.
 
 use std::fs;
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use flow_rs::hooks::validate_ask_user::{set_blocked, user_only_skill_carve_out_applies, validate};
 use serde_json::{json, Value};
@@ -436,22 +435,7 @@ fn test_set_blocked_preserves_other_fields() {
 // --- run() subprocess test ---
 
 fn run_hook(cwd: &Path, stdin_input: &str) -> (i32, String, String) {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-ask-user"])
-        .current_dir(cwd)
-        .env_remove("FLOW_CI_RUNNING")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(stdin_input.as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().expect("wait");
+    let output = crate::common::spawn_hook("validate-ask-user", cwd, stdin_input, &[]);
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stdout).to_string(),
@@ -778,23 +762,12 @@ fn validate_ask_user_carve_out_subprocess_allows_during_in_progress_auto() {
     let transcript = carve_out_transcript_fixture(&root, jsonl);
     let payload = json!({"transcript_path": transcript.to_string_lossy()});
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-ask-user"])
-        .current_dir(&root)
-        .env_remove("FLOW_CI_RUNNING")
-        .env("HOME", &root)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(payload.to_string().as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().unwrap();
+    let output = crate::common::spawn_hook(
+        "validate-ask-user",
+        &root,
+        &payload.to_string(),
+        &[("HOME", root.to_str().unwrap())],
+    );
     // Without the carve-out the in_progress + auto block would
     // exit 2. Verify it exited 0 and stderr is empty.
     assert_eq!(
@@ -844,23 +817,12 @@ fn validate_ask_user_block_persists_when_no_carve_out_during_in_progress_auto() 
     let transcript = carve_out_transcript_fixture(&root, jsonl);
     let payload = json!({"transcript_path": transcript.to_string_lossy()});
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-ask-user"])
-        .current_dir(&root)
-        .env_remove("FLOW_CI_RUNNING")
-        .env("HOME", &root)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(payload.to_string().as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().unwrap();
+    let output = crate::common::spawn_hook(
+        "validate-ask-user",
+        &root,
+        &payload.to_string(),
+        &[("HOME", root.to_str().unwrap())],
+    );
     assert_eq!(output.status.code().unwrap_or(-1), 2);
     assert!(String::from_utf8_lossy(&output.stderr).contains("BLOCKED"));
 }
@@ -918,23 +880,12 @@ fn shared_config_subprocess_fixture(state: &Value) -> (tempfile::TempDir, std::p
 /// `<home>/.claude/projects/` prefix check resolves to the same root
 /// the transcript fixture is written under.
 fn run_validate_ask_user(root: &Path, payload: &Value) -> (i32, String, String) {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-ask-user"])
-        .current_dir(root)
-        .env_remove("FLOW_CI_RUNNING")
-        .env("HOME", root)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(payload.to_string().as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().unwrap();
+    let output = crate::common::spawn_hook(
+        "validate-ask-user",
+        root,
+        &payload.to_string(),
+        &[("HOME", root.to_str().unwrap())],
+    );
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stdout).to_string(),

--- a/tests/hooks/validate_claude_paths.rs
+++ b/tests/hooks/validate_claude_paths.rs
@@ -504,7 +504,8 @@ fn run_impl_main_cwd_with_flow_states_directly_resolves_root() {
 // --- run() subprocess tests ---
 
 fn run_hook_subprocess(cwd: &Path, stdin_input: &str) -> (i32, String, String) {
-    let output = crate::common::spawn_hook("validate-claude-paths", cwd, stdin_input, &[]);
+    let output =
+        crate::common::spawn_hook("validate-claude-paths", cwd, stdin_input.as_bytes(), &[]);
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stdout).to_string(),

--- a/tests/hooks/validate_claude_paths.rs
+++ b/tests/hooks/validate_claude_paths.rs
@@ -4,9 +4,7 @@
 //! src/protected_paths.rs) — only the hook-specific `validate` and
 //! `run_impl_main` surface is exercised here.
 
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 use flow_rs::hooks::validate_claude_paths::{run_impl_main, validate};
 
@@ -506,22 +504,7 @@ fn run_impl_main_cwd_with_flow_states_directly_resolves_root() {
 // --- run() subprocess tests ---
 
 fn run_hook_subprocess(cwd: &Path, stdin_input: &str) -> (i32, String, String) {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-claude-paths"])
-        .current_dir(cwd)
-        .env_remove("FLOW_CI_RUNNING")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(stdin_input.as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().expect("wait");
+    let output = crate::common::spawn_hook("validate-claude-paths", cwd, stdin_input, &[]);
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stdout).to_string(),

--- a/tests/hooks/validate_pretool.rs
+++ b/tests/hooks/validate_pretool.rs
@@ -1468,7 +1468,7 @@ fn run_hook_with_bg(bg: Value) -> (i32, String, String) {
     let output = crate::common::spawn_hook(
         "validate-pretool",
         isolation.path(),
-        &serde_json::to_string(&input).unwrap(),
+        serde_json::to_string(&input).unwrap().as_bytes(),
         &[("HOME", isolation.path().to_str().unwrap())],
     );
     (

--- a/tests/hooks/validate_pretool.rs
+++ b/tests/hooks/validate_pretool.rs
@@ -1459,29 +1459,18 @@ fn run_hook_with_bg(bg: Value) -> (i32, String, String) {
     // FLOW state is irrelevant to that decision but reaches
     // Layer 11 when bg is falsy and the bg check falls through.
     let isolation = tempfile::tempdir().expect("tempdir");
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-pretool"])
-        .current_dir(isolation.path())
-        .env("HOME", isolation.path())
-        .env_remove("FLOW_CI_RUNNING")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    {
-        let stdin = child.stdin.as_mut().unwrap();
-        let input = json!({
-            "tool_input": {
-                "command": "bin/flow ci",
-                "run_in_background": bg,
-            }
-        });
-        stdin
-            .write_all(serde_json::to_string(&input).unwrap().as_bytes())
-            .unwrap();
-    }
-    let output = child.wait_with_output().unwrap();
+    let input = json!({
+        "tool_input": {
+            "command": "bin/flow ci",
+            "run_in_background": bg,
+        }
+    });
+    let output = crate::common::spawn_hook(
+        "validate-pretool",
+        isolation.path(),
+        &serde_json::to_string(&input).unwrap(),
+        &[("HOME", isolation.path().to_str().unwrap())],
+    );
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stdout).to_string(),

--- a/tests/hooks/validate_skill.rs
+++ b/tests/hooks/validate_skill.rs
@@ -470,9 +470,15 @@ fn run_impl_main_blocks_user_only_skill_via_validate() {
 
 // --- subprocess integration tests ---
 
+/// Spawn `validate-skill` from an inert tempdir cwd (no git repo, no
+/// `.flow-states/` state file) so branch detection finds no active flow
+/// — the right fixture for the basic stdin/exit-code path tests. Tests
+/// that need the gate to see an active flow build their own worktree +
+/// state file and spawn through `spawn_skill_with_payload_cwd` instead.
 fn run_hook_subprocess(stdin_input: &str) -> (i32, String, String) {
     let dir = tempfile::tempdir().expect("tempdir");
-    let output = crate::common::spawn_hook("validate-skill", dir.path(), stdin_input, &[]);
+    let output =
+        crate::common::spawn_hook("validate-skill", dir.path(), stdin_input.as_bytes(), &[]);
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stdout).to_string(),
@@ -493,7 +499,7 @@ fn spawn_skill_with_payload_cwd(real_cwd: &Path, stdin_input: &str) -> (i32, Str
     let output = crate::common::spawn_hook(
         "validate-skill",
         real_cwd,
-        stdin_input,
+        stdin_input.as_bytes(),
         &[("HOME", real_cwd.to_str().unwrap())],
     );
     (
@@ -553,7 +559,7 @@ fn subprocess_validate_skill_blocks_user_only_invocation_without_user_command() 
     let output = crate::common::spawn_hook(
         "validate-skill",
         home,
-        &payload.to_string(),
+        payload.to_string().as_bytes(),
         &[("HOME", home.to_str().unwrap())],
     );
     assert_eq!(output.status.code().unwrap_or(-1), 2);
@@ -579,7 +585,7 @@ fn subprocess_validate_skill_allows_when_user_invocation_present() {
     let output = crate::common::spawn_hook(
         "validate-skill",
         home,
-        &payload.to_string(),
+        payload.to_string().as_bytes(),
         &[("HOME", home.to_str().unwrap())],
     );
     assert_eq!(output.status.code().unwrap_or(-1), 0);
@@ -600,7 +606,7 @@ fn subprocess_validate_skill_allows_when_skill_not_user_only() {
     let output = crate::common::spawn_hook(
         "validate-skill",
         home,
-        &payload.to_string(),
+        payload.to_string().as_bytes(),
         &[("HOME", home.to_str().unwrap())],
     );
     assert_eq!(output.status.code().unwrap_or(-1), 0);

--- a/tests/hooks/validate_skill.rs
+++ b/tests/hooks/validate_skill.rs
@@ -8,9 +8,7 @@
 //! `tests/common/mod.rs` via `crate::common` because
 //! `tests/hooks/main.rs` declares the path-aliased common module.
 
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 use flow_rs::hooks::transcript_walker::USER_ONLY_SKILLS;
 use flow_rs::hooks::validate_skill::{run_impl_main, validate};
@@ -473,21 +471,8 @@ fn run_impl_main_blocks_user_only_skill_via_validate() {
 // --- subprocess integration tests ---
 
 fn run_hook_subprocess(stdin_input: &str) -> (i32, String, String) {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-skill"])
-        .env_remove("FLOW_CI_RUNNING")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(stdin_input.as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().expect("wait");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = crate::common::spawn_hook("validate-skill", dir.path(), stdin_input, &[]);
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stdout).to_string(),
@@ -505,23 +490,12 @@ fn write_jsonl_fixture(home: &Path, jsonl: &str) -> std::path::PathBuf {
 /// `cwd`, not env::current_dir(). HOME is pinned to `real_cwd` per
 /// `.claude/rules/subprocess-test-hygiene.md`. Returns (exit, stderr).
 fn spawn_skill_with_payload_cwd(real_cwd: &Path, stdin_input: &str) -> (i32, String) {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-skill"])
-        .env_remove("FLOW_CI_RUNNING")
-        .env("HOME", real_cwd)
-        .current_dir(real_cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(stdin_input.as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().expect("wait");
+    let output = crate::common::spawn_hook(
+        "validate-skill",
+        real_cwd,
+        stdin_input,
+        &[("HOME", real_cwd.to_str().unwrap())],
+    );
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stderr).to_string(),
@@ -576,22 +550,12 @@ fn subprocess_validate_skill_blocks_user_only_invocation_without_user_command() 
     });
     // Override HOME for the subprocess so is_safe_transcript_path
     // accepts the tempdir-rooted fixture.
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-skill"])
-        .env_remove("FLOW_CI_RUNNING")
-        .env("HOME", home)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(payload.to_string().as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().expect("wait");
+    let output = crate::common::spawn_hook(
+        "validate-skill",
+        home,
+        &payload.to_string(),
+        &[("HOME", home.to_str().unwrap())],
+    );
     assert_eq!(output.status.code().unwrap_or(-1), 2);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("BLOCKED"), "stderr: {}", stderr);
@@ -612,22 +576,12 @@ fn subprocess_validate_skill_allows_when_user_invocation_present() {
         "tool_input": {"skill": "flow:flow-abort"},
         "transcript_path": path.to_string_lossy(),
     });
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-skill"])
-        .env_remove("FLOW_CI_RUNNING")
-        .env("HOME", home)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(payload.to_string().as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().expect("wait");
+    let output = crate::common::spawn_hook(
+        "validate-skill",
+        home,
+        &payload.to_string(),
+        &[("HOME", home.to_str().unwrap())],
+    );
     assert_eq!(output.status.code().unwrap_or(-1), 0);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.is_empty(), "stderr should be empty: {}", stderr);
@@ -643,22 +597,12 @@ fn subprocess_validate_skill_allows_when_skill_not_user_only() {
         "tool_input": {"skill": "flow:flow-status"},
         "transcript_path": path.to_string_lossy(),
     });
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-skill"])
-        .env_remove("FLOW_CI_RUNNING")
-        .env("HOME", home)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(payload.to_string().as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().expect("wait");
+    let output = crate::common::spawn_hook(
+        "validate-skill",
+        home,
+        &payload.to_string(),
+        &[("HOME", home.to_str().unwrap())],
+    );
     assert_eq!(output.status.code().unwrap_or(-1), 0);
 }
 

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -1023,7 +1023,12 @@ fn shared_config_blocks_when_worktree_unresolvable() {
 
 fn run_hook(stdin_input: &str) -> (i32, String, String) {
     let dir = tempfile::tempdir().expect("tempdir");
-    let output = crate::common::spawn_hook("validate-worktree-paths", dir.path(), stdin_input, &[]);
+    let output = crate::common::spawn_hook(
+        "validate-worktree-paths",
+        dir.path(),
+        stdin_input.as_bytes(),
+        &[],
+    );
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stdout).to_string(),
@@ -1133,7 +1138,12 @@ fn run_subprocess_exits_2_when_editing_shared_config_in_worktree() {
         cargo_toml.display()
     );
 
-    let output = crate::common::spawn_hook("validate-worktree-paths", &worktree, &payload, &[]);
+    let output = crate::common::spawn_hook(
+        "validate-worktree-paths",
+        &worktree,
+        payload.as_bytes(),
+        &[],
+    );
     assert_eq!(
         output.status.code(),
         Some(2),
@@ -1389,7 +1399,7 @@ fn spawn_hook_with_cwd(
     let output = crate::common::spawn_hook(
         "validate-worktree-paths",
         worktree_cwd,
-        &stdin_input,
+        stdin_input.as_bytes(),
         &[("HOME", home.to_str().unwrap())],
     );
     (
@@ -1434,7 +1444,7 @@ fn spawn_with_payload_cwd(
     let output = crate::common::spawn_hook(
         "validate-worktree-paths",
         real_cwd,
-        &stdin_input,
+        stdin_input.as_bytes(),
         &[("HOME", real_cwd.to_str().unwrap())],
     );
     (

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -1022,21 +1022,8 @@ fn shared_config_blocks_when_worktree_unresolvable() {
 // --- run() subprocess smoke test ---
 
 fn run_hook(stdin_input: &str) -> (i32, String, String) {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-worktree-paths"])
-        .env_remove("FLOW_CI_RUNNING")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(stdin_input.as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().expect("wait");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = crate::common::spawn_hook("validate-worktree-paths", dir.path(), stdin_input, &[]);
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stdout).to_string(),
@@ -1146,22 +1133,7 @@ fn run_subprocess_exits_2_when_editing_shared_config_in_worktree() {
         cargo_toml.display()
     );
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-worktree-paths"])
-        .env_remove("FLOW_CI_RUNNING")
-        .current_dir(&worktree)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(payload.as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().expect("wait");
+    let output = crate::common::spawn_hook("validate-worktree-paths", &worktree, &payload, &[]);
     assert_eq!(
         output.status.code(),
         Some(2),
@@ -1414,23 +1386,12 @@ fn spawn_hook_with_cwd(
         r#"{{"tool_name":"{}","tool_input":{{"{}":"{}"}}}}"#,
         tool_name, path_field, file_path
     );
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-worktree-paths"])
-        .env_remove("FLOW_CI_RUNNING")
-        .env("HOME", home)
-        .current_dir(worktree_cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(stdin_input.as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().expect("wait");
+    let output = crate::common::spawn_hook(
+        "validate-worktree-paths",
+        worktree_cwd,
+        &stdin_input,
+        &[("HOME", home.to_str().unwrap())],
+    );
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stdout).to_string(),
@@ -1470,23 +1431,12 @@ fn spawn_with_payload_cwd(
         r#"{{"cwd":"{}","tool_name":"Read","tool_input":{{"file_path":"{}"}}}}"#,
         payload_cwd, file_path
     );
-    let mut child = Command::new(env!("CARGO_BIN_EXE_flow-rs"))
-        .args(["hook", "validate-worktree-paths"])
-        .env_remove("FLOW_CI_RUNNING")
-        .env("HOME", real_cwd)
-        .current_dir(real_cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn flow-rs");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(stdin_input.as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().expect("wait");
+    let output = crate::common::spawn_hook(
+        "validate-worktree-paths",
+        real_cwd,
+        &stdin_input,
+        &[("HOME", real_cwd.to_str().unwrap())],
+    );
     (
         output.status.code().unwrap_or(-1),
         String::from_utf8_lossy(&output.stderr).to_string(),


### PR DESCRIPTION
## What

#1776.

Closes #1776

## Artifacts

| File | Path |
|------|------|
| Log | `.flow-states/consolidate-duplicated-hook-test/log` |
| State | `.flow-states/consolidate-duplicated-hook-test/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/6c08c08e-2452-477f-b0d4-80f28543756a.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 9h 13m |
| Review | 52m |
| Learn | 4m |
| Complete | <1m |
| **Total** | **10h 11m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 1.9M | $3.390 |
| Code | 112.6M | $72.464 |
| Review | 40.6M | $21.621 |
| Learn | 0 | $0.000 |
| Complete | 0 | $0.000 |
| **Total** | **155.1M** | **$97.476** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **Pre-mortem: validate-ask-user smoke tests assert only stdout.contains('defer'), which cannot distinguish the Allow arm from the AllowWithMark arm of validate_ask_user::run()**
  - Dismissed — Pre-existing test-assertion weakness NOT introduced by this PR; the migration actually repaired a host-environment leak in these tests. The validate-ask-user decision logic (Allow vs AllowWithMark vs Block) is covered to 100% by other named tests. Assertion-fidelity strengthening is a separate concern from this spawn-consolidation refactor.
- ✗ **Pre-mortem/adversarial: spawn_hook's universal env_remove('HOME') is not behavior-preserving for HOME-dependent hooks and gives callers no way to inherit the parent's HOME**
  - Dismissed — Intentional, correct design per .claude/rules/subprocess-test-hygiene.md 'Working Directory Isolation': subprocess tests must NEVER inherit the runner's real HOME; callers needing a specific HOME pass it explicitly via the env slice, which every migrated HOME-dependent caller does. The adversarial agent confirmed no existing migrated test's outcome silently changed. Inheriting the real HOME is exactly the hostile-config trap the hygiene rule forbids; the universal removal is the design working as intended, not a bug.
- ✓ **spawn_hook stdin parameter typed as &str, forcing byte-callers (post_compact, stop_failure, dispatcher, capture_session) through a bytes-&gt;str-&gt;bytes round-trip and making non-UTF-8 robustness payloads inexpressible**
  - Fixed — Changed spawn_hook signature to stdin: &[u8] and .write_all(stdin) directly. Byte-callers drop their from_utf8 wrappers; str-callers pass .as_bytes(). Removes the pointless round-trip AND preserves the ability to feed non-UTF-8 stdin to hook robustness tests. Tenant 2 (simplicity) + Tenant 5 (test coverage).
- ✓ **spawn_hook doc comment described env handling ambiguously ('empty slice') and did not state that HOME is removed unconditionally**
  - Fixed — Rewrote the spawn_hook doc comment to state explicitly that FLOW_CI_RUNNING, FLOW_SIMULATE_BRANCH, and HOME are removed unconditionally (no way to inherit the real HOME, deliberate per subprocess-test-hygiene.md Working Directory Isolation), that the env slice is applied last (last-write-wins), and that stdin is raw bytes. Tenant 6 (documentation).
- ✓ **dispatcher.rs run_hook and run_hook_no_simulate doc comments did not mention that the shared spawn_hook removes HOME**
  - Fixed — Updated the dispatcher helper doc comments to note that routing through spawn_hook removes HOME (and FLOW_SIMULATE_BRANCH, re-set via the env slice for run_hook). Tenant 6 (documentation).
- ✓ **dispatcher.rs run_hook_in had no doc comment after migration to spawn_hook**
  - Fixed — Added a full doc comment to run_hook_in describing its parameters, the empty env slice, and the spawn_hook delegation. Tenant 3 (maintainability).
- ✓ **validate_skill.rs run_hook_subprocess used a tempdir cwd without documenting why (Working Directory Isolation requirement)**
  - Fixed — Added a doc note on run_hook_subprocess explaining the tempdir cwd satisfies subprocess-test-hygiene.md Working Directory Isolation (the spawned validate-skill must resolve a fixture branch, not the real worktree's in-flight state). Tenant 3 (maintainability).
- ✓ **subprocess-test-hygiene.md Canonical Helper Pattern said every spawn test should define a per-file flow_rs_no_recursion and go through it exclusively, which the PR made inaccurate for the ten hook-test files now routing through shared spawn_hook**
  - Fixed — Updated the rule via write-rule: scoped the per-file flow_rs_no_recursion pattern to non-hook subprocess tests, added a 'Hook Subprocess Tests Route Through the Shared Helper' subsection documenting crate::common::spawn_hook's recursion-guard + worktree-isolation contract, and updated the hook-row of the neutralizer table. PR-caused doc drift fixed in-PR per docs-with-behavior. Tenant 6 (documentation).

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/consolidate-duplicated-hook-test.json</summary>

````json
{
  "schema_version": 1,
  "branch": "consolidate-duplicated-hook-test",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1781,
  "pr_url": "https://github.com/benkruger/flow/pull/1781",
  "started_at": "2026-05-31T08:55:43-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": null,
    "dag": null,
    "log": ".flow-states/consolidate-duplicated-hook-test/log",
    "state": ".flow-states/consolidate-duplicated-hook-test/state.json"
  },
  "session_tty": "/dev/ttys011",
  "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/6c08c08e-2452-477f-b0d4-80f28543756a.jsonl",
  "notes": [],
  "prompt": "#1776",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-05-31T08:55:43-07:00",
      "completed_at": "2026-05-31T08:56:24-07:00",
      "session_started_at": null,
      "cumulative_seconds": 41,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-31T08:55:43-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 71,
        "seven_day_pct": 61,
        "session_input_tokens": 4916,
        "session_output_tokens": 2980,
        "session_cache_creation_tokens": 260935,
        "session_cache_read_tokens": 2952564,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4916,
            "output": 2980,
            "cache_create": 260935,
            "cache_read": 2952564
          }
        },
        "turn_count": 12,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 277575,
        "context_window_pct": 138.7875
      },
      "window_at_complete": {
        "captured_at": "2026-05-31T08:56:24-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 72,
        "seven_day_pct": 61,
        "session_input_tokens": 235619,
        "session_output_tokens": 4461,
        "session_cache_creation_tokens": 500822,
        "session_cache_read_tokens": 4353709,
        "by_model": {
          "claude-opus-4-8": {
            "input": 235619,
            "output": 4461,
            "cache_create": 500822,
            "cache_read": 4353709
          }
        },
        "turn_count": 17,
        "tool_call_count": 4,
        "context_at_last_turn_tokens": 517333,
        "context_window_pct": 258.6665
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-05-31T08:56:32-07:00",
      "completed_at": "2026-05-31T18:10:12-07:00",
      "session_started_at": null,
      "cumulative_seconds": 33220,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-31T08:56:32-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 72,
        "seven_day_pct": 61,
        "session_input_tokens": 235752,
        "session_output_tokens": 4799,
        "session_cache_creation_tokens": 503854,
        "session_cache_read_tokens": 5390531,
        "by_model": {
          "claude-opus-4-8": {
            "input": 235752,
            "output": 4799,
            "cache_create": 503854,
            "cache_read": 5390531
          }
        },
        "turn_count": 19,
        "tool_call_count": 5,
        "context_at_last_turn_tokens": 520365,
        "context_window_pct": 260.1825
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-05-31T09:05:06-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 76,
          "seven_day_pct": 61,
          "session_input_tokens": 236481,
          "session_output_tokens": 34161,
          "session_cache_creation_tokens": 569609,
          "session_cache_read_tokens": 29154733,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236481,
              "output": 34161,
              "cache_create": 569609,
              "cache_read": 29154733
            }
          },
          "turn_count": 61,
          "tool_call_count": 19,
          "context_at_last_turn_tokens": 586120,
          "context_window_pct": 293.06
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-05-31T18:02:52-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 69,
          "seven_day_pct": 80,
          "session_input_tokens": 242650,
          "session_output_tokens": 133289,
          "session_cache_creation_tokens": 2598336,
          "session_cache_read_tokens": 98100993,
          "by_model": {
            "claude-opus-4-8": {
              "input": 242650,
              "output": 133289,
              "cache_create": 2598336,
              "cache_read": 98100993
            }
          },
          "turn_count": 166,
          "tool_call_count": 50,
          "context_at_last_turn_tokens": 798555,
          "context_window_pct": 399.2775
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-05-31T18:02:52-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 69,
          "seven_day_pct": 80,
          "session_input_tokens": 242650,
          "session_output_tokens": 133289,
          "session_cache_creation_tokens": 2598336,
          "session_cache_read_tokens": 98100993,
          "by_model": {
            "claude-opus-4-8": {
              "input": 242650,
              "output": 133289,
              "cache_create": 2598336,
              "cache_read": 98100993
            }
          },
          "turn_count": 166,
          "tool_call_count": 50,
          "context_at_last_turn_tokens": 798555,
          "context_window_pct": 399.2775
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-05-31T18:02:52-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 69,
          "seven_day_pct": 80,
          "session_input_tokens": 242650,
          "session_output_tokens": 133289,
          "session_cache_creation_tokens": 2598336,
          "session_cache_read_tokens": 98100993,
          "by_model": {
            "claude-opus-4-8": {
              "input": 242650,
              "output": 133289,
              "cache_create": 2598336,
              "cache_read": 98100993
            }
          },
          "turn_count": 166,
          "tool_call_count": 50,
          "context_at_last_turn_tokens": 798555,
          "context_window_pct": 399.2775
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-05-31T18:09:23-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 71,
          "seven_day_pct": 80,
          "session_input_tokens": 243079,
          "session_output_tokens": 156874,
          "session_cache_creation_tokens": 2660257,
          "session_cache_read_tokens": 115687347,
          "by_model": {
            "claude-opus-4-8": {
              "input": 243079,
              "output": 156874,
              "cache_create": 2660257,
              "cache_read": 115687347
            }
          },
          "turn_count": 187,
          "tool_call_count": 61,
          "context_at_last_turn_tokens": 860476,
          "context_window_pct": 430.238
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-31T18:10:12-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 72,
        "seven_day_pct": 80,
        "session_input_tokens": 243079,
        "session_output_tokens": 156874,
        "session_cache_creation_tokens": 2660257,
        "session_cache_read_tokens": 115687347,
        "by_model": {
          "claude-opus-4-8": {
            "input": 243079,
            "output": 156874,
            "cache_create": 2660257,
            "cache_read": 115687347
          }
        },
        "turn_count": 187,
        "tool_call_count": 61,
        "context_at_last_turn_tokens": 860476,
        "context_window_pct": 430.238
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-05-31T18:10:29-07:00",
      "completed_at": "2026-05-31T19:03:24-07:00",
      "session_started_at": null,
      "cumulative_seconds": 3175,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-31T18:10:29-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 72,
        "seven_day_pct": 80,
        "session_input_tokens": 243079,
        "session_output_tokens": 156874,
        "session_cache_creation_tokens": 2660257,
        "session_cache_read_tokens": 115687347,
        "by_model": {
          "claude-opus-4-8": {
            "input": 243079,
            "output": 156874,
            "cache_create": 2660257,
            "cache_read": 115687347
          }
        },
        "turn_count": 187,
        "tool_call_count": 61,
        "context_at_last_turn_tokens": 860476,
        "context_window_pct": 430.238
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-05-31T18:11:22-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 72,
          "seven_day_pct": 80,
          "session_input_tokens": 243079,
          "session_output_tokens": 156874,
          "session_cache_creation_tokens": 2660257,
          "session_cache_read_tokens": 115687347,
          "by_model": {
            "claude-opus-4-8": {
              "input": 243079,
              "output": 156874,
              "cache_create": 2660257,
              "cache_read": 115687347
            }
          },
          "turn_count": 187,
          "tool_call_count": 61,
          "context_at_last_turn_tokens": 860476,
          "context_window_pct": 430.238
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-05-31T18:26:12-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 81,
          "seven_day_pct": 82,
          "session_input_tokens": 247881,
          "session_output_tokens": 174483,
          "session_cache_creation_tokens": 2773085,
          "session_cache_read_tokens": 150202248,
          "by_model": {
            "claude-opus-4-8": {
              "input": 247881,
              "output": 174483,
              "cache_create": 2773085,
              "cache_read": 150202248
            }
          },
          "turn_count": 225,
          "tool_call_count": 74,
          "context_at_last_turn_tokens": 973304,
          "context_window_pct": 486.652
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-05-31T18:27:45-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 82,
          "seven_day_pct": 82,
          "session_input_tokens": 247885,
          "session_output_tokens": 176209,
          "session_cache_creation_tokens": 2782418,
          "session_cache_read_tokens": 152156651,
          "by_model": {
            "claude-opus-4-8": {
              "input": 247885,
              "output": 176209,
              "cache_create": 2782418,
              "cache_read": 152156651
            }
          },
          "turn_count": 227,
          "tool_call_count": 74,
          "context_at_last_turn_tokens": 982637,
          "context_window_pct": 491.3185
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-05-31T19:02:57-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 95,
          "seven_day_pct": 85,
          "session_input_tokens": 248022,
          "session_output_tokens": 179758,
          "session_cache_creation_tokens": 2790950,
          "session_cache_read_tokens": 156102749,
          "by_model": {
            "claude-opus-4-8": {
              "input": 248022,
              "output": 179758,
              "cache_create": 2790950,
              "cache_read": 156102749
            }
          },
          "turn_count": 231,
          "tool_call_count": 75,
          "context_at_last_turn_tokens": 991169,
          "context_window_pct": 495.5845
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-05-31T18:25:46-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-05-31T18:25:51-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-05-31T18:25:59-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-05-31T18:26:06-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-31T19:03:24-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 95,
        "seven_day_pct": 85,
        "session_input_tokens": 248022,
        "session_output_tokens": 179758,
        "session_cache_creation_tokens": 2790950,
        "session_cache_read_tokens": 156102749,
        "by_model": {
          "claude-opus-4-8": {
            "input": 248022,
            "output": 179758,
            "cache_create": 2790950,
            "cache_read": 156102749
          }
        },
        "turn_count": 231,
        "tool_call_count": 75,
        "context_at_last_turn_tokens": 991169,
        "context_window_pct": 495.5845
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-05-31T19:03:36-07:00",
      "completed_at": "2026-05-31T19:07:42-07:00",
      "session_started_at": null,
      "cumulative_seconds": 246,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-31T19:03:36-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 95,
        "seven_day_pct": 85,
        "session_input_tokens": 248022,
        "session_output_tokens": 179758,
        "session_cache_creation_tokens": 2790950,
        "session_cache_read_tokens": 156102749,
        "by_model": {
          "claude-opus-4-8": {
            "input": 248022,
            "output": 179758,
            "cache_create": 2790950,
            "cache_read": 156102749
          }
        },
        "turn_count": 231,
        "tool_call_count": 75,
        "context_at_last_turn_tokens": 991169,
        "context_window_pct": 495.5845
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-05-31T19:06:29-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-05-31T19:06:31-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 98,
          "seven_day_pct": 86,
          "session_input_tokens": 248022,
          "session_output_tokens": 179758,
          "session_cache_creation_tokens": 2790950,
          "session_cache_read_tokens": 156102749,
          "by_model": {
            "claude-opus-4-8": {
              "input": 248022,
              "output": 179758,
              "cache_create": 2790950,
              "cache_read": 156102749
            }
          },
          "turn_count": 231,
          "tool_call_count": 75,
          "context_at_last_turn_tokens": 991169,
          "context_window_pct": 495.5845
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-05-31T19:06:39-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 99,
          "seven_day_pct": 86,
          "session_input_tokens": 248022,
          "session_output_tokens": 179758,
          "session_cache_creation_tokens": 2790950,
          "session_cache_read_tokens": 156102749,
          "by_model": {
            "claude-opus-4-8": {
              "input": 248022,
              "output": 179758,
              "cache_create": 2790950,
              "cache_read": 156102749
            }
          },
          "turn_count": 231,
          "tool_call_count": 75,
          "context_at_last_turn_tokens": 991169,
          "context_window_pct": 495.5845
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-05-31T19:06:49-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 99,
          "seven_day_pct": 86,
          "session_input_tokens": 248022,
          "session_output_tokens": 179758,
          "session_cache_creation_tokens": 2790950,
          "session_cache_read_tokens": 156102749,
          "by_model": {
            "claude-opus-4-8": {
              "input": 248022,
              "output": 179758,
              "cache_create": 2790950,
              "cache_read": 156102749
            }
          },
          "turn_count": 231,
          "tool_call_count": 75,
          "context_at_last_turn_tokens": 991169,
          "context_window_pct": 495.5845
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-05-31T19:07:02-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 99,
          "seven_day_pct": 86,
          "session_input_tokens": 248022,
          "session_output_tokens": 179758,
          "session_cache_creation_tokens": 2790950,
          "session_cache_read_tokens": 156102749,
          "by_model": {
            "claude-opus-4-8": {
              "input": 248022,
              "output": 179758,
              "cache_create": 2790950,
              "cache_read": 156102749
            }
          },
          "turn_count": 231,
          "tool_call_count": 75,
          "context_at_last_turn_tokens": 991169,
          "context_window_pct": 495.5845
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-05-31T19:07:04-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 99,
          "seven_day_pct": 86,
          "session_input_tokens": 248022,
          "session_output_tokens": 179758,
          "session_cache_creation_tokens": 2790950,
          "session_cache_read_tokens": 156102749,
          "by_model": {
            "claude-opus-4-8": {
              "input": 248022,
              "output": 179758,
              "cache_create": 2790950,
              "cache_read": 156102749
            }
          },
          "turn_count": 231,
          "tool_call_count": 75,
          "context_at_last_turn_tokens": 991169,
          "context_window_pct": 495.5845
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-05-31T19:07:31-07:00",
          "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 99,
          "seven_day_pct": 86,
          "session_input_tokens": 248022,
          "session_output_tokens": 179758,
          "session_cache_creation_tokens": 2790950,
          "session_cache_read_tokens": 156102749,
          "by_model": {
            "claude-opus-4-8": {
              "input": 248022,
              "output": 179758,
              "cache_create": 2790950,
              "cache_read": 156102749
            }
          },
          "turn_count": 231,
          "tool_call_count": 75,
          "context_at_last_turn_tokens": 991169,
          "context_window_pct": 495.5845
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-05-31T19:07:42-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 99,
        "seven_day_pct": 86,
        "session_input_tokens": 248022,
        "session_output_tokens": 179758,
        "session_cache_creation_tokens": 2790950,
        "session_cache_read_tokens": 156102749,
        "by_model": {
          "claude-opus-4-8": {
            "input": 248022,
            "output": 179758,
            "cache_create": 2790950,
            "cache_read": 156102749
          }
        },
        "turn_count": 231,
        "tool_call_count": 75,
        "context_at_last_turn_tokens": 991169,
        "context_window_pct": 495.5845
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-05-31T19:08:14-07:00",
      "completed_at": "2026-05-31T19:08:43-07:00",
      "session_started_at": null,
      "cumulative_seconds": 29,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-05-31T19:08:14-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 99,
        "seven_day_pct": 86,
        "session_input_tokens": 248022,
        "session_output_tokens": 179758,
        "session_cache_creation_tokens": 2790950,
        "session_cache_read_tokens": 156102749,
        "by_model": {
          "claude-opus-4-8": {
            "input": 248022,
            "output": 179758,
            "cache_create": 2790950,
            "cache_read": 156102749
          }
        },
        "turn_count": 231,
        "tool_call_count": 75,
        "context_at_last_turn_tokens": 991169,
        "context_window_pct": 495.5845
      },
      "window_at_complete": {
        "captured_at": "2026-05-31T19:08:43-07:00",
        "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 99,
        "seven_day_pct": 86,
        "session_input_tokens": 248022,
        "session_output_tokens": 179758,
        "session_cache_creation_tokens": 2790950,
        "session_cache_read_tokens": 156102749,
        "by_model": {
          "claude-opus-4-8": {
            "input": 248022,
            "output": 179758,
            "cache_create": 2790950,
            "cache_read": 156102749
          }
        },
        "turn_count": 231,
        "tool_call_count": 75,
        "context_at_last_turn_tokens": 991169,
        "context_window_pct": 495.5845
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-05-31T08:56:32-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-05-31T18:10:29-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-05-31T19:03:36-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-05-31T19:08:14-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-05-31T08:55:43-07:00",
    "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
    "model": "claude-opus-4-8",
    "five_hour_pct": 71,
    "seven_day_pct": 61,
    "session_input_tokens": 4916,
    "session_output_tokens": 2980,
    "session_cache_creation_tokens": 260935,
    "session_cache_read_tokens": 2952564,
    "by_model": {
      "claude-opus-4-8": {
        "input": 4916,
        "output": 2980,
        "cache_create": 260935,
        "cache_read": 2952564
      }
    },
    "turn_count": 12,
    "tool_call_count": 2,
    "context_at_last_turn_tokens": 277575,
    "context_window_pct": 138.7875
  },
  "code_tasks_total": 5,
  "code_task": 5,
  "diff_stats": {
    "files_changed": 10,
    "insertions": 220,
    "deletions": 412,
    "captured_at": "2026-05-31T18:10:12-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "findings": [
    {
      "finding": "Pre-mortem: validate-ask-user smoke tests assert only stdout.contains('defer'), which cannot distinguish the Allow arm from the AllowWithMark arm of validate_ask_user::run()",
      "reason": "Pre-existing test-assertion weakness NOT introduced by this PR; the migration actually repaired a host-environment leak in these tests. The validate-ask-user decision logic (Allow vs AllowWithMark vs Block) is covered to 100% by other named tests. Assertion-fidelity strengthening is a separate concern from this spawn-consolidation refactor.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-31T18:27:17-07:00"
    },
    {
      "finding": "Pre-mortem/adversarial: spawn_hook's universal env_remove('HOME') is not behavior-preserving for HOME-dependent hooks and gives callers no way to inherit the parent's HOME",
      "reason": "Intentional, correct design per .claude/rules/subprocess-test-hygiene.md 'Working Directory Isolation': subprocess tests must NEVER inherit the runner's real HOME; callers needing a specific HOME pass it explicitly via the env slice, which every migrated HOME-dependent caller does. The adversarial agent confirmed no existing migrated test's outcome silently changed. Inheriting the real HOME is exactly the hostile-config trap the hygiene rule forbids; the universal removal is the design working as intended, not a bug.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-31T18:27:28-07:00"
    },
    {
      "finding": "spawn_hook stdin parameter typed as &str, forcing byte-callers (post_compact, stop_failure, dispatcher, capture_session) through a bytes->str->bytes round-trip and making non-UTF-8 robustness payloads inexpressible",
      "reason": "Changed spawn_hook signature to stdin: &[u8] and .write_all(stdin) directly. Byte-callers drop their from_utf8 wrappers; str-callers pass .as_bytes(). Removes the pointless round-trip AND preserves the ability to feed non-UTF-8 stdin to hook robustness tests. Tenant 2 (simplicity) + Tenant 5 (test coverage).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-31T18:42:08-07:00"
    },
    {
      "finding": "spawn_hook doc comment described env handling ambiguously ('empty slice') and did not state that HOME is removed unconditionally",
      "reason": "Rewrote the spawn_hook doc comment to state explicitly that FLOW_CI_RUNNING, FLOW_SIMULATE_BRANCH, and HOME are removed unconditionally (no way to inherit the real HOME, deliberate per subprocess-test-hygiene.md Working Directory Isolation), that the env slice is applied last (last-write-wins), and that stdin is raw bytes. Tenant 6 (documentation).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-31T18:42:11-07:00"
    },
    {
      "finding": "dispatcher.rs run_hook and run_hook_no_simulate doc comments did not mention that the shared spawn_hook removes HOME",
      "reason": "Updated the dispatcher helper doc comments to note that routing through spawn_hook removes HOME (and FLOW_SIMULATE_BRANCH, re-set via the env slice for run_hook). Tenant 6 (documentation).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-31T18:42:13-07:00"
    },
    {
      "finding": "dispatcher.rs run_hook_in had no doc comment after migration to spawn_hook",
      "reason": "Added a full doc comment to run_hook_in describing its parameters, the empty env slice, and the spawn_hook delegation. Tenant 3 (maintainability).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-31T18:42:15-07:00"
    },
    {
      "finding": "validate_skill.rs run_hook_subprocess used a tempdir cwd without documenting why (Working Directory Isolation requirement)",
      "reason": "Added a doc note on run_hook_subprocess explaining the tempdir cwd satisfies subprocess-test-hygiene.md Working Directory Isolation (the spawned validate-skill must resolve a fixture branch, not the real worktree's in-flight state). Tenant 3 (maintainability).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-31T18:42:17-07:00"
    },
    {
      "finding": "subprocess-test-hygiene.md Canonical Helper Pattern said every spawn test should define a per-file flow_rs_no_recursion and go through it exclusively, which the PR made inaccurate for the ten hook-test files now routing through shared spawn_hook",
      "reason": "Updated the rule via write-rule: scoped the per-file flow_rs_no_recursion pattern to non-hook subprocess tests, added a 'Hook Subprocess Tests Route Through the Shared Helper' subsection documenting crate::common::spawn_hook's recursion-guard + worktree-isolation contract, and updated the hook-row of the neutralizer table. PR-caused doc drift fixed in-PR per docs-with-behavior. Tenant 6 (documentation).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-05-31T18:42:20-07:00"
    }
  ],
  "compact_summary": "<analysis>\nLet me chronologically analyze the conversation, which is a FLOW plugin lifecycle execution on issue #1776.\n\n**Initial invocation:** User typed `/flow:flow-start #1776`. This is the FLOW plugin's Phase 1 (Start) skill. The task is consolidating duplicated hook-test boilerplate.\n\n**Phase 1 (Start):** I ran start-init (feature name \"1776\"), got canonical branch `consolidate-duplicated-hook-test`, ran start-gate (clean), start-workspace (created worktree + PR #1781), plan-from-issue (extracted 5-task plan, tasks_total=5), phase-finalize (continue_action=invoke). Auto-advanced to Code.\n\n**The plan (5 tasks):** Consolidate duplicated `Command::new(env!(\"CARGO_BIN_EXE_flow-rs\"))` spawn boilerplate across ten `tests/hooks/*.rs` files into a shared `spawn_hook` helper in `tests/common/mod.rs`. Tasks: (1) add spawn_hook + migrate post_compact proof caller; (2) migrate exit-tuple callers; (3) migrate full-Output callers; (4) migrate env-variant callers; (5) validate.\n\n**Phase 2 (Code):** \n- Task 1: Added `spawn_hook(hook_name: &str, cwd: &Path, stdin: &str, env: &[(&str, &str)]) -> Output` to tests/common/mod.rs. Key design DEVIATION I made and logged: the plan said env-variant callers \"keep a thin wrapper that performs the extra env_remove and delegates the rest to spawn_hook\" — structurally impossible because spawn_hook owns spawn+wait. I redesigned: spawn_hook universally env_removes FLOW_CI_RUNNING + FLOW_SIMULATE_BRANCH + HOME, then applies the env slice (last-write-wins lets dispatcher/capture_session re-set). Verified safe: dispatcher.rs:84 sets FLOW_SIMULATE_BRANCH (re-settable via slice); all HOME usages in tests/hooks are explicit .env(\"HOME\",...) sets. Migrated post_compact's run_post_compact. Committed (SHA 50c2805, full CI 100/100/100).\n- Tasks 2-4 (batched into one commit per optimization-driven batching): Migrated 8 files. Classified sites: MIGRATE (route through spawn_hook): stop_failure, validate_skill (5 sites), validate_claude_paths, validate_worktree_paths (4 sites: run_hook, inline shared-config, spawn_hook_with_cwd, spawn_with_payload_cwd), validate_pretool (run_hook_with_bg), validate_ask_user (4 sites), dispatcher (3 sites: run_hook, run_hook_no_simulate, run_hook_in — I initially missed run_hook_in causing a compile error, then fixed it), capture_session (2 sites: run_capture_session, inline relative-home). KEEP as documented exceptions: pre_exec(setsid)/pre_exec(rmdir) spawns (validate_worktree_paths:1079, validate_pretool:3038, stop_continue:548), non-hook subcommands (stop_continue:1398, capture_session:17 flow_rs_no_recursion which serves the BrokenPipe caps test + current-session-id), validate_pretool's Option-cwd/Option-home run_hook_with_input_and_home. Net −248 lines. Committed (SHA 5f04452, full CI 100/100/100).\n- Task 5: validation (measurement-only, no file changes). Grep confirmed 6 remaining Command::new sites, all exceptions. Empty commit.\n\n**Mid-flow interruptions:** During Code phase, the user typed `/flow:flow-continue` THREE times. The flow was NOT actually halted (no `_halt_pending` in state). clear-halt returned \"unauthorized\" twice then \"ok\" the third time. I read the state file and confirmed no halt; resumed work.\n\n**Phantom-miss diagnosis:** validate_pretool dropped to 99.06% in the per-file gate. I diagnosed via `bin/test --funcs hooks/validate_pretool.rs` — initially saw two crate hashes (phantom-miss symptom), ran `bin/flow ci --clean`, but it persisted. Then I correctly diagnosed it as the documented \"covered elsewhere\" cross-module blind spot: closure `run_impl_main::{closure#1}` (subagent_type `|v| v.as_str()`) is covered by `dispatcher::validate_pretool_agent_prompt_outside_worktree_skips_scan_exits_zero` (an Agent-branch test the per-file gate doesn't run). The full CI confirmed 100/100/100.\n\n**Recurring annoyances:** resume-anchor kept returning a stale foreign `counter-learn` worktree path (overwritten by the CI test suite). I correctly ignored it (verified cwd via pwd) per the \"error/no_marker\" treatment.\n\n**Phase 2 → Phase 3 (Review):** phase-finalize, continue_action=invoke, advanced to Review.\n\n**Phase 3 (Review):**\n- Step 1 (Gather): base-branch=main, capture-diff (full + substantive diff files), changed files all test files → doc_paths = just CLAUDE.md, adversarial path = tests/test_adversarial_flow.rs, tombstone-audit stale=[].\n- Step 2 (Launch agents): Launched 4 agents. Reviewer + adversarial were BLOCKED by agent-prompt scanner (out-of-worktree path tokens: `/pre_exec` from \"pre_exec(setsid)/pre_exec(rmdir)\", and absolute `/Users/ben/code/flow/bin/flow`). Pre-mortem + documentation returned. I re-launched reviewer + adversarial with corrected prompts (removed slash-tokens, used worktree bin/flow path). All 4 returned. Recorded all 4 via record-agent-return.\n  - Reviewer: NO findings.\n  - Pre-mortem: 3 findings (F1 validate-ask-user weak assertions, F2 HOME removal footgun, F3 non-UTF-8 narrowing via &str signature).\n  - Adversarial: 1 finding (HOME removal not behavior-preserving — latent, no test broke; non-UTF-8 + post-compact probes passed). Wrote probe to tests/test_adversarial_flow.rs.\n  - Documentation: 5 findings (F1 spawn_hook doc \"empty slice\" phrasing, F2 subprocess-test-hygiene.md Canonical Helper Pattern superseded, F3 dispatcher doc comments omit HOME, F4 run_hook_in no doc comment, F5 validate_skill run_hook_subprocess tempdir rationale undocumented).\n- Step 3 (Triage): Supersession check — none. REAL findings (6 + probe deletion): (1) spawn_hook stdin &str→&[u8] [T2/T5], (2) spawn_hook doc clarity [T6], (3) dispatcher run_hook/run_hook_no_simulate doc HOME mention [T6], (4) run_hook_in doc comment [T3], (5) validate_skill run_hook_subprocess tempdir note [T3], (6) subprocess-test-hygiene.md spawn_hook note [T6], (7) delete adversarial probe. FALSE POSITIVES (2, recorded via add-finding --outcome dismissed): pre-mortem F1 (weak assertions, pre-existing) and pre-mortem F2/adversarial F1 (HOME footgun, intentional hygiene design).\n- Step 4 (Fix): Currently executing. I've made these edits so far:\n  - spawn_hook: changed `stdin: &str` → `stdin: &[u8]`, `.write_all(stdin.as_bytes())` → `.write_all(stdin)`, rewrote doc comment (HOME clarity + new param doc).\n  - post_compact run_post_compact: removed from_utf8 wrapper.\n  - stop_failure run_stop_failure: removed from_utf8 wrapper.\n  - dispatcher run_hook: removed from_utf8, added HOME doc bullet.\n  - dispatcher run_hook_no_simulate: removed from_utf8, added HOME doc mention.\n  - dispatcher run_hook_in: removed from_utf8, added full doc comment.\n  - capture_session run_capture_session: removed from_utf8 (now byte-caller).\n  - capture_session inline relative-home: `r#\"...\"#` → `br#\"...\"#`.\n  - validate_claude_paths run_hook_subprocess: stdin_input → stdin_input.as_bytes().\n  - validate_ask_user run_hook: stdin_input → stdin_input.as_bytes().\n  - validate_ask_user 3 callsites: `&payload.to_string()` → `payload.to_string().as_bytes()` (replace_all).\n  - validate_skill run_hook_subprocess: stdin_input → .as_bytes() + added F5 tempdir doc note.\n  - validate_skill spawn_skill_with_payload_cwd: stdin_input → .as_bytes().\n  - validate_skill 3 inline: `&payload.to_string()` → `payload.to_string().as_bytes()` (replace_all).\n\nThe very last action: I ran `grep -n \"crate::common::spawn_hook\" tests/hooks/validate_worktree_paths.rs` and got 4 matches at lines 1026, 1136, 1389, 1434. I was about to edit these 4 validate_worktree_paths callsites to add .as_bytes().\n\nREMAINING Step 4 work:\n- validate_worktree_paths: run_hook (line 1026: `stdin_input` → `.as_bytes()`), inline shared-config (line 1136: `&payload` → `payload.as_bytes()`), spawn_hook_with_cwd (line 1389 region: `&stdin_input` → `stdin_input.as_bytes()`), spawn_with_payload_cwd (line 1434 region: `&stdin_input` → `stdin_input.as_bytes()`).\n- validate_pretool run_hook_with_bg: `&serde_json::to_string(&input).unwrap()` → `serde_json::to_string(&input).unwrap().as_bytes()`.\n- subprocess-test-hygiene.md: add spawn_hook note (via bin/flow write-rule, since .claude/rules edits during a flow route through write-rule).\n- Delete adversarial probe tests/test_adversarial_flow.rs (per adversarial-probe-lifecycle, via fs/Write — actually the probe is untracked/excluded; it currently FAILS so must be reconciled. Note: per ephemeral-file-cleanup, rm is blocked; need to empty it or it's disposed at Complete. But it currently fails CI so must be deleted/emptied in Step 4).\n- Record each REAL finding via `bin/flow add-finding --outcome fixed`.\n- Run `bin/flow ci` (must be green).\n- Remove stale tombstones (none — audit was empty).\n- Set _continue_context, _continue_pending=commit, invoke /flow:flow-commit.\n- Set review_step=4, self-invoke flow:flow-review --continue-step.\n\nThen Done: phase-finalize flow-review, continue_action → invoke flow:flow-learn → Phase 4 (Learn) → Phase 5 (Complete).\n\nKey environment/constraint details to preserve:\n- Branch: consolidate-duplicated-hook-test; worktree: /Users/ben/code/flow/.worktrees/consolidate-duplicated-hook-test; PR #1781; project root /Users/ben/code/flow.\n- commit=auto, continue=auto for all phases.\n- bin/flow at /Users/ben/code/flow/bin/flow (absolute) for state commands; worktree bin/flow or relative for ci/test.\n- .flow-states/ lives at MAIN repo root (/Users/ben/code/flow/.flow-states/...), NOT the worktree — Write tool blocked otherwise.\n- Grep tool is NOT available this session; use Bash grep (but RTK rewrites grep to ripgrep, so avoid `\\|` alternation and unescaped `(`).\n- No compound bash commands (|, &&, ||, >, <) — blocked by validate-pretool.\n- Banners output as text, not Bash.\n- Use 10-min timeout (600000) for bin/flow ci/finalize-commit/start-gate.\n- Commit message via Write to .flow-states/<branch>/commit-msg-content.txt then bin/flow write-rule to commit-msg.txt, then finalize-commit.\n- Layer 11 blocks bin/flow ci during Code phase (use per-file bin/test); but Review Step 4 explicitly runs bin/flow ci.\n- Never raw git commit; never finalize-commit outside flow-commit.\n\nUser's global rules from CLAUDE.md/RTK.md/memory: bash shell only; git allowed: status/diff/log/branch/blame/show/add/commit/push; after committing always push; never add Co-Authored-By; forbidden git: checkout/reset/stash; never heredoc for git commit; RTK token-killer proxy. Memory feedback: never commit without explicit approval (but commit=auto in FLOW handles this via the skill), use flow-commit always, etc.\n\nThis is a FLOW-plugin development flow — I AM developing the FLOW plugin itself (the worktree IS the plugin source).\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user invoked `/flow:flow-start #1776` — launching the FLOW plugin's 5-phase lifecycle (Start → Code → Review → Learn → Complete) on GitHub issue #1776 in the FLOW plugin repo itself. Issue #1776's pre-decomposed plan: **consolidate duplicated hook-test subprocess-spawn boilerplate** across ten `tests/hooks/*.rs` files into a single shared `spawn_hook` helper in `tests/common/mod.rs`. The flow runs autonomously (commit=auto, continue=auto for all phases). The user's only direct messages after the initial `/flow:flow-start #1776` were three `/flow:flow-continue` slash-command invocations (no prose). The intent is to execute the entire lifecycle autonomously to completion (merge PR, remove worktree).\n\n2. Key Technical Concepts:\n   - FLOW plugin: opinionated 5-phase dev lifecycle enforced via skills (SKILL.md), PreToolUse hooks (validate-pretool, validate-skill, validate-ask-user, validate-worktree-paths, validate-claude-paths), bin/flow Rust subcommands, contract tests. State at `.flow-states/<branch>/state.json`, worktrees at `.worktrees/<branch>/`.\n   - Rust test infrastructure: `Command::new(env!(\"CARGO_BIN_EXE_flow-rs\"))`, `Stdio::piped()`, `wait_with_output()`, `std::process::Output`.\n   - subprocess-test-hygiene rule: tests must neutralize env (FLOW_CI_RUNNING, FLOW_SIMULATE_BRANCH, HOME); \"Working Directory Isolation\" — never inherit runner's cwd/HOME.\n   - 100% coverage gate (no waivers); per-file gate `bin/test tests/<name>.rs`; full CI `bin/flow ci` (100/100/100). Phantom-miss diagnosis via `bin/test --funcs hooks/<file>.rs` (two crate hashes = stale binary) and `bin/flow ci --clean`; \"covered elsewhere\" cross-module blind spot (per-file gate only runs that module's tests).\n   - Cognitive isolation: 4 Review agents (reviewer context-rich, pre-mortem/adversarial/documentation context-sparse) read diff files. agent_prompt_scan blocks out-of-worktree path tokens in Agent prompts.\n   - plan-commit-atomicity \"Optimization-Driven Batching\"; plan-signature-deviation logging; adversarial-probe-lifecycle (probe at tests/test_adversarial_flow.rs, untracked/excluded, disposed at Complete, must be reconciled in Step 4 if failing).\n   - Layer 11 blocks `bin/flow ci` during Code phase (per-file gate instead); commit-time CI runs inside finalize-commit; Review Step 4 explicitly runs `bin/flow ci`.\n\n3. Files and Code Sections:\n   - **tests/common/mod.rs** — Added `spawn_hook` (the shared helper). Currently (after Step 4 edit) signature is `pub fn spawn_hook(hook_name: &str, cwd: &Path, stdin: &[u8], env: &[(&str, &str)]) -> Output`. Body: `Command::new(env!(\"CARGO_BIN_EXE_flow-rs\"))`, `.args([\"hook\", hook_name])`, `.env_remove(\"FLOW_CI_RUNNING\")`, `.env_remove(\"FLOW_SIMULATE_BRANCH\")`, `.env_remove(\"HOME\")`, `.current_dir(cwd)`, three `Stdio::piped()`, then `for (key, value) in env { cmd.env(key, value); }`, spawn, `.write_all(stdin).expect(\"write stdin to flow-rs hook\")`, `wait_with_output()`. Imports added: `use std::io::Write;` and `Stdio` in `use std::process::{Command, Output, Stdio};`. Doc comment rewritten to clarify HOME is UNCONDITIONALLY removed (no way to inherit real HOME — deliberate per Working Directory Isolation) and stdin is raw bytes (enables non-UTF-8 probes).\n   - **tests/hooks/post_compact.rs** — `run_post_compact(cwd, stdin: &[u8])` → `crate::common::spawn_hook(\"post-compact\", cwd, stdin, &[])` (byte-caller, from_utf8 removed in Step 4). Removed flow_rs_no_recursion + Write/Stdio imports.\n   - **tests/hooks/stop_failure.rs** — `run_stop_failure(cwd, stdin: &[u8])` → `crate::common::spawn_hook(\"stop-failure\", cwd, stdin, &[])`.\n   - **tests/hooks/dispatcher.rs** — Migrated `run_hook` (passes `&[(\"FLOW_SIMULATE_BRANCH\", branch)]`), `run_hook_no_simulate` (`&[]`), `run_hook_in` (`&[]`). Removed `flow_rs()` helper + Stdio/Write imports. Added/updated doc comments mentioning HOME removal; added full doc comment to run_hook_in.\n   - **tests/hooks/capture_session.rs** — `run_capture_session` now byte-caller: `crate::common::spawn_hook(\"capture-session\", dir.path(), stdin_bytes, &env)`. Inline relative-home test uses `br#\"{\"session_id\":\"valid-sid\"}\"#`. KEEPS `flow_rs_no_recursion()` (line 17) for caps_stdin (BrokenPipe-tolerant) + current-session-id (non-hook).\n   - **tests/hooks/validate_skill.rs** — 5 sites: run_hook_subprocess (tempdir cwd + .as_bytes() + F5 doc note), spawn_skill_with_payload_cwd (.as_bytes()), 3 inline (`payload.to_string().as_bytes()`).\n   - **tests/hooks/validate_claude_paths.rs** — run_hook_subprocess: `stdin_input.as_bytes()`.\n   - **tests/hooks/validate_ask_user.rs** — run_hook (.as_bytes()), 3 callsites (`payload.to_string().as_bytes()`).\n   - **tests/hooks/validate_worktree_paths.rs** — REMAINING: 4 spawn_hook calls at lines 1026 (`stdin_input`), 1136 (`&payload`), 1389 region (`&stdin_input`), 1434 region (`&stdin_input`) still need `.as_bytes()`. KEEPS pre_exec rmdir site (~line 1079).\n   - **tests/hooks/validate_pretool.rs** — REMAINING: run_hook_with_bg passes `&serde_json::to_string(&input).unwrap()` — needs `.as_bytes()`. KEEPS run_hook_with_input_and_home (line 1592) + pre_exec rmdir (3038).\n   - **tests/hooks/stop_continue.rs** — NOT migrated (exceptions): run_hook_inner (548, pre_exec setsid), run_marker_subcommand (1398, non-hook).\n   - **.claude/rules/subprocess-test-hygiene.md** — REMAINING Step 4: add a note that hook subprocess tests route through `crate::common::spawn_hook` (must use `bin/flow write-rule` since .claude/rules edits during a flow are redirected).\n   - **tests/test_adversarial_flow.rs** — adversarial probe (untracked) currently FAILS (asserts HOME-removal divergence). REMAINING: must be deleted/emptied in Step 4 (reconciliation).\n\n4. Errors and fixes:\n   - **Compile error E0423/E0433 in dispatcher.rs:** I removed `flow_rs()` but missed a third caller `run_hook_in` (line 808) that used it + Stdio. Fixed by migrating run_hook_in to spawn_hook too. (My grep only matched `Command::new(env!())` literal, missing `flow_rs()` callers.)\n   - **validate_pretool 99.06% coverage:** Initially looked like a regression. Diagnosed via `bin/test --funcs hooks/validate_pretool.rs` (two crate hashes → suspected phantom-miss; ran `bin/flow ci --clean` which persisted). Correctly re-diagnosed as the \"covered elsewhere\" cross-module blind spot: closure `run_impl_main::{closure#1}` covered by `dispatcher::validate_pretool_agent_prompt_outside_worktree_skips_scan_exits_zero`. Full CI confirmed 100/100/100 — NOT a regression.\n   - **Write to .flow-states inside worktree blocked:** validate-worktree-paths blocked Write to `<worktree>/.flow-states/...`. Fixed by using the canonical main-repo path `/Users/ben/code/flow/.flow-states/...`.\n   - **Agent launches blocked:** reviewer + adversarial agent prompts contained out-of-worktree path tokens (`/pre_exec` from \"pre_exec(setsid)/pre_exec(rmdir)\"; absolute `/Users/ben/code/flow/bin/flow`). Fixed by removing slash-path tokens and using worktree bin/flow path; re-launched the two blocked agents.\n   - **clear-halt \"unauthorized\" twice:** User's /flow:flow-continue failed twice (most-recent-user-turn check) then succeeded. Diagnosed: no `_halt_pending` was set — flow was never actually halted. Resumed work directly.\n   - **resume-anchor stale foreign path:** Repeatedly returned `/private/tmp/.../counter-learn` (overwritten by CI test suite). Ignored it after verifying actual cwd via `pwd` (treated as no_marker).\n\n5. Problem Solving:\n   - Designed `spawn_hook` with universal-remove-then-reset env contract (logged as a plan deviation since the plan's stated mechanism was structurally impossible).\n   - Classified ~24 spawn sites into migratable vs. 6 documented exceptions (pre_exec, non-hook subcommands, BrokenPipe caps, Option-inherit helper).\n   - Batched Tasks 2-4 into one commit (optimization batching, logged).\n   - Resolved the validate_pretool coverage scare as a known cross-module per-file-gate limitation, confirmed by full CI.\n   - In Review, decided the `stdin: &[u8]` change is a Real Tenant 2/5 finding (removes pointless bytes→str→bytes round-trip at byte-callers; preserves non-UTF-8 robustness testing).\n\n6. All user messages:\n   - `/flow:flow-start #1776` (with the flow-start skill body, ARGUMENTS: #1776).\n   - `/flow:flow-continue` (×3, slash-command invocations only, no prose). The third one cleared the halt successfully (status ok); the first two returned `unauthorized`.\n   - No prose messages, corrections, or security constraints were given by the user beyond the slash commands. (Global constraints from CLAUDE.md: bash only; allowed git = status/diff/log/branch/blame/show/add/commit/push; always push after commit; never Co-Authored-By; forbidden git = checkout/reset/stash; no heredoc for git commit; never commit without approval — satisfied here by FLOW's commit=auto + flow-commit skill; always use flow-commit, never raw git commit or finalize-commit outside flow-commit; never commit to main outside a flow.)\n\n7. Pending Tasks:\n   - Complete Review Step 4 fixes (the &[u8] migration of validate_worktree_paths 4 sites + validate_pretool run_hook_with_bg; subprocess-test-hygiene.md note via write-rule; delete the failing adversarial probe; record each REAL finding via add-finding --outcome fixed; run `bin/flow ci` green; commit via /flow:flow-commit; set review_step=4; self-invoke).\n   - Review Done: phase-finalize flow-review → advance to Phase 4 (Learn) → Phase 5 (Complete), merging PR #1781 and removing the worktree.\n\n8. Current Work:\n   I am in **Phase 3 (Review), Step 4 (Fix)**, executing the `stdin: &str` → `stdin: &[u8]` migration across all spawn_hook callers (the substantive REAL finding). I have already edited spawn_hook itself and 8 caller files (post_compact, stop_failure, dispatcher×3, capture_session×2, validate_claude_paths, validate_ask_user×4, validate_skill×5). My most recent action was running `grep -n \"crate::common::spawn_hook\" tests/hooks/validate_worktree_paths.rs`, which returned 4 matches:\n   ```\n   1026: spawn_hook(\"validate-worktree-paths\", dir.path(), stdin_input, &[])\n   1136: spawn_hook(\"validate-worktree-paths\", &worktree, &payload, &[])\n   1389: spawn_hook(   (spawn_hook_with_cwd, uses &stdin_input)\n   1434: spawn_hook(   (spawn_with_payload_cwd, uses &stdin_input)\n   ```\n   I was about to edit these 4 validate_worktree_paths callsites: line 1026 `stdin_input` → `stdin_input.as_bytes()`; line 1136 `&payload` → `payload.as_bytes()`; lines 1389/1434 `&stdin_input` → `stdin_input.as_bytes()`.\n\n9. Optional Next Step:\n   Edit the 4 `validate_worktree_paths.rs` spawn_hook callsites to add `.as_bytes()` (line 1026: `stdin_input` → `stdin_input.as_bytes()`; line 1136: `&payload` → `payload.as_bytes()`; lines 1389/1434: `&stdin_input` → `stdin_input.as_bytes()`), then edit `validate_pretool.rs` run_hook_with_bg (`&serde_json::to_string(&input).unwrap()` → add `.as_bytes()`), then update subprocess-test-hygiene.md (via `bin/flow write-rule`), delete the failing adversarial probe `tests/test_adversarial_flow.rs`, record the 6 REAL findings via `bin/flow add-finding --outcome fixed --phase flow-review`, run `bin/flow ci` (10-min timeout) until green, then set continuation context + `_continue_pending=commit` and invoke `/flow:flow-commit`, then `set-timestamp --set review_step=4` and self-invoke `flow:flow-review --continue-step`. This is directly in line with completing Review Step 4 for the autonomous flow the user initiated. (No remaining `Command::new(env!())` migration is needed for the &[u8] change — only the .as_bytes() additions remain among str-callers; byte-callers are already done.)\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/consolidate-duplicated-hook-test",
  "compact_count": 1,
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 5,
  "complete_step": 5,
  "window_at_complete": {
    "captured_at": "2026-05-31T19:08:43-07:00",
    "session_id": "6c08c08e-2452-477f-b0d4-80f28543756a",
    "model": "claude-opus-4-8",
    "five_hour_pct": 99,
    "seven_day_pct": 86,
    "session_input_tokens": 248022,
    "session_output_tokens": 179758,
    "session_cache_creation_tokens": 2790950,
    "session_cache_read_tokens": 156102749,
    "by_model": {
      "claude-opus-4-8": {
        "input": 248022,
        "output": 179758,
        "cache_create": 2790950,
        "cache_read": 156102749
      }
    },
    "turn_count": 231,
    "tool_call_count": 75,
    "context_at_last_turn_tokens": 991169,
    "context_window_pct": 495.5845
  },
  "_auto_continue": "/flow:flow-complete"
}
````

</details>