### PR TITLE
Prevent A Crash When Linking

### DIFF
--- a/src/issue.rs
+++ b/src/issue.rs
@@ -376,6 +376,9 @@ fn retry_with_label(
 
 fn build_issue_result(repo: &str, url: String) -> IssueResult {
     let number = parse_issue_number(&url);
+    // The database ID is a best-effort enrichment of the result: the issue
+    // has already been created, so a failed lookup degrades `id` to None
+    // rather than failing the whole operation.
     let db_id = number.and_then(|n| fetch_database_id(repo, n).ok());
     IssueResult {
         url,

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -278,20 +278,16 @@ pub fn parse_issue_number(url: &str) -> Option<i64> {
     re.captures(url).and_then(|cap| cap[1].parse().ok())
 }
 
-/// Fetch the REST API database ID for an issue. Returns (id, error).
-/// Used cross-module by `link_blocked_by.rs`.
-pub fn fetch_database_id(repo: &str, number: i64) -> (Option<i64>, Option<String>) {
+/// Fetch the REST API database ID for an issue. Returns `Ok(id)` on
+/// success, `Err(msg)` on a `gh` runner error or a non-numeric API
+/// response. Used cross-module by `link_blocked_by.rs`.
+pub fn fetch_database_id(repo: &str, number: i64) -> Result<i64, String> {
     let api_path = format!("repos/{}/issues/{}", repo, number);
-    match run_gh_cmd(&["gh", "api", &api_path, "--jq", ".id"]) {
-        Ok(stdout) => match stdout.trim().parse::<i64>() {
-            Ok(id) => (Some(id), None),
-            Err(_) => (
-                None,
-                Some(format!("Invalid ID from API: {}", stdout.trim())),
-            ),
-        },
-        Err(e) => (None, Some(e)),
-    }
+    let stdout = run_gh_cmd(&["gh", "api", &api_path, "--jq", ".id"])?;
+    stdout
+        .trim()
+        .parse::<i64>()
+        .map_err(|_| format!("Invalid ID from API: {}", stdout.trim()))
 }
 
 /// Run gh issue create and return issue details. Includes label-not-
@@ -380,10 +376,7 @@ fn retry_with_label(
 
 fn build_issue_result(repo: &str, url: String) -> IssueResult {
     let number = parse_issue_number(&url);
-    let db_id = number.and_then(|n| {
-        let (id, _) = fetch_database_id(repo, n);
-        id
-    });
+    let db_id = number.and_then(|n| fetch_database_id(repo, n).ok());
     IssueResult {
         url,
         number,

--- a/src/link_blocked_by.rs
+++ b/src/link_blocked_by.rs
@@ -52,22 +52,11 @@ pub fn link_blocked_by(
         ));
     }
 
-    let (_, err) = fetch_database_id(repo, blocked_number);
-    if let Some(e) = err {
-        return Err(format!(
-            "Failed to resolve blocked #{}: {}",
-            blocked_number, e
-        ));
-    }
+    fetch_database_id(repo, blocked_number)
+        .map_err(|e| format!("Failed to resolve blocked #{}: {}", blocked_number, e))?;
 
-    let (blocking_id, err) = fetch_database_id(repo, blocking_number);
-    if let Some(e) = err {
-        return Err(format!(
-            "Failed to resolve blocking #{}: {}",
-            blocking_number, e
-        ));
-    }
-    let blocking_id = blocking_id.unwrap();
+    let blocking_id = fetch_database_id(repo, blocking_number)
+        .map_err(|e| format!("Failed to resolve blocking #{}: {}", blocking_number, e))?;
 
     let api_path = format!(
         "repos/{}/issues/{}/dependencies/blocked_by",

--- a/src/link_blocked_by.rs
+++ b/src/link_blocked_by.rs
@@ -52,6 +52,9 @@ pub fn link_blocked_by(
         ));
     }
 
+    // Resolve the blocked issue only to verify it exists and surface a clear
+    // error if it does not; its database ID is not needed for the dependency
+    // POST, which keys off the blocking issue's ID.
     fetch_database_id(repo, blocked_number)
         .map_err(|e| format!("Failed to resolve blocked #{}: {}", blocked_number, e))?;
 


### PR DESCRIPTION
## What

#1817.

Closes #1817

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/prevent-a-crash-when-linking/plan.md` |
| Log | `.flow-states/prevent-a-crash-when-linking/log` |
| State | `.flow-states/prevent-a-crash-when-linking/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/8cae2183-696f-4004-9b07-3796053a7876.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 8m |
| Review | 17m |
| Learn | 3m |
| Complete | <1m |
| **Total** | **31m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 1.9M | $0.980 |
| Code | 17.3M | $11.614 |
| Review | 26.0M | $14.107 |
| Learn | 12.6M | $6.724 ↻ |
| Complete | 1.5M | $0.750 |
| **Total** | **59.2M** | **$34.175** |

*↻ rate-limit window reset observed mid-flow.*

<!-- end:Token Cost -->

## Review Findings

- ✓ **build_issue_result .ok() callsite lacks a why-comment for swallowing the error**
  - Fixed — Added an inline comment naming the best-effort enrichment intent (issue already created; failed lookup degrades id to None)
- ✓ **link_blocked_by blocked-number lookup discards the id with no explanation**
  - Fixed — Added an inline comment explaining the lookup is an existence check; the dependency POST keys off the blocking issue id

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/prevent-a-crash-when-linking.json</summary>

```json
{
  "schema_version": 1,
  "branch": "prevent-a-crash-when-linking",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1820,
  "pr_url": "https://github.com/benkruger/flow/pull/1820",
  "started_at": "2026-06-03T09:49:43-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/prevent-a-crash-when-linking/plan.md",
    "log": ".flow-states/prevent-a-crash-when-linking/log",
    "state": ".flow-states/prevent-a-crash-when-linking/state.json"
  },
  "session_tty": "/dev/ttys007",
  "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/8cae2183-696f-4004-9b07-3796053a7876.jsonl",
  "notes": [],
  "prompt": "#1817",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-06-03T09:49:43-07:00",
      "completed_at": "2026-06-03T09:50:33-07:00",
      "session_started_at": null,
      "cumulative_seconds": 50,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-03T09:49:43-07:00",
        "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
        "model": "claude-opus-4-8",
        "five_hour_pct": 20,
        "seven_day_pct": 42,
        "session_input_tokens": 366,
        "session_output_tokens": 1227,
        "session_cache_creation_tokens": 247827,
        "session_cache_read_tokens": 16525,
        "by_model": {
          "claude-opus-4-8": {
            "input": 366,
            "output": 1227,
            "cache_create": 247827,
            "cache_read": 16525
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 264718,
        "context_window_pct": 132.359
      },
      "window_at_complete": {
        "captured_at": "2026-06-03T09:50:33-07:00",
        "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
        "model": "claude-opus-4-8",
        "five_hour_pct": 20,
        "seven_day_pct": 43,
        "session_input_tokens": 509,
        "session_output_tokens": 2311,
        "session_cache_creation_tokens": 250983,
        "session_cache_read_tokens": 1880991,
        "by_model": {
          "claude-opus-4-8": {
            "input": 509,
            "output": 2311,
            "cache_create": 250983,
            "cache_read": 1880991
          }
        },
        "turn_count": 8,
        "tool_call_count": 2,
        "context_at_last_turn_tokens": 267639,
        "context_window_pct": 133.8195
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-06-03T09:50:43-07:00",
      "completed_at": "2026-06-03T09:59:30-07:00",
      "session_started_at": null,
      "cumulative_seconds": 527,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-03T09:50:43-07:00",
        "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
        "model": "claude-opus-4-8",
        "five_hour_pct": 20,
        "seven_day_pct": 43,
        "session_input_tokens": 513,
        "session_output_tokens": 2685,
        "session_cache_creation_tokens": 251459,
        "session_cache_read_tokens": 2416304,
        "by_model": {
          "claude-opus-4-8": {
            "input": 513,
            "output": 2685,
            "cache_create": 251459,
            "cache_read": 2416304
          }
        },
        "turn_count": 10,
        "tool_call_count": 3,
        "context_at_last_turn_tokens": 267986,
        "context_window_pct": 133.993
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-06-03T09:53:34-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 21,
          "seven_day_pct": 43,
          "session_input_tokens": 236044,
          "session_output_tokens": 9169,
          "session_cache_creation_tokens": 510431,
          "session_cache_read_tokens": 11685967,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236044,
              "output": 9169,
              "cache_create": 510431,
              "cache_read": 11685967
            }
          },
          "turn_count": 31,
          "tool_call_count": 10,
          "context_at_last_turn_tokens": 526958,
          "context_window_pct": 263.479
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-06-03T09:53:34-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 21,
          "seven_day_pct": 43,
          "session_input_tokens": 236044,
          "session_output_tokens": 9169,
          "session_cache_creation_tokens": 510431,
          "session_cache_read_tokens": 11685967,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236044,
              "output": 9169,
              "cache_create": 510431,
              "cache_read": 11685967
            }
          },
          "turn_count": 31,
          "tool_call_count": 10,
          "context_at_last_turn_tokens": 526958,
          "context_window_pct": 263.479
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-06-03T09:53:34-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 21,
          "seven_day_pct": 43,
          "session_input_tokens": 236044,
          "session_output_tokens": 9169,
          "session_cache_creation_tokens": 510431,
          "session_cache_read_tokens": 11685967,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236044,
              "output": 9169,
              "cache_create": 510431,
              "cache_read": 11685967
            }
          },
          "turn_count": 31,
          "tool_call_count": 10,
          "context_at_last_turn_tokens": 526958,
          "context_window_pct": 263.479
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-06-03T09:53:34-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 21,
          "seven_day_pct": 43,
          "session_input_tokens": 236044,
          "session_output_tokens": 9169,
          "session_cache_creation_tokens": 510431,
          "session_cache_read_tokens": 11685967,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236044,
              "output": 9169,
              "cache_create": 510431,
              "cache_read": 11685967
            }
          },
          "turn_count": 31,
          "tool_call_count": 10,
          "context_at_last_turn_tokens": 526958,
          "context_window_pct": 263.479
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-06-03T09:59:30-07:00",
        "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
        "model": "claude-opus-4-8",
        "five_hour_pct": 26,
        "seven_day_pct": 44,
        "session_input_tokens": 236329,
        "session_output_tokens": 14108,
        "session_cache_creation_tokens": 534309,
        "session_cache_read_tokens": 19180277,
        "by_model": {
          "claude-opus-4-8": {
            "input": 236329,
            "output": 14108,
            "cache_create": 534309,
            "cache_read": 19180277
          }
        },
        "turn_count": 45,
        "tool_call_count": 17,
        "context_at_last_turn_tokens": 550836,
        "context_window_pct": 275.418
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-06-03T09:59:40-07:00",
      "completed_at": "2026-06-03T10:17:31-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1071,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-03T09:59:40-07:00",
        "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
        "model": "claude-opus-4-8",
        "five_hour_pct": 26,
        "seven_day_pct": 44,
        "session_input_tokens": 236463,
        "session_output_tokens": 14717,
        "session_cache_creation_tokens": 550087,
        "session_cache_read_tokens": 20833334,
        "by_model": {
          "claude-opus-4-8": {
            "input": 236463,
            "output": 14717,
            "cache_create": 550087,
            "cache_read": 20833334
          }
        },
        "turn_count": 48,
        "tool_call_count": 17,
        "context_at_last_turn_tokens": 566742,
        "context_window_pct": 283.371
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-06-03T10:00:32-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 26,
          "seven_day_pct": 44,
          "session_input_tokens": 236606,
          "session_output_tokens": 15995,
          "session_cache_creation_tokens": 551998,
          "session_cache_read_tokens": 24805812,
          "by_model": {
            "claude-opus-4-8": {
              "input": 236606,
              "output": 15995,
              "cache_create": 551998,
              "cache_read": 24805812
            }
          },
          "turn_count": 55,
          "tool_call_count": 22,
          "context_at_last_turn_tokens": 568654,
          "context_window_pct": 284.327
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-06-03T10:07:35-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 32,
          "seven_day_pct": 45,
          "session_input_tokens": 239625,
          "session_output_tokens": 26079,
          "session_cache_creation_tokens": 577444,
          "session_cache_read_tokens": 28854473,
          "by_model": {
            "claude-opus-4-8": {
              "input": 239625,
              "output": 26079,
              "cache_create": 577444,
              "cache_read": 28854473
            }
          },
          "turn_count": 62,
          "tool_call_count": 25,
          "context_at_last_turn_tokens": 596976,
          "context_window_pct": 298.488
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-06-03T10:08:18-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 32,
          "seven_day_pct": 45,
          "session_input_tokens": 239766,
          "session_output_tokens": 29741,
          "session_cache_creation_tokens": 606078,
          "session_cache_read_tokens": 32527297,
          "by_model": {
            "claude-opus-4-8": {
              "input": 239766,
              "output": 29741,
              "cache_create": 606078,
              "cache_read": 32527297
            }
          },
          "turn_count": 68,
          "tool_call_count": 28,
          "context_at_last_turn_tokens": 622734,
          "context_window_pct": 311.367
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-06-03T10:17:13-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 33,
          "seven_day_pct": 45,
          "session_input_tokens": 240061,
          "session_output_tokens": 34854,
          "session_cache_creation_tokens": 636580,
          "session_cache_read_tokens": 44730809,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240061,
              "output": 34854,
              "cache_create": 636580,
              "cache_read": 44730809
            }
          },
          "turn_count": 87,
          "tool_call_count": 39,
          "context_at_last_turn_tokens": 653107,
          "context_window_pct": 326.5535
        }
      ],
      "agents_returned": [
        {
          "agent": "pre-mortem",
          "timestamp": "2026-06-03T10:01:30-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-06-03T10:01:43-07:00"
        },
        {
          "agent": "reviewer",
          "timestamp": "2026-06-03T10:04:33-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-06-03T10:04:39-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-06-03T10:17:31-07:00",
        "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
        "model": "claude-opus-4-8",
        "five_hour_pct": 33,
        "seven_day_pct": 45,
        "session_input_tokens": 240196,
        "session_output_tokens": 35215,
        "session_cache_creation_tokens": 652357,
        "session_cache_read_tokens": 46705982,
        "by_model": {
          "claude-opus-4-8": {
            "input": 240196,
            "output": 35215,
            "cache_create": 652357,
            "cache_read": 46705982
          }
        },
        "turn_count": 90,
        "tool_call_count": 41,
        "context_at_last_turn_tokens": 669013,
        "context_window_pct": 334.5065
      }
    },
    "flow-learn": {
      "name": "Learn",
      "status": "complete",
      "started_at": "2026-06-03T10:17:42-07:00",
      "completed_at": "2026-06-03T10:21:01-07:00",
      "session_started_at": null,
      "cumulative_seconds": 199,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-03T10:17:42-07:00",
        "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
        "model": "claude-opus-4-8",
        "five_hour_pct": 33,
        "seven_day_pct": 45,
        "session_input_tokens": 240200,
        "session_output_tokens": 35562,
        "session_cache_creation_tokens": 652766,
        "session_cache_read_tokens": 48044001,
        "by_model": {
          "claude-opus-4-8": {
            "input": 240200,
            "output": 35562,
            "cache_create": 652766,
            "cache_read": 48044001
          }
        },
        "turn_count": 92,
        "tool_call_count": 42,
        "context_at_last_turn_tokens": 669293,
        "context_window_pct": 334.6465
      },
      "agents_returned": [
        {
          "agent": "learn-analyst",
          "timestamp": "2026-06-03T10:18:37-07:00"
        }
      ],
      "step_snapshots": [
        {
          "step": 1,
          "field": "learn_step",
          "captured_at": "2026-06-03T10:20:00-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 34,
          "seven_day_pct": 45,
          "session_input_tokens": 240342,
          "session_output_tokens": 39036,
          "session_cache_creation_tokens": 679795,
          "session_cache_read_tokens": 52845985,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240342,
              "output": 39036,
              "cache_create": 679795,
              "cache_read": 52845985
            }
          },
          "turn_count": 99,
          "tool_call_count": 45,
          "context_at_last_turn_tokens": 696322,
          "context_window_pct": 348.161
        },
        {
          "step": 2,
          "field": "learn_step",
          "captured_at": "2026-06-03T10:20:05-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 0,
          "seven_day_pct": 45,
          "session_input_tokens": 240346,
          "session_output_tokens": 39949,
          "session_cache_creation_tokens": 683614,
          "session_cache_read_tokens": 54241616,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240346,
              "output": 39949,
              "cache_create": 683614,
              "cache_read": 54241616
            }
          },
          "turn_count": 101,
          "tool_call_count": 46,
          "context_at_last_turn_tokens": 700141,
          "context_window_pct": 350.0705
        },
        {
          "step": 3,
          "field": "learn_step",
          "captured_at": "2026-06-03T10:20:10-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 0,
          "seven_day_pct": 45,
          "session_input_tokens": 240348,
          "session_output_tokens": 40062,
          "session_cache_creation_tokens": 683765,
          "session_cache_read_tokens": 54941755,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240348,
              "output": 40062,
              "cache_create": 683765,
              "cache_read": 54941755
            }
          },
          "turn_count": 102,
          "tool_call_count": 47,
          "context_at_last_turn_tokens": 700292,
          "context_window_pct": 350.146
        },
        {
          "step": 4,
          "field": "learn_step",
          "captured_at": "2026-06-03T10:20:23-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 0,
          "seven_day_pct": 45,
          "session_input_tokens": 240350,
          "session_output_tokens": 40220,
          "session_cache_creation_tokens": 683911,
          "session_cache_read_tokens": 55642045,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240350,
              "output": 40220,
              "cache_create": 683911,
              "cache_read": 55642045
            }
          },
          "turn_count": 103,
          "tool_call_count": 47,
          "context_at_last_turn_tokens": 700438,
          "context_window_pct": 350.219
        },
        {
          "step": 5,
          "field": "learn_step",
          "captured_at": "2026-06-03T10:20:27-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 0,
          "seven_day_pct": 45,
          "session_input_tokens": 240481,
          "session_output_tokens": 40428,
          "session_cache_creation_tokens": 684094,
          "session_cache_read_tokens": 56342481,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240481,
              "output": 40428,
              "cache_create": 684094,
              "cache_read": 56342481
            }
          },
          "turn_count": 104,
          "tool_call_count": 47,
          "context_at_last_turn_tokens": 700750,
          "context_window_pct": 350.375
        },
        {
          "step": 6,
          "field": "learn_step",
          "captured_at": "2026-06-03T10:20:52-07:00",
          "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
          "model": "claude-opus-4-8",
          "five_hour_pct": 0,
          "seven_day_pct": 45,
          "session_input_tokens": 240493,
          "session_output_tokens": 41283,
          "session_cache_creation_tokens": 701212,
          "session_cache_read_tokens": 60597429,
          "by_model": {
            "claude-opus-4-8": {
              "input": 240493,
              "output": 41283,
              "cache_create": 701212,
              "cache_read": 60597429
            }
          },
          "turn_count": 110,
          "tool_call_count": 51,
          "context_at_last_turn_tokens": 717739,
          "context_window_pct": 358.8695
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-06-03T10:21:01-07:00",
        "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
        "model": "claude-opus-4-8",
        "five_hour_pct": 0,
        "seven_day_pct": 45,
        "session_input_tokens": 240493,
        "session_output_tokens": 41283,
        "session_cache_creation_tokens": 701212,
        "session_cache_read_tokens": 60597429,
        "by_model": {
          "claude-opus-4-8": {
            "input": 240493,
            "output": 41283,
            "cache_create": 701212,
            "cache_read": 60597429
          }
        },
        "turn_count": 110,
        "tool_call_count": 51,
        "context_at_last_turn_tokens": 717739,
        "context_window_pct": 358.8695
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-06-03T10:21:21-07:00",
      "completed_at": "2026-06-03T10:21:44-07:00",
      "session_started_at": null,
      "cumulative_seconds": 23,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-03T10:21:21-07:00",
        "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
        "model": "claude-opus-4-8",
        "five_hour_pct": 0,
        "seven_day_pct": 45,
        "session_input_tokens": 240627,
        "session_output_tokens": 42252,
        "session_cache_creation_tokens": 712141,
        "session_cache_read_tokens": 62751764,
        "by_model": {
          "claude-opus-4-8": {
            "input": 240627,
            "output": 42252,
            "cache_create": 712141,
            "cache_read": 62751764
          }
        },
        "turn_count": 113,
        "tool_call_count": 51,
        "context_at_last_turn_tokens": 728667,
        "context_window_pct": 364.3335
      },
      "window_at_complete": {
        "captured_at": "2026-06-03T10:21:44-07:00",
        "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
        "model": "claude-opus-4-8",
        "five_hour_pct": 0,
        "seven_day_pct": 45,
        "session_input_tokens": 240631,
        "session_output_tokens": 42893,
        "session_cache_creation_tokens": 713005,
        "session_cache_read_tokens": 64209317,
        "by_model": {
          "claude-opus-4-8": {
            "input": 240631,
            "output": 42893,
            "cache_create": 713005,
            "cache_read": 64209317
          }
        },
        "turn_count": 115,
        "tool_call_count": 51,
        "context_at_last_turn_tokens": 729532,
        "context_window_pct": 364.766
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-06-03T09:50:43-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-06-03T09:59:40-07:00"
    },
    {
      "from": "flow-learn",
      "to": "flow-learn",
      "timestamp": "2026-06-03T10:17:42-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-06-03T10:21:21-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-06-03T09:49:43-07:00",
    "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
    "model": "claude-opus-4-8",
    "five_hour_pct": 20,
    "seven_day_pct": 42,
    "session_input_tokens": 366,
    "session_output_tokens": 1227,
    "session_cache_creation_tokens": 247827,
    "session_cache_read_tokens": 16525,
    "by_model": {
      "claude-opus-4-8": {
        "input": 366,
        "output": 1227,
        "cache_create": 247827,
        "cache_read": 16525
      }
    },
    "turn_count": 1,
    "tool_call_count": 0,
    "context_at_last_turn_tokens": 264718,
    "context_window_pct": 132.359
  },
  "code_tasks_total": 4,
  "code_task_name": "Refactor fetch_database_id to Result + update callers",
  "code_task": 4,
  "diff_stats": {
    "files_changed": 2,
    "insertions": 14,
    "deletions": 32,
    "captured_at": "2026-06-03T09:59:30-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "findings": [
    {
      "finding": "build_issue_result .ok() callsite lacks a why-comment for swallowing the error",
      "reason": "Added an inline comment naming the best-effort enrichment intent (issue already created; failed lookup degrades id to None)",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-03T10:08:58-07:00"
    },
    {
      "finding": "link_blocked_by blocked-number lookup discards the id with no explanation",
      "reason": "Added an inline comment explaining the lookup is an existence check; the dependency POST keys off the blocking issue id",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-03T10:09:07-07:00"
    }
  ],
  "learn_steps_total": 7,
  "learn_step": 6,
  "complete_steps_total": 5,
  "complete_step": 5,
  "window_at_complete": {
    "captured_at": "2026-06-03T10:21:44-07:00",
    "session_id": "8cae2183-696f-4004-9b07-3796053a7876",
    "model": "claude-opus-4-8",
    "five_hour_pct": 0,
    "seven_day_pct": 45,
    "session_input_tokens": 240631,
    "session_output_tokens": 42893,
    "session_cache_creation_tokens": 713005,
    "session_cache_read_tokens": 64209317,
    "by_model": {
      "claude-opus-4-8": {
        "input": 240631,
        "output": 42893,
        "cache_create": 713005,
        "cache_read": 64209317
      }
    },
    "turn_count": 115,
    "tool_call_count": 51,
    "context_at_last_turn_tokens": 729532,
    "context_window_pct": 364.766
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>