### PR TITLE
Review Phase Deadlocks When

### DIFF
--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -552,3 +552,59 @@ ordering is locked by an explicit regression test
 turns and tool_results predating the most recent real user turn
 are invisible to the helper — only the active confirmation
 window matters.
+
+## Agent-Skip-Handoff Carve-Out
+
+The autonomous-phase block above protects against model-initiated
+prompts. flow-review's Done handler runs `bin/flow phase-finalize`,
+which returns `{"status":"error","reason":"agents_skipped",...}` or
+`{"status":"error","reason":"required_agent_not_returned",...}` when
+a review agent is recorded in neither `agents_returned` nor
+`agents_skipped`. The handler then fires an `AskUserQuestion` asking
+the user how to proceed (retry / accept / abort). That prompt is the
+designed user-handoff for an unaccounted-for agent — but in an
+in-progress autonomous Review phase the autonomous-phase block in
+`validate-ask-user` would otherwise refuse it, deadlocking the flow.
+The carve-out lets the prompt fire instead.
+
+`validate-ask-user`'s `run_impl_main` calls
+`crate::hooks::transcript_walker::recent_phase_finalize_agent_skip`
+after the shared-config carve-out and before the block return. The
+helper walks the persisted transcript backward from the file tail,
+capped at `SHARED_CONFIG_BLOCK_BYTE_CAP` (4 MB), and returns `true`
+when the most recent real user turn carries a `tool_result` whose
+content names a phase-finalize agent-skip handoff. phase-finalize
+returns these business errors with exit 0, so the Bash tool_result's
+`is_error` is false; the helper scans every tool_result regardless
+of the flag (unlike the shared-config sibling, which keys on
+`is_error: true`).
+
+Detection signal: the JSON reason key-value form
+`"reason":"agents_skipped"` or `"reason":"required_agent_not_returned"`
+— not the bare token `agents_skipped`. The bare token would also
+match `bin/flow add-skipped-agent`'s success envelope
+`{"status":"ok","agents_skipped_count":N}` (the model runs
+`add-skipped-agent` during Review), spuriously releasing the block.
+Anchoring on the `"reason":` key-value pair excludes that success
+envelope so the carve-out fires only for a genuine phase-finalize
+handoff. The reason values inside the `"reason":` slot are emitted
+only by FLOW's own `phase-finalize` JSON, a trusted producer.
+
+The carve-out is phase-agnostic: phase-finalize's required-agents
+gate emits the same handoff for any phase with required agents
+(flow-review and flow-learn both have them), so the release fires
+whenever the most recent user-channel tool_result is a genuine
+handoff. The most-recent-user-turn window bounds the surface — a
+stale handoff from an earlier phase is invisible once a newer user
+turn or tool_result intervenes.
+
+This is the third sanctioned carve-out to the autonomous-phase
+`AskUserQuestion` block, after the User-Only Skill carve-out and the
+Shared-Config carve-out above; the three are checked in that order
+in `run_impl_main`. The trigger is system-initiated (the Done
+handler raises the prompt in response to phase-finalize's handoff),
+not model-initiated, so it does not violate the autonomous-mode
+discipline against self-imposed pauses. See
+`.claude/rules/hook-vs-instruction.md` "Mechanically-Enforced Gates"
+(the `validate-ask-user` entry) for the mechanical enforcement
+reference.

--- a/.claude/rules/hook-vs-instruction.md
+++ b/.claude/rules/hook-vs-instruction.md
@@ -212,7 +212,7 @@ insufficient:
 - **`AskUserQuestion` during an autonomous in-progress phase**
   — `validate-ask-user` rejects with exit 2 when
   `phases.<current_phase>.status == "in_progress"` AND
-  `skills.<current_phase>.continue == "auto"`. Two carve-outs
+  `skills.<current_phase>.continue == "auto"`. Three carve-outs
   suppress the block:
     - **User-only-skill carve-out**: when the most recent
       assistant Skill tool_use call (since the most recent
@@ -239,6 +239,21 @@ insufficient:
       carve-out is checked first. See
       `.claude/rules/autonomous-phase-discipline.md`
       "Shared-Config Carve-Out".
+    - **Agent-skip-handoff carve-out**: when the most recent
+      user-role turn carries a `phase-finalize` agent-skip
+      handoff (a `tool_result` whose content contains the
+      reason substring `agents_skipped` or
+      `required_agent_not_returned`), the block is suppressed
+      so flow-review's Done-handler `AskUserQuestion` — which
+      asks the user how to proceed when a review agent is
+      recorded in neither `agents_returned` nor
+      `agents_skipped` — can fire instead of deadlocking the
+      autonomous Review phase. phase-finalize returns these
+      business errors with exit 0, so the tool_result's
+      `is_error` is false; the carve-out scans every
+      tool_result regardless of the flag. Checked after the
+      shared-config carve-out. Backed by
+      `crate::hooks::transcript_walker::recent_phase_finalize_agent_skip`.
 - **Autonomous Stop refusal** — `stop_continue::run` composes
   three predicates in order: `check_in_progress_utility_skill`
   (refuses turn-end when a multi-step utility skill marker

--- a/src/hooks/capture_session.rs
+++ b/src/hooks/capture_session.rs
@@ -25,6 +25,15 @@
 //! `record-agent-return` reports `phase_marker_not_found` for every
 //! Review and Learn agent. `refresh_active_flow_session` keeps the
 //! pointer current so the verifier reads the live session's transcript.
+//!
+//! Known limitation: the refresh repoints the flow at the rotated
+//! session's transcript wholesale. A resume that lands *mid-phase* —
+//! the `phase-enter` marker in the prior session's file and the
+//! agents' tool_use/tool_result pairs in the rotated file — is not
+//! covered by the refresh alone; `verify_agent_returned_in_phase`
+//! anchors on the marker, which now sits in a file the flow no longer
+//! points at. Closing that gap needs a session-lineage union scan
+//! across the prior and rotated transcripts and is deferred.
 
 use std::fs;
 use std::io::Read;

--- a/src/hooks/capture_session.rs
+++ b/src/hooks/capture_session.rs
@@ -14,6 +14,17 @@
 //! last-writer-wins: a wrong session_id at flow-start would cause the
 //! cost lookup to fail gracefully (no cost file matches), which is no
 //! worse than the pre-fix state where session_id was always Null.
+//!
+//! After the global capture write, the hook also refreshes the active
+//! flow's `session_id` and `transcript_path` in
+//! `.flow-states/<branch>/state.json` (keyed by branch-from-cwd). The
+//! global capture file seeds NEW flows at flow-start; an already-running
+//! flow holds the pointers it captured when it started. When the Claude
+//! Code session rotates mid-flow (resume|clear|compact), the rotated
+//! transcript no longer matches the flow's stored pointer and
+//! `record-agent-return` reports `phase_marker_not_found` for every
+//! Review and Learn agent. `refresh_active_flow_session` keeps the
+//! pointer current so the verifier reads the live session's transcript.
 
 use std::fs;
 use std::io::Read;
@@ -21,6 +32,9 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
+use crate::flow_paths::FlowPaths;
+use crate::hooks::{detect_branch_from_path, is_flow_active, resolve_hook_cwd, resolve_main_root};
+use crate::lock::mutate_state;
 use crate::session_metrics::{
     home_dir_or_empty, is_safe_session_id, is_safe_transcript_path_structural,
 };
@@ -115,8 +129,8 @@ pub fn run() {
         .filter(|p| is_safe_transcript_path_structural(p, &home))
         .map(|p| p.to_string_lossy().to_string());
     let payload = json!({
-        "session_id": session_id,
-        "transcript_path": transcript_path,
+        "session_id": session_id.clone(),
+        "transcript_path": transcript_path.clone(),
     });
     let path = capture_file_path(&home);
     // `capture_file_path` always returns `<home>/.claude/<basename>`,
@@ -142,4 +156,80 @@ pub fn run() {
         }
     }
     let _ = fs::write(&path, payload.to_string());
+
+    // Refresh the active flow's session pointers from the same payload.
+    // The global capture file above seeds NEW flows at flow-start, but
+    // an already-running flow holds the session_id/transcript_path
+    // captured when it started. When the Claude Code session rotates
+    // mid-flow (resume|clear|compact), the rotated transcript no longer
+    // matches the flow's stored pointer, and `record-agent-return`
+    // reports `phase_marker_not_found` for every Review/Learn agent.
+    // Refreshing the active flow's state file here keeps the pointer
+    // current. The cwd identifies which flow to refresh; a degenerate
+    // or absent cwd resolves to no active flow and the refresh no-ops.
+    // `resolve_hook_cwd` returns `None` only when the payload carries no
+    // `cwd` AND `env::current_dir()` fails — an empty-string fallback
+    // resolves no branch in `refresh_active_flow_session`, so the
+    // unreachable-in-practice None case collapses into the same no-op.
+    let cwd = resolve_hook_cwd(&input).unwrap_or_default();
+    refresh_active_flow_session(&cwd, &session_id, transcript_path.as_deref());
+}
+
+/// Refresh the active flow's `session_id` AND `transcript_path` to the
+/// rotated session's values.
+///
+/// `cwd` is the SessionStart payload's working directory: during an
+/// active flow it is the worktree, from which `detect_branch_from_path`
+/// derives the branch and `resolve_main_root` derives the main repo
+/// root. Both pointer fields are overwritten together in one
+/// `mutate_state` so a half-updated pair cannot leave
+/// `resolve_transcript_path` (which prefers `transcript_path`) reading
+/// a rotated session_id against a stale transcript.
+///
+/// `transcript_path` carries the value already validated by `run()`'s
+/// structural check (`is_safe_transcript_path_structural`); `None`
+/// (absent or invalid in the payload) is written as JSON null so the
+/// stale value is not retained.
+///
+/// Fail-open at every boundary — no detectable branch, no active flow,
+/// a wrong-root-type state file — so the hook never blocks or panics on
+/// the SessionStart event:
+/// - `detect_branch_from_path` returns `None` when `cwd` is not inside a
+///   worktree (no flow to refresh).
+/// - `is_flow_active` returns `false` for an invalid (slash-bearing)
+///   branch or a branch with no `state.json` (no active flow).
+/// - the `mutate_state` closure's object guard returns without mutating
+///   when the state file is a wrong root type (array, string, number),
+///   per `.claude/rules/state-files.md` "Corruption Resilience".
+fn refresh_active_flow_session(cwd: &str, session_id: &str, transcript_path: Option<&str>) {
+    let cwd_path = Path::new(cwd);
+    let branch = match detect_branch_from_path(cwd_path) {
+        Some(b) => b,
+        None => return,
+    };
+    let main_root = resolve_main_root(cwd_path);
+    if !is_flow_active(&branch, &main_root) {
+        return;
+    }
+    // `is_flow_active` returned true, so the branch passed
+    // `FlowPaths::is_valid_branch` AND the state file exists —
+    // `try_new` is infallible here. The `.expect` documents that
+    // upstream guarantee per `.claude/rules/branch-path-safety.md`
+    // (documentation, not a reachable panic).
+    let state_path = FlowPaths::try_new(&main_root, &branch)
+        .expect("is_flow_active confirmed branch is valid")
+        .state_file();
+    let _ = mutate_state(&state_path, &mut |state| {
+        // Guard: string-key IndexMut panics on array/bool/number/string
+        // roots. Fail-open on any non-writable shape (Null is
+        // auto-vivified to an object by serde_json's IndexMut).
+        if !(state.is_object() || state.is_null()) {
+            return;
+        }
+        state["session_id"] = Value::String(session_id.to_string());
+        state["transcript_path"] = match transcript_path {
+            Some(tp) => Value::String(tp.to_string()),
+            None => Value::Null,
+        };
+    });
 }

--- a/src/hooks/transcript_walker.rs
+++ b/src/hooks/transcript_walker.rs
@@ -1460,6 +1460,93 @@ pub fn recent_edit_blocked_on_shared_config(transcript_path: &Path, home: &Path)
     false
 }
 
+/// Returns `true` iff the persisted transcript shows the most recent
+/// user-role turn carries a `phase-finalize` agent-skip handoff — a
+/// `tool_result` whose content contains the reason substring
+/// `agents_skipped` or `required_agent_not_returned`.
+///
+/// Companion to validate-ask-user's agent-skip-handoff carve-out.
+/// flow-review's Done handler runs `bin/flow phase-finalize`; when a
+/// review agent is recorded in neither `agents_returned` nor
+/// `agents_skipped`, the command returns
+/// `{"status":"error","reason":"required_agent_not_returned",...}`,
+/// and when a skipped agent is pending it returns
+/// `{"status":"error","reason":"agents_skipped",...}`. The handler
+/// then fires `AskUserQuestion` to ask the user how to proceed. In an
+/// in-progress autonomous Review phase, `validate-ask-user` blocks
+/// `AskUserQuestion` — so without this carve-out a genuine agent skip
+/// deadlocks the flow. The reason values are emitted only by FLOW's
+/// own `phase-finalize` JSON, a trusted producer, so a literal
+/// substring match without normalization is correct (cf.
+/// `recent_edit_blocked_on_shared_config`).
+///
+/// Walks lines backward from the file tail (read via
+/// `read_recent_turns`, capped at `SHARED_CONFIG_BLOCK_BYTE_CAP`) and
+/// stops at the most recent user-role turn, examining ONLY that
+/// turn's content. The carve-out fires iff the latest user-channel
+/// interaction was the skip handoff. If any other tool_result
+/// intervenes (a different command's result), the most recent user
+/// turn is no longer the handoff and the carve-out does not fire —
+/// keeping a stale handoff from authorizing an unrelated
+/// AskUserQuestion later.
+///
+/// `transcript_path` is validated through
+/// `crate::session_metrics::is_safe_transcript_path` per
+/// `.claude/rules/external-input-path-construction.md` (rejects
+/// empty, NUL-byte, relative, ParentDir-component, prefix-escaping,
+/// and symlink-escape paths). Synthetic string-content turns
+/// (hook-feedback `isMeta:true`, compaction-continuation
+/// `isCompactSummary:true`) are skipped via the inline targeted skip
+/// per `.claude/rules/transcript-shape.md` — this walker cannot
+/// delegate to `is_real_user_turn` because it legitimately consumes
+/// the array-content tool_result wrapper that helper rejects.
+pub fn recent_phase_finalize_agent_skip(transcript_path: &Path, home: &Path) -> bool {
+    if !is_safe_transcript_path(transcript_path, home) {
+        return false;
+    }
+    let lines = match read_recent_turns(transcript_path) {
+        Some(s) => s,
+        None => return false,
+    };
+    for line in lines.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let turn: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let turn_type =
+            normalize_gate_input(turn.get("type").and_then(|v| v.as_str()).unwrap_or(""));
+        if turn_type != "user" {
+            continue;
+        }
+        // Skip the two string-content synthetic shapes (hook-feedback
+        // `isMeta:true`, compaction-continuation `isCompactSummary:true`)
+        // via the targeted inline skip. The handoff lives in an
+        // array-content tool_result wrapper, so this walker cannot use
+        // `is_real_user_turn` (which rejects array-content turns). Any
+        // future string-content synthetic shape must be added here too.
+        // Per `.claude/rules/transcript-shape.md`.
+        let is_string_content = turn
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_str())
+            .is_some();
+        if is_string_content && is_meta_marker_present(turn.get("isMeta")) {
+            continue;
+        }
+        if is_string_content && is_compact_summary_turn(&turn) {
+            continue;
+        }
+        // Most recent non-synthetic user-role turn reached. Examine
+        // its content and RETURN — do not walk further back.
+        return user_turn_carries_phase_finalize_skip(&turn);
+    }
+    false
+}
+
 /// Scan every `tool_result` block in `turn` whose `is_error` is
 /// truthy and return `true` as soon as `pred` accepts that block's
 /// text. Returns `false` for string-content user turns (the user
@@ -1475,7 +1562,11 @@ pub fn recent_edit_blocked_on_shared_config(transcript_path: &Path, home: &Path)
 /// `user_turn_carries_shared_config_block` and the
 /// `user_approved_shared_config_edit` block-corroboration check so
 /// the extraction logic lives in one place.
-fn any_error_tool_result_text<F: FnMut(&str) -> bool>(turn: &Value, mut pred: F) -> bool {
+fn any_tool_result_text<F: FnMut(&str) -> bool>(
+    turn: &Value,
+    require_error: bool,
+    mut pred: F,
+) -> bool {
     let content = match turn.get("message").and_then(|m| m.get("content")) {
         Some(c) => c,
         None => return false,
@@ -1491,7 +1582,13 @@ fn any_error_tool_result_text<F: FnMut(&str) -> bool>(turn: &Value, mut pred: F)
         if block.get("type").and_then(|v| v.as_str()) != Some("tool_result") {
             continue;
         }
-        if !is_truthy(block.get("is_error")) {
+        // The shared-config block carve-out keys on `is_error: true`
+        // because `validate_worktree_paths` emits its BLOCKED message
+        // as an error tool_result. The phase-finalize skip handoff is
+        // a business error returned with exit 0 (`is_error: false`),
+        // so its caller passes `require_error = false` to scan every
+        // tool_result regardless of the flag.
+        if require_error && !is_truthy(block.get("is_error")) {
             continue;
         }
         let block_content = match block.get("content") {
@@ -1527,8 +1624,27 @@ fn any_error_tool_result_text<F: FnMut(&str) -> bool>(turn: &Value, mut pred: F)
 /// user turns (the user typed a message), missing or non-array
 /// content, and array content where no block matches.
 fn user_turn_carries_shared_config_block(turn: &Value) -> bool {
-    any_error_tool_result_text(turn, |t| {
+    any_tool_result_text(turn, true, |t| {
         t.contains("is a shared configuration file that affects every engineer")
+    })
+}
+
+/// Returns `true` when the user-role turn carries a tool_result
+/// block whose content names a phase-finalize agent-skip handoff —
+/// the literal reason substring `agents_skipped` or
+/// `required_agent_not_returned`. Scans every tool_result regardless
+/// of `is_error` (phase-finalize returns these business errors with
+/// exit 0, so the Bash tool_result's `is_error` is false). Returns
+/// `false` for string-content user turns, missing or non-array
+/// content, and array content where no block matches.
+///
+/// The two reason values are emitted only by FLOW's own
+/// `phase-finalize` JSON (`src/phase_finalize.rs`), a trusted
+/// producer, so a literal substring match without normalization is
+/// the correct posture (cf. the shared-config sibling).
+fn user_turn_carries_phase_finalize_skip(turn: &Value) -> bool {
+    any_tool_result_text(turn, false, |t| {
+        t.contains("agents_skipped") || t.contains("required_agent_not_returned")
     })
 }
 
@@ -1656,7 +1772,7 @@ pub fn user_approved_shared_config_edit(
         // block only corroborates the grant once the approval (more
         // recent) has been seen, and must name the target basename.
         if approval_seen
-            && any_error_tool_result_text(&turn, |t| {
+            && any_tool_result_text(&turn, true, |t| {
                 t.contains("is a shared configuration file that affects every engineer")
                     && t.contains(target_path)
             })

--- a/src/hooks/transcript_walker.rs
+++ b/src/hooks/transcript_walker.rs
@@ -1547,21 +1547,27 @@ pub fn recent_phase_finalize_agent_skip(transcript_path: &Path, home: &Path) -> 
     false
 }
 
-/// Scan every `tool_result` block in `turn` whose `is_error` is
-/// truthy and return `true` as soon as `pred` accepts that block's
-/// text. Returns `false` for string-content user turns (the user
-/// typed a message — not a tool_result wrapper), missing or
-/// non-array content, and array content where no error block's
-/// text satisfies `pred`.
+/// Scan `tool_result` blocks in `turn` and return `true` as soon as
+/// `pred` accepts a block's text. When `require_error` is true, only
+/// blocks whose `is_error` is truthy are examined (the shared-config
+/// carve-out keys on `validate_worktree_paths`'s error tool_result);
+/// when false, every tool_result block is examined regardless of the
+/// flag (phase-finalize returns its agent-skip handoff as a business
+/// error with exit 0, so its tool_result's `is_error` is false).
+/// Returns `false` for string-content user turns (the user typed a
+/// message — not a tool_result wrapper), missing or non-array
+/// content, and array content where no qualifying block's text
+/// satisfies `pred`.
 ///
 /// `tool_result.content` is either a plain string or an array of
 /// content blocks (each typically a `text` block); both wire
 /// formats are flattened per block so `pred` sees the same text
 /// either way. Per-block short-circuit (no cross-block
 /// accumulation) keeps the branch surface minimal. Shared by
-/// `user_turn_carries_shared_config_block` and the
-/// `user_approved_shared_config_edit` block-corroboration check so
-/// the extraction logic lives in one place.
+/// `user_turn_carries_shared_config_block` (require_error = true),
+/// the `user_approved_shared_config_edit` block-corroboration check
+/// (require_error = true), and `user_turn_carries_phase_finalize_skip`
+/// (require_error = false) so the extraction logic lives in one place.
 fn any_tool_result_text<F: FnMut(&str) -> bool>(
     turn: &Value,
     require_error: bool,
@@ -1631,20 +1637,28 @@ fn user_turn_carries_shared_config_block(turn: &Value) -> bool {
 
 /// Returns `true` when the user-role turn carries a tool_result
 /// block whose content names a phase-finalize agent-skip handoff —
-/// the literal reason substring `agents_skipped` or
-/// `required_agent_not_returned`. Scans every tool_result regardless
-/// of `is_error` (phase-finalize returns these business errors with
-/// exit 0, so the Bash tool_result's `is_error` is false). Returns
-/// `false` for string-content user turns, missing or non-array
-/// content, and array content where no block matches.
+/// the JSON reason key-value form `"reason":"agents_skipped"` or
+/// `"reason":"required_agent_not_returned"`. Scans every tool_result
+/// regardless of `is_error` (phase-finalize returns these business
+/// errors with exit 0, so the Bash tool_result's `is_error` is
+/// false). Returns `false` for string-content user turns, missing or
+/// non-array content, and array content where no block matches.
 ///
-/// The two reason values are emitted only by FLOW's own
-/// `phase-finalize` JSON (`src/phase_finalize.rs`), a trusted
-/// producer, so a literal substring match without normalization is
-/// the correct posture (cf. the shared-config sibling).
+/// The match anchors on the `"reason":` key-value pair rather than
+/// the bare token `agents_skipped`, because `bin/flow
+/// add-skipped-agent` — a command the model runs during Review —
+/// emits a success envelope `{"status":"ok","agents_skipped_count":N}`
+/// whose `agents_skipped_count` field contains `agents_skipped` as a
+/// substring. Anchoring on `"reason":"<value>"` excludes that success
+/// envelope so the carve-out fires only for a genuine phase-finalize
+/// handoff. The reason values inside the `"reason":` slot are emitted
+/// only by FLOW's own `phase-finalize` JSON (`src/phase_finalize.rs`),
+/// a trusted producer serializing compact JSON, so the exact
+/// `"reason":"<value>"` form is stable.
 fn user_turn_carries_phase_finalize_skip(turn: &Value) -> bool {
     any_tool_result_text(turn, false, |t| {
-        t.contains("agents_skipped") || t.contains("required_agent_not_returned")
+        t.contains("\"reason\":\"agents_skipped\"")
+            || t.contains("\"reason\":\"required_agent_not_returned\"")
     })
 }
 

--- a/src/hooks/validate_ask_user.rs
+++ b/src/hooks/validate_ask_user.rs
@@ -1,6 +1,6 @@
 //! PreToolUse hook for AskUserQuestion — enforces autonomous-phase discipline.
 //!
-//! Five outcomes, evaluated in order:
+//! Six outcomes, evaluated in order:
 //!
 //! 1. **Block** (exit 2, stderr message) — when the current phase is
 //!    mid-execution (`phases.<current_phase>.status == "in_progress"`)
@@ -32,11 +32,21 @@
 //!    `crate::hooks::transcript_walker::recent_edit_blocked_on_shared_config`.
 //!    See `.claude/rules/autonomous-phase-discipline.md`
 //!    "Shared-Config Carve-Out" subsection.
-//! 4. **Auto-answer** (exit 0, JSON on stdout) — when `_auto_continue`
+//! 4. **Agent-skip-handoff carve-out** — when `validate` would have
+//!    blocked the prompt but the most recent user-role turn carries a
+//!    `phase-finalize` agent-skip handoff (a tool_result whose content
+//!    contains the reason substring `agents_skipped` or
+//!    `required_agent_not_returned`). flow-review's Done handler fires
+//!    `AskUserQuestion` to ask the user how to proceed when a review
+//!    agent is unaccounted-for; this carve-out lets that prompt fire
+//!    during an in-progress autonomous Review phase instead of
+//!    deadlocking. Checked after the shared-config carve-out. Backed by
+//!    `crate::hooks::transcript_walker::recent_phase_finalize_agent_skip`.
+//! 5. **Auto-answer** (exit 0, JSON on stdout) — when `_auto_continue`
 //!    is set and the block did not fire. Answers the AskUserQuestion
 //!    with the successor skill command so phase transitions advance
 //!    even if the skill's HARD-GATE was ignored.
-//! 5. **Allow** (exit 0, stdout: `{"permissionDecision":"defer"}`) —
+//! 6. **Allow** (exit 0, stdout: `{"permissionDecision":"defer"}`) —
 //!    otherwise. The explicit defer signal tells Claude Code the hook
 //!    has no opinion on this tool call, routing it through normal
 //!    permission handling without relying on empty-stdout implicit
@@ -54,6 +64,7 @@ use crate::flow_paths::FlowPaths;
 use crate::git::{current_branch, project_root};
 use crate::hooks::transcript_walker::{
     most_recent_skill_in_user_only_set, recent_edit_blocked_on_shared_config,
+    recent_phase_finalize_agent_skip,
 };
 use crate::lock::mutate_state;
 use crate::session_metrics::home_dir_or_empty;
@@ -289,6 +300,22 @@ fn run_impl_main(
             .map(|p| recent_edit_blocked_on_shared_config(p, home))
             .unwrap_or(false);
         if allow_shared_config {
+            return HookAction::AllowWithMark(state_path);
+        }
+        // Carve-out: flow-review's Done handler fires AskUserQuestion
+        // when `phase-finalize` returns an `agents_skipped` or
+        // `required_agent_not_returned` handoff (a review agent is
+        // unaccounted-for and the user must choose retry/accept/abort).
+        // In an in-progress autonomous Review phase the block above
+        // would deadlock that prompt; this carve-out releases it when
+        // the transcript shows the recent handoff. Checked after the
+        // shared-config branch; all three carve-outs produce the same
+        // AllowWithMark outcome.
+        let allow_agent_skip = transcript_path
+            .as_deref()
+            .map(|p| recent_phase_finalize_agent_skip(p, home))
+            .unwrap_or(false);
+        if allow_agent_skip {
             return HookAction::AllowWithMark(state_path);
         }
         // `set_blocked` is intentionally not called — the hook

--- a/tests/hooks/capture_session.rs
+++ b/tests/hooks/capture_session.rs
@@ -757,3 +757,122 @@ fn refresh_only_touches_cwd_branch() {
         "sibling flow's state must be untouched"
     );
 }
+
+/// End-to-end contract for the session-rotation refresh: a mid-flow
+/// session rotation (capture-session) must refresh the active flow's
+/// transcript pointer so the downstream `record-agent-return`
+/// verifier reads the LIVE transcript and confirms the agent. Without
+/// the refresh, `record-agent-return` reads the stale flow-start
+/// transcript, `verify_agent_returned_in_phase` finds no agent
+/// invocation, and the verifier reports failure — the Review/Learn
+/// deadlock this fix resolves.
+///
+/// The fixture uses a REAL linked git worktree so `project_root()`
+/// (`git worktree list --porcelain`) resolves the worktree cwd back to
+/// the main repo where `.flow-states/` lives, matching production.
+#[test]
+fn e2e_session_rotation_refresh_lets_record_agent_return_pass() {
+    let dir = tempfile::tempdir().unwrap();
+    let main_repo = crate::common::create_git_repo_with_remote(dir.path());
+    let main_repo = main_repo.canonicalize().unwrap();
+    let branch = "feat";
+    let worktree = main_repo.join(".worktrees").join(branch);
+    let add = Command::new("git")
+        .args(["worktree", "add", worktree.to_str().unwrap(), "-b", branch])
+        .current_dir(&main_repo)
+        .output()
+        .unwrap();
+    assert!(
+        add.status.success(),
+        "git worktree add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    let home = dir.path().canonicalize().unwrap();
+
+    // The flow-start transcript: shape-valid and present, but carries
+    // no agent invocation — the verifier must fail against it.
+    let stale = make_transcript_path(&home, "stale", "stale-session.jsonl");
+    fs::write(
+        &stale,
+        b"{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+    )
+    .unwrap();
+
+    // Active flow state pointing at the stale transcript.
+    let state_dir = main_repo.join(".flow-states").join(branch);
+    fs::create_dir_all(&state_dir).unwrap();
+    let state_path = state_dir.join("state.json");
+    let state = serde_json::json!({
+        "branch": branch,
+        "session_id": "stale-session",
+        "transcript_path": stale.to_string_lossy(),
+        "phases": {"flow-review": {"status": "in_progress"}},
+    });
+    fs::write(&state_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    // The rotated (live) transcript carries the phase-enter marker and
+    // the reviewer Agent tool_use/tool_result pair.
+    let live = make_transcript_path(&home, "live", "live-session.jsonl");
+    let happy = "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"toolu_b1\",\"input\":{\"command\":\"bin/flow phase-enter --phase flow-review\"}}]}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Agent\",\"id\":\"toolu_a1\",\"input\":{\"subagent_type\":\"flow:reviewer\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_a1\",\"content\":\"findings\"}]}}\n";
+    fs::write(&live, happy).unwrap();
+
+    let run_rar = |worktree: &Path, home: &Path| -> serde_json::Value {
+        let out = flow_rs_no_recursion()
+            .args([
+                "record-agent-return",
+                "--branch",
+                branch,
+                "--agent",
+                "reviewer",
+                "--phase",
+                "flow-review",
+            ])
+            .current_dir(worktree)
+            .env("HOME", home)
+            .env("GH_TOKEN", "invalid")
+            .env("CLAUDE_PLUGIN_ROOT", env!("CARGO_MANIFEST_DIR"))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        serde_json::from_str(stdout.trim().lines().last().unwrap_or(""))
+            .unwrap_or(serde_json::Value::Null)
+    };
+
+    // Before rotation: the verifier reads the stale transcript and
+    // fails — proving the test exercises the real verification path.
+    let before = run_rar(&worktree, &home);
+    assert_eq!(
+        before["status"], "error",
+        "stale transcript must fail verification; got {}",
+        before
+    );
+
+    // Rotate the session: SessionStart fires with the live session's
+    // id, transcript, and the worktree cwd.
+    let stdin = format!(
+        r#"{{"session_id":"live-session","transcript_path":"{}","cwd":"{}"}}"#,
+        live.display(),
+        worktree.display()
+    );
+    let cap = crate::common::spawn_hook(
+        "capture-session",
+        &worktree,
+        stdin.as_bytes(),
+        &[("HOME", home.to_str().unwrap())],
+    );
+    assert_eq!(cap.status.code(), Some(0));
+
+    // After rotation: the verifier reads the refreshed (live)
+    // transcript and confirms the agent.
+    let after = run_rar(&worktree, &home);
+    assert_eq!(
+        after["status"], "ok",
+        "refreshed transcript must verify; got {}",
+        after
+    );
+}

--- a/tests/hooks/capture_session.rs
+++ b/tests/hooks/capture_session.rs
@@ -483,3 +483,277 @@ fn run_persists_transcript_path_when_jsonl_does_not_exist() {
         parsed["transcript_path"]
     );
 }
+
+// --- refresh_active_flow_session ---
+//
+// When the Claude Code session rotates mid-flow (startup|resume|clear|
+// compact), the SessionStart hook receives the new session_id and
+// transcript_path. Without refreshing the active flow's state file,
+// `record-agent-return` keeps reading the flow-start session's
+// transcript and reports `phase_marker_not_found` for every Review and
+// Learn agent. `capture_session::run` therefore refreshes the active
+// flow's `session_id` AND `transcript_path` from the same payload,
+// keyed by branch-from-cwd, fail-open. These tests drive the hook
+// through the compiled binary and assert the state file update.
+
+/// Build a refresh fixture: a main-root tempdir with a worktree at
+/// `.worktrees/<branch>/` (carrying a `.git` marker file so
+/// `detect_branch_from_path` resolves the branch from the path alone,
+/// not a git subprocess) and a state file at
+/// `.flow-states/<branch>/state.json` carrying `state_json`. The
+/// tempdir is canonicalized so the child binary's cwd-derived paths
+/// match the test's constructed paths on macOS (per
+/// `.claude/rules/testing-gotchas.md` "macOS Subprocess Path
+/// Canonicalization"). Returns `(TempDir, main_root, worktree_cwd,
+/// state_path)`; the `TempDir` keeps the directory alive for the test
+/// body's lifetime.
+fn setup_refresh_fixture(
+    branch: &str,
+    state_json: &str,
+) -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let main_root = dir.path().canonicalize().unwrap();
+    let worktree = main_root.join(".worktrees").join(branch);
+    fs::create_dir_all(&worktree).unwrap();
+    fs::write(worktree.join(".git"), "gitdir: /dev/null\n").unwrap();
+    let state_dir = main_root.join(".flow-states").join(branch);
+    fs::create_dir_all(&state_dir).unwrap();
+    let state_path = state_dir.join("state.json");
+    fs::write(&state_path, state_json).unwrap();
+    (dir, main_root, worktree, state_path)
+}
+
+/// Construct a transcript path under `<home>/.claude/projects/<proj>/`
+/// so it passes the structural validator. Creates the projects
+/// directory; the JSONL file itself need not exist (SessionStart
+/// delivers the path before Claude Code creates the file).
+fn make_transcript_path(home: &Path, proj: &str, name: &str) -> PathBuf {
+    let dir = home.join(".claude").join("projects").join(proj);
+    fs::create_dir_all(&dir).unwrap();
+    dir.join(name)
+}
+
+fn read_state(state_path: &Path) -> serde_json::Value {
+    serde_json::from_str(&fs::read_to_string(state_path).unwrap()).unwrap()
+}
+
+#[test]
+fn refresh_updates_session_id_and_transcript_path_when_flow_active() {
+    let (_dir, main_root, worktree, state_path) = setup_refresh_fixture(
+        "feat",
+        r#"{"session_id":"old-sid","transcript_path":"/old/path.jsonl"}"#,
+    );
+    let new_transcript = make_transcript_path(&main_root, "proj", "new-session.jsonl");
+    let stdin = format!(
+        r#"{{"session_id":"new-sid","transcript_path":"{}","cwd":"{}"}}"#,
+        new_transcript.display(),
+        worktree.display()
+    );
+    let output = crate::common::spawn_hook(
+        "capture-session",
+        &worktree,
+        stdin.as_bytes(),
+        &[("HOME", main_root.to_str().unwrap())],
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let state = read_state(&state_path);
+    assert_eq!(state["session_id"], "new-sid");
+    assert_eq!(
+        state["transcript_path"].as_str(),
+        Some(new_transcript.to_string_lossy().as_ref()),
+        "active flow's transcript_path must be refreshed; got {}",
+        state["transcript_path"]
+    );
+}
+
+#[test]
+fn refresh_writes_null_transcript_path_when_payload_transcript_invalid() {
+    // An invalid transcript_path (outside ~/.claude/projects/) is
+    // dropped to None by run()'s structural validator; the refresh
+    // overwrites BOTH fields together so transcript_path becomes null
+    // rather than retaining the stale value.
+    let (_dir, main_root, worktree, state_path) = setup_refresh_fixture(
+        "feat",
+        r#"{"session_id":"old-sid","transcript_path":"/old/path.jsonl"}"#,
+    );
+    let stdin = format!(
+        r#"{{"session_id":"new-sid","transcript_path":"/etc/passwd","cwd":"{}"}}"#,
+        worktree.display()
+    );
+    let output = crate::common::spawn_hook(
+        "capture-session",
+        &worktree,
+        stdin.as_bytes(),
+        &[("HOME", main_root.to_str().unwrap())],
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let state = read_state(&state_path);
+    assert_eq!(state["session_id"], "new-sid");
+    assert!(
+        state["transcript_path"].is_null(),
+        "invalid transcript_path must be written as null; got {}",
+        state["transcript_path"]
+    );
+}
+
+#[test]
+fn refresh_no_op_when_cwd_missing() {
+    // Payload omits `cwd`; the spawn cwd (main_root) is not inside a
+    // worktree, so branch detection yields None and the refresh is a
+    // no-op. The stale state is preserved.
+    let (_dir, main_root, _worktree, state_path) = setup_refresh_fixture(
+        "feat",
+        r#"{"session_id":"old-sid","transcript_path":"/old/path.jsonl"}"#,
+    );
+    let stdin = r#"{"session_id":"new-sid"}"#;
+    let output = crate::common::spawn_hook(
+        "capture-session",
+        &main_root,
+        stdin.as_bytes(),
+        &[("HOME", main_root.to_str().unwrap())],
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let state = read_state(&state_path);
+    assert_eq!(
+        state["session_id"], "old-sid",
+        "no cwd → branch undetectable → state must be unchanged"
+    );
+}
+
+#[test]
+fn refresh_no_op_when_branch_has_slash() {
+    // A `.git` marker nested two levels deep under .worktrees/ makes
+    // detect_branch_from_path resolve a slash-containing branch
+    // (`a/b`), which FlowPaths::try_new rejects, so is_flow_active is
+    // false and the refresh is a no-op.
+    let dir = tempfile::tempdir().unwrap();
+    let main_root = dir.path().canonicalize().unwrap();
+    let nested = main_root.join(".worktrees").join("a").join("b");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join(".git"), "gitdir: /dev/null\n").unwrap();
+    // A state file at the slash-branch path is unreachable via
+    // FlowPaths; create one anyway to prove it is never touched.
+    let state_dir = main_root.join(".flow-states").join("a").join("b");
+    fs::create_dir_all(&state_dir).unwrap();
+    let state_path = state_dir.join("state.json");
+    fs::write(&state_path, r#"{"session_id":"old-sid"}"#).unwrap();
+
+    let stdin = format!(r#"{{"session_id":"new-sid","cwd":"{}"}}"#, nested.display());
+    let output = crate::common::spawn_hook(
+        "capture-session",
+        &nested,
+        stdin.as_bytes(),
+        &[("HOME", main_root.to_str().unwrap())],
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let state = read_state(&state_path);
+    assert_eq!(
+        state["session_id"], "old-sid",
+        "slash branch → no active flow → state must be unchanged"
+    );
+}
+
+#[test]
+fn refresh_no_op_when_no_active_flow() {
+    // A worktree exists but no state file → is_flow_active is false →
+    // the refresh is a no-op and no state file is created.
+    let dir = tempfile::tempdir().unwrap();
+    let main_root = dir.path().canonicalize().unwrap();
+    let worktree = main_root.join(".worktrees").join("feat");
+    fs::create_dir_all(&worktree).unwrap();
+    fs::write(worktree.join(".git"), "gitdir: /dev/null\n").unwrap();
+    let state_path = main_root
+        .join(".flow-states")
+        .join("feat")
+        .join("state.json");
+
+    let stdin = format!(
+        r#"{{"session_id":"new-sid","cwd":"{}"}}"#,
+        worktree.display()
+    );
+    let output = crate::common::spawn_hook(
+        "capture-session",
+        &worktree,
+        stdin.as_bytes(),
+        &[("HOME", main_root.to_str().unwrap())],
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        !state_path.exists(),
+        "no active flow → refresh must not create a state file"
+    );
+}
+
+#[test]
+fn refresh_no_op_when_state_file_is_array() {
+    // A wrong-root-type state file (JSON array) hits the object guard
+    // inside the mutate_state closure: the closure returns without
+    // mutating, so the array is written back unchanged. Defends
+    // against a corrupted or hand-edited state file panicking the
+    // hook on string-key IndexMut.
+    let (_dir, main_root, worktree, state_path) = setup_refresh_fixture("feat", "[]");
+    let stdin = format!(
+        r#"{{"session_id":"new-sid","cwd":"{}"}}"#,
+        worktree.display()
+    );
+    let output = crate::common::spawn_hook(
+        "capture-session",
+        &worktree,
+        stdin.as_bytes(),
+        &[("HOME", main_root.to_str().unwrap())],
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let state = read_state(&state_path);
+    assert!(
+        state.is_array() && state.as_array().unwrap().is_empty(),
+        "array-root state must be preserved unchanged; got {}",
+        state
+    );
+}
+
+#[test]
+fn refresh_only_touches_cwd_branch() {
+    // Two active flows under the same main root; the cwd points at
+    // branch A's worktree. Only A's state is refreshed; B's stays
+    // stale, proving the refresh is scoped to the cwd's branch.
+    let (_dir, main_root, worktree_a, state_a) = setup_refresh_fixture(
+        "feat-a",
+        r#"{"session_id":"old-a","transcript_path":"/old/a.jsonl"}"#,
+    );
+    // Add a second flow under the same main root.
+    let worktree_b = main_root.join(".worktrees").join("feat-b");
+    fs::create_dir_all(&worktree_b).unwrap();
+    fs::write(worktree_b.join(".git"), "gitdir: /dev/null\n").unwrap();
+    let state_b_dir = main_root.join(".flow-states").join("feat-b");
+    fs::create_dir_all(&state_b_dir).unwrap();
+    let state_b = state_b_dir.join("state.json");
+    fs::write(
+        &state_b,
+        r#"{"session_id":"old-b","transcript_path":"/old/b.jsonl"}"#,
+    )
+    .unwrap();
+
+    let stdin = format!(
+        r#"{{"session_id":"new-a","cwd":"{}"}}"#,
+        worktree_a.display()
+    );
+    let output = crate::common::spawn_hook(
+        "capture-session",
+        &worktree_a,
+        stdin.as_bytes(),
+        &[("HOME", main_root.to_str().unwrap())],
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    assert_eq!(read_state(&state_a)["session_id"], "new-a");
+    assert_eq!(
+        read_state(&state_b)["session_id"],
+        "old-b",
+        "sibling flow's state must be untouched"
+    );
+}

--- a/tests/hooks/transcript_walker.rs
+++ b/tests/hooks/transcript_walker.rs
@@ -15,9 +15,9 @@ use flow_rs::hooks::transcript_walker::{
     any_skill_in_set_since_user, last_user_message_invokes_skill,
     most_recent_skill_in_user_only_set, most_recent_skill_since_user,
     most_recent_user_message_since_skill_action, read_full, read_recency_window, read_recent_turns,
-    recent_edit_blocked_on_shared_config, user_approved_shared_config_edit,
-    verify_agent_returned_in_phase, SHARED_CONFIG_BLOCK_BYTE_CAP, TRANSCRIPT_BYTE_CAP,
-    USER_ONLY_SKILLS,
+    recent_edit_blocked_on_shared_config, recent_phase_finalize_agent_skip,
+    user_approved_shared_config_edit, verify_agent_returned_in_phase, SHARED_CONFIG_BLOCK_BYTE_CAP,
+    TRANSCRIPT_BYTE_CAP, USER_ONLY_SKILLS,
 };
 
 // --- last_user_message_invokes_skill ---
@@ -1103,6 +1103,254 @@ fn helper_continues_when_tool_result_content_is_number() {
 {\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":7,\"is_error\":true}]}}\n";
     let path = crate::common::transcript_fixture(home, "p", jsonl);
     assert!(!recent_edit_blocked_on_shared_config(&path, home));
+}
+
+// --- recent_phase_finalize_agent_skip ---
+//
+// Companion to validate-ask-user's agent-skip-handoff carve-out.
+// flow-review's Done handler runs `bin/flow phase-finalize`, which
+// returns `{"status":"error","reason":"agents_skipped",...}` or
+// `{"status":"error","reason":"required_agent_not_returned",...}`
+// when a review agent is unaccounted-for. The handler then fires
+// AskUserQuestion to ask the user how to proceed — but in an
+// in-progress autonomous Review phase, validate-ask-user blocks it.
+// This walker detects the recent phase-finalize skip handoff so the
+// carve-out can release the prompt. Detection signal: the literal
+// reason substring `agents_skipped` or `required_agent_not_returned`
+// inside a `tool_result` block in the most recent user-role turn.
+// Unlike the shared-config block, phase-finalize returns exit 0 for
+// these business errors, so the tool_result's `is_error` is false —
+// the walker scans every tool_result regardless of `is_error`.
+
+#[test]
+fn recent_phase_finalize_agent_skip_returns_true_for_agents_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"finalize review\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"toolu_01\",\"input\":{\"command\":\"bin/flow phase-finalize --phase flow-review --branch feat\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01\",\"content\":\"{\\\"status\\\":\\\"error\\\",\\\"reason\\\":\\\"agents_skipped\\\",\\\"skipped\\\":[\\\"reviewer\\\"]}\",\"is_error\":false}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_returns_true_for_required_agent_not_returned() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"finalize review\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"toolu_02\",\"input\":{\"command\":\"bin/flow phase-finalize --phase flow-review --branch feat\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_02\",\"content\":\"{\\\"status\\\":\\\"error\\\",\\\"reason\\\":\\\"required_agent_not_returned\\\",\\\"missing\\\":[\\\"adversarial\\\"]}\",\"is_error\":false}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_matches_text_array_content() {
+    // tool_result.content can be an array of text blocks. The shared
+    // flattening joins them and matches the reason substring against
+    // the joined string.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":[{\"type\":\"text\",\"text\":\"{\\\"status\\\":\\\"error\\\",\\\"reason\\\":\\\"agents_skipped\\\"}\"}],\"is_error\":false}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_returns_false_when_no_reason() {
+    // A successful phase-finalize `{"status":"ok",...}` tool_result
+    // carries neither reason substring — the walker returns false so
+    // the autonomous-phase block stands.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"finalize\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"toolu_03\",\"input\":{\"command\":\"bin/flow phase-finalize\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_03\",\"content\":\"{\\\"status\\\":\\\"ok\\\",\\\"formatted_time\\\":\\\"<1m\\\"}\",\"is_error\":false}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_returns_false_when_block_predates_user_turn() {
+    // The skip handoff is in the transcript but a fresh real user
+    // prose turn intervenes after it. Walking backward the walker
+    // hits the user prose first and returns false — the older
+    // handoff is outside the window.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"first\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"{\\\"status\\\":\\\"error\\\",\\\"reason\\\":\\\"agents_skipped\\\"}\",\"is_error\":false}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"now do something else\"}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_iterates_past_trailing_assistant() {
+    // When the LAST line is an assistant turn (after the user-array
+    // tool_result), the walker continues past it (turn_type != user)
+    // and reaches the user-array turn carrying the skip handoff.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"{\\\"status\\\":\\\"error\\\",\\\"reason\\\":\\\"agents_skipped\\\"}\",\"is_error\":false}]}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"thinking\"}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_skips_unparseable_jsonl_lines() {
+    // A non-empty line that fails JSON parsing is skipped via
+    // continue; the valid handoff on the previous line still drives
+    // the walker's true return.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"go\"}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"{\\\"status\\\":\\\"error\\\",\\\"reason\\\":\\\"agents_skipped\\\"}\",\"is_error\":false}]}}\n\
+not valid json at all\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_returns_false_when_transcript_path_unsafe() {
+    // The validator rejects relative and traversal paths before any
+    // I/O, matching the sibling walkers' rejection profile.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let relative = std::path::Path::new("relative/path.jsonl");
+    assert!(!recent_phase_finalize_agent_skip(relative, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_returns_false_when_transcript_missing() {
+    // File does not exist — read_recent_turns returns None and the
+    // walker falls open to false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let missing = home
+        .join(".claude")
+        .join("projects")
+        .join("p")
+        .join("nonexistent.jsonl");
+    assert!(!recent_phase_finalize_agent_skip(&missing, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_returns_false_on_empty_transcript() {
+    // Empty file — no lines to walk, the walker returns false.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let path = crate::common::transcript_fixture(home, "p", "");
+    assert!(!recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_returns_false_when_transcript_file_unreadable() {
+    // The file EXISTS (so `is_safe_transcript_path`'s canonicalize
+    // succeeds — it stats components, not opens), but `File::open`
+    // inside `read_recent_turns` returns Err(PermissionDenied), so the
+    // walker hits the `None => return false` arm of the read match. A
+    // missing-file test instead trips the path validator first, so
+    // this chmod-000 case is the one that reaches the read-failure
+    // branch.
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let proj = home.join(".claude").join("projects").join("p");
+    fs::create_dir_all(&proj).unwrap();
+    let path = proj.join("session.jsonl");
+    fs::write(&path, b"{\"type\":\"user\"}\n").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+    struct PermGuard(std::path::PathBuf);
+    impl Drop for PermGuard {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(&self.0, fs::Permissions::from_mode(0o644));
+        }
+    }
+    let _g = PermGuard(path.clone());
+    assert!(!recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_returns_false_when_only_assistant_turns() {
+    // A transcript with only assistant turns (no user turn). The
+    // walker enters the loop, skips every non-user turn (turn_type !=
+    // "user" continue), exhausts the iterator without returning, and
+    // falls through to false — the loop-iterated-then-exhausted path
+    // distinct from the empty-transcript case (loop never runs).
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"thinking\"}]}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"more thinking\"}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_skips_blank_lines() {
+    // A blank (whitespace-only) line between turns is skipped via the
+    // `trimmed.is_empty()` continue; the handoff on the line behind
+    // it still drives the true return.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"{\\\"status\\\":\\\"error\\\",\\\"reason\\\":\\\"agents_skipped\\\"}\",\"is_error\":false}]}}\n\
+   \n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_skips_hook_feedback_string_content_ismeta_true() {
+    // Real user prose → assistant Bash phase-finalize tool_use →
+    // tool_result-wrapped user turn carrying the agents_skipped
+    // handoff → hook-feedback string-content user turn with
+    // `isMeta:true` at the tail. The walker must skip the
+    // hook-feedback turn and reach the tool_result-wrapped user turn
+    // to detect the handoff. Without the filter, the walker stops at
+    // the hook-feedback turn, finds no handoff, and the carve-out
+    // fails to fire — deadlocking the autonomous Review handoff
+    // prompt.
+    //
+    // Regression guard per `.claude/rules/transcript-shape.md`
+    // Enforcement. Named consumer: the agent-skip-handoff carve-out
+    // in `validate-ask-user::run_impl_main`.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"finalize review\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"toolu_01\",\"input\":{\"command\":\"bin/flow phase-finalize\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01\",\"content\":\"{\\\"status\\\":\\\"error\\\",\\\"reason\\\":\\\"agents_skipped\\\"}\",\"is_error\":false}]}}\n\
+{\"type\":\"user\",\"isMeta\":true,\"message\":{\"role\":\"user\",\"content\":\"Stop hook feedback:\\nStop Refused: Continue, you can do it.\"}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_skips_compact_summary_turn() {
+    // Real user prose → assistant Bash phase-finalize tool_use →
+    // tool_result-wrapped user turn carrying the agents_skipped
+    // handoff → compaction-summary continuation turn at the tail.
+    // This walker uses an INLINE synthetic-turn skip (not
+    // `is_real_user_turn`), so it needs its own compact-summary skip
+    // to pass the continuation turn and reach the array-content
+    // tool_result turn. Without it, the walker stops at the
+    // compaction-summary turn (string content, no handoff) and
+    // returns false, deadlocking the autonomous Review handoff
+    // prompt.
+    //
+    // Regression guard per `.claude/rules/transcript-shape.md`
+    // Enforcement. Named consumer: the agent-skip-handoff carve-out
+    // in `validate-ask-user::run_impl_main`.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"finalize review\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"toolu_01\",\"input\":{\"command\":\"bin/flow phase-finalize\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01\",\"content\":\"{\\\"status\\\":\\\"error\\\",\\\"reason\\\":\\\"agents_skipped\\\"}\",\"is_error\":false}]}}\n\
+{\"type\":\"user\",\"isCompactSummary\":true,\"message\":{\"role\":\"user\",\"content\":\"This session is being continued from a previous conversation that ran out of context.\"}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(recent_phase_finalize_agent_skip(&path, home));
 }
 
 // --- user_approved_shared_config_edit ---

--- a/tests/hooks/transcript_walker.rs
+++ b/tests/hooks/transcript_walker.rs
@@ -1115,9 +1115,12 @@ fn helper_continues_when_tool_result_content_is_number() {
 // AskUserQuestion to ask the user how to proceed — but in an
 // in-progress autonomous Review phase, validate-ask-user blocks it.
 // This walker detects the recent phase-finalize skip handoff so the
-// carve-out can release the prompt. Detection signal: the literal
-// reason substring `agents_skipped` or `required_agent_not_returned`
-// inside a `tool_result` block in the most recent user-role turn.
+// carve-out can release the prompt. Detection signal: the JSON
+// reason key-value form `"reason":"agents_skipped"` or
+// `"reason":"required_agent_not_returned"` inside a `tool_result`
+// block in the most recent user-role turn. The key-value anchor (not
+// a bare `agents_skipped` substring) excludes `add-skipped-agent`'s
+// `agents_skipped_count` success envelope.
 // Unlike the shared-config block, phase-finalize returns exit 0 for
 // these business errors, so the tool_result's `is_error` is false —
 // the walker scans every tool_result regardless of `is_error`.
@@ -1167,6 +1170,25 @@ fn recent_phase_finalize_agent_skip_returns_false_when_no_reason() {
     let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"finalize\"}}\n\
 {\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"toolu_03\",\"input\":{\"command\":\"bin/flow phase-finalize\"}}]}}\n\
 {\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_03\",\"content\":\"{\\\"status\\\":\\\"ok\\\",\\\"formatted_time\\\":\\\"<1m\\\"}\",\"is_error\":false}]}}\n";
+    let path = crate::common::transcript_fixture(home, "p", jsonl);
+    assert!(!recent_phase_finalize_agent_skip(&path, home));
+}
+
+#[test]
+fn recent_phase_finalize_agent_skip_returns_false_for_add_skipped_agent_count_envelope() {
+    // `bin/flow add-skipped-agent` runs during Review and emits a
+    // SUCCESS envelope `{"status":"ok","agents_skipped_count":N,...}`.
+    // Its `agents_skipped_count` field contains `agents_skipped` as a
+    // substring, but the envelope is NOT a phase-finalize handoff.
+    // Anchoring the match on the `"reason":` key-value form excludes
+    // it so the carve-out does not spuriously release the
+    // autonomous-phase AskUserQuestion block. Regression guard for the
+    // gate-integrity bug the adversarial probe surfaced.
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"record the skip\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"toolu_cnt\",\"input\":{\"command\":\"bin/flow add-skipped-agent --phase flow-review --agent reviewer --reason api_error\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_cnt\",\"content\":\"{\\\"status\\\":\\\"ok\\\",\\\"agents_skipped_count\\\":1,\\\"phase\\\":\\\"flow-review\\\"}\",\"is_error\":false}]}}\n";
     let path = crate::common::transcript_fixture(home, "p", jsonl);
     assert!(!recent_phase_finalize_agent_skip(&path, home));
 }

--- a/tests/hooks/validate_ask_user.rs
+++ b/tests/hooks/validate_ask_user.rs
@@ -1093,3 +1093,78 @@ fn subprocess_integration_shared_config_block_persists_no_marker() {
     assert_eq!(code, 2, "stderr: {}", stderr);
     assert!(stderr.contains("BLOCKED"), "stderr: {}", stderr);
 }
+
+// --- Agent-skip-handoff carve-out wiring ---
+//
+// Verifies the third carve-out in `run_impl_main`: when the transcript
+// shows a recent `phase-finalize` agent-skip handoff (reason
+// `agents_skipped` or `required_agent_not_returned`), the
+// AskUserQuestion that flow-review's Done handler fires to ask the
+// user how to proceed must be allowed even during an in-progress
+// autonomous Review phase. Without the carve-out, a genuine agent
+// skip deadlocks the autonomous flow. Backed by
+// `transcript_walker::recent_phase_finalize_agent_skip`.
+
+#[test]
+fn agent_skip_carve_out_allows_ask_for_agents_skipped() {
+    // in_progress + auto Review + recent phase-finalize agents_skipped
+    // handoff. The carve-out fires and AskUserQuestion is allowed
+    // (exit 0).
+    let state = json!({
+        "current_phase": "flow-review",
+        "branch": "test",
+        "phases": {"flow-review": {"status": "in_progress"}},
+        "skills": {"flow-review": {"continue": "auto"}},
+    });
+    let (_tmp, root) = shared_config_subprocess_fixture(&state);
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"finalize review\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"t1\",\"input\":{\"command\":\"bin/flow phase-finalize --phase flow-review --branch test\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\",\"content\":\"{\\\"status\\\":\\\"error\\\",\\\"reason\\\":\\\"agents_skipped\\\",\\\"skipped\\\":[\\\"reviewer\\\"]}\",\"is_error\":false}]}}\n";
+    let transcript = carve_out_transcript_fixture(&root, jsonl);
+    let payload = json!({"transcript_path": transcript.to_string_lossy()});
+    let (code, _stdout, stderr) = run_validate_ask_user(&root, &payload);
+    assert_eq!(code, 0, "stderr: {}", stderr);
+}
+
+#[test]
+fn agent_skip_carve_out_allows_ask_for_required_agent_not_returned() {
+    // The same carve-out fires for the required_agent_not_returned
+    // reason.
+    let state = json!({
+        "current_phase": "flow-review",
+        "branch": "test",
+        "phases": {"flow-review": {"status": "in_progress"}},
+        "skills": {"flow-review": {"continue": "auto"}},
+    });
+    let (_tmp, root) = shared_config_subprocess_fixture(&state);
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"finalize review\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"t1\",\"input\":{\"command\":\"bin/flow phase-finalize --phase flow-review --branch test\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\",\"content\":\"{\\\"status\\\":\\\"error\\\",\\\"reason\\\":\\\"required_agent_not_returned\\\",\\\"missing\\\":[\\\"adversarial\\\"]}\",\"is_error\":false}]}}\n";
+    let transcript = carve_out_transcript_fixture(&root, jsonl);
+    let payload = json!({"transcript_path": transcript.to_string_lossy()});
+    let (code, _stdout, stderr) = run_validate_ask_user(&root, &payload);
+    assert_eq!(code, 0, "stderr: {}", stderr);
+}
+
+#[test]
+fn agent_skip_carve_out_does_not_fire_on_ok_finalize() {
+    // Negative case: in_progress + auto Review + a successful
+    // phase-finalize `{"status":"ok"}` tool_result. No handoff
+    // reason, no user-only Skill, no shared-config block — the
+    // autonomous-phase block still fires (exit 2).
+    let state = json!({
+        "current_phase": "flow-review",
+        "branch": "test",
+        "phases": {"flow-review": {"status": "in_progress"}},
+        "skills": {"flow-review": {"continue": "auto"}},
+    });
+    let (_tmp, root) = shared_config_subprocess_fixture(&state);
+    let jsonl = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"finalize review\"}}\n\
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"id\":\"t1\",\"input\":{\"command\":\"bin/flow phase-finalize --phase flow-review --branch test\"}}]}}\n\
+{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\",\"content\":\"{\\\"status\\\":\\\"ok\\\",\\\"formatted_time\\\":\\\"<1m\\\"}\",\"is_error\":false}]}}\n";
+    let transcript = carve_out_transcript_fixture(&root, jsonl);
+    let payload = json!({"transcript_path": transcript.to_string_lossy()});
+    let (code, _stdout, stderr) = run_validate_ask_user(&root, &payload);
+    assert_eq!(code, 2, "stderr: {}", stderr);
+    assert!(stderr.contains("BLOCKED"), "stderr: {}", stderr);
+}


### PR DESCRIPTION
## What

#1799.

Closes #1799

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/review-phase-deadlocks-when/plan.md` |
| Log | `.flow-states/review-phase-deadlocks-when/log` |
| State | `.flow-states/review-phase-deadlocks-when/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/0809a7d3-c328-4b45-a459-fea191303867.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 1h 10m |
| Review | 34m |
| Learn | 4m |
| Complete | <1m |
| **Total** | **1h 50m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 1.9M | $1.013 |
| Code | 122.9M | $71.119 |
| Review | 52.7M | — |
| Learn | 10.5M | — |
| Complete | 1.6M | — |
| **Total** | **189.5M** | **$72.132**\* |

| Model | Tokens |
|-------|--------|
| claude-opus-4-8 | 189.5M |
| <synthetic> | 0 |

*Partial: some phases had no cost data.*

<!-- end:Token Cost -->

## Review Findings

- ✗ **Pre-mortem F1: SessionStart cross-flow contamination via detect_branch_from_path git-subprocess fallback**
  - Dismissed — Not reachable: FLOW checks the feature branch out in the worktree (.worktrees/&lt;branch&gt;), so the main repo is never on a flow branch; resolve_main_root scopes is_flow_active to the cwd's own repo, so refresh never writes another flow's state. The git-fallback resolves only the integration branch or a non-flow branch, for which no state.json exists.
- ✗ **Pre-mortem F2: agent-skip carve-out fires in any in-progress autonomous phase, not only flow-review**
  - Dismissed — Intentional: phase-finalize's required-agents gate emits agents_skipped/required_agent_not_returned for flow-learn too (learn-analyst is a required agent), so the carve-out must be phase-agnostic. The most-recent-user-turn walker window prevents a stale Review handoff from releasing an unrelated later-phase prompt.
- ✗ **Pre-mortem F4: mid-phase session-rotation resume gap (phase-enter marker in prior transcript, agent pair in rotated transcript)**
  - Dismissed — Documented out-of-scope limitation: capture_session.rs module doc and the plan both name this as deferred future work requiring a session-lineage union scan across prior and rotated transcripts. It is a separate capability, not a defect in this PR's refresh; the refresh E2E test covers the single-transcript rotation case it targets.
- ✗ **Pre-mortem F5: refresh_active_flow_session writes session_id to state without is_safe_session_id validation at the write boundary**
  - Dismissed — False: capture_session::run() validates session_id via is_safe_session_id at function entry (Some(s) if is_safe_session_id(s) =&gt; ..., else return) BEFORE calling refresh_active_flow_session(&cwd, &session_id, ...). The refresh receives an already-validated value; the validation is at the boundary, the write consumes the validated value.
- ✓ **user_turn_carries_phase_finalize_skip matched bare substring agents_skipped, colliding with add-skipped-agent's agents_skipped_count success envelope and spuriously releasing the autonomous-phase AskUserQuestion block during Review**
  - Fixed — Fixed: tightened the predicate to match the JSON key-value form "reason":"agents_skipped" / "reason":"required_agent_not_returned" instead of the bare token, excluding the agents_skipped_count success field. Updated the doc comment and added regression test recent_phase_finalize_agent_skip_returns_false_for_add_skipped_agent_count_envelope. Adversarial probe reconciled (emptied).
- ✓ **any_tool_result_text doc comment stale: claimed it scans only is_error-truthy blocks unconditionally, omitted the require_error param and the new consumer user_turn_carries_phase_finalize_skip**
  - Fixed — Fixed: rewrote the doc comment to describe require_error (true = error-only, false = every tool_result) and listed all three consumers with their require_error value.
- ✓ **autonomous-phase-discipline.md documented the User-Only Skill and Shared-Config carve-outs per-subsection but lacked a parallel subsection for the new Agent-Skip-Handoff carve-out this PR introduced**
  - Fixed — Fixed: added an Agent-Skip-Handoff Carve-Out section parallel to the other two, describing the walker, the is_error-false scan, the reason-key-value detection signal and the add-skipped-agent collision it avoids, the phase-agnostic scope, ordering, and the cross-ref to hook-vs-instruction.md. Routed via bin/flow write-rule (56 insertions, 0 deletions).

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/review-phase-deadlocks-when.json</summary>

````json
{
  "schema_version": 1,
  "branch": "review-phase-deadlocks-when",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1800,
  "pr_url": "https://github.com/benkruger/flow/pull/1800",
  "started_at": "2026-06-01T15:44:37-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/review-phase-deadlocks-when/plan.md",
    "log": ".flow-states/review-phase-deadlocks-when/log",
    "state": ".flow-states/review-phase-deadlocks-when/state.json"
  },
  "session_tty": "/dev/ttys007",
  "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/0809a7d3-c328-4b45-a459-fea191303867.jsonl",
  "notes": [],
  "prompt": "#1799",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-06-01T15:44:37-07:00",
      "completed_at": "2026-06-01T15:45:25-07:00",
      "session_started_at": null,
      "cumulative_seconds": 48,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-01T15:44:37-07:00",
        "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
        "model": "claude-opus-4-8",
        "five_hour_pct": 3,
        "seven_day_pct": 6,
        "session_input_tokens": 4808,
        "session_output_tokens": 1068,
        "session_cache_creation_tokens": 245428,
        "session_cache_read_tokens": 16509,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4808,
            "output": 1068,
            "cache_create": 245428,
            "cache_read": 16509
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 266745,
        "context_window_pct": 133.3725
      },
      "window_at_complete": {
        "captured_at": "2026-06-01T15:45:25-07:00",
        "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
        "model": "claude-opus-4-8",
        "five_hour_pct": 3,
        "seven_day_pct": 6,
        "session_input_tokens": 4951,
        "session_output_tokens": 2190,
        "session_cache_creation_tokens": 253050,
        "session_cache_read_tokens": 1889838,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4951,
            "output": 2190,
            "cache_create": 253050,
            "cache_read": 1889838
          }
        },
        "turn_count": 8,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 269561,
        "context_window_pct": 134.7805
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-06-01T15:45:34-07:00",
      "completed_at": "2026-06-01T16:55:59-07:00",
      "session_started_at": null,
      "cumulative_seconds": 4225,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-01T15:45:34-07:00",
        "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
        "model": "claude-opus-4-8",
        "five_hour_pct": 3,
        "seven_day_pct": 6,
        "session_input_tokens": 4955,
        "session_output_tokens": 2582,
        "session_cache_creation_tokens": 253389,
        "session_cache_read_tokens": 2429100,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4955,
            "output": 2582,
            "cache_create": 253389,
            "cache_read": 2429100
          }
        },
        "turn_count": 10,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 269900,
        "context_window_pct": 134.95
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-06-01T15:52:35-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 4,
          "seven_day_pct": 6,
          "session_input_tokens": 238038,
          "session_output_tokens": 31769,
          "session_cache_creation_tokens": 578261,
          "session_cache_read_tokens": 16406477,
          "by_model": {
            "claude-opus-4-8": {
              "input": 238038,
              "output": 31769,
              "cache_create": 578261,
              "cache_read": 16406477
            }
          },
          "turn_count": 38,
          "tool_call_count": 8,
          "context_at_last_turn_tokens": 594772,
          "context_window_pct": 297.386
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-06-01T15:52:35-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 4,
          "seven_day_pct": 6,
          "session_input_tokens": 238038,
          "session_output_tokens": 31769,
          "session_cache_creation_tokens": 578261,
          "session_cache_read_tokens": 16406477,
          "by_model": {
            "claude-opus-4-8": {
              "input": 238038,
              "output": 31769,
              "cache_create": 578261,
              "cache_read": 16406477
            }
          },
          "turn_count": 38,
          "tool_call_count": 8,
          "context_at_last_turn_tokens": 594772,
          "context_window_pct": 297.386
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-06-01T16:18:48-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 9,
          "seven_day_pct": 7,
          "session_input_tokens": 243343,
          "session_output_tokens": 100470,
          "session_cache_creation_tokens": 721437,
          "session_cache_read_tokens": 66827578,
          "by_model": {
            "claude-opus-4-8": {
              "input": 243343,
              "output": 100470,
              "cache_create": 721437,
              "cache_read": 66827578
            }
          },
          "turn_count": 114,
          "tool_call_count": 37,
          "context_at_last_turn_tokens": 737948,
          "context_window_pct": 368.974
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-06-01T16:18:48-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 9,
          "seven_day_pct": 7,
          "session_input_tokens": 243343,
          "session_output_tokens": 100470,
          "session_cache_creation_tokens": 721437,
          "session_cache_read_tokens": 66827578,
          "by_model": {
            "claude-opus-4-8": {
              "input": 243343,
              "output": 100470,
              "cache_create": 721437,
              "cache_read": 66827578
            }
          },
          "turn_count": 114,
          "tool_call_count": 37,
          "context_at_last_turn_tokens": 737948,
          "context_window_pct": 368.974
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-06-01T16:18:48-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 9,
          "seven_day_pct": 7,
          "session_input_tokens": 243343,
          "session_output_tokens": 100470,
          "session_cache_creation_tokens": 721437,
          "session_cache_read_tokens": 66827578,
          "by_model": {
            "claude-opus-4-8": {
              "input": 243343,
              "output": 100470,
              "cache_create": 721437,
              "cache_read": 66827578
            }
          },
          "turn_count": 114,
          "tool_call_count": 37,
          "context_at_last_turn_tokens": 737948,
          "context_window_pct": 368.974
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-06-01T16:18:48-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 9,
          "seven_day_pct": 7,
          "session_input_tokens": 243343,
          "session_output_tokens": 100470,
          "session_cache_creation_tokens": 721437,
          "session_cache_read_tokens": 66827578,
          "by_model": {
            "claude-opus-4-8": {
              "input": 243343,
              "output": 100470,
              "cache_create": 721437,
              "cache_read": 66827578
            }
          },
          "turn_count": 114,
          "tool_call_count": 37,
          "context_at_last_turn_tokens": 737948,
          "context_window_pct": 368.974
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-06-01T16:52:06-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 13,
          "seven_day_pct": 8,
          "session_input_tokens": 244754,
          "session_output_tokens": 202045,
          "session_cache_creation_tokens": 880145,
          "session_cache_read_tokens": 116081035,
          "by_model": {
            "claude-opus-4-8": {
              "input": 244754,
              "output": 202045,
              "cache_create": 880145,
              "cache_read": 116081035
            }
          },
          "turn_count": 175,
          "tool_call_count": 58,
          "context_at_last_turn_tokens": 896785,
          "context_window_pct": 448.3925
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-06-01T16:55:59-07:00",
        "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
        "model": "claude-opus-4-8",
        "five_hour_pct": 14,
        "seven_day_pct": 8,
        "session_input_tokens": 244900,
        "session_output_tokens": 204560,
        "session_cache_creation_tokens": 890626,
        "session_cache_read_tokens": 124203961,
        "by_model": {
          "claude-opus-4-8": {
            "input": 244900,
            "output": 204560,
            "cache_create": 890626,
            "cache_read": 124203961
          }
        },
        "turn_count": 184,
        "tool_call_count": 63,
        "context_at_last_turn_tokens": 907137,
        "context_window_pct": 453.5685
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-06-01T16:56:11-07:00",
      "completed_at": "2026-06-01T17:30:47-07:00",
      "session_started_at": null,
      "cumulative_seconds": 2076,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-01T16:56:11-07:00",
        "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
        "model": "claude-opus-4-8",
        "five_hour_pct": 14,
        "seven_day_pct": 8,
        "session_input_tokens": 248639,
        "session_output_tokens": 205109,
        "session_cache_creation_tokens": 895940,
        "session_cache_read_tokens": 126019458,
        "by_model": {
          "claude-opus-4-8": {
            "input": 248639,
            "output": 205109,
            "cache_create": 895940,
            "cache_read": 126019458
          }
        },
        "turn_count": 186,
        "tool_call_count": 63,
        "context_at_last_turn_tokens": 912451,
        "context_window_pct": 456.2255
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-06-01T16:57:13-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 14,
          "seven_day_pct": 8,
          "session_input_tokens": 248785,
          "session_output_tokens": 206746,
          "session_cache_creation_tokens": 915273,
          "session_cache_read_tokens": 134376032,
          "by_model": {
            "claude-opus-4-8": {
              "input": 248785,
              "output": 206746,
              "cache_create": 915273,
              "cache_read": 134376032
            }
          },
          "turn_count": 195,
          "tool_call_count": 69,
          "context_at_last_turn_tokens": 931784,
          "context_window_pct": 465.892
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-06-01T17:07:41-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 20,
          "seven_day_pct": 9,
          "session_input_tokens": 258623,
          "session_output_tokens": 233585,
          "session_cache_creation_tokens": 977703,
          "session_cache_read_tokens": 143002065,
          "by_model": {
            "claude-opus-4-8": {
              "input": 258623,
              "output": 233585,
              "cache_create": 977703,
              "cache_read": 143002065
            }
          },
          "turn_count": 204,
          "tool_call_count": 73,
          "context_at_last_turn_tokens": 994214,
          "context_window_pct": 497.107
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-06-01T17:14:44-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 22,
          "seven_day_pct": 9,
          "session_input_tokens": 523088,
          "session_output_tokens": 241896,
          "session_cache_creation_tokens": 1861999,
          "session_cache_read_tokens": 151659997,
          "by_model": {
            "claude-opus-4-8": {
              "input": 523088,
              "output": 241896,
              "cache_create": 1861999,
              "cache_read": 151659997
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 221,
          "tool_call_count": 77,
          "context_at_last_turn_tokens": 581751,
          "context_window_pct": 290.8755
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-06-01T17:30:03-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 24,
          "seven_day_pct": 10,
          "session_input_tokens": 523800,
          "session_output_tokens": 292293,
          "session_cache_creation_tokens": 1958698,
          "session_cache_read_tokens": 173140179,
          "by_model": {
            "claude-opus-4-8": {
              "input": 523800,
              "output": 292293,
              "cache_create": 1958698,
              "cache_read": 173140179
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 255,
          "tool_call_count": 87,
          "context_at_last_turn_tokens": 678321,
          "context_window_pct": 339.1605
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-06-01T17:07:13-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-06-01T17:07:19-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-06-01T17:07:24-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-06-01T17:07:30-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-06-01T17:30:47-07:00",
        "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
        "model": "claude-opus-4-8",
        "five_hour_pct": 24,
        "seven_day_pct": 10,
        "session_input_tokens": 523941,
        "session_output_tokens": 294744,
        "session_cache_creation_tokens": 1978169,
        "session_cache_read_tokens": 177267478,
        "by_model": {
          "claude-opus-4-8": {
            "input": 523941,
            "output": 294744,
            "cache_create": 1978169,
            "cache_read": 177267478
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 261,
        "tool_call_count": 89,
        "context_at_last_turn_tokens": 697792,
        "context_window_pct": 348.896
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-06-01T17:31:04-07:00",
      "completed_at": "2026-06-01T17:35:18-07:00",
      "session_started_at": null,
      "cumulative_seconds": 254,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-01T17:31:04-07:00",
        "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
        "model": "claude-opus-4-8",
        "five_hour_pct": 24,
        "seven_day_pct": 10,
        "session_input_tokens": 523945,
        "session_output_tokens": 295271,
        "session_cache_creation_tokens": 1978882,
        "session_cache_read_tokens": 178663618,
        "by_model": {
          "claude-opus-4-8": {
            "input": 523945,
            "output": 295271,
            "cache_create": 1978882,
            "cache_read": 178663618
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 263,
        "tool_call_count": 90,
        "context_at_last_turn_tokens": 698505,
        "context_window_pct": 349.2525
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-06-01T17:34:10-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-06-01T17:34:16-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 26,
          "seven_day_pct": 10,
          "session_input_tokens": 524216,
          "session_output_tokens": 303711,
          "session_cache_creation_tokens": 2034059,
          "session_cache_read_tokens": 183775441,
          "by_model": {
            "claude-opus-4-8": {
              "input": 524216,
              "output": 303711,
              "cache_create": 2034059,
              "cache_read": 183775441
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 270,
          "tool_call_count": 91,
          "context_at_last_turn_tokens": 753811,
          "context_window_pct": 376.9055
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-06-01T17:34:23-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 26,
          "seven_day_pct": 10,
          "session_input_tokens": 524216,
          "session_output_tokens": 303711,
          "session_cache_creation_tokens": 2034059,
          "session_cache_read_tokens": 183775441,
          "by_model": {
            "claude-opus-4-8": {
              "input": 524216,
              "output": 303711,
              "cache_create": 2034059,
              "cache_read": 183775441
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 270,
          "tool_call_count": 91,
          "context_at_last_turn_tokens": 753811,
          "context_window_pct": 376.9055
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-06-01T17:34:28-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 26,
          "seven_day_pct": 10,
          "session_input_tokens": 524220,
          "session_output_tokens": 304258,
          "session_cache_creation_tokens": 2034801,
          "session_cache_read_tokens": 185283072,
          "by_model": {
            "claude-opus-4-8": {
              "input": 524220,
              "output": 304258,
              "cache_create": 2034801,
              "cache_read": 185283072
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 272,
          "tool_call_count": 92,
          "context_at_last_turn_tokens": 754424,
          "context_window_pct": 377.212
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-06-01T17:34:42-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 26,
          "seven_day_pct": 10,
          "session_input_tokens": 524222,
          "session_output_tokens": 304417,
          "session_cache_creation_tokens": 2034943,
          "session_cache_read_tokens": 186037494,
          "by_model": {
            "claude-opus-4-8": {
              "input": 524222,
              "output": 304417,
              "cache_create": 2034943,
              "cache_read": 186037494
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 273,
          "tool_call_count": 92,
          "context_at_last_turn_tokens": 754566,
          "context_window_pct": 377.283
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-06-01T17:34:52-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 26,
          "seven_day_pct": 10,
          "session_input_tokens": 524224,
          "session_output_tokens": 304787,
          "session_cache_creation_tokens": 2035127,
          "session_cache_read_tokens": 186792058,
          "by_model": {
            "claude-opus-4-8": {
              "input": 524224,
              "output": 304787,
              "cache_create": 2035127,
              "cache_read": 186792058
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 274,
          "tool_call_count": 92,
          "context_at_last_turn_tokens": 754750,
          "context_window_pct": 377.375
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-06-01T17:35:03-07:00",
          "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
          "model": "claude-opus-4-8",
          "five_hour_pct": 26,
          "seven_day_pct": 10,
          "session_input_tokens": 524228,
          "session_output_tokens": 304983,
          "session_cache_creation_tokens": 2035679,
          "session_cache_read_tokens": 188301957,
          "by_model": {
            "claude-opus-4-8": {
              "input": 524228,
              "output": 304983,
              "cache_create": 2035679,
              "cache_read": 188301957
            },
            "<synthetic>": {
              "input": 0,
              "output": 0,
              "cache_create": 0,
              "cache_read": 0
            }
          },
          "turn_count": 276,
          "tool_call_count": 94,
          "context_at_last_turn_tokens": 755302,
          "context_window_pct": 377.651
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-06-01T17:35:18-07:00",
        "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
        "model": "claude-opus-4-8",
        "five_hour_pct": 26,
        "seven_day_pct": 10,
        "session_input_tokens": 524359,
        "session_output_tokens": 305342,
        "session_cache_creation_tokens": 2052454,
        "session_cache_read_tokens": 189057257,
        "by_model": {
          "claude-opus-4-8": {
            "input": 524359,
            "output": 305342,
            "cache_create": 2052454,
            "cache_read": 189057257
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 277,
        "tool_call_count": 94,
        "context_at_last_turn_tokens": 772206,
        "context_window_pct": 386.103
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-06-01T17:35:33-07:00",
      "completed_at": "2026-06-01T17:35:53-07:00",
      "session_started_at": null,
      "cumulative_seconds": 20,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-01T17:35:33-07:00",
        "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
        "model": "claude-opus-4-8",
        "five_hour_pct": 26,
        "seven_day_pct": 10,
        "session_input_tokens": 524363,
        "session_output_tokens": 306447,
        "session_cache_creation_tokens": 2053863,
        "session_cache_read_tokens": 190601928,
        "by_model": {
          "claude-opus-4-8": {
            "input": 524363,
            "output": 306447,
            "cache_create": 2053863,
            "cache_read": 190601928
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 279,
        "tool_call_count": 94,
        "context_at_last_turn_tokens": 773486,
        "context_window_pct": 386.743
      },
      "window_at_complete": {
        "captured_at": "2026-06-01T17:35:53-07:00",
        "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
        "model": "claude-opus-4-8",
        "five_hour_pct": 26,
        "seven_day_pct": 10,
        "session_input_tokens": 524366,
        "session_output_tokens": 307171,
        "session_cache_creation_tokens": 2064453,
        "session_cache_read_tokens": 192158985,
        "by_model": {
          "claude-opus-4-8": {
            "input": 524366,
            "output": 307171,
            "cache_create": 2064453,
            "cache_read": 192158985
          },
          "<synthetic>": {
            "input": 0,
            "output": 0,
            "cache_create": 0,
            "cache_read": 0
          }
        },
        "turn_count": 281,
        "tool_call_count": 94,
        "context_at_last_turn_tokens": 784076,
        "context_window_pct": 392.038
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-06-01T15:45:34-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-06-01T16:56:11-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-06-01T17:31:04-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-06-01T17:35:33-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-06-01T15:44:37-07:00",
    "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
    "model": "claude-opus-4-8",
    "five_hour_pct": 3,
    "seven_day_pct": 6,
    "session_input_tokens": 4808,
    "session_output_tokens": 1068,
    "session_cache_creation_tokens": 245428,
    "session_cache_read_tokens": 16509,
    "by_model": {
      "claude-opus-4-8": {
        "input": 4808,
        "output": 1068,
        "cache_create": 245428,
        "cache_read": 16509
      }
    },
    "turn_count": 1,
    "tool_call_count": 0,
    "context_at_last_turn_tokens": 266745,
    "context_window_pct": 133.3725
  },
  "code_tasks_total": 7,
  "code_task": 7,
  "code_task_name": "E2E resume contract test + docs",
  "diff_stats": {
    "files_changed": 7,
    "insertions": 986,
    "deletions": 13,
    "captured_at": "2026-06-01T16:55:59-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "compact_summary": "<analysis>\nThis is a FLOW plugin development session. The user invoked `/flow:flow-start #1799`, which kicked off an autonomous (continue=auto, commit=auto) 5-phase lifecycle for GitHub issue #1799. The session has progressed through Phase 1 (Start), Phase 2 (Code, all 7 tasks), and is now in Phase 3 (Review), Step 2 (agent launch).\n\nThe issue (#1799) addresses two Review-phase deadlocks:\n- **Bug 1**: Session rotation mid-flow leaves the active flow pointing at the stale flow-start transcript → `record-agent-return` reports `phase_marker_not_found`. Fix: `capture_session::refresh_active_flow_session` refreshes session_id + transcript_path on SessionStart.\n- **Bug 2**: `phase-finalize` agents_skipped/required_agent_not_returned handoff fires AskUserQuestion that gets blocked by validate-ask-user in autonomous Review. Fix: third validate-ask-user carve-out backed by new walker `recent_phase_finalize_agent_skip`.\n\nLet me trace the work chronologically:\n\n**Phase 1 (Start)**: ran start-init (branch `review-phase-deadlocks-when`), start-gate (clean), start-workspace (PR #1800, worktree), plan-from-issue (7 tasks), phase-finalize. Auto-advanced to Code.\n\n**Phase 2 (Code)** — the plan has 7 tasks:\n- Tasks 1-2 (TDD pair): refresh helper tests + impl. Committed SHA `1fde509b`. Hit 100% coverage after collapsing an `if let Some(cwd)` into `unwrap_or_default()` for the unreachable None branch.\n- Tasks 3-6 (batched): skip-detect walker (tests + impl) + carve-out (tests + impl). Committed SHA `c6f28d8a`. Had a major coverage debugging episode: per-file gate showed 85%/54% (cross-module tested files), then full CI showed exactly 1 missed region (line 1509 `None => return false` in read_recent_turns match). The missing test was an unreadable-file (chmod 000) case, not a missing-file case (which trips is_safe_transcript_path first). Found via `bin/test --report` (cargo llvm-cov report --show-missing-lines).\n- Task 7: E2E contract test (capture-session rotation → record-agent-return passes) + docs (capture_session.rs limitation note, hook-vs-instruction.md \"Two\"→\"Three carve-outs\" via write-rule). Committed SHA `c7bafc1f`. Logged docs decisions deferring CLAUDE.md Key Files entry and autonomous-phase-discipline.md subsection.\n\nCode phase finalized (1h 10m), auto-advanced to Review.\n\n**Phase 3 (Review)**:\n- Step 1 (Gather): base-branch=main, capture-diff (full/substantive paths), name-only (7 files), adversarial-path=tests/test_adversarial_flow.rs, tombstone-audit (no stale). Recorded review_step=1.\n- Step 2 (Launch): I launched all 4 agents in ONE response. Results:\n  - **Reviewer agent** (a2a9e2466b441e50b) — returned cleanly with 2 findings:\n    - Finding 1 (Low/Architecture): autonomous-phase-discipline.md missing agent-skip carve-out subsection\n    - Finding 2 (Low/Correctness): `agents_skipped` substring also matches `agents_skipped_count` from add_skipped_agent.rs:180-186 success envelope. Doc-comment claim \"emitted only by phase-finalize JSON\" is technically inaccurate. Recommends tightening to `\"reason\":\"agents_skipped\"` OR correcting doc comment. Confirmed NO runtime bug in documented flow (most-recent-turn windowing scopes it safe).\n  - **Pre-mortem agent** — BLOCKED by validate-pretool: my prompt referenced path `/state.json` (out of worktree). Did NOT run.\n  - **Adversarial agent** — BLOCKED by validate-pretool: my prompt referenced `/Users/ben/code/flow/bin/flow` (out of worktree). Did NOT run.\n  - **Documentation agent** (a3bac6a8474930e08) — returned cleanly with 2 findings:\n    - Finding 1 (Documentation): `any_tool_result_text` doc comment still says \"whose is_error is truthy\" — stale after adding `require_error` param; also missing new consumer `user_turn_carries_phase_finalize_skip` in the \"Private implementation for\" list.\n    - Finding 2 (Documentation): autonomous-phase-discipline.md missing \"Agent-Skip-Handoff Carve-Out\" subsection (same as reviewer Finding 1). Documentation agent argues the deferral is NOT sound — material gap.\n\nSo 2 of 4 agents BLOCKED due to my prompt containing out-of-worktree paths. The Agent prompt scan (agent_prompt_scan::validate_agent_prompt) rejects out-of-worktree paths. The pre-mortem prompt had `/state.json` (I wrote \".flow-states/<branch>/state.json\" which got scanned and `/state.json` flagged). The adversarial prompt had `/Users/ben/code/flow/bin/flow` (the main-repo bin/flow path, out of worktree).\n\nThe skill's HARD-GATE says all 4 agents must launch in ONE response and per-agent accounting runs ONLY after all four return. Two failed to launch. Per the skill's Step 2, this requires retry (the agents are not \"skipped\" via Class 2 — they were blocked by a hook before running). I need to re-launch the 2 blocked agents with corrected prompts (drop/fix out-of-worktree paths).\n\nCritical fix for relaunch: the pre-mortem and adversarial prompts must NOT reference out-of-worktree paths. The substantive diff file path `/Users/ben/code/flow/.flow-states/review-phase-deadlocks-when/substantive-diff.diff` IS carved out (under .flow-states/<branch>/). But:\n- pre-mortem prompt had `.flow-states/<branch>/state.json` which the scanner saw as `/state.json` — need to phrase without that path token.\n- adversarial prompt had `/Users/ben/code/flow/bin/flow` (main-repo) and CLAUDE.md path at worktree (OK). Need to drop the main-repo bin/flow absolute path. The reviewer used worktree paths + the carved-out .flow-states diff path and succeeded. The documentation agent also succeeded with worktree paths + carved-out diff path.\n\nImportant: the reviewer and documentation agents SUCCEEDED, so their findings stand. I must NOT re-launch them (re-launching all 4 would re-bias). But the skill says launch all 4 in one response. Two were blocked (not returned). The retry path: re-launch only the blocked ones. The per-agent accounting (record-agent-return) for the 2 that succeeded + retry for the 2 blocked.\n\nActually, re-reading the skill HARD-GATE: \"Issue NO other tool call between the first agent's launch and the fourth agent's return.\" Two agents were blocked (didn't return). I should re-launch just the 2 blocked agents (pre-mortem, adversarial) in one response with fixed prompts. Then do per-agent accounting for all 4.\n\nNow for triage of the findings (Step 3): the findings are all Low and mostly documentation. Real findings to fix in Step 4:\n- Finding (reviewer F2 / could be dismissed or fixed): `agents_skipped` substring vs `agents_skipped_count`. The reviewer confirmed no runtime bug but the doc claim is inaccurate. Best fix: tighten match to `agents_skipped\\\"` or correct doc. This is a legitimate Real finding (correctness/precision + doc accuracy).\n- Finding (documentation F1): `any_tool_result_text` doc comment stale (is_error truthy claim + missing consumer). Real finding — source-local doc drift.\n- Finding (reviewer F1 / documentation F2): autonomous-phase-discipline.md missing agent-skip subsection. Both agents flagged it as material. My earlier logged deferral is challenged. I should fix it now (add the subsection via write-rule).\n\nI need to be careful about the out-of-worktree path issue when re-launching agents. The user has not given explicit feedback in this window — this is all autonomous flow execution. The \"user messages\" are the slash-command invocations and the skill prompts (which are technically the harness/skill, not the user).\n\nThe most recent work: I was in Step 2 of Review, having launched 4 agents; 2 succeeded (reviewer, documentation) and 2 were blocked by the out-of-worktree-path hook (pre-mortem, adversarial). I need to re-launch the 2 blocked agents with corrected prompts.\n\nLet me note all the SHAs, key paths, and the exact findings for continuation.\n\nSecurity/constraint notes from the global CLAUDE.md and rules that remain in effect:\n- Shell: bash only.\n- Git: never checkout/reset/stash; push immediately after commit; never Co-Authored-By; never heredoc for git commit.\n- Never use raw git commit during a flow — always /flow:flow-commit.\n- Never run bin/flow ci during Code phase (Layer 11) — but in Review Step 4, bin/flow ci IS the gate (run it).\n- Compound commands (pipes, &&, >, ;) blocked by validate-pretool.\n- .claude/ edits redirected to bin/flow write-rule (full file content).\n- The skill's Round 6 finalize-commit example uses a STALE flat path `<branch>-commit-msg.txt`; the correct path is `.flow-states/<branch>/commit-msg.txt`. I learned to use the subdir path.\n- Failed finalize-commit clears `_continue_pending`; must restore it (`set-timestamp --set _continue_pending=commit`) before re-running while still inside /flow:flow-commit.\n- resume-anchor returned a FOREIGN worktree (counter-learn) on --continue-step; I did NOT cd into it, verified cwd was correct.\n\nLet me write the summary.\n</analysis>\n\n<summary>\n\n1. Primary Request and Intent:\n   The user invoked `/flow:flow-start #1799` to run the FLOW plugin's autonomous 5-phase development lifecycle (Start→Code→Review→Learn→Complete) for GitHub issue #1799. The flow is configured `continue=auto, commit=auto` (fully autonomous). Issue #1799 fixes two Review-phase deadlocks in the FLOW plugin (the repo being developed IS the FLOW plugin itself, at `/Users/ben/code/flow`, worktree `/Users/ben/code/flow/.worktrees/review-phase-deadlocks-when`):\n   - **Bug 1 (AC1)**: A mid-flow Claude Code session rotation (startup|resume|clear|compact) leaves the active flow's `state.json` pointing at the stale flow-start transcript, so `record-agent-return`'s verifier reads the wrong transcript and reports `phase_marker_not_found` — deadlocking every Review/Learn agent. Fix: the SessionStart hook `capture_session::run` now also refreshes the active flow's `session_id` AND `transcript_path` via new private fn `refresh_active_flow_session(cwd, session_id, transcript_path)`, keyed by branch-from-cwd, fail-open.\n   - **Bug 2 (AC2)**: When `phase-finalize` returns an `agents_skipped`/`required_agent_not_returned` handoff during an in-progress autonomous Review phase, the `flow-review` Done handler's `AskUserQuestion` is blocked by `validate-ask-user`, deadlocking the flow. Fix: a third `validate-ask-user` carve-out in `run_impl_main`, backed by a new transcript walker `recent_phase_finalize_agent_skip`.\n   The intent is to execute the pre-decomposed 7-task plan through the full lifecycle autonomously.\n\n2. Key Technical Concepts:\n   - FLOW plugin 5-phase lifecycle; skills as SKILL.md, hooks as `bin/flow hook <name>`, Rust subcommands.\n   - Rust (flow-rs crate), `cargo-llvm-cov nextest` with pinned 100/100/100 coverage gate (no waivers).\n   - Per-file coverage gate `bin/test tests/<name>.rs` (filters to that module's tests; UNRELIABLE for cross-module-tested files like `transcript_walker.rs`/`validate_ask_user.rs` which need cross-module/subprocess tests). `bin/test --report` runs `cargo llvm-cov report --show-missing-lines` (compact, uses existing profdata, lists uncovered line numbers). `bin/test --show <file>` and `--funcs <file>` (—show output persists to BLOCKED `~/.claude/projects/.../tool-results/` path in autonomous flows).\n   - Transcript walkers: `read_recent_turns` (4MB cap), `read_recency_window` (50MB), `read_full` (uncapped); synthetic-turn discrimination (`is_real_user_turn`, `is_meta_marker_present`, `is_compact_summary_turn`) per transcript-shape.md. Per-walker regression tests `<walker>_skips_hook_feedback_string_content_ismeta_true` and `<walker>_skips_compact_summary_turn` are MANDATORY.\n   - `mutate_state`, `FlowPaths::try_new`, `detect_branch_from_path`, `resolve_main_root`, `is_flow_active`, `resolve_hook_cwd`.\n   - Layer 10 commit gate (blocks direct finalize-commit during flow; carve-out needs `_continue_pending=commit` + transcript showing flow:flow-commit as most-recent Skill). Layer 11 blocks `bin/flow ci` during Code phase. Agent-prompt scan (`agent_prompt_scan::validate_agent_prompt`) blocks out-of-worktree paths in Agent prompts (`.flow-states/<branch>/` IS carved out).\n   - `.claude/` edits redirected to `bin/flow write-rule --path <target> --content-file <temp>` (full-file overwrite only, no patch mode).\n   - validate-ask-user carve-outs (now THREE): user-only-skill, shared-config, agent-skip-handoff.\n\n3. Files and Code Sections:\n   - **src/hooks/capture_session.rs** (Tasks 1-2, committed `1fde509b`; Task 7 limitation note `c7bafc1f`):\n     - Added imports: `use crate::flow_paths::FlowPaths; use crate::hooks::{detect_branch_from_path, is_flow_active, resolve_hook_cwd, resolve_main_root}; use crate::lock::mutate_state;`\n     - In `run()`, after the global capture write: `let cwd = resolve_hook_cwd(&input).unwrap_or_default(); refresh_active_flow_session(&cwd, &session_id, transcript_path.as_deref());` (the `unwrap_or_default` collapses the unreachable None branch for 100% coverage).\n     - New private fn:\n       ```rust\n       fn refresh_active_flow_session(cwd: &str, session_id: &str, transcript_path: Option<&str>) {\n           let cwd_path = Path::new(cwd);\n           let branch = match detect_branch_from_path(cwd_path) { Some(b) => b, None => return };\n           let main_root = resolve_main_root(cwd_path);\n           if !is_flow_active(&branch, &main_root) { return; }\n           let state_path = FlowPaths::try_new(&main_root, &branch)\n               .expect(\"is_flow_active confirmed branch is valid\").state_file();\n           let _ = mutate_state(&state_path, &mut |state| {\n               if !(state.is_object() || state.is_null()) { return; }\n               state[\"session_id\"] = Value::String(session_id.to_string());\n               state[\"transcript_path\"] = match transcript_path {\n                   Some(tp) => Value::String(tp.to_string()), None => Value::Null };\n           });\n       }\n       ```\n     - Module doc updated (refresh behavior + \"Known limitation\" note about mid-phase resume needing a session-lineage union scan, deferred).\n   - **src/hooks/transcript_walker.rs** (Tasks 3-4, committed `c6f28d8a`):\n     - Renamed `any_error_tool_result_text` → `any_tool_result_text<F>(turn: &Value, require_error: bool, mut pred: F) -> bool`; added guard `if require_error && !is_truthy(block.get(\"is_error\")) { continue; }`. THREE callers: `user_turn_carries_shared_config_block` (require_error=true, line ~1627), `user_approved_shared_config_edit` corroboration (require_error=true, line ~1775), and new `user_turn_carries_phase_finalize_skip` (require_error=false, line ~1646).\n     - New private `user_turn_carries_phase_finalize_skip(turn) -> bool` = `any_tool_result_text(turn, false, |t| t.contains(\"agents_skipped\") || t.contains(\"required_agent_not_returned\"))`.\n     - New public `recent_phase_finalize_agent_skip(transcript_path: &Path, home: &Path) -> bool` (mirrors `recent_edit_blocked_on_shared_config`; validates path, `read_recent_turns`, walks backward skipping synthetic string-content turns via inline `is_meta_marker_present`/`is_compact_summary_turn` skips, returns `user_turn_carries_phase_finalize_skip` on most-recent user turn). The `None => return false` arm at line 1509 was the one uncovered region (fixed by chmod-000 unreadable-file test).\n   - **src/hooks/validate_ask_user.rs** (Task 6, committed `c6f28d8a`):\n     - Added import `recent_phase_finalize_agent_skip`.\n     - Module doc: \"Five outcomes\" → \"Six outcomes\"; renumbered (agent-skip is outcome 4, auto-answer 5, allow 6) — `3b.` numbering caused clippy `doc-lazy-continuation` error, fixed by renumbering.\n     - In `run_impl_main`, after shared-config carve-out branch:\n       ```rust\n       let allow_agent_skip = transcript_path.as_deref()\n           .map(|p| recent_phase_finalize_agent_skip(p, home)).unwrap_or(false);\n       if allow_agent_skip { return HookAction::AllowWithMark(state_path); }\n       ```\n   - **tests/hooks/capture_session.rs**: added `// --- refresh_active_flow_session ---` section (setup_refresh_fixture helper, make_transcript_path, read_state, 7 refresh tests incl array-root/slash-branch/no-active-flow/missing-cwd/cwd-scoping), and `e2e_session_rotation_refresh_lets_record_agent_return_pass` (real git worktree via `git worktree add`, stale vs live transcript, asserts record-agent-return errors before rotation and `status==ok` after).\n   - **tests/hooks/transcript_walker.rs**: added `// --- recent_phase_finalize_agent_skip ---` section with ~14 tests including the two mandated synthetic-skip regression tests, `..._returns_false_when_transcript_file_unreadable` (chmod-000, covers line 1509), `..._returns_false_when_only_assistant_turns`, `..._skips_blank_lines`. Import added to the top `use flow_rs::hooks::transcript_walker::{...}` block.\n   - **tests/hooks/validate_ask_user.rs**: added `// --- Agent-skip-handoff carve-out wiring ---` section: `agent_skip_carve_out_allows_ask_for_agents_skipped`, `..._for_required_agent_not_returned`, `agent_skip_carve_out_does_not_fire_on_ok_finalize` (subprocess tests via `run_validate_ask_user`).\n   - **.claude/rules/hook-vs-instruction.md** (Task 7, via write-rule): \"Two carve-outs\" → \"Three carve-outs\" + new Agent-skip-handoff carve-out bullet (16 insertions, 1 deletion — verified surgical).\n   - **.flow-states/review-phase-deadlocks-when/plan.md**: the 7-task plan (read; tasks 1-7 as described above).\n\n4. Errors and fixes:\n   - **finalize-commit \"could not read log file '...-commit-msg.txt'\"**: The flow-commit SKILL.md Round 6 example uses STALE flat path `<branch>-commit-msg.txt`, but Round 5's write-rule canonicalizes `commit-msg.txt` to `.flow-states/<branch>/commit-msg.txt` (subdir). Fix: invoke finalize-commit with the subdir path. Logged as a possible skill bug. This recurred on every commit; I consistently used the subdir path.\n   - **Layer 10 BLOCKED on finalize-commit retry**: The failed finalize-commit cleared `_continue_pending`. Fix: restore `bin/flow set-timestamp --set _continue_pending=commit` before re-running (still inside /flow:flow-commit, so the carve-out's transcript condition held).\n   - **resume-anchor returned foreign worktree** (`/private/tmp/.../counter-learn`) on --continue-step: did NOT cd into it; verified cwd was correct via `git branch --show-current`; logged for Learn.\n   - **Coverage at 99.91% (1 missed region)**: line 1509 `None => return false`. My `transcript_missing` test tripped `is_safe_transcript_path` first (missing files fail canonicalize). Fix: added chmod-000 unreadable-file test (file exists so path-validator passes, but `read_recent_turns` File::open fails → None arm). Found via `bin/test --report`.\n   - **clippy doc-lazy-continuation on `//! 3b.`**: fixed by renumbering the validate_ask_user module doc list (Five→Six outcomes, 4/5/6).\n   - **MOST RECENT — 2 of 4 review agents BLOCKED**: My pre-mortem prompt referenced `/state.json` (from \".flow-states/<branch>/state.json\" text) and my adversarial prompt referenced `/Users/ben/code/flow/bin/flow` (main-repo, out-of-worktree) — both rejected by validate-pretool's agent_prompt_scan. Reviewer and documentation agents succeeded (their prompts used worktree paths + the carved-out `.flow-states/<branch>/substantive-diff.diff`). NOT YET FIXED — need to re-launch the 2 blocked agents with prompts free of out-of-worktree path tokens.\n\n5. Problem Solving:\n   Solved: 100% coverage on cross-module-tested files (used full-CI commit gate + `bin/test --report` to pinpoint the single missed line); the commit-msg path mismatch; the carve-out marker restoration. Ongoing: re-launching the 2 blocked Review agents; then triaging the 4 findings (2 from reviewer, 2 from documentation).\n\n6. All user messages:\n   - `/clear` (command)\n   - `/flow:flow-start #1799` (the only substantive user instruction — start the autonomous flow for issue #1799). All subsequent \"messages\" are skill prompts injected by the FLOW harness (flow-start, flow-code, flow-commit, flow-review SKILL.md content), not direct user input. No mid-flow user corrections were given. Global standing constraints (from ~/.claude/CLAUDE.md and project rules, in effect): bash only; never git checkout/reset/stash; push after commit; no Co-Authored-By; never raw git commit during a flow (use /flow:flow-commit); never run bin/flow ci during Code phase; .claude/ edits via bin/flow write-rule; terse responses.\n\n7. Pending Tasks:\n   - Re-launch the 2 blocked Review agents (pre-mortem, adversarial) with corrected prompts (no out-of-worktree path tokens).\n   - Step 2 per-agent accounting: `record-agent-return` for the 4 agents (reviewer + documentation already returned).\n   - Step 3 triage of findings; Step 4 fix Real findings (likely: tighten `agents_skipped` match or fix its doc comment; fix `any_tool_result_text` stale doc comment; add Agent-Skip-Handoff Carve-Out subsection to autonomous-phase-discipline.md).\n   - Complete Review, then Phase 4 Learn, Phase 5 Complete.\n\n8. Current Work:\n   In Phase 3 Review, Step 2 (Launch agents). I launched all 4 agents in one response. Two returned cleanly:\n   - **Reviewer** (agentId a2a9e2466b441e50b): Finding 1 (Low) autonomous-phase-discipline.md missing agent-skip subsection; Finding 2 (Low/Correctness) `agents_skipped` substring also matches `agents_skipped_count` (from `src/add_skipped_agent.rs:180-186`), doc-comment claim \"emitted only by phase-finalize JSON\" inaccurate — recommends tightening match to `\"reason\":\"agents_skipped\"` OR correcting doc; confirmed no runtime bug (most-recent-turn windowing). Everything else verified clean.\n   - **Documentation** (agentId a3bac6a8474930e08): Finding 1 `any_tool_result_text` doc comment stale (\"whose is_error is truthy\" no longer always true; `require_error` param undocumented; missing consumer `user_turn_carries_phase_finalize_skip` in \"Private implementation for\" list); Finding 2 autonomous-phase-discipline.md missing \"Agent-Skip-Handoff Carve-Out\" subsection (argues deferral NOT sound, material gap). Validated the CLAUDE.md Key Files skip decision as sound.\n   Two were BLOCKED before running (out-of-worktree paths in prompts): pre-mortem (`/state.json`) and adversarial (`/Users/ben/code/flow/bin/flow`).\n\n9. Optional Next Step:\n   Re-launch ONLY the 2 blocked agents (pre-mortem and adversarial) in a single response, with prompts that contain NO out-of-worktree path tokens — reference only the carved-out substantive diff path `/Users/ben/code/flow/.flow-states/review-phase-deadlocks-when/substantive-diff.diff`, worktree paths under `/Users/ben/code/flow/.worktrees/review-phase-deadlocks-when/`, and use plugin-root-prefixed `bin/flow` WITHOUT the absolute main-repo path (or omit the bin/flow path entirely / phrase the adversarial test command without the out-of-worktree absolute prefix). The skill HARD-GATE states: \"You MUST launch ALL applicable agents... Never skip an agent... Issue NO other tool call... between the first agent's launch and the fourth agent's return.\" Since these two never returned, they must be relaunched. After all four are accounted for, do per-agent `record-agent-return` (only after all return), then proceed to Step 3 triage. (Do NOT re-launch reviewer/documentation — they succeeded and re-running would re-bias.)\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/review-phase-deadlocks-when",
  "compact_count": 1,
  "findings": [
    {
      "finding": "Pre-mortem F1: SessionStart cross-flow contamination via detect_branch_from_path git-subprocess fallback",
      "reason": "Not reachable: FLOW checks the feature branch out in the worktree (.worktrees/<branch>), so the main repo is never on a flow branch; resolve_main_root scopes is_flow_active to the cwd's own repo, so refresh never writes another flow's state. The git-fallback resolves only the integration branch or a non-flow branch, for which no state.json exists.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-01T17:14:11-07:00"
    },
    {
      "finding": "Pre-mortem F2: agent-skip carve-out fires in any in-progress autonomous phase, not only flow-review",
      "reason": "Intentional: phase-finalize's required-agents gate emits agents_skipped/required_agent_not_returned for flow-learn too (learn-analyst is a required agent), so the carve-out must be phase-agnostic. The most-recent-user-turn walker window prevents a stale Review handoff from releasing an unrelated later-phase prompt.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-01T17:14:22-07:00"
    },
    {
      "finding": "Pre-mortem F4: mid-phase session-rotation resume gap (phase-enter marker in prior transcript, agent pair in rotated transcript)",
      "reason": "Documented out-of-scope limitation: capture_session.rs module doc and the plan both name this as deferred future work requiring a session-lineage union scan across prior and rotated transcripts. It is a separate capability, not a defect in this PR's refresh; the refresh E2E test covers the single-transcript rotation case it targets.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-01T17:14:29-07:00"
    },
    {
      "finding": "Pre-mortem F5: refresh_active_flow_session writes session_id to state without is_safe_session_id validation at the write boundary",
      "reason": "False: capture_session::run() validates session_id via is_safe_session_id at function entry (Some(s) if is_safe_session_id(s) => ..., else return) BEFORE calling refresh_active_flow_session(&cwd, &session_id, ...). The refresh receives an already-validated value; the validation is at the boundary, the write consumes the validated value.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-01T17:14:38-07:00"
    },
    {
      "finding": "user_turn_carries_phase_finalize_skip matched bare substring agents_skipped, colliding with add-skipped-agent's agents_skipped_count success envelope and spuriously releasing the autonomous-phase AskUserQuestion block during Review",
      "reason": "Fixed: tightened the predicate to match the JSON key-value form \"reason\":\"agents_skipped\" / \"reason\":\"required_agent_not_returned\" instead of the bare token, excluding the agents_skipped_count success field. Updated the doc comment and added regression test recent_phase_finalize_agent_skip_returns_false_for_add_skipped_agent_count_envelope. Adversarial probe reconciled (emptied).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-01T17:23:47-07:00"
    },
    {
      "finding": "any_tool_result_text doc comment stale: claimed it scans only is_error-truthy blocks unconditionally, omitted the require_error param and the new consumer user_turn_carries_phase_finalize_skip",
      "reason": "Fixed: rewrote the doc comment to describe require_error (true = error-only, false = every tool_result) and listed all three consumers with their require_error value.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-01T17:23:57-07:00"
    },
    {
      "finding": "autonomous-phase-discipline.md documented the User-Only Skill and Shared-Config carve-outs per-subsection but lacked a parallel subsection for the new Agent-Skip-Handoff carve-out this PR introduced",
      "reason": "Fixed: added an Agent-Skip-Handoff Carve-Out section parallel to the other two, describing the walker, the is_error-false scan, the reason-key-value detection signal and the add-skipped-agent collision it avoids, the phase-agnostic scope, ordering, and the cross-ref to hook-vs-instruction.md. Routed via bin/flow write-rule (56 insertions, 0 deletions).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-01T17:24:04-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 5,
  "complete_step": 5,
  "window_at_complete": {
    "captured_at": "2026-06-01T17:35:53-07:00",
    "session_id": "0809a7d3-c328-4b45-a459-fea191303867",
    "model": "claude-opus-4-8",
    "five_hour_pct": 26,
    "seven_day_pct": 10,
    "session_input_tokens": 524366,
    "session_output_tokens": 307171,
    "session_cache_creation_tokens": 2064453,
    "session_cache_read_tokens": 192158985,
    "by_model": {
      "claude-opus-4-8": {
        "input": 524366,
        "output": 307171,
        "cache_create": 2064453,
        "cache_read": 192158985
      },
      "<synthetic>": {
        "input": 0,
        "output": 0,
        "cache_create": 0,
        "cache_read": 0
      }
    },
    "turn_count": 281,
    "tool_call_count": 94,
    "context_at_last_turn_tokens": 784076,
    "context_window_pct": 392.038
  },
  "_auto_continue": "/flow:flow-complete"
}
````

</details>