### PR TITLE
Auto Correct Misplaced Flow

### DIFF
--- a/.claude/rules/autonomous-flow-self-recovery.md
+++ b/.claude/rules/autonomous-flow-self-recovery.md
@@ -39,12 +39,19 @@ identical retry. Apply the fix and retry — do not prompt the user.
 
 - **`validate-worktree-paths` hook rejections** — the hook responds
   with a `BLOCKED:` message that names the canonical destination.
-  Reissue the call against the canonical path. (Reference:
+  Reissue the call against the canonical path. This covers the
+  main-repo redirect, the out-of-project gate, and a misplaced
+  `.flow-states/` Read/Glob/Grep. (Reference:
   `.claude/rules/file-tool-preflights.md` "Canonical Location for
   `.flow-states/`".)
-- **Path mismatches between worktree and main repo** — the hook
-  redirects worktree-internal `.flow-states/` writes to the main
-  repo's canonical location. Reissue against the main repo path.
+- **Worktree-internal `.flow-states/` Write/Edit** — auto-rewritten,
+  no model action required. `validate-worktree-paths` redirects a
+  misplaced worktree-internal `.flow-states/` Write or Edit to the
+  canonical `<project_root>/.flow-states/` path via a PreToolUse
+  `updatedInput` envelope (exit 0), so Claude Code reissues the call
+  against the canonical path automatically — the model never sees a
+  block. Only a misplaced `.flow-states/` Read/Glob/Grep still
+  produces the `BLOCKED:` redirect handled by the bullet above.
 - **Relative-vs-absolute path confusion** — when a CLI subcommand or
   file tool rejects a relative path, retry with the absolute form
   (or vice versa) using the path the error message names.

--- a/.claude/rules/autonomous-phase-discipline.md
+++ b/.claude/rules/autonomous-phase-discipline.md
@@ -332,8 +332,11 @@ The gate covers the `bin/flow set-timestamp` CLI write path only.
 Direct Edit/Write tool calls against
 `<project_root>/.flow-states/<branch>/state.json` from inside an
 active-flow worktree are not blocked by `validate-worktree-paths`
-(which only blocks misplaced worktree-internal copies under
-`.worktrees/<branch>/.flow-states/`) or `validate-claude-paths`
+(which only acts on misplaced worktree-internal copies under
+`.worktrees/<branch>/.flow-states/` — auto-rewriting a Write/Edit
+to the canonical destination and blocking a Read/Glob/Grep —
+never the canonical `<project_root>/.flow-states/` file itself) or
+`validate-claude-paths`
 (which protects `.claude/` paths, not `.flow-states/`), so a model
 with Edit/Write access remains a broader trust surface tracked
 separately from this gate.

--- a/.claude/rules/file-tool-preflights.md
+++ b/.claude/rules/file-tool-preflights.md
@@ -77,9 +77,23 @@ The `validate-worktree-paths` PreToolUse hook
 location at the tool-call layer. The
 `detect_misplaced_flow_states(file_path, project_root)` helper detects
 the misplacement via pure string operations and returns the canonical
-destination. When the helper matches, `validate()` returns
-`(false, message)` with a `BLOCKED` message naming the canonical path
-the caller should use instead.
+destination. The hook's response then depends on the tool:
+
+- **Write / Edit** — silently rewritten, not blocked. `run_impl_main`
+  consults `misplaced_flow_states_rewrite` first; on a match it
+  returns `WorktreeAction::Rewrite`, and `run()` emits a PreToolUse
+  `updatedInput` JSON envelope to stdout (exit 0) that replaces only
+  `file_path` with the canonical `<project_root>/.flow-states/`
+  destination. Claude Code reissues the call against the canonical
+  path with no model-visible stumble — every other tool-input field
+  (`content`, `old_string`, `new_string`, `replace_all`) is preserved
+  verbatim.
+- **Read / Glob / Grep** — still blocked. The rewrite helper returns
+  `None` (these tools carry no `content`/`file_path` pairing that can
+  be auto-redirected without returning data the model did not ask
+  for), so control falls through to `validate()`, which returns
+  `(false, message)` with a `BLOCKED` message naming the canonical
+  path the caller should use instead.
 
 The check fires on every Edit, Write, Read, Glob, and Grep tool call
 the hook is registered for. Both `file_path` (Edit/Write/Read) and

--- a/.claude/rules/hook-vs-instruction.md
+++ b/.claude/rules/hook-vs-instruction.md
@@ -224,6 +224,23 @@ insufficient:
   where the early "not in a worktree" return leaves path
   jurisdiction to Claude Code. See
   `src/hooks/validate_worktree_paths.rs`.
+- **Misplaced worktree-internal `.flow-states/` Write/Edit
+  auto-rewrite** — `validate-worktree-paths` does NOT block a
+  misplaced worktree-internal `.flow-states/` Write or Edit.
+  `run_impl_main` consults `misplaced_flow_states_rewrite`
+  first; on a match it returns `WorktreeAction::Rewrite` and
+  `run()` emits a PreToolUse `updatedInput` JSON envelope to
+  stdout (exit 0) that replaces only `file_path` with the
+  canonical `<project_root>/.flow-states/` destination — every
+  other tool-input field is preserved verbatim. Claude Code
+  reissues the call against the canonical path with no
+  model-visible stumble. A misplaced `.flow-states/`
+  Read/Glob/Grep still blocks (exit 2) via `validate()`
+  because it has no `content`/`file_path` pairing that can be
+  auto-redirected without returning data the model did not ask
+  for. See `src/hooks/validate_worktree_paths.rs` and
+  `.claude/rules/file-tool-preflights.md` "Canonical Location
+  for `.flow-states/`".
 - **`AskUserQuestion` during an autonomous in-progress phase**
   — `validate-ask-user` rejects with exit 2 when
   `phases.<current_phase>.status == "in_progress"` AND

--- a/src/hooks/validate_worktree_paths.rs
+++ b/src/hooks/validate_worktree_paths.rs
@@ -335,6 +335,43 @@ pub fn build_rewrite_envelope(tool_input: &Value, canonical: &str) -> Option<Val
     }))
 }
 
+/// Decide whether a misplaced worktree-internal `.flow-states/` tool
+/// call should be silently rewritten to its canonical destination,
+/// returning the PreToolUse `updatedInput` envelope when so.
+///
+/// Returns `Some(envelope)` ONLY for the two mutating tools (`Write`,
+/// `Edit`): their `tool_input` carries everything needed to reissue
+/// the call against the canonical path, so the redirect can be a no-op
+/// the model never sees. `Read`/`Glob`/`Grep` return `None` — they
+/// have no `content`/`file_path` pairing that can be auto-redirected
+/// without returning data the model did not ask for, so they fall
+/// through to the block.
+///
+/// `tool_name` is compared against the canonical platform-emitted
+/// values (`Write`/`Edit`) with exact `==`; the hook payload field is
+/// controlled by Claude Code, not user-supplied state, so no
+/// normalization is warranted (matching how `run_impl_main` already
+/// compares `tool_name` for the shared-config gate).
+///
+/// Reuses `compute_worktree_paths` (to resolve `project_root` outside
+/// `validate`) and `detect_misplaced_flow_states` (to compute the
+/// canonical destination). `None` from either — a non-worktree cwd,
+/// or a path that is not a misplaced `.flow-states/` write — means no
+/// rewrite.
+pub fn misplaced_flow_states_rewrite(
+    file_path: &str,
+    cwd: &str,
+    tool_name: &str,
+    tool_input: &Value,
+) -> Option<Value> {
+    if tool_name != "Write" && tool_name != "Edit" {
+        return None;
+    }
+    let (project_root, _) = compute_worktree_paths(cwd)?;
+    let canonical = detect_misplaced_flow_states(file_path, project_root)?;
+    build_rewrite_envelope(tool_input, &canonical)
+}
+
 /// Approved `/tmp/` file extensions for the out-of-project surface,
 /// matched ASCII-case-insensitively.
 ///

--- a/src/hooks/validate_worktree_paths.rs
+++ b/src/hooks/validate_worktree_paths.rs
@@ -26,8 +26,20 @@
 //!
 //! Fires on Edit, Write, Read, Glob, and Grep tool calls.
 //!
-//! Exit 0 — allow (path is fine or not in a worktree)
-//! Exit 2 — block (path targets main repo, out-of-project, or shared config Edit/Write)
+//! A misplaced worktree-internal `.flow-states/` Write or Edit is NOT
+//! blocked: `run_impl_main` returns `WorktreeAction::Rewrite` and `run()`
+//! emits a PreToolUse `updatedInput` envelope to stdout (exit 0) that
+//! redirects the call to the canonical `<project_root>/.flow-states/`
+//! destination, so Claude Code reissues it there with no model-visible
+//! stumble. Read/Glob/Grep on the same misplaced path still block —
+//! they have no `content`/`file_path` pairing that can be auto-redirected
+//! without returning data the model did not ask for.
+//!
+//! Exit 0 — allow (path is fine or not in a worktree), OR a rewrite
+//!   envelope was emitted to stdout for a misplaced `.flow-states/`
+//!   Write/Edit
+//! Exit 2 — block (path targets main repo, out-of-project, a misplaced
+//!   `.flow-states/` Read/Glob/Grep, or shared config Edit/Write)
 
 use std::path::Path;
 
@@ -671,15 +683,49 @@ pub fn validate(file_path: &str, cwd: &str, home: &str) -> (bool, String) {
     )
 }
 
-/// Decision core for the validate-worktree-paths hook. Returns
-/// `(exit_code, Option<stderr_message>)` so `run()` can translate to
-/// `process::exit` + `eprintln!` side effects. Integration tests
-/// drive every branch through the hook subprocess with fixture
-/// stdin payloads.
-fn run_impl_main(hook_input: Option<Value>, cwd: Option<String>) -> (i32, Option<String>) {
+/// The outcome `run_impl_main` hands to `run()` for a file tool call.
+///
+/// - `Allow` — exit 0, no output. The path is fine, or the cwd is not
+///   inside a worktree, or there is no file path to validate.
+/// - `Block(msg)` — exit 2 with `msg` on stderr. The path targets the
+///   main repo, is out-of-project, is a misplaced `.flow-states/`
+///   Read/Glob/Grep, or is an unapproved shared-config Edit/Write.
+/// - `Rewrite(envelope)` — exit 0 with `envelope` (a PreToolUse
+///   `updatedInput` JSON object) on stdout. A misplaced worktree-
+///   internal `.flow-states/` Write/Edit is silently redirected to its
+///   canonical destination so Claude Code reissues the call there with
+///   no model-visible block.
+enum WorktreeAction {
+    Allow,
+    Block(String),
+    Rewrite(Value),
+}
+
+/// Decision core for the validate-worktree-paths hook. Returns a
+/// `WorktreeAction` so `run()` can translate it into `process::exit`
+/// plus the matching stdout/stderr side effect. Integration tests
+/// drive every arm through the hook subprocess with fixture stdin
+/// payloads.
+///
+/// Order of evaluation:
+/// 1. Missing hook input, empty file path, or absent cwd → `Allow`
+///    (nothing to validate).
+/// 2. **Rewrite shortcut** — a misplaced worktree-internal
+///    `.flow-states/` Write/Edit yields `Rewrite`. This runs BEFORE
+///    the out-of-project and shared-config gates: a misplaced
+///    `.flow-states/` path is inside `project_root` and is not
+///    shared-config, so neither gate would mis-fire, but consulting
+///    the rewrite first keeps the precedence explicit. Read/Glob/Grep
+///    return `None` from the rewrite helper and fall through.
+/// 3. `validate` → `Block` on a main-repo / out-of-project / misplaced
+///    `.flow-states/` Read-Glob-Grep path.
+/// 4. `validate_shared_config` → `Block` on an unapproved shared-config
+///    Edit/Write.
+/// 5. Otherwise `Allow`.
+fn run_impl_main(hook_input: Option<Value>, cwd: Option<String>) -> WorktreeAction {
     let hook_input = match hook_input {
         Some(v) => v,
-        None => return (0, None),
+        None => return WorktreeAction::Allow,
     };
 
     let tool_input = hook_input
@@ -689,13 +735,27 @@ fn run_impl_main(hook_input: Option<Value>, cwd: Option<String>) -> (i32, Option
 
     let file_path = get_file_path(&tool_input);
     if file_path.is_empty() {
-        return (0, None);
+        return WorktreeAction::Allow;
     }
 
     let cwd = match cwd {
         Some(p) => p,
-        None => return (0, None),
+        None => return WorktreeAction::Allow,
     };
+
+    let tool_name = hook_input
+        .get("tool_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    // Rewrite shortcut: a misplaced worktree-internal `.flow-states/`
+    // Write/Edit is silently redirected to its canonical destination
+    // rather than hard-blocked. Read/Glob/Grep return None here and
+    // fall through to the existing block surfaces below.
+    if let Some(envelope) = misplaced_flow_states_rewrite(&file_path, &cwd, tool_name, &tool_input)
+    {
+        return WorktreeAction::Rewrite(envelope);
+    }
 
     // Env-var-derived $HOME for the out-of-project approved-memory
     // class. An unset HOME yields an empty string, which
@@ -704,25 +764,26 @@ fn run_impl_main(hook_input: Option<Value>, cwd: Option<String>) -> (i32, Option
 
     let (allowed, message) = validate(&file_path, &cwd, &home);
     if !allowed {
-        return (2, Some(message));
+        return WorktreeAction::Block(message);
     }
-
-    let tool_name = hook_input
-        .get("tool_name")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
 
     let (sc_allowed, sc_message) = validate_shared_config(&file_path, &cwd, tool_name);
     if !sc_allowed {
-        return (2, Some(sc_message));
+        return WorktreeAction::Block(sc_message);
     }
 
-    (0, None)
+    WorktreeAction::Allow
 }
 
 /// Run the validate-worktree-paths hook (entry point from CLI). Thin
-/// wrapper around `run_impl_main` that translates decisions into
-/// stderr + exit code side effects.
+/// wrapper around `run_impl_main` that translates the `WorktreeAction`
+/// into the matching `process::exit` + stdout/stderr side effect:
+///
+/// - `Allow` → exit 0, no output.
+/// - `Block(msg)` → `eprintln!(msg)` + exit 2.
+/// - `Rewrite(envelope)` → `println!(envelope)` (the PreToolUse
+///   `updatedInput` JSON to stdout, the surface Claude Code reads to
+///   reissue the call against the canonical path) + exit 0.
 ///
 /// The cwd is resolved from the hook payload's `cwd` field via
 /// `resolve_hook_cwd` (with `std::env::current_dir()` as fallback),
@@ -734,9 +795,15 @@ fn run_impl_main(hook_input: Option<Value>, cwd: Option<String>) -> (i32, Option
 pub fn run() {
     let hook_input = read_hook_input();
     let cwd = hook_input.as_ref().and_then(crate::hooks::resolve_hook_cwd);
-    let (code, message) = run_impl_main(hook_input, cwd);
-    if let Some(msg) = message {
-        eprintln!("{}", msg);
+    match run_impl_main(hook_input, cwd) {
+        WorktreeAction::Allow => std::process::exit(0),
+        WorktreeAction::Block(msg) => {
+            eprintln!("{}", msg);
+            std::process::exit(2);
+        }
+        WorktreeAction::Rewrite(envelope) => {
+            println!("{}", envelope);
+            std::process::exit(0);
+        }
     }
-    std::process::exit(code);
 }

--- a/src/hooks/validate_worktree_paths.rs
+++ b/src/hooks/validate_worktree_paths.rs
@@ -306,6 +306,35 @@ fn sanitize_canonical_suffix(suffix: &str) -> String {
         .join("/")
 }
 
+/// Build a PreToolUse `updatedInput` envelope that silently rewrites a
+/// misplaced `.flow-states/` write to its canonical destination.
+///
+/// Returns `None` when `tool_input` is not a JSON object — there is no
+/// `file_path` key to overwrite, so the caller falls through to the
+/// block path. On an object input, clones `tool_input` and overwrites
+/// only the `file_path` key with `canonical`, leaving every other key
+/// (`content`, `old_string`, `new_string`, `replace_all`, and any
+/// future Edit/Write field) verbatim.
+///
+/// Clone-and-overwrite-one-key is field-agnostic by design: the
+/// `updatedInput` object REPLACES the entire tool input that Claude
+/// Code reissues, so a dropped key would corrupt the rewritten call.
+/// Preserving every key except `file_path` is the only safe shape.
+pub fn build_rewrite_envelope(tool_input: &Value, canonical: &str) -> Option<Value> {
+    if !tool_input.is_object() {
+        return None;
+    }
+    let mut updated = tool_input.clone();
+    updated["file_path"] = Value::String(canonical.to_string());
+    Some(serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "updatedInput": updated,
+        }
+    }))
+}
+
 /// Approved `/tmp/` file extensions for the out-of-project surface,
 /// matched ASCII-case-insensitively.
 ///

--- a/src/hooks/validate_worktree_paths.rs
+++ b/src/hooks/validate_worktree_paths.rs
@@ -332,6 +332,26 @@ fn sanitize_canonical_suffix(suffix: &str) -> String {
 /// `updatedInput` object REPLACES the entire tool input that Claude
 /// Code reissues, so a dropped key would corrupt the rewritten call.
 /// Preserving every key except `file_path` is the only safe shape.
+///
+/// **Envelope contract.** The wrapped
+/// `hookSpecificOutput { hookEventName: "PreToolUse", permissionDecision:
+/// "allow", updatedInput: <object> }` shape is the documented Claude
+/// Code PreToolUse mechanism for rewriting tool input — when
+/// `permissionDecision` is `"allow"` and `updatedInput` is the full
+/// modified tool-input object, Claude Code reissues the call against the
+/// modified input. The flat top-level `{permissionDecision, updatedInput}`
+/// shape is NOT valid for input rewrite. See
+/// `code.claude.com/docs/en/hooks.md` "Modifying Tool Input with
+/// `updatedInput`". (The flat shape `validate_ask_user` emits is the
+/// AskUserQuestion answer-injection mechanism, a different event.)
+///
+/// `pub` so the envelope shape — including the non-object `None` branch,
+/// which `run_impl_main` never reaches (a non-object `tool_input` yields
+/// an empty `file_path` from `get_file_path`, so `run_impl_main` returns
+/// `Allow` before consulting `misplaced_flow_states_rewrite`) — can be
+/// unit-tested directly, the same pattern as the sibling pure helper
+/// `detect_misplaced_flow_states`. The sole production caller is
+/// `misplaced_flow_states_rewrite`, itself called only by `run_impl_main`.
 pub fn build_rewrite_envelope(tool_input: &Value, canonical: &str) -> Option<Value> {
     if !tool_input.is_object() {
         return None;
@@ -370,6 +390,14 @@ pub fn build_rewrite_envelope(tool_input: &Value, canonical: &str) -> Option<Val
 /// canonical destination). `None` from either — a non-worktree cwd,
 /// or a path that is not a misplaced `.flow-states/` write — means no
 /// rewrite.
+///
+/// The sole production caller is `run_impl_main`, which consults this
+/// helper as its rewrite-shortcut check before the out-of-project and
+/// shared-config gates. `pub` so the tool-gating dispatch
+/// (Write/Edit → `Some`, Read/Glob/Grep / non-misplaced / non-worktree
+/// → `None`) can be unit-tested directly — several of those `None`
+/// branches are unreachable through the full hook subprocess — mirroring
+/// the sibling pure helpers (`detect_misplaced_flow_states`, `validate`).
 pub fn misplaced_flow_states_rewrite(
     file_path: &str,
     cwd: &str,

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -1505,26 +1505,39 @@ fn validate_subprocess_memory_read_allowed_via_resolved_home() {
     );
 }
 
+/// A misplaced worktree-internal .flow-states/ Write is no longer
+/// hard-blocked — run() emits the rewrite envelope to stdout (exit 0)
+/// so Claude Code reissues the Write against the canonical project-root
+/// path with no model-visible stumble. Drives run_impl_main's
+/// WorktreeAction::Rewrite arm and run()'s stdout println.
 #[test]
-fn validate_subprocess_rejects_worktree_flow_states_write() {
+fn validate_subprocess_rewrites_worktree_flow_states_write() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let (root, worktree_cwd) = worktree_fixture(&tmp);
     let target = worktree_cwd.join(".flow-states/plan.md");
     let canonical = root.join(".flow-states/plan.md");
-    let (code, _, stderr) = spawn_hook_with_cwd(
+    let (code, stdout, stderr) = spawn_hook_with_cwd(
         &worktree_cwd,
         &root,
         "Write",
         "file_path",
         target.to_str().unwrap(),
     );
-    assert_eq!(code, 2, "stderr: {}", stderr);
-    assert!(stderr.contains("BLOCKED"), "stderr: {}", stderr);
-    assert!(stderr.contains(".flow-states/"), "stderr: {}", stderr);
+    assert_eq!(code, 0, "stderr: {}", stderr);
     assert!(
-        stderr.contains(canonical.to_str().unwrap()),
-        "stderr: {}",
-        stderr
+        stdout.contains("\"hookEventName\":\"PreToolUse\""),
+        "stdout: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("\"permissionDecision\":\"allow\""),
+        "stdout: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains(canonical.to_str().unwrap()),
+        "stdout: {}",
+        stdout
     );
 }
 
@@ -1550,25 +1563,33 @@ fn validate_subprocess_rejects_worktree_flow_states_read() {
     );
 }
 
+/// A misplaced worktree-internal .flow-states/ Edit is rewritten the
+/// same way a Write is — exit 0 with the rewrite envelope on stdout,
+/// preserving the Edit's old_string/new_string fields verbatim while
+/// only file_path is redirected to the canonical destination.
 #[test]
-fn validate_subprocess_rejects_worktree_flow_states_edit() {
+fn validate_subprocess_rewrites_worktree_flow_states_edit() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let (root, worktree_cwd) = worktree_fixture(&tmp);
     let target = worktree_cwd.join(".flow-states/plan.md");
     let canonical = root.join(".flow-states/plan.md");
-    let (code, _, stderr) = spawn_hook_with_cwd(
+    let (code, stdout, stderr) = spawn_hook_with_cwd(
         &worktree_cwd,
         &root,
         "Edit",
         "file_path",
         target.to_str().unwrap(),
     );
-    assert_eq!(code, 2, "stderr: {}", stderr);
-    assert!(stderr.contains("BLOCKED"), "stderr: {}", stderr);
+    assert_eq!(code, 0, "stderr: {}", stderr);
     assert!(
-        stderr.contains(canonical.to_str().unwrap()),
-        "stderr: {}",
-        stderr
+        stdout.contains("\"permissionDecision\":\"allow\""),
+        "stdout: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains(canonical.to_str().unwrap()),
+        "stdout: {}",
+        stdout
     );
 }
 

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -5,8 +5,9 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 
 use flow_rs::hooks::validate_worktree_paths::{
-    detect_misplaced_flow_states, get_file_path, is_approved_out_of_project_path, is_shared_config,
-    validate, validate_shared_config, APPROVED_TMP_EXTENSIONS,
+    build_rewrite_envelope, detect_misplaced_flow_states, get_file_path,
+    is_approved_out_of_project_path, is_shared_config, validate, validate_shared_config,
+    APPROVED_TMP_EXTENSIONS,
 };
 use serde_json::json;
 
@@ -1689,6 +1690,53 @@ fn validate_subprocess_accepts_main_repo_flow_states_grep() {
         target.to_str().unwrap(),
     );
     assert_eq!(code, 0, "stderr: {}", stderr);
+}
+
+// --- build_rewrite_envelope tests ---
+
+#[test]
+fn build_rewrite_envelope_write_input_replaces_file_path_preserves_content() {
+    let tool_input = json!({
+        "file_path": "/proj/.worktrees/feat/.flow-states/plan.md",
+        "content": "X"
+    });
+    let canonical = "/proj/.flow-states/plan.md";
+    let env = build_rewrite_envelope(&tool_input, canonical).expect("object input yields envelope");
+    let hso = &env["hookSpecificOutput"];
+    assert_eq!(hso["hookEventName"], "PreToolUse");
+    assert_eq!(hso["permissionDecision"], "allow");
+    let updated = &hso["updatedInput"];
+    assert_eq!(updated["file_path"], canonical);
+    // Field-agnostic preservation: content survives the rewrite.
+    assert_eq!(updated["content"], "X");
+}
+
+#[test]
+fn build_rewrite_envelope_edit_input_preserves_all_non_path_fields() {
+    let tool_input = json!({
+        "file_path": "/proj/.worktrees/feat/.flow-states/plan.md",
+        "old_string": "a",
+        "new_string": "b",
+        "replace_all": true
+    });
+    let canonical = "/proj/.flow-states/plan.md";
+    let env = build_rewrite_envelope(&tool_input, canonical).expect("object input yields envelope");
+    let updated = &env["hookSpecificOutput"]["updatedInput"];
+    // Only file_path changes; every Edit field is preserved verbatim.
+    assert_eq!(updated["file_path"], canonical);
+    assert_eq!(updated["old_string"], "a");
+    assert_eq!(updated["new_string"], "b");
+    assert_eq!(updated["replace_all"], true);
+}
+
+#[test]
+fn build_rewrite_envelope_non_object_input_returns_none() {
+    // A non-object tool_input (a JSON string) cannot carry a file_path
+    // key to overwrite, so the helper signals "no rewrite" and the
+    // caller falls through to the block.
+    let tool_input = json!("not-an-object");
+    let result = build_rewrite_envelope(&tool_input, "/proj/.flow-states/plan.md");
+    assert!(result.is_none());
 }
 
 // --- Presence contract: shared-config BLOCKED phrase ---

--- a/tests/hooks/validate_worktree_paths.rs
+++ b/tests/hooks/validate_worktree_paths.rs
@@ -6,8 +6,8 @@ use std::process::{Command, Stdio};
 
 use flow_rs::hooks::validate_worktree_paths::{
     build_rewrite_envelope, detect_misplaced_flow_states, get_file_path,
-    is_approved_out_of_project_path, is_shared_config, validate, validate_shared_config,
-    APPROVED_TMP_EXTENSIONS,
+    is_approved_out_of_project_path, is_shared_config, misplaced_flow_states_rewrite, validate,
+    validate_shared_config, APPROVED_TMP_EXTENSIONS,
 };
 use serde_json::json;
 
@@ -1737,6 +1737,76 @@ fn build_rewrite_envelope_non_object_input_returns_none() {
     let tool_input = json!("not-an-object");
     let result = build_rewrite_envelope(&tool_input, "/proj/.flow-states/plan.md");
     assert!(result.is_none());
+}
+
+// --- misplaced_flow_states_rewrite tests ---
+
+const MISPLACED: &str = "/proj/.worktrees/feat/.flow-states/plan.md";
+const MISPLACED_CWD: &str = "/proj/.worktrees/feat";
+const MISPLACED_CANONICAL: &str = "/proj/.flow-states/plan.md";
+
+#[test]
+fn misplaced_rewrite_write_returns_envelope() {
+    let tool_input = json!({"file_path": MISPLACED, "content": "X"});
+    let env = misplaced_flow_states_rewrite(MISPLACED, MISPLACED_CWD, "Write", &tool_input)
+        .expect("Write + misplaced path yields a rewrite");
+    assert_eq!(
+        env["hookSpecificOutput"]["updatedInput"]["file_path"],
+        MISPLACED_CANONICAL
+    );
+}
+
+#[test]
+fn misplaced_rewrite_edit_returns_envelope() {
+    let tool_input = json!({"file_path": MISPLACED, "old_string": "a", "new_string": "b"});
+    let env = misplaced_flow_states_rewrite(MISPLACED, MISPLACED_CWD, "Edit", &tool_input)
+        .expect("Edit + misplaced path yields a rewrite");
+    assert_eq!(
+        env["hookSpecificOutput"]["updatedInput"]["file_path"],
+        MISPLACED_CANONICAL
+    );
+}
+
+#[test]
+fn misplaced_rewrite_read_returns_none() {
+    // Read is not a mutating tool — no auto-rewrite, falls through to block.
+    let tool_input = json!({"file_path": MISPLACED});
+    assert!(misplaced_flow_states_rewrite(MISPLACED, MISPLACED_CWD, "Read", &tool_input).is_none());
+}
+
+#[test]
+fn misplaced_rewrite_glob_returns_none() {
+    let tool_input = json!({"path": MISPLACED});
+    assert!(misplaced_flow_states_rewrite(MISPLACED, MISPLACED_CWD, "Glob", &tool_input).is_none());
+}
+
+#[test]
+fn misplaced_rewrite_grep_returns_none() {
+    let tool_input = json!({"path": MISPLACED});
+    assert!(misplaced_flow_states_rewrite(MISPLACED, MISPLACED_CWD, "Grep", &tool_input).is_none());
+}
+
+#[test]
+fn misplaced_rewrite_write_non_misplaced_path_returns_none() {
+    // A path inside the worktree proper (not a misplaced .flow-states/)
+    // produces no canonical destination → no rewrite.
+    let inside = "/proj/.worktrees/feat/src/lib.rs";
+    let tool_input = json!({"file_path": inside, "content": "X"});
+    assert!(misplaced_flow_states_rewrite(inside, MISPLACED_CWD, "Write", &tool_input).is_none());
+}
+
+#[test]
+fn misplaced_rewrite_empty_file_path_returns_none() {
+    let tool_input = json!({"file_path": "", "content": "X"});
+    assert!(misplaced_flow_states_rewrite("", MISPLACED_CWD, "Write", &tool_input).is_none());
+}
+
+#[test]
+fn misplaced_rewrite_cwd_not_in_worktree_returns_none() {
+    // compute_worktree_paths returns None for a non-worktree cwd, so
+    // there is no project_root to resolve the canonical destination.
+    let tool_input = json!({"file_path": MISPLACED, "content": "X"});
+    assert!(misplaced_flow_states_rewrite(MISPLACED, "/proj", "Write", &tool_input).is_none());
 }
 
 // --- Presence contract: shared-config BLOCKED phrase ---


### PR DESCRIPTION
## What

#1801.

Closes #1801

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/auto-correct-misplaced-flow/plan.md` |
| Log | `.flow-states/auto-correct-misplaced-flow/log` |
| State | `.flow-states/auto-correct-misplaced-flow/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/21c9a000-041c-41be-ba6e-566144e49d30.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | 3m |
| Code | 32m |
| Review | 28m |
| Learn | 12m |
| Complete | <1m |
| **Total** | **1h 17m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 1.9M | $1.011 |
| Code | 68.6M | $40.396 |
| Review | 46.5M | $26.179 |
| Learn | 22.7M | $16.921 |
| Complete | 1.8M | $0.967 |
| **Total** | **141.4M** | **$85.474** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **Pre-mortem: hookSpecificOutput envelope shape diverges from validate_ask_user flat shape; rewrite may fail open if shape is wrong**
  - Dismissed — Refuted by verifying the live Claude Code hooks contract via the claude-code-guide agent and code.claude.com/docs/en/hooks.md: the wrapped hookSpecificOutput {hookEventName, permissionDecision, updatedInput} is the correct and only documented PreToolUse mechanism for rewriting tool input. The new code is correct. validate_ask_user's flat shape is pre-existing, for AskUserQuestion answer-injection (a different mechanism), and not touched by this PR.
- ✗ **Pre-mortem: rewrite matches any path with a /.flow-states/ segment (no basename allowlist), silently redirecting non-state writes into the gitignored root and risking cross-flow collisions**
  - Dismissed — The path matching (detect_misplaced_flow_states) and suffix mapping are pre-existing and unchanged by this PR; only the response changes from block to rewrite. Any worktree-internal .flow-states/ write is by definition misplaced per file-tool-preflights.md and is correctly redirected. The silent redirect is the intended behavior requested in issue #1801. The old block surfaced the same canonical destination; the suffix mapping was identical.
- ✗ **Pre-mortem: extending the rewrite to Edit re-points old_string-bearing input at a different physical file, risking content corruption**
  - Dismissed — Speculative/degenerate. A misplaced worktree-internal .flow-states/ file typically does not exist (the gate has always prevented writes there), so an Edit against it fails Claude Code's Read-first preflight before the hook runs. Edit's exact-unique-match semantics make a mismatch fail cleanly (old_string not found) rather than silently corrupt; a non-unique match with replace_all=false errors. The misplaced-Edit scenario is not a realistic corruption path.
- ✓ **Reviewer/Documentation: envelope shape correctness asserted only at byte level; pub helpers do not cite the PreToolUse contract or name their production consumer**
  - Fixed — Verified the wrapped hookSpecificOutput updatedInput shape against the live Claude Code hooks contract (code.claude.com/docs/en/hooks.md) via the claude-code-guide agent. Added an Envelope contract paragraph citing the docs to build_rewrite_envelope, plus pub-rationale + sole-production-caller (run_impl_main) notes to both build_rewrite_envelope and misplaced_flow_states_rewrite doc comments, satisfying test-placement.md and discharging the verify-automation-e2e obligation via documented contract verification.
- ✓ **Documentation: autonomous-phase-discipline.md parenthetical described validate-worktree-paths as blocking misplaced worktree-internal .flow-states/ copies, now stale**
  - Fixed — After this PR, validate-worktree-paths auto-rewrites misplaced worktree-internal .flow-states/ Write/Edit and blocks only Read/Glob/Grep. Updated the parenthetical to say it 'only acts on misplaced worktree-internal copies — auto-rewriting Write/Edit, blocking Read/Glob/Grep — never the canonical file', preserving the trust-boundary point while correcting the block-vs-rewrite drift.

<!-- end:Review Findings -->

## Learn Findings

- ✗ **Tenant 1 candidate: validate-pretool agent_prompt_scan blocked several Review/Learn agent launches when the prompt carried out-of-worktree path tokens (absolute plugin-root bin/flow, project-root .flow-states/ prose, literal dot-dot)**
  - Dismissed — The block is working as designed and the flow-review/flow-learn skills document that agent prompts must use worktree-relative paths. The blocks were caused by the parent (me) initially embedding absolute/out-of-worktree tokens; recovery was mechanical (worktree-relative bin/flow, drop the tokens). Per filing-issues.md 'Friction Is Not a Process Gap' this is a single-flow, working-block, mechanically-recoverable case — not a filable gap.
- → **Subprocess test run_phase_enter (tests/phase_enter.rs:148) spawns bin/flow phase-enter without isolating HOME or clearing CLAUDE_CODE_SESSION_ID; during a bin/flow ci run inside an active flow, test_step_counter_field_names writes a phase-anchor marker into the real ~/.claude/flow/ keyed by the inherited session id, clobbering the active flow's marker so resume-anchor returns a stale fixture worktree path**
  - Filed — Real Tenant-1 process gap: not caught or remediated by any phase gate, destructive failure mode (a --continue-step resume could cd into a nonexistent fixture worktree), recurs on every CI run during an active flow. Verified against src/phase_anchor.rs and the observed counter-learn stale path. Filed on benkruger/flow.

<!-- end:Learn Findings -->

## State File

<details>
<summary>.flow-states/auto-correct-misplaced-flow.json</summary>

```json
{
  "schema_version": 1,
  "branch": "auto-correct-misplaced-flow",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1807,
  "pr_url": "https://github.com/benkruger/flow/pull/1807",
  "started_at": "2026-06-02T18:15:06-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/auto-correct-misplaced-flow/plan.md",
    "log": ".flow-states/auto-correct-misplaced-flow/log",
    "state": ".flow-states/auto-correct-misplaced-flow/state.json"
  },
  "session_tty": "/dev/ttys012",
  "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/21c9a000-041c-41be-ba6e-566144e49d30.jsonl",
  "notes": [],
  "prompt": "#1801",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-06-02T18:15:06-07:00",
      "completed_at": "2026-06-02T18:18:49-07:00",
      "session_started_at": null,
      "cumulative_seconds": 223,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-02T18:15:06-07:00",
        "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
        "model": "claude-opus-4-8",
        "five_hour_pct": 30,
        "seven_day_pct": 33,
        "session_input_tokens": 4808,
        "session_output_tokens": 779,
        "session_cache_creation_tokens": 245802,
        "session_cache_read_tokens": 16509,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4808,
            "output": 779,
            "cache_create": 245802,
            "cache_read": 16509
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 267119,
        "context_window_pct": 133.5595
      },
      "window_at_complete": {
        "captured_at": "2026-06-02T18:18:49-07:00",
        "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
        "model": "claude-opus-4-8",
        "five_hour_pct": 30,
        "seven_day_pct": 33,
        "session_input_tokens": 4951,
        "session_output_tokens": 1890,
        "session_cache_creation_tokens": 253106,
        "session_cache_read_tokens": 1891205,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4951,
            "output": 1890,
            "cache_create": 253106,
            "cache_read": 1891205
          }
        },
        "turn_count": 8,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 269746,
        "context_window_pct": 134.873
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-06-02T18:18:59-07:00",
      "completed_at": "2026-06-02T18:51:22-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1943,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-02T18:18:59-07:00",
        "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
        "model": "claude-opus-4-8",
        "five_hour_pct": 30,
        "seven_day_pct": 33,
        "session_input_tokens": 4955,
        "session_output_tokens": 2263,
        "session_cache_creation_tokens": 253580,
        "session_cache_read_tokens": 2430731,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4955,
            "output": 2263,
            "cache_create": 253580,
            "cache_read": 2430731
          }
        },
        "turn_count": 10,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 270091,
        "context_window_pct": 135.0455
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-06-02T18:21:10-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 31,
          "seven_day_pct": 33,
          "session_input_tokens": 238324,
          "session_output_tokens": 8885,
          "session_cache_creation_tokens": 553426,
          "session_cache_read_tokens": 6666682,
          "by_model": {
            "claude-opus-4-8": {
              "input": 238324,
              "output": 8885,
              "cache_create": 553426,
              "cache_read": 6666682
            }
          },
          "turn_count": 21,
          "tool_call_count": 6,
          "context_at_last_turn_tokens": 570066,
          "context_window_pct": 285.033
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-06-02T18:22:08-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 31,
          "seven_day_pct": 33,
          "session_input_tokens": 238336,
          "session_output_tokens": 12763,
          "session_cache_creation_tokens": 561859,
          "session_cache_read_tokens": 10117318,
          "by_model": {
            "claude-opus-4-8": {
              "input": 238336,
              "output": 12763,
              "cache_create": 561859,
              "cache_read": 10117318
            }
          },
          "turn_count": 27,
          "tool_call_count": 8,
          "context_at_last_turn_tokens": 578370,
          "context_window_pct": 289.185
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-06-02T18:28:57-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 32,
          "seven_day_pct": 33,
          "session_input_tokens": 238896,
          "session_output_tokens": 28849,
          "session_cache_creation_tokens": 599681,
          "session_cache_read_tokens": 23202177,
          "by_model": {
            "claude-opus-4-8": {
              "input": 238896,
              "output": 28849,
              "cache_create": 599681,
              "cache_read": 23202177
            }
          },
          "turn_count": 49,
          "tool_call_count": 14,
          "context_at_last_turn_tokens": 616192,
          "context_window_pct": 308.096
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-06-02T18:31:07-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 32,
          "seven_day_pct": 33,
          "session_input_tokens": 239041,
          "session_output_tokens": 34624,
          "session_cache_creation_tokens": 607723,
          "session_cache_read_tokens": 28156003,
          "by_model": {
            "claude-opus-4-8": {
              "input": 239041,
              "output": 34624,
              "cache_create": 607723,
              "cache_read": 28156003
            }
          },
          "turn_count": 57,
          "tool_call_count": 17,
          "context_at_last_turn_tokens": 624234,
          "context_window_pct": 312.117
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-06-02T18:37:39-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 33,
          "seven_day_pct": 34,
          "session_input_tokens": 239603,
          "session_output_tokens": 49343,
          "session_cache_creation_tokens": 645567,
          "session_cache_read_tokens": 42881787,
          "by_model": {
            "claude-opus-4-8": {
              "input": 239603,
              "output": 49343,
              "cache_create": 645567,
              "cache_read": 42881787
            }
          },
          "turn_count": 80,
          "tool_call_count": 26,
          "context_at_last_turn_tokens": 662207,
          "context_window_pct": 331.1035
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-06-02T18:41:34-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 33,
          "seven_day_pct": 34,
          "session_input_tokens": 239756,
          "session_output_tokens": 61527,
          "session_cache_creation_tokens": 658333,
          "session_cache_read_tokens": 50911963,
          "by_model": {
            "claude-opus-4-8": {
              "input": 239756,
              "output": 61527,
              "cache_create": 658333,
              "cache_read": 50911963
            }
          },
          "turn_count": 92,
          "tool_call_count": 29,
          "context_at_last_turn_tokens": 674844,
          "context_window_pct": 337.422
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-06-02T18:47:22-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 34,
          "seven_day_pct": 34,
          "session_input_tokens": 240042,
          "session_output_tokens": 89949,
          "session_cache_creation_tokens": 705857,
          "session_cache_read_tokens": 60718286,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240042,
              "output": 89949,
              "cache_create": 705857,
              "cache_read": 60718286
            }
          },
          "turn_count": 106,
          "tool_call_count": 33,
          "context_at_last_turn_tokens": 722368,
          "context_window_pct": 361.184
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-06-02T18:51:22-07:00",
        "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
        "model": "claude-opus-4-8",
        "five_hour_pct": 34,
        "seven_day_pct": 34,
        "session_input_tokens": 243787,
        "session_output_tokens": 94477,
        "session_cache_creation_tokens": 733961,
        "session_cache_read_tokens": 70218947,
        "by_model": {
          "claude-opus-4-8": {
            "input": 243787,
            "output": 94477,
            "cache_create": 733961,
            "cache_read": 70218947
          }
        },
        "turn_count": 119,
        "tool_call_count": 39,
        "context_at_last_turn_tokens": 750472,
        "context_window_pct": 375.236
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-06-02T18:51:32-07:00",
      "completed_at": "2026-06-02T19:20:24-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1732,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-02T18:51:32-07:00",
        "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
        "model": "claude-opus-4-8",
        "five_hour_pct": 34,
        "seven_day_pct": 34,
        "session_input_tokens": 243920,
        "session_output_tokens": 94979,
        "session_cache_creation_tokens": 734546,
        "session_cache_read_tokens": 71720036,
        "by_model": {
          "claude-opus-4-8": {
            "input": 243920,
            "output": 94979,
            "cache_create": 734546,
            "cache_read": 71720036
          }
        },
        "turn_count": 121,
        "tool_call_count": 39,
        "context_at_last_turn_tokens": 751057,
        "context_window_pct": 375.5285
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-06-02T18:53:21-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 34,
          "seven_day_pct": 34,
          "session_input_tokens": 244064,
          "session_output_tokens": 97937,
          "session_cache_creation_tokens": 753426,
          "session_cache_read_tokens": 77846265,
          "by_model": {
            "claude-opus-4-8": {
              "input": 244064,
              "output": 97937,
              "cache_create": 753426,
              "cache_read": 77846265
            }
          },
          "turn_count": 129,
          "tool_call_count": 44,
          "context_at_last_turn_tokens": 769937,
          "context_window_pct": 384.9685
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-06-02T19:05:51-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 40,
          "seven_day_pct": 35,
          "session_input_tokens": 244333,
          "session_output_tokens": 121830,
          "session_cache_creation_tokens": 808280,
          "session_cache_read_tokens": 84183325,
          "by_model": {
            "claude-opus-4-8": {
              "input": 244333,
              "output": 121830,
              "cache_create": 808280,
              "cache_read": 84183325
            }
          },
          "turn_count": 137,
          "tool_call_count": 45,
          "context_at_last_turn_tokens": 824791,
          "context_window_pct": 412.3955
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-06-02T19:11:12-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 40,
          "seven_day_pct": 35,
          "session_input_tokens": 244613,
          "session_output_tokens": 143314,
          "session_cache_creation_tokens": 849417,
          "session_cache_read_tokens": 93459855,
          "by_model": {
            "claude-opus-4-8": {
              "input": 244613,
              "output": 143314,
              "cache_create": 849417,
              "cache_read": 93459855
            }
          },
          "turn_count": 148,
          "tool_call_count": 50,
          "context_at_last_turn_tokens": 865928,
          "context_window_pct": 432.964
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-06-02T19:20:06-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 41,
          "seven_day_pct": 35,
          "session_input_tokens": 245179,
          "session_output_tokens": 168775,
          "session_cache_creation_tokens": 912281,
          "session_cache_read_tokens": 116072977,
          "by_model": {
            "claude-opus-4-8": {
              "input": 245179,
              "output": 168775,
              "cache_create": 912281,
              "cache_read": 116072977
            }
          },
          "turn_count": 173,
          "tool_call_count": 58,
          "context_at_last_turn_tokens": 928921,
          "context_window_pct": 464.4605
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-06-02T18:54:21-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-06-02T18:54:48-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-06-02T18:59:59-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-06-02T19:03:00-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-06-02T19:20:24-07:00",
        "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
        "model": "claude-opus-4-8",
        "five_hour_pct": 41,
        "seven_day_pct": 35,
        "session_input_tokens": 245183,
        "session_output_tokens": 169282,
        "session_cache_creation_tokens": 928112,
        "session_cache_read_tokens": 117931144,
        "by_model": {
          "claude-opus-4-8": {
            "input": 245183,
            "output": 169282,
            "cache_create": 928112,
            "cache_read": 117931144
          }
        },
        "turn_count": 175,
        "tool_call_count": 59,
        "context_at_last_turn_tokens": 944623,
        "context_window_pct": 472.3115
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-06-02T19:20:37-07:00",
      "completed_at": "2026-06-02T19:32:51-07:00",
      "session_started_at": null,
      "cumulative_seconds": 734,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-02T19:20:37-07:00",
        "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
        "model": "claude-opus-4-8",
        "five_hour_pct": 41,
        "seven_day_pct": 35,
        "session_input_tokens": 245187,
        "session_output_tokens": 169692,
        "session_cache_creation_tokens": 928722,
        "session_cache_read_tokens": 119820842,
        "by_model": {
          "claude-opus-4-8": {
            "input": 245187,
            "output": 169692,
            "cache_create": 928722,
            "cache_read": 119820842
          }
        },
        "turn_count": 177,
        "tool_call_count": 60,
        "context_at_last_turn_tokens": 945233,
        "context_window_pct": 472.6165
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-06-02T19:22:15-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-06-02T19:25:15-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 42,
          "seven_day_pct": 36,
          "session_input_tokens": 245329,
          "session_output_tokens": 175948,
          "session_cache_creation_tokens": 959388,
          "session_cache_read_tokens": 126560528,
          "by_model": {
            "claude-opus-4-8": {
              "input": 245329,
              "output": 175948,
              "cache_create": 959388,
              "cache_read": 126560528
            }
          },
          "turn_count": 184,
          "tool_call_count": 62,
          "context_at_last_turn_tokens": 975899,
          "context_window_pct": 487.9495
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-06-02T19:28:55-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 42,
          "seven_day_pct": 36,
          "session_input_tokens": 245605,
          "session_output_tokens": 189442,
          "session_cache_creation_tokens": 980497,
          "session_cache_read_tokens": 135473569,
          "by_model": {
            "claude-opus-4-8": {
              "input": 245605,
              "output": 189442,
              "cache_create": 980497,
              "cache_read": 135473569
            }
          },
          "turn_count": 193,
          "tool_call_count": 65,
          "context_at_last_turn_tokens": 997137,
          "context_window_pct": 498.5685
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-06-02T19:31:37-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 44,
          "seven_day_pct": 36,
          "session_input_tokens": 513627,
          "session_output_tokens": 201137,
          "session_cache_creation_tokens": 1522701,
          "session_cache_read_tokens": 138781174,
          "by_model": {
            "claude-opus-4-8": {
              "input": 513627,
              "output": 201137,
              "cache_create": 1522701,
              "cache_read": 138781174
            }
          },
          "turn_count": 201,
          "tool_call_count": 65,
          "context_at_last_turn_tokens": 558715,
          "context_window_pct": 279.3575
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-06-02T19:32:03-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 44,
          "seven_day_pct": 36,
          "session_input_tokens": 513629,
          "session_output_tokens": 202701,
          "session_cache_creation_tokens": 1528301,
          "session_cache_read_tokens": 139339887,
          "by_model": {
            "claude-opus-4-8": {
              "input": 513629,
              "output": 202701,
              "cache_create": 1528301,
              "cache_read": 139339887
            }
          },
          "turn_count": 202,
          "tool_call_count": 65,
          "context_at_last_turn_tokens": 564315,
          "context_window_pct": 282.1575
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-06-02T19:32:03-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 44,
          "seven_day_pct": 36,
          "session_input_tokens": 513629,
          "session_output_tokens": 202701,
          "session_cache_creation_tokens": 1528301,
          "session_cache_read_tokens": 139339887,
          "by_model": {
            "claude-opus-4-8": {
              "input": 513629,
              "output": 202701,
              "cache_create": 1528301,
              "cache_read": 139339887
            }
          },
          "turn_count": 202,
          "tool_call_count": 65,
          "context_at_last_turn_tokens": 564315,
          "context_window_pct": 282.1575
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-06-02T19:32:28-07:00",
          "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
          "model": "claude-opus-4-8",
          "five_hour_pct": 44,
          "seven_day_pct": 36,
          "session_input_tokens": 513766,
          "session_output_tokens": 205917,
          "session_cache_creation_tokens": 1533387,
          "session_cache_read_tokens": 141607328,
          "by_model": {
            "claude-opus-4-8": {
              "input": 513766,
              "output": 205917,
              "cache_create": 1533387,
              "cache_read": 141607328
            }
          },
          "turn_count": 206,
          "tool_call_count": 67,
          "context_at_last_turn_tokens": 569401,
          "context_window_pct": 284.7005
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-06-02T19:32:51-07:00",
        "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
        "model": "claude-opus-4-8",
        "five_hour_pct": 44,
        "seven_day_pct": 36,
        "session_input_tokens": 513766,
        "session_output_tokens": 205917,
        "session_cache_creation_tokens": 1533387,
        "session_cache_read_tokens": 141607328,
        "by_model": {
          "claude-opus-4-8": {
            "input": 513766,
            "output": 205917,
            "cache_create": 1533387,
            "cache_read": 141607328
          }
        },
        "turn_count": 206,
        "tool_call_count": 67,
        "context_at_last_turn_tokens": 569401,
        "context_window_pct": 284.7005
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-06-02T19:33:31-07:00",
      "completed_at": "2026-06-02T19:33:54-07:00",
      "session_started_at": null,
      "cumulative_seconds": 23,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-02T19:33:31-07:00",
        "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
        "model": "claude-opus-4-8",
        "five_hour_pct": 44,
        "seven_day_pct": 36,
        "session_input_tokens": 513900,
        "session_output_tokens": 208355,
        "session_cache_creation_tokens": 1545330,
        "session_cache_read_tokens": 143317429,
        "by_model": {
          "claude-opus-4-8": {
            "input": 513900,
            "output": 208355,
            "cache_create": 1545330,
            "cache_read": 143317429
          }
        },
        "turn_count": 209,
        "tool_call_count": 67,
        "context_at_last_turn_tokens": 581472,
        "context_window_pct": 290.736
      },
      "window_at_complete": {
        "captured_at": "2026-06-02T19:33:54-07:00",
        "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
        "model": "claude-opus-4-8",
        "five_hour_pct": 44,
        "seven_day_pct": 36,
        "session_input_tokens": 513906,
        "session_output_tokens": 211235,
        "session_cache_creation_tokens": 1548709,
        "session_cache_read_tokens": 145064692,
        "by_model": {
          "claude-opus-4-8": {
            "input": 513906,
            "output": 211235,
            "cache_create": 1548709,
            "cache_read": 145064692
          }
        },
        "turn_count": 212,
        "tool_call_count": 68,
        "context_at_last_turn_tokens": 584723,
        "context_window_pct": 292.3615
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-06-02T18:18:59-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-06-02T18:51:32-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-06-02T19:20:37-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-06-02T19:33:31-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-06-02T18:15:06-07:00",
    "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
    "model": "claude-opus-4-8",
    "five_hour_pct": 30,
    "seven_day_pct": 33,
    "session_input_tokens": 4808,
    "session_output_tokens": 779,
    "session_cache_creation_tokens": 245802,
    "session_cache_read_tokens": 16509,
    "by_model": {
      "claude-opus-4-8": {
        "input": 4808,
        "output": 779,
        "cache_create": 245802,
        "cache_read": 16509
      }
    },
    "turn_count": 1,
    "tool_call_count": 0,
    "context_at_last_turn_tokens": 267119,
    "context_window_pct": 133.5595
  },
  "code_tasks_total": 7,
  "code_task": 7,
  "code_task_name": "Auto-correct misplaced .flow-states/ Write/Edit",
  "diff_stats": {
    "files_changed": 5,
    "insertions": 359,
    "deletions": 49,
    "captured_at": "2026-06-02T18:51:22-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "findings": [
    {
      "finding": "Pre-mortem: hookSpecificOutput envelope shape diverges from validate_ask_user flat shape; rewrite may fail open if shape is wrong",
      "reason": "Refuted by verifying the live Claude Code hooks contract via the claude-code-guide agent and code.claude.com/docs/en/hooks.md: the wrapped hookSpecificOutput {hookEventName, permissionDecision, updatedInput} is the correct and only documented PreToolUse mechanism for rewriting tool input. The new code is correct. validate_ask_user's flat shape is pre-existing, for AskUserQuestion answer-injection (a different mechanism), and not touched by this PR.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-02T19:10:48-07:00"
    },
    {
      "finding": "Pre-mortem: rewrite matches any path with a /.flow-states/ segment (no basename allowlist), silently redirecting non-state writes into the gitignored root and risking cross-flow collisions",
      "reason": "The path matching (detect_misplaced_flow_states) and suffix mapping are pre-existing and unchanged by this PR; only the response changes from block to rewrite. Any worktree-internal .flow-states/ write is by definition misplaced per file-tool-preflights.md and is correctly redirected. The silent redirect is the intended behavior requested in issue #1801. The old block surfaced the same canonical destination; the suffix mapping was identical.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-02T19:10:57-07:00"
    },
    {
      "finding": "Pre-mortem: extending the rewrite to Edit re-points old_string-bearing input at a different physical file, risking content corruption",
      "reason": "Speculative/degenerate. A misplaced worktree-internal .flow-states/ file typically does not exist (the gate has always prevented writes there), so an Edit against it fails Claude Code's Read-first preflight before the hook runs. Edit's exact-unique-match semantics make a mismatch fail cleanly (old_string not found) rather than silently corrupt; a non-unique match with replace_all=false errors. The misplaced-Edit scenario is not a realistic corruption path.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-02T19:11:04-07:00"
    },
    {
      "finding": "Reviewer/Documentation: envelope shape correctness asserted only at byte level; pub helpers do not cite the PreToolUse contract or name their production consumer",
      "reason": "Verified the wrapped hookSpecificOutput updatedInput shape against the live Claude Code hooks contract (code.claude.com/docs/en/hooks.md) via the claude-code-guide agent. Added an Envelope contract paragraph citing the docs to build_rewrite_envelope, plus pub-rationale + sole-production-caller (run_impl_main) notes to both build_rewrite_envelope and misplaced_flow_states_rewrite doc comments, satisfying test-placement.md and discharging the verify-automation-e2e obligation via documented contract verification.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-02T19:15:33-07:00"
    },
    {
      "finding": "Documentation: autonomous-phase-discipline.md parenthetical described validate-worktree-paths as blocking misplaced worktree-internal .flow-states/ copies, now stale",
      "reason": "After this PR, validate-worktree-paths auto-rewrites misplaced worktree-internal .flow-states/ Write/Edit and blocks only Read/Glob/Grep. Updated the parenthetical to say it 'only acts on misplaced worktree-internal copies — auto-rewriting Write/Edit, blocking Read/Glob/Grep — never the canonical file', preserving the trust-boundary point while correcting the block-vs-rewrite drift.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-02T19:15:40-07:00"
    },
    {
      "finding": "Tenant 1 candidate: validate-pretool agent_prompt_scan blocked several Review/Learn agent launches when the prompt carried out-of-worktree path tokens (absolute plugin-root bin/flow, project-root .flow-states/ prose, literal dot-dot)",
      "reason": "The block is working as designed and the flow-review/flow-learn skills document that agent prompts must use worktree-relative paths. The blocks were caused by the parent (me) initially embedding absolute/out-of-worktree tokens; recovery was mechanical (worktree-relative bin/flow, drop the tokens). Per filing-issues.md 'Friction Is Not a Process Gap' this is a single-flow, working-block, mechanically-recoverable case — not a filable gap.",
      "outcome": "dismissed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-06-02T19:27:18-07:00"
    },
    {
      "finding": "Subprocess test run_phase_enter (tests/phase_enter.rs:148) spawns bin/flow phase-enter without isolating HOME or clearing CLAUDE_CODE_SESSION_ID; during a bin/flow ci run inside an active flow, test_step_counter_field_names writes a phase-anchor marker into the real ~/.claude/flow/ keyed by the inherited session id, clobbering the active flow's marker so resume-anchor returns a stale fixture worktree path",
      "reason": "Real Tenant-1 process gap: not caught or remediated by any phase gate, destructive failure mode (a --continue-step resume could cd into a nonexistent fixture worktree), recurs on every CI run during an active flow. Verified against src/phase_anchor.rs and the observed counter-learn stale path. Filed on benkruger/flow.",
      "outcome": "filed",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-06-02T19:32:24-07:00",
      "issue_url": "https://github.com/benkruger/flow/issues/1808"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "compact_summary": "<analysis>\nThe conversation is a FLOW plugin development session executing `/flow:flow-start #1801` — a full 5-phase lifecycle (Start → Code → Review → Learn → Complete) on the FLOW plugin repo itself. The flow is fully autonomous (commit=auto, continue=auto for all phases).\n\nLet me trace chronologically:\n\n1. **Flow start (#1801)**: Issue derived branch `auto-correct-misplaced-flow`, PR #1807. The issue/plan: convert a misplaced worktree-internal `.flow-states/` Write/Edit in `src/hooks/validate_worktree_paths.rs` from a hard block into a silent rewrite. 7 tasks.\n\n2. **Code phase (7 tasks, 3 commits)**:\n   - Tasks 1-2 (commit 765ae38): `build_rewrite_envelope` pure helper + tests.\n   - Tasks 3-4 (commit 9e54088): `misplaced_flow_states_rewrite` gating helper + tests.\n   - Tasks 5-7 (commit 7b55593): `WorktreeAction` enum + `run_impl_main`/`run()` routing + retargeted subprocess tests + doc-sync to 3 rule files.\n\n3. **Review phase**: 4 agents launched (reviewer, pre-mortem, adversarial, documentation). Several agent launches were BLOCKED by `validate-pretool` agent_prompt_scan due to out-of-worktree path tokens. Findings: pre-mortem flagged envelope-shape divergence (`hookSpecificOutput` wrapper vs `validate_ask_user` flat shape) as possible fail-open. I verified via claude-code-guide agent that the WRAPPED `hookSpecificOutput` shape is the correct/only documented PreToolUse contract → the new code is correct. 3 dismissed, 3 fixed (Review-fix commit 59fe779): doc-comment contract citation + pub-consumer notes on both helpers, and corrected stale parenthetical in `autonomous-phase-discipline.md`.\n\n4. **Learn phase (in progress)**: learn-analyst returned ZERO findings (END-OF-FINDINGS, all candidates filtered). I'm in Step 2 synthesis, investigating my own two runtime observations: (a) agent_prompt_scan friction, (b) stale phase-anchor marker. I verified the phase-anchor mechanism and was grepping to find the offending test — found `tests/phase_enter.rs:390: let branch2 = \"counter-learn\";` — the test that clobbers the marker.\n\nKey technical details:\n- Recurring error: `validate-pretool` agent_prompt_scan blocks Agent prompts containing out-of-worktree path tokens (`/Users/ben/code/flow/bin/flow`, `<project_root>/.flow-states/` prose), `..`/`...` traversal tokens, and ellipses. The carve-out allows `<project_root>/.flow-states/<branch>/` (the diff file path). Fix: use worktree-relative `bin/flow`, drop out-of-worktree prose tokens.\n- Recurring error: phantom misses — coverage dropped to ~51-66% after small fully-tested edits; fixed via `bin/flow ci --clean` (Layer 11 carve-out).\n- Recurring error: `.flow-states/` Write blocked by validate-worktree-paths (current OLD plugin still blocks); recovery: write to canonical project-root path.\n- resume-anchor returned stale `counter-learn` tempdir path twice; cwd persisted via Bash so no harm.\n\nGlobal instructions/constraints to preserve: bash shell only; never use `git checkout/reset/stash`; always push after commit; no Co-Authored-By; never heredoc for git commit; terse responses; RTK; per-file tests; never invoke cargo directly; the entire `.claude/rules/` corpus + CLAUDE.md.\n\nThe most recent state: I was mid-Learn-Step-2, having just run `grep -rn \"counter-learn\"` which returned `tests/phase_enter.rs:390`. I was deciding whether to FILE a Tenant-1 process-gap issue (phase-anchor marker clobbering — verified mechanism) or DISMISS. The agent_prompt_scan friction I had already mentally classified as NOT a gap (system working + my path error).\n\nNo summary instructions beyond the standard structure were provided in this turn.\n</analysis>\n\n<summary>\n1. Primary Request and Intent:\n   The user invoked `/flow:flow-start #1801` to run the FLOW plugin's full autonomous 5-phase lifecycle (Start → Code → Review → Learn → Complete) on GitHub issue #1801 against the FLOW plugin repo itself. Issue #1801: \"Auto-correct misplaced `.flow-states/` Write/Edit\" — convert a misplaced worktree-internal `.flow-states/` Write/Edit in `src/hooks/validate_worktree_paths.rs` from a hard block (exit 2 + BLOCKED stderr) into a silent rewrite (PreToolUse `updatedInput` envelope to stdout, exit 0). Branch: `auto-correct-misplaced-flow`, PR #1807. All phases configured `commit=auto, continue=auto` (fully autonomous). The user's intent is to ship this feature through the disciplined FLOW lifecycle. There were NO mid-flow user corrections (`notes: []`, no `/flow:flow-note` was used).\n\n2. Key Technical Concepts:\n   - FLOW plugin 5-phase lifecycle with self-invocation via `--continue-step`, state at `.flow-states/<branch>/state.json`, worktree at `.worktrees/<branch>/`.\n   - PreToolUse hook contract: WRAPPED `{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\",\"updatedInput\":<object>}}` is the ONLY valid shape for rewriting tool input (verified via claude-code-guide against code.claude.com/docs/en/hooks.md). The flat `{permissionDecision,updatedInput}` shape (used by `validate_ask_user` for AskUserQuestion answer-injection) is NOT valid for input rewrite.\n   - 100/100/100 coverage gate enforced by `bin/test`; `.claude/rules/no-waivers.md`.\n   - Phantom misses (stale instrumented binaries) → `bin/flow ci --clean` recovery.\n   - `validate-pretool` agent_prompt_scan blocks Agent prompts with out-of-worktree path tokens, `..`/`...`/ellipsis tokens; carve-out for `<project_root>/.flow-states/<branch>/`.\n   - `bin/flow write-rule` required for `.claude/rules/` and `CLAUDE.md` edits during active flow (Edit tool blocked by validate-claude-paths); writes full file content from a content temp file.\n   - Cognitive isolation: Review uses 4 isolated agents (reviewer, pre-mortem, adversarial, documentation); Learn uses learn-analyst. Agents must launch in one response; `END-OF-FINDINGS` marker = normal completion.\n   - test-placement.md bright-line: `pub` items must name non-test production consumer; carve-out for unreachable branches/sibling-helper convention.\n   - phase-anchor markers: `<home>/.claude/flow/phase-anchor-<session_id>.json`, written by `phase-enter`, session_id resolved from env var.\n\n3. Files and Code Sections:\n   - `src/hooks/validate_worktree_paths.rs` (the core change):\n     - Added `pub fn build_rewrite_envelope(tool_input: &Value, canonical: &str) -> Option<Value>` — clones tool_input, overwrites only `file_path`, wraps in hookSpecificOutput allow envelope; returns None for non-object.\n     - Added `pub fn misplaced_flow_states_rewrite(file_path: &str, cwd: &str, tool_name: &str, tool_input: &Value) -> Option<Value>` — gates on `tool_name == \"Write\" || \"Edit\"`, reuses `compute_worktree_paths` + `detect_misplaced_flow_states` + `build_rewrite_envelope`.\n     - Added `enum WorktreeAction { Allow, Block(String), Rewrite(Value) }`; `run_impl_main` returns `WorktreeAction` (rewrite shortcut runs BEFORE validate/validate_shared_config; tool_name extraction hoisted earlier); `run()` matches the 3 arms (Rewrite → `println!` stdout + exit 0).\n     - Updated module doc comment, run_impl_main doc, run() doc.\n     - Review fixes: added \"Envelope contract\" paragraph citing code.claude.com/docs/en/hooks.md, plus pub-rationale/sole-caller (run_impl_main) notes to both helpers.\n   - `tests/hooks/validate_worktree_paths.rs`: added build_rewrite_envelope tests (3), misplaced_flow_states_rewrite tests (8), retargeted `validate_subprocess_rejects_worktree_flow_states_write/edit` → `..._rewrites_...` (assert exit 0 + stdout envelope); kept Read/Glob/Grep block tests.\n   - `.claude/rules/file-tool-preflights.md`: \"Canonical Location for `.flow-states/`\" section updated with per-tool behavior (Write/Edit rewritten, Read/Glob/Grep blocked).\n   - `.claude/rules/hook-vs-instruction.md`: added catalog bullet for the misplaced-`.flow-states/` Write/Edit auto-rewrite.\n   - `.claude/rules/autonomous-flow-self-recovery.md`: updated mechanical-failures bullets (Write/Edit auto-rewritten).\n   - `.claude/rules/autonomous-phase-discipline.md`: Review fix — corrected parenthetical at line ~334-336 (\"only acts on misplaced worktree-internal copies — auto-rewriting Write/Edit, blocking Read/Glob/Grep — never the canonical file\").\n   - `src/phase_anchor.rs` (read in Learn): `resolve_session_id(home, env_value)` reads session_id from env var or `read_captured_session(home)`; `marker_path` = `<home>/.claude/flow/phase-anchor-<session_id>.json`; gated by `is_safe_home`/`is_safe_session_id`.\n   - `tests/phase_enter.rs:390`: `let branch2 = \"counter-learn\";` — the suspected test clobbering the phase-anchor marker.\n\n4. Errors and fixes:\n   - agent_prompt_scan blocked pre-mortem (prose `<project_root>/.flow-states/`), adversarial (absolute `/Users/ben/code/flow/bin/flow`, then literal `..`), claude-code-guide (`...modified`/ellipsis), learn-analyst (`/flow` token in friction narrative). Fixed by scrubbing to worktree-relative `bin/flow` and removing out-of-worktree/`..`/ellipsis tokens; logged the friction.\n   - Phantom misses: coverage dropped to 66%/51% after small tested edits; fixed with `bin/flow ci --clean` (twice), then 100/100/100.\n   - First `.flow-states/` commit-msg Write blocked by validate-worktree-paths (current OLD plugin); reissued against canonical project-root path; logged mechanical recovery.\n   - Compound-command/backtick blocks on `bin/flow log` (pipe `|`, backtick); fixed by removing them.\n   - resume-anchor returned stale `counter-learn` tempdir path twice; did NOT cd there (cwd persisted via Bash); logged the observation.\n\n5. Problem Solving:\n   - Verified the load-bearing correctness question (envelope shape) via claude-code-guide agent — wrapped hookSpecificOutput is correct → feature is correct, NOT fail-open. Discharged verify-automation-e2e via documented contract citation in doc comment.\n   - All commits green at 100/100/100. Review found 5 findings (3 dismissed pre-mortem, 2 fixed doc); Learn found 0 (learn-analyst). \n\n6. All user messages:\n   - `/flow:flow-start #1801` (with args `#1801`) — the only user message; everything else is skill-injected SKILL.md content or tool results. Global standing instructions (from CLAUDE.md/system): bash only; git allowed: status/diff/log/branch/blame/show/add/commit/push; FORBIDDEN: checkout/reset/stash; always push after commit; never add Co-Authored-By; never heredoc for git commit (use `-m` or `-F`); never `git reset HEAD <file>`; terse responses; never invoke cargo directly; repo-level rules only (never write `~/.claude/`); never use general-purpose sub-agents in flows.\n\n7. Pending Tasks:\n   - Complete Learn Step 2 (synthesis): decide file-vs-dismiss for the two observations (agent_prompt_scan friction; phase-anchor marker clobbering).\n   - Learn Steps 3-7: route/apply rules (none expected — zero findings), promote permissions (Step 4), conditional commit (Step 5 — likely skip, no rule changes), file GitHub issues (Step 6 — pending the phase-anchor decision), present report (Step 7), phase-finalize, advance to Complete.\n   - Phase 5 Complete: merge PR #1807, remove worktree, delete state file.\n\n8. Current Work:\n   I was in **Learn Step 2 (Synthesis)**. The learn-analyst agent returned ZERO findings (END-OF-FINDINGS marker present) across all three tenants. `notes: []` so no mandatory correction-note routing. I was assessing my two own runtime observations (logged via `bin/flow log`, NOT given to the cognitively-isolated learn-analyst). I had decided the **agent_prompt_scan friction is NOT a filable gap** (intentional working block + my own out-of-worktree-path error + mechanical recovery; single flow). For the **phase-anchor stale-marker observation**, I verified the mechanism by reading `src/phase_anchor.rs` (confirmed: `resolve_session_id` reads env session-id, marker writes to `<home>/.claude/flow/`, so a subprocess test spawning `phase-enter` without HOME isolation + inheriting the session-id env clobbers the active flow's marker — a real test-hygiene bug with a destructive failure mode where resume-anchor returns a wrong worktree_cwd). I then ran `grep -rn \"counter-learn\"` which returned exactly `tests/phase_enter.rs:390: let branch2 = \"counter-learn\";` — the candidate offending test. I was about to decide whether to file a Tenant-1 process-gap issue (verified-enough mechanism, destructive failure mode, would recur every flow that runs `bin/flow ci`) or dismiss it (the cognitively-isolated learn-analyst found nothing; single-flow observation; per filing-issues \"Verify Before Filing\" I'd want the exact test confirmed).\n\n9. Optional Next Step:\n   Read `tests/phase_enter.rs` around line 390 to confirm whether the `counter-learn` test spawns `phase-enter`/`write-phase-anchor` WITHOUT isolating `HOME` (and inheriting the session-id env var), which is the exact subprocess-test-hygiene violation per `.claude/rules/subprocess-test-hygiene.md` \"Working Directory Isolation\"/HOME neutralization. If confirmed, file a Tenant-1 process-gap issue against `benkruger/flow` (a subprocess test clobbers the active session's phase-anchor marker → resume-anchor returns a stale worktree_cwd that the `--continue-step` resume path would cd into); if the test already isolates HOME or the mechanism cannot be confirmed quickly, dismiss the observation with rationale and record it via `bin/flow add-finding --outcome dismissed`. Then complete Learn Steps 2-7 (set `learn_step=2`, route any findings, promote permissions, conditional commit, present report, phase-finalize) and advance to Complete. Direct quote from where I left off: the grep returned \"`/Users/ben/code/flow/.worktrees/auto-correct-misplaced-flow/tests/phase_enter.rs:390: let branch2 = \"counter-learn\";`\" — I was verifying the phase-anchor marker-clobbering mechanism per \"Verify Before Filing\" before deciding file-vs-dismiss.\n</summary>",
  "compact_cwd": "/Users/ben/code/flow/.worktrees/auto-correct-misplaced-flow",
  "compact_count": 1,
  "issues_filed": [
    {
      "label": "Tech Debt",
      "title": "Subprocess test run_phase_enter clobbers active session's phase-anchor marker (HOME/CLAUDE_CODE_SESSION_ID not isolated)",
      "url": "https://github.com/benkruger/flow/issues/1808",
      "phase": "flow-learn",
      "phase_name": "Learn",
      "timestamp": "2026-06-02T19:32:16-07:00"
    }
  ],
  "complete_steps_total": 5,
  "complete_step": 5,
  "window_at_complete": {
    "captured_at": "2026-06-02T19:33:54-07:00",
    "session_id": "21c9a000-041c-41be-ba6e-566144e49d30",
    "model": "claude-opus-4-8",
    "five_hour_pct": 44,
    "seven_day_pct": 36,
    "session_input_tokens": 513906,
    "session_output_tokens": 211235,
    "session_cache_creation_tokens": 1548709,
    "session_cache_read_tokens": 145064692,
    "by_model": {
      "claude-opus-4-8": {
        "input": 513906,
        "output": 211235,
        "cache_create": 1548709,
        "cache_read": 145064692
      }
    },
    "turn_count": 212,
    "tool_call_count": 68,
    "context_at_last_turn_tokens": 584723,
    "context_window_pct": 292.3615
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>

## Issues Filed

| Label | Title | Phase | URL |
|-------|-------|-------|-----|
| Tech Debt | Subprocess test run_phase_enter clobbers active session's phase-anchor marker (HOME/CLAUDE_CODE_SESSION_ID not isolated) | Learn | #1808 |

<!-- end:Issues Filed -->