### PR TITLE
Stop Flow Sub Agents

### DIFF
--- a/.claude/rules/agent-command-paths.md
+++ b/.claude/rules/agent-command-paths.md
@@ -2,19 +2,17 @@
 
 A command embedded in a FLOW sub-agent's prompt for the sub-agent to
 run must not carry the plugin-root prefix (an unexpanded
-`bin/flow`-locating env-var token): the child session does not expand
-it, so the literal token fails. The parent resolves the absolute plugin
-`bin/flow` path via `bin/flow plugin-bin-flow` and substitutes it into
-the agent prompt.
+`bin/flow`-locating env-var token). The parent resolves the absolute
+plugin `bin/flow` path via `bin/flow plugin-bin-flow` and substitutes
+that into the agent prompt.
 
-- Resolve it in the parent SKILL bash fence (the env var expands
-  there); capture the trimmed stdout — an absolute `…/bin/flow` path.
+- Resolve it in the parent SKILL bash fence; capture the trimmed
+  stdout — an absolute `…/bin/flow` path.
 - Substitute that path into the agent prompt; the sub-agent runs it
   verbatim.
-- If `plugin-bin-flow` exits non-zero (the plugin root is unset, empty,
-  or non-absolute), surface the error and halt — never embed the
-  non-path error string in the prompt and never fall back to the
-  unexpanded token.
+- If `plugin-bin-flow` exits non-zero (plugin root unset, empty, or
+  non-absolute), surface the error and halt — never embed the non-path
+  error string and never fall back to the unexpanded token.
 
 Parent SKILL bash fences (run by Claude Code, not a sub-agent) keep the
-plugin-root prefix — expansion works there.
+plugin-root prefix.

--- a/.claude/rules/agent-command-paths.md
+++ b/.claude/rules/agent-command-paths.md
@@ -1,0 +1,20 @@
+# Agent Command Paths
+
+A command embedded in a FLOW sub-agent's prompt for the sub-agent to
+run must not carry the plugin-root prefix (an unexpanded
+`bin/flow`-locating env-var token): the child session does not expand
+it, so the literal token fails. The parent resolves the absolute plugin
+`bin/flow` path via `bin/flow plugin-bin-flow` and substitutes it into
+the agent prompt.
+
+- Resolve it in the parent SKILL bash fence (the env var expands
+  there); capture the trimmed stdout — an absolute `…/bin/flow` path.
+- Substitute that path into the agent prompt; the sub-agent runs it
+  verbatim.
+- If `plugin-bin-flow` exits non-zero (the plugin root is unset, empty,
+  or non-absolute), surface the error and halt — never embed the
+  non-path error string in the prompt and never fall back to the
+  unexpanded token.
+
+Parent SKILL bash fences (run by Claude Code, not a sub-agent) keep the
+plugin-root prefix — expansion works there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Permanent on-main artifacts that future-session readers should know about by nam
 - `src/wait_for_release_ci.rs` — `bin/flow wait-for-release-ci` polls the latest integration-branch GitHub Actions run for the current HEAD with a bounded real-sleep loop until it reaches a terminal conclusion, so flow-release reads the CI result from a single bounded command.
 - `src/phase_anchor.rs` — writes a session-keyed `<home>/.claude/flow/phase-anchor-<session_id>.json` marker at `phase-enter` so a later `--continue-step` resume can recover `worktree_cwd` after a same-session cwd reset, breaking the cwd-dependent branch-detection cycle.
 - `bin/flow resume-anchor` (`src/resume_anchor.rs`) — read-side resolver for the phase-anchor marker; recovers `worktree_cwd` from the session-keyed marker so a `--continue-step` resume re-anchors cwd, emitting `ok`/`no_marker`/`error` (fail-closed on a corrupt marker).
+- `bin/flow plugin-bin-flow` (`src/plugin_bin_flow.rs`) — resolves and prints the absolute plugin `bin/flow` path so a parent skill substitutes it into a sub-agent command instead of the unexpanded plugin-root token (the child session does not expand env vars); fail-closed structured error when the plugin root is unset/empty/non-absolute.
 - `src/commands/blocked_common.rs` — shared entry helper for the `_blocked` state mutators; `resolve_blocked_state_path()` reads+discards stdin, resolves the branch, and derives the state-file path for `set-blocked`/`clear-blocked` (no existence check — each mutator keeps its own).
 
 ## Maintainer Skills (private to this repo)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,3 +152,4 @@ When developing FLOW itself, point Claude Code at the local plugin source via `c
 - **User evidence is ground truth** — when a user provides screenshots or logs that contradict your code analysis, trust the evidence. Your code reading is a hypothesis; the user's evidence is an observation.
 - **Transcript walker real-vs-synthetic discrimination** — see `.claude/rules/transcript-shape.md`.
 - **No performative pause** — see `.claude/rules/no-performative-pause.md`. <!-- no-performative-pause: legitimate-citation -->
+- **Agent command paths (resolve the plugin `bin/flow` path for sub-agent commands)** — see `.claude/rules/agent-command-paths.md`.

--- a/agents/adversarial.md
+++ b/agents/adversarial.md
@@ -34,7 +34,11 @@ investigation and probe iteration on larger PRs.
 
 The branch name, project CLAUDE.md path, temp test file path
 (`<temp_test_file>`, including its file extension), and test
-command (`<test_command>`) are also provided in the prompt. The
+command (`<test_command>`) are also provided in the prompt.
+`<test_command>` is a fully-resolved absolute invocation — the
+calling skill already substituted the absolute plugin `bin/flow`
+path into it, so run it verbatim. It contains no unexpanded
+environment-variable token and needs no expansion. The temp test
 path was chosen by the project's `bin/test --adversarial-path`,
 normalized by the calling skill (trailing whitespace stripped),
 and points inside the project's test tree so the language test

--- a/agents/ci-fixer.md
+++ b/agents/ci-fixer.md
@@ -13,6 +13,13 @@ You are fixing CI failures in a project that uses the FLOW development
 lifecycle. Your job is to diagnose and fix the failures, then verify
 the fix.
 
+## Input
+
+`<flow_cli>` is provided in your prompt — the absolute path to the
+plugin `bin/flow`, resolved by the calling skill. Run it verbatim
+(e.g. `<flow_cli> ci`); it is a fully-resolved absolute invocation
+with no unexpanded environment-variable token and needs no expansion.
+
 ## Workflow
 
 1. Read the CI output provided in your prompt
@@ -21,7 +28,7 @@ the fix.
 1. Re-run CI to verify:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/bin/flow ci
+<flow_cli> ci
 ```
 
 1. If still failing, repeat (max 3 attempts total)

--- a/docs/skills/flow-review.md
+++ b/docs/skills/flow-review.md
@@ -44,7 +44,11 @@ rules files, the adversarial agent's probe path resolved by shelling
 out to `bin/test --adversarial-path` (the path lives inside the
 project's test tree so the language runner can discover it; halt on
 exit 2 from an unconfigured stub), the `bin/flow ci --test --file`
-runner command, and a narrowed list of doc paths likely affected by
+runner command built from the absolute plugin `bin/flow` path
+resolved via `bin/flow plugin-bin-flow` (so the adversarial sub-agent
+runs a fully-resolved command with no unexpanded plugin-root token;
+halt if the plugin root cannot be resolved), and a narrowed list of
+doc paths likely affected by
 the diff (derived from `git diff --name-only` via filename
 heuristics — passed to the documentation agent in Step 2 so it
 investigates only those paths instead of the full docs tree). Run

--- a/skills/flow-complete/SKILL.md
+++ b/skills/flow-complete/SKILL.md
@@ -178,14 +178,27 @@ ${CLAUDE_PLUGIN_ROOT}/bin/flow set-timestamp --set "_continue_context=Self-invok
 To continue, invoke `flow:flow-complete --continue-step` using
 the Skill tool as your final action. Do not output anything else after this invocation.
 
-**If `"path": "ci_failed"`** — local CI failed. Launch the
-`ci-fixer` sub-agent to diagnose and fix. Use the Agent tool:
+**If `"path": "ci_failed"`** — local CI failed. First resolve the
+absolute plugin `bin/flow` path for the ci-fixer prompt (the sub-agent
+runs it in its own session, where the plugin-root prefix is not
+expanded):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow plugin-bin-flow
+```
+
+Capture the trimmed stdout as `<flow_cli>`. If it exits non-zero (the
+plugin root is unset, empty, or non-absolute), surface the stderr
+message and halt — do NOT embed the unexpanded plugin-root token in
+the ci-fixer prompt. Then launch the `ci-fixer` sub-agent to diagnose
+and fix. Use the Agent tool:
 
 - `subagent_type`: `"flow:ci-fixer"`
 - `description`: `"Fix CI failures before merge"`
 
-Provide the `output` field from the JSON in the prompt so the sub-agent
-knows what failed.
+Provide the `output` field from the JSON AND the resolved `<flow_cli>`
+path in the prompt, so the sub-agent knows what failed and which
+`bin/flow` to run.
 
 If fixed, set the resume step, continuation flags, and commit:
 
@@ -279,11 +292,25 @@ ${CLAUDE_PLUGIN_ROOT}/bin/flow ci
 
 If it passes, continue to Step 3.
 
-If it fails, launch the `ci-fixer` sub-agent to diagnose and fix.
-Use the Agent tool:
+If it fails, first resolve the absolute plugin `bin/flow` path for the
+ci-fixer prompt (the sub-agent runs it in its own session, where the
+plugin-root prefix is not expanded):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow plugin-bin-flow
+```
+
+Capture the trimmed stdout as `<flow_cli>`. If it exits non-zero (the
+plugin root is unset, empty, or non-absolute), surface the stderr
+message and halt — do NOT embed the unexpanded plugin-root token in
+the ci-fixer prompt. Then launch the `ci-fixer` sub-agent to diagnose
+and fix. Use the Agent tool:
 
 - `subagent_type`: `"flow:ci-fixer"`
 - `description`: `"Fix CI failures before merge"`
+
+Provide the CI `output` AND the resolved `<flow_cli>` path in the
+prompt, so the sub-agent knows what failed and which `bin/flow` to run.
 
 If fixed, record the resume step, set continuation flags, commit, and
 self-invoke to re-check:
@@ -434,14 +461,26 @@ Continue to Step 5.
 **If `"status": "ci_failed"`** — main had new commits that were merged
 into the branch without conflicts and pushed, but the inline CI on the
 freshly-merged tree failed. The `output` field carries the CI output.
-Launch the `ci-fixer` sub-agent to diagnose and fix. Use the Agent
-tool:
+First resolve the absolute plugin `bin/flow` path for the ci-fixer
+prompt (the sub-agent runs it in its own session, where the
+plugin-root prefix is not expanded):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow plugin-bin-flow
+```
+
+Capture the trimmed stdout as `<flow_cli>`. If it exits non-zero (the
+plugin root is unset, empty, or non-absolute), surface the stderr
+message and halt — do NOT embed the unexpanded plugin-root token in
+the ci-fixer prompt. Then launch the `ci-fixer` sub-agent to diagnose
+and fix. Use the Agent tool:
 
 - `subagent_type`: `"flow:ci-fixer"`
 - `description`: `"Fix CI failures before merge"`
 
-Provide the `output` field from the JSON in the prompt so the sub-agent
-knows what failed.
+Provide the `output` field from the JSON AND the resolved `<flow_cli>`
+path in the prompt, so the sub-agent knows what failed and which
+`bin/flow` to run.
 
 If fixed, record the resume step, set continuation flags, and commit:
 

--- a/skills/flow-review/SKILL.md
+++ b/skills/flow-review/SKILL.md
@@ -355,13 +355,36 @@ cwd, matching the `assets/bin-stubs/test.sh` examples
 (`tests/test_adversarial_flow.rs`,
 `test/adversarial_flow_test.rb`, etc.).
 
-Capture these two values for Step 2 (use the trimmed path
-verbatim, including extension — the project's `bin/test` owns
-both):
+**Resolve the absolute plugin `bin/flow` path.**
+
+The adversarial agent runs `<test_command>` from inside its own
+sub-agent session, where the plugin-root prefix is not expanded and the
+literal token would not resolve. Resolve the absolute path here in the
+parent and substitute it into the agent prompt instead:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow plugin-bin-flow
+```
+
+Capture the trimmed stdout as `<flow_cli>` — an absolute path ending
+`/bin/flow`.
+
+<HARD-GATE>
+If `plugin-bin-flow` exits non-zero (the plugin root is unset, empty,
+or non-absolute), surface the stderr message and halt. Do NOT embed the
+non-path error string into the adversarial agent prompt, and do NOT
+fall back to the unexpanded plugin-root token. Resolve the plugin root
+and re-run Review.
+</HARD-GATE>
+
+Capture these values for Step 2 (use the trimmed path verbatim,
+including extension — the project's `bin/test` owns both):
 
 - `<temp_test_file>` = (trimmed output of `bin/test --adversarial-path`)
+- `<flow_cli>` = (trimmed output of `bin/flow plugin-bin-flow`)
 - `<test_command>` = the bash invocation shown below, with
-  `<temp_test_file>` substituted by the value captured above
+  `<temp_test_file>` and `<flow_cli>` substituted by the values
+  captured above
 
 The adversarial agent invokes `<test_command>` with a 10-minute
 Bash tool timeout (`timeout: 600000`) — CI runs can take 3–4
@@ -369,7 +392,7 @@ minutes and the default 2-minute timeout would background the
 process, defeating the gate (per `.claude/rules/ci-is-a-gate.md`):
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/bin/flow ci --test --file <temp_test_file>
+<flow_cli> ci --test --file <temp_test_file>
 ```
 
 The adversarial agent always launches when `bin/test

--- a/skills/flow-start/SKILL.md
+++ b/skills/flow-start/SKILL.md
@@ -228,14 +228,26 @@ queued flow would hit the same failure. The 30-minute stale timeout
 releases the lock if the user does not act.
 
 **If `"status": "deps_ci_failed"`** — dependencies were updated but
-post-deps CI failed consistently. Launch the `ci-fixer` sub-agent to
-diagnose and fix. Use the Agent tool:
+post-deps CI failed consistently. First resolve the absolute plugin
+`bin/flow` path for the ci-fixer prompt (the sub-agent runs it in its
+own session, where the plugin-root prefix is not expanded):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/flow plugin-bin-flow
+```
+
+Capture the trimmed stdout as `<flow_cli>`. If it exits non-zero (the
+plugin root is unset, empty, or non-absolute), surface the stderr
+message and halt — do NOT embed the unexpanded plugin-root token in
+the ci-fixer prompt. Then launch the `ci-fixer` sub-agent to diagnose
+and fix. Use the Agent tool:
 
 - `subagent_type`: `"flow:ci-fixer"`
 - `description`: `"Fix bin/flow ci failures after dependency update"`
 
-Provide the CI output from the `output` field in the prompt so the
-sub-agent knows what failed.
+Provide the CI output from the `output` field AND the resolved
+`<flow_cli>` path in the prompt, so the sub-agent knows what failed
+and which `bin/flow` to run.
 
 Wait for the sub-agent to return.
 

--- a/src/hooks/agent_prompt_scan.rs
+++ b/src/hooks/agent_prompt_scan.rs
@@ -33,15 +33,18 @@
 //!   substantive-diff path there. The carve-out is scoped to the
 //!   current flow's branch subdirectory, NOT the whole
 //!   `.flow-states/` root that every concurrent flow shares.
-//!   A second carve-out admits candidates under the plugin root
-//!   (`plugin_root`, the caller-supplied `CLAUDE_PLUGIN_ROOT` value):
-//!   the parent substitutes the resolved absolute plugin `bin/flow`
-//!   path (from `bin/flow plugin-bin-flow`) into the adversarial /
-//!   ci-fixer agent prompts, and that path is outside the worktree.
-//!   The plugin-root value is validated non-empty and absolute and
-//!   fails closed (no carve-out) when it is `None`, empty, or
-//!   non-absolute. The caller — not this module — reads the env value
-//!   so the carve-out stays env-race-free unit-testable.
+//!   A second carve-out admits exactly the resolved
+//!   `<plugin_root>/bin/flow` path (`plugin_root` is the
+//!   caller-supplied `CLAUDE_PLUGIN_ROOT` value): the parent
+//!   substitutes that resolved absolute path (from `bin/flow
+//!   plugin-bin-flow`) into the adversarial / ci-fixer agent prompts,
+//!   and it is outside the worktree. The carve-out is scoped to the
+//!   single `bin/flow` path the resolver emits — NOT the whole plugin
+//!   subtree, since a non-`bin/flow` plugin path is still
+//!   out-of-worktree. The plugin-root value is validated non-empty and
+//!   absolute and fails closed (no carve-out) when it is `None`, empty,
+//!   or non-absolute. The caller — not this module — reads the env
+//!   value so the carve-out stays env-race-free unit-testable.
 //!
 //! The `Constructor Invariant Audit` for this module per
 //! `.claude/rules/extract-helper-refactor.md`:
@@ -182,12 +185,13 @@ fn normalize_path_lexical(p: &Path) -> PathBuf {
 ///
 /// `plugin_root` is the caller-supplied `CLAUDE_PLUGIN_ROOT` value
 /// (the caller reads the env so this function stays env-race-free
-/// unit-testable). A candidate that normalizes under a non-empty,
-/// absolute `plugin_root` is allowed — the parent substitutes the
-/// resolved absolute plugin `bin/flow` path into the adversarial /
-/// ci-fixer agent prompts, and that path is outside the worktree.
-/// The carve-out fails closed (candidate stays blocked) when
-/// `plugin_root` is `None`, empty after trimming, or non-absolute.
+/// unit-testable). A candidate that normalizes under the resolved
+/// `<plugin_root>/bin/flow` path is allowed — the parent substitutes
+/// that path into the adversarial / ci-fixer agent prompts, and it is
+/// outside the worktree. The carve-out admits only the `bin/flow` path
+/// the resolver emits, not the whole plugin subtree, and fails closed
+/// (candidate stays blocked) when `plugin_root` is `None`, empty after
+/// trimming, or non-absolute.
 pub fn validate_agent_prompt(
     prompt: Option<&str>,
     worktree_root: &Path,
@@ -271,13 +275,17 @@ pub fn validate_agent_prompt(
             // Plugin-root carve-out: the parent substitutes the
             // resolved absolute plugin `bin/flow` path (from
             // `bin/flow plugin-bin-flow`) into the adversarial /
-            // ci-fixer agent prompts. That path lives under the plugin
-            // root, outside the worktree, so without this carve-out
-            // engaging the worktree gate would hard-block every such
-            // launch. Allow candidates that lexically normalize under a
-            // non-empty, absolute `plugin_root`. The env value is
-            // hygiene-stripped of NUL bytes and surrounding whitespace,
-            // but the prefix comparison is case-preserving (paths are
+            // ci-fixer agent prompts. That path lives outside the
+            // worktree, so without this carve-out engaging the worktree
+            // gate would hard-block every such launch. Admit ONLY the
+            // resolved `<plugin_root>/bin/flow` path — the single shape
+            // the resolver ever emits — NOT the whole plugin subtree: a
+            // non-`bin/flow` path under the plugin root is still
+            // out-of-worktree (in a target project the plugin lives
+            // outside the project) and must stay blocked. The env value
+            // is hygiene-stripped of NUL bytes and surrounding
+            // whitespace (matching `plugin_bin_flow::run_impl`), but the
+            // prefix comparison is case-preserving (paths are
             // case-sensitive) — both sides are compared as
             // lexically-normalized paths. Fail closed (no carve-out,
             // candidate stays blocked) when `plugin_root` is `None`,
@@ -290,8 +298,8 @@ pub fn validate_agent_prompt(
                 if !pr_clean.is_empty() {
                     let pr_path = Path::new(pr_clean);
                     if pr_path.is_absolute() {
-                        let pr_norm = normalize_path_lexical(pr_path);
-                        if resolved_norm.starts_with(&pr_norm) {
+                        let pr_bin_flow = normalize_path_lexical(&pr_path.join("bin").join("flow"));
+                        if resolved_norm.starts_with(&pr_bin_flow) {
                             continue;
                         }
                     }

--- a/src/hooks/agent_prompt_scan.rs
+++ b/src/hooks/agent_prompt_scan.rs
@@ -33,6 +33,15 @@
 //!   substantive-diff path there. The carve-out is scoped to the
 //!   current flow's branch subdirectory, NOT the whole
 //!   `.flow-states/` root that every concurrent flow shares.
+//!   A second carve-out admits candidates under the plugin root
+//!   (`plugin_root`, the caller-supplied `CLAUDE_PLUGIN_ROOT` value):
+//!   the parent substitutes the resolved absolute plugin `bin/flow`
+//!   path (from `bin/flow plugin-bin-flow`) into the adversarial /
+//!   ci-fixer agent prompts, and that path is outside the worktree.
+//!   The plugin-root value is validated non-empty and absolute and
+//!   fails closed (no carve-out) when it is `None`, empty, or
+//!   non-absolute. The caller — not this module — reads the env value
+//!   so the carve-out stays env-race-free unit-testable.
 //!
 //! The `Constructor Invariant Audit` for this module per
 //! `.claude/rules/extract-helper-refactor.md`:
@@ -170,10 +179,20 @@ fn normalize_path_lexical(p: &Path) -> PathBuf {
 /// is sliced at `AGENT_PROMPT_BYTE_CAP` along a UTF-8 char boundary
 /// BEFORE the regex sweep so unbounded input cannot produce
 /// unbounded I/O.
+///
+/// `plugin_root` is the caller-supplied `CLAUDE_PLUGIN_ROOT` value
+/// (the caller reads the env so this function stays env-race-free
+/// unit-testable). A candidate that normalizes under a non-empty,
+/// absolute `plugin_root` is allowed — the parent substitutes the
+/// resolved absolute plugin `bin/flow` path into the adversarial /
+/// ci-fixer agent prompts, and that path is outside the worktree.
+/// The carve-out fails closed (candidate stays blocked) when
+/// `plugin_root` is `None`, empty after trimming, or non-absolute.
 pub fn validate_agent_prompt(
     prompt: Option<&str>,
     worktree_root: &Path,
     flow_active: bool,
+    plugin_root: Option<&str>,
 ) -> (bool, String) {
     if !flow_active {
         return (true, String::new());
@@ -247,6 +266,35 @@ pub fn validate_agent_prompt(
                 );
                 if resolved_norm.starts_with(&flow_states_branch) {
                     continue;
+                }
+            }
+            // Plugin-root carve-out: the parent substitutes the
+            // resolved absolute plugin `bin/flow` path (from
+            // `bin/flow plugin-bin-flow`) into the adversarial /
+            // ci-fixer agent prompts. That path lives under the plugin
+            // root, outside the worktree, so without this carve-out
+            // engaging the worktree gate would hard-block every such
+            // launch. Allow candidates that lexically normalize under a
+            // non-empty, absolute `plugin_root`. The env value is
+            // hygiene-stripped of NUL bytes and surrounding whitespace,
+            // but the prefix comparison is case-preserving (paths are
+            // case-sensitive) — both sides are compared as
+            // lexically-normalized paths. Fail closed (no carve-out,
+            // candidate stays blocked) when `plugin_root` is `None`,
+            // empty after trimming, or non-absolute, per
+            // `.claude/rules/security-gates.md` "Fail Closed" and the
+            // env-validation requirement.
+            if let Some(pr) = plugin_root {
+                let pr_clean = pr.replace('\0', "");
+                let pr_clean = pr_clean.trim();
+                if !pr_clean.is_empty() {
+                    let pr_path = Path::new(pr_clean);
+                    if pr_path.is_absolute() {
+                        let pr_norm = normalize_path_lexical(pr_path);
+                        if resolved_norm.starts_with(&pr_norm) {
+                            continue;
+                        }
+                    }
                 }
             }
             return (

--- a/src/hooks/validate_pretool.rs
+++ b/src/hooks/validate_pretool.rs
@@ -2013,11 +2013,19 @@ fn handle_agent_call(
         crate::flow_paths::compute_worktree_root(&c.to_string_lossy()).map(PathBuf::from)
     });
     if let Some(root) = worktree_root {
+        // Read CLAUDE_PLUGIN_ROOT here (the hook's own env) so the
+        // prompt scan's plugin-root carve-out admits the resolved
+        // absolute plugin `bin/flow` path the parent substitutes into
+        // adversarial / ci-fixer agent prompts. The value is threaded
+        // as a parameter (not read inside the scan) so the carve-out
+        // stays env-race-free unit-testable.
+        let plugin_root = std::env::var("CLAUDE_PLUGIN_ROOT").ok();
         let (prompt_allowed, prompt_message) =
             crate::hooks::agent_prompt_scan::validate_agent_prompt(
                 prompt_field,
                 &root,
                 flow_active,
+                plugin_root.as_deref(),
             );
         if !prompt_allowed {
             return Some((2, Some(prompt_message)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod phase_finalize;
 pub mod phase_transition;
 pub mod plan_deviation;
 pub mod plan_from_issue;
+pub mod plugin_bin_flow;
 pub mod pricing;
 pub mod prime_check;
 pub mod prime_setup;

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ use flow_rs::phase_enter;
 use flow_rs::phase_finalize;
 use flow_rs::phase_transition;
 use flow_rs::plan_from_issue;
+use flow_rs::plugin_bin_flow;
 use flow_rs::prime_check;
 use flow_rs::prime_setup;
 use flow_rs::promote_permissions;
@@ -417,6 +418,12 @@ enum Commands {
     /// Print the integration branch this flow coordinates against.
     #[command(name = "base-branch")]
     BaseBranch,
+
+    /// Resolve and print the absolute plugin `bin/flow` path for
+    /// substitution into FLOW sub-agent commands (replaces the
+    /// unexpanded plugin-root prefix on `bin/flow`).
+    #[command(name = "plugin-bin-flow")]
+    PluginBinFlow,
 
     /// Poll the latest integration-branch CI run until it concludes.
     #[command(name = "wait-for-release-ci")]
@@ -923,6 +930,13 @@ fn main() {
                 }
             }
         }
+        Some(Commands::PluginBinFlow) => match plugin_bin_flow::run_impl_main() {
+            Ok((text, code)) => flow_rs::dispatch::dispatch_text(&text, code),
+            Err((msg, code)) => {
+                eprintln!("{}", msg);
+                process::exit(code);
+            }
+        },
         Some(Commands::WaitForReleaseCi(args)) => {
             let cwd = std::env::current_dir().unwrap_or(std::path::PathBuf::from("."));
             let (value, code) = wait_for_release_ci::run_impl_main(&args, &cwd);

--- a/src/plugin_bin_flow.rs
+++ b/src/plugin_bin_flow.rs
@@ -30,19 +30,26 @@ use std::path::Path;
 /// absolute. Returns `Err((msg, 1))` when it is unset/empty (the
 /// `None`/empty arm) or non-absolute.
 ///
+/// Applies the same NUL-strip + surrounding-whitespace-trim hygiene the
+/// `agent_prompt_scan` plugin-root carve-out applies, so the path this
+/// resolver emits and the prefix that carve-out admits derive
+/// identically from the same `CLAUDE_PLUGIN_ROOT` value — the
+/// one-source contract holds even for a hygiene-affected env value (a
+/// trailing-newline or NUL-padded root would otherwise produce a path
+/// the trimmed/NUL-stripped carve-out could never admit).
+///
 /// Pure over its input so every branch is reachable without mutating
 /// process env; `run_impl_main` reads the env and delegates here.
 pub fn run_impl(claude_plugin_root: Option<&str>) -> Result<(String, i32), (String, i32)> {
-    let root = match claude_plugin_root {
-        Some(r) if !r.is_empty() => r,
-        _ => {
-            return Err((
-                "CLAUDE_PLUGIN_ROOT is unset or empty; cannot resolve the plugin bin/flow path"
-                    .to_string(),
-                1,
-            ));
-        }
-    };
+    let cleaned = claude_plugin_root.unwrap_or("").replace('\0', "");
+    let root = cleaned.trim();
+    if root.is_empty() {
+        return Err((
+            "CLAUDE_PLUGIN_ROOT is unset or empty; cannot resolve the plugin bin/flow path"
+                .to_string(),
+            1,
+        ));
+    }
     if !Path::new(root).is_absolute() {
         return Err((
             format!(

--- a/src/plugin_bin_flow.rs
+++ b/src/plugin_bin_flow.rs
@@ -1,0 +1,64 @@
+//! `bin/flow plugin-bin-flow` — resolve and print the absolute plugin
+//! `bin/flow` path for substitution into FLOW sub-agent commands.
+//!
+//! The plugin-root prefix on `bin/flow` is correct inside a parent
+//! SKILL bash fence (Claude Code expands the plugin-root env var there)
+//! but wrong inside a sub-agent prompt: the child runs the command with
+//! no expansion and the literal unexpanded token, and the resolved
+//! absolute path — being outside the worktree — would otherwise trip
+//! the parent-side `agent_prompt_scan` gate. The parent calls this
+//! subcommand, captures the absolute path, and substitutes it into the
+//! adversarial / ci-fixer agent prompt, so the sub-agent runs a plain
+//! absolute `…/bin/flow …`.
+//!
+//! The resolved path is `<CLAUDE_PLUGIN_ROOT>/bin/flow`, reading the
+//! same `CLAUDE_PLUGIN_ROOT` env value the `agent_prompt_scan`
+//! plugin-root carve-out reads — one source for the path the gate then
+//! allows. On an unset, empty, or non-absolute `CLAUDE_PLUGIN_ROOT` the
+//! subcommand returns a non-zero structured error (never a path, never
+//! a panic) so every consumer halts and surfaces the error rather than
+//! embedding a non-path string into an agent prompt.
+//!
+//! Tests live at `tests/plugin_bin_flow.rs` and drive the binary
+//! through `CARGO_BIN_EXE_flow-rs`.
+
+use std::path::Path;
+
+/// Resolve the absolute plugin `bin/flow` path from a
+/// `CLAUDE_PLUGIN_ROOT` value. Returns `Ok((path, 0))` — the path is
+/// `<root>/bin/flow` — when the value is present, non-empty, and
+/// absolute. Returns `Err((msg, 1))` when it is unset/empty (the
+/// `None`/empty arm) or non-absolute.
+///
+/// Pure over its input so every branch is reachable without mutating
+/// process env; `run_impl_main` reads the env and delegates here.
+pub fn run_impl(claude_plugin_root: Option<&str>) -> Result<(String, i32), (String, i32)> {
+    let root = match claude_plugin_root {
+        Some(r) if !r.is_empty() => r,
+        _ => {
+            return Err((
+                "CLAUDE_PLUGIN_ROOT is unset or empty; cannot resolve the plugin bin/flow path"
+                    .to_string(),
+                1,
+            ));
+        }
+    };
+    if !Path::new(root).is_absolute() {
+        return Err((
+            format!(
+                "CLAUDE_PLUGIN_ROOT `{}` is not an absolute path; cannot resolve the plugin bin/flow path",
+                root
+            ),
+            1,
+        ));
+    }
+    let path = Path::new(root).join("bin").join("flow");
+    Ok((path.to_string_lossy().into_owned(), 0))
+}
+
+/// Main-arm dispatcher reading `CLAUDE_PLUGIN_ROOT` from the process
+/// env. `dispatch::dispatch_text` appends the trailing newline on the
+/// `Ok` path; the `Err` message lands on stderr with exit 1.
+pub fn run_impl_main() -> Result<(String, i32), (String, i32)> {
+    run_impl(std::env::var("CLAUDE_PLUGIN_ROOT").ok().as_deref())
+}

--- a/tests/hooks/agent_prompt_scan.rs
+++ b/tests/hooks/agent_prompt_scan.rs
@@ -162,12 +162,18 @@ fn validator_normalizes_input_per_security_gates() {
 
 const WORKTREE: &str = "/Users/alice/.worktrees/feat";
 
+// Existing call sites pass `None` for plugin_root: these cases exercise
+// behavior unrelated to the plugin-root carve-out, so no carve-out is in
+// effect. The carve-out's own cases below pass a `Some(...)` value.
+const NO_PLUGIN_ROOT: Option<&str> = None;
+
 #[test]
 fn validate_agent_prompt_silent_outside_active_flow() {
     let (allowed, msg) = validate_agent_prompt(
         Some("Read /etc/hosts for inspection."),
         Path::new(WORKTREE),
         false,
+        NO_PLUGIN_ROOT,
     );
     assert!(allowed);
     assert!(msg.is_empty());
@@ -175,14 +181,14 @@ fn validate_agent_prompt_silent_outside_active_flow() {
 
 #[test]
 fn validate_agent_prompt_allows_missing_prompt_field() {
-    let (allowed, msg) = validate_agent_prompt(None, Path::new(WORKTREE), true);
+    let (allowed, msg) = validate_agent_prompt(None, Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
     assert!(allowed);
     assert!(msg.is_empty());
 }
 
 #[test]
 fn validate_agent_prompt_allows_empty_prompt() {
-    let (allowed, msg) = validate_agent_prompt(Some(""), Path::new(WORKTREE), true);
+    let (allowed, msg) = validate_agent_prompt(Some(""), Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
     assert!(allowed);
     assert!(msg.is_empty());
 }
@@ -193,14 +199,16 @@ fn validate_agent_prompt_allows_in_worktree_path() {
     // inside — exercises both the relative-candidate `Path::join`
     // branch and the CurDir arm of `normalize_path_lexical`.
     let prompt = "Read ./src/lib.rs for context.";
-    let (allowed, msg) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
+    let (allowed, msg) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
     assert!(allowed, "expected allow; got msg={}", msg);
 }
 
 #[test]
 fn validate_agent_prompt_blocks_absolute_path_outside_worktree() {
     let prompt = "Read /etc/hosts and report the contents.";
-    let (allowed, _) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
+    let (allowed, _) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
     assert!(!allowed);
 }
 
@@ -212,13 +220,19 @@ fn validate_agent_prompt_blocks_dotvenv_path_outside_worktree() {
     // pins the bare ".venv" candidate which contains traversal-free
     // segments and resolves to an out-of-worktree absolute reference.
     let prompt = "Inspect /home/alice/.venv/lib/foo.py";
-    let (allowed, _) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
+    let (allowed, _) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
     assert!(!allowed);
 }
 
 #[test]
 fn validate_agent_prompt_message_names_offending_path_and_worktree() {
-    let (_, msg) = validate_agent_prompt(Some("Read /etc/hosts."), Path::new(WORKTREE), true);
+    let (_, msg) = validate_agent_prompt(
+        Some("Read /etc/hosts."),
+        Path::new(WORKTREE),
+        true,
+        NO_PLUGIN_ROOT,
+    );
     assert!(
         msg.contains("/etc/hosts"),
         "message must name path: {}",
@@ -241,7 +255,8 @@ fn validate_agent_prompt_byte_capped_at_prompt_length_limit() {
     // no candidates → allow.
     let pad_len = AGENT_PROMPT_BYTE_CAP - 2;
     let prompt = format!("{}{}{}", "a".repeat(pad_len), "🦀", " /etc/hosts");
-    let (allowed, _) = validate_agent_prompt(Some(&prompt), Path::new(WORKTREE), true);
+    let (allowed, _) =
+        validate_agent_prompt(Some(&prompt), Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
     assert!(allowed, "post-cap content must not reach the scanner");
 }
 
@@ -251,7 +266,8 @@ fn validate_agent_prompt_blocks_traversal_path() {
     // containing `/../` — exercises the malformed-candidate branch
     // in validate_agent_prompt.
     let prompt = "Read /etc/../passwd and report.";
-    let (allowed, msg) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
+    let (allowed, msg) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
     assert!(!allowed);
     assert!(
         msg.contains("malformed"),
@@ -268,8 +284,92 @@ fn validate_agent_prompt_blocks_absolute_with_trailing_parentdir() {
     // arm of normalize_path_lexical and the outside-worktree
     // rejection in validate_agent_prompt.
     let prompt = "Inspect /tmp/foo/.. and report.";
-    let (allowed, _) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
+    let (allowed, _) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
     assert!(!allowed);
+}
+
+// --- plugin-root carve-out ---
+
+const PLUGIN_ROOT: &str = "/Users/alice/.claude/plugins/flow";
+
+#[test]
+fn agent_prompt_allows_path_under_plugin_root() {
+    // The parent substitutes the resolved absolute plugin `bin/flow`
+    // path into the adversarial / ci-fixer agent prompt. That path is
+    // under the plugin root, outside the worktree — the carve-out must
+    // allow it so engaging the worktree gate does not hard-block the
+    // launch.
+    let prompt = "Re-run /Users/alice/.claude/plugins/flow/bin/flow ci to verify.";
+    let (allowed, msg) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, Some(PLUGIN_ROOT));
+    assert!(allowed, "plugin-root path must be allowed; msg={msg}");
+}
+
+#[test]
+fn agent_prompt_blocks_out_of_worktree_path_when_plugin_root_set() {
+    // The carve-out is scoped to the plugin-root subtree only: a path
+    // outside both the worktree AND the plugin root is still blocked
+    // even when plugin_root is a valid absolute path.
+    let prompt = "Read /etc/hosts and report.";
+    let (allowed, _) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, Some(PLUGIN_ROOT));
+    assert!(
+        !allowed,
+        "non-plugin-root out-of-worktree path must block even with plugin_root set"
+    );
+}
+
+#[test]
+fn agent_prompt_plugin_root_carveout_fails_closed_when_unset() {
+    // Fail closed: plugin_root None means no carve-out — a path that
+    // WOULD be under the plugin root is blocked because the gate cannot
+    // confirm the plugin root.
+    let prompt = "Run /Users/alice/.claude/plugins/flow/bin/flow ci now.";
+    let (allowed, _) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
+    assert!(!allowed, "unset plugin_root must not admit the carve-out");
+}
+
+#[test]
+fn agent_prompt_plugin_root_carveout_fails_closed_when_empty() {
+    // Fail closed: an empty plugin_root (after trim) is not a usable
+    // root — block.
+    let prompt = "Run /Users/alice/.claude/plugins/flow/bin/flow ci now.";
+    let (allowed, _) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, Some("   "));
+    assert!(!allowed, "empty plugin_root must not admit the carve-out");
+}
+
+#[test]
+fn agent_prompt_plugin_root_carveout_fails_closed_when_not_absolute() {
+    // Fail closed: a non-absolute plugin_root is rejected before the
+    // prefix comparison.
+    let prompt = "Run /Users/alice/.claude/plugins/flow/bin/flow ci now.";
+    let (allowed, _) = validate_agent_prompt(
+        Some(prompt),
+        Path::new(WORKTREE),
+        true,
+        Some("relative/plugins/flow"),
+    );
+    assert!(
+        !allowed,
+        "non-absolute plugin_root must not admit the carve-out"
+    );
+}
+
+#[test]
+fn agent_prompt_plugin_root_carveout_trims_and_strips_nul() {
+    // The env value is hygiene-normalized (NUL strip + surrounding
+    // whitespace trim) before the absolute/prefix checks — but the
+    // comparison itself is case-preserving (paths are case-sensitive).
+    let prompt = "Re-run /Users/alice/.claude/plugins/flow/bin/flow ci to verify.";
+    let padded = "  \0/Users/alice/.claude/plugins/flow\0  ";
+    let (allowed, msg) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, Some(padded));
+    assert!(
+        allowed,
+        "trimmed/NUL-stripped plugin_root must admit the carve-out; msg={msg}"
+    );
 }
 
 // --- .flow-states/ carve-out (Task 10 Branch Enumeration Table) ---
@@ -285,7 +385,8 @@ fn agent_prompt_allows_flow_states_diff_path() {
     // launches.
     let prompt = "Read the substantive diff at \
                   /Users/alice/.flow-states/feat/full-diff.diff and review it.";
-    let (allowed, msg) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
+    let (allowed, msg) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
     assert!(allowed, "flow-states diff path must be allowed; msg={msg}");
 }
 
@@ -296,7 +397,8 @@ fn agent_prompt_blocks_arbitrary_out_of_worktree_path() {
     // still blocked. The carve-out is scoped to the branch subtree
     // only — it does not widen to the whole project root.
     let prompt = "Read /Users/alice/src/other.rs and report.";
-    let (allowed, _) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
+    let (allowed, _) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
     assert!(!allowed, "non-.flow-states out-of-worktree path must block");
 }
 
@@ -309,7 +411,7 @@ fn agent_prompt_flow_states_derive_handles_no_worktrees_segment() {
     // than crashing.
     let worktree_root = Path::new("/Users/alice/plainroot");
     let prompt = "Read /Users/alice/elsewhere/.flow-states/x and report.";
-    let (allowed, _) = validate_agent_prompt(Some(prompt), worktree_root, true);
+    let (allowed, _) = validate_agent_prompt(Some(prompt), worktree_root, true, NO_PLUGIN_ROOT);
     assert!(
         !allowed,
         "no-/.worktrees/ worktree_root yields no project_root → block"
@@ -328,7 +430,7 @@ fn agent_prompt_flow_states_derive_uses_rightmost_worktrees() {
     // derivation would have blocked it.
     let worktree_root = Path::new("/home/dev/.worktrees/outer/.worktrees/feat");
     let prompt = "Review /home/dev/.worktrees/outer/.flow-states/feat/full-diff.diff now.";
-    let (allowed, msg) = validate_agent_prompt(Some(prompt), worktree_root, true);
+    let (allowed, msg) = validate_agent_prompt(Some(prompt), worktree_root, true, NO_PLUGIN_ROOT);
     assert!(
         allowed,
         "rightmost project_root .flow-states/<branch>/ must be allowed; msg={msg}"
@@ -347,7 +449,8 @@ fn agent_prompt_blocks_other_branch_flow_states() {
     // per-branch state. A whole-`.flow-states/`-root carve-out would
     // have allowed it.
     let prompt = "Read /Users/alice/.flow-states/other-branch/state.json and report.";
-    let (allowed, _) = validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true);
+    let (allowed, _) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, NO_PLUGIN_ROOT);
     assert!(
         !allowed,
         "a .flow-states/ path under a different branch must be blocked"

--- a/tests/hooks/agent_prompt_scan.rs
+++ b/tests/hooks/agent_prompt_scan.rs
@@ -162,9 +162,9 @@ fn validator_normalizes_input_per_security_gates() {
 
 const WORKTREE: &str = "/Users/alice/.worktrees/feat";
 
-// Existing call sites pass `None` for plugin_root: these cases exercise
-// behavior unrelated to the plugin-root carve-out, so no carve-out is in
-// effect. The carve-out's own cases below pass a `Some(...)` value.
+// A `None` plugin_root disables the plugin-root carve-out; cases using
+// this constant exercise behavior where the carve-out is not in effect.
+// The carve-out's own cases below pass a `Some(...)` value.
 const NO_PLUGIN_ROOT: Option<&str> = None;
 
 #[test]
@@ -294,7 +294,7 @@ fn validate_agent_prompt_blocks_absolute_with_trailing_parentdir() {
 const PLUGIN_ROOT: &str = "/Users/alice/.claude/plugins/flow";
 
 #[test]
-fn agent_prompt_allows_path_under_plugin_root() {
+fn agent_prompt_allows_resolved_plugin_bin_flow_path() {
     // The parent substitutes the resolved absolute plugin `bin/flow`
     // path into the adversarial / ci-fixer agent prompt. That path is
     // under the plugin root, outside the worktree — the carve-out must
@@ -303,12 +303,15 @@ fn agent_prompt_allows_path_under_plugin_root() {
     let prompt = "Re-run /Users/alice/.claude/plugins/flow/bin/flow ci to verify.";
     let (allowed, msg) =
         validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, Some(PLUGIN_ROOT));
-    assert!(allowed, "plugin-root path must be allowed; msg={msg}");
+    assert!(
+        allowed,
+        "resolved plugin bin/flow path must be allowed; msg={msg}"
+    );
 }
 
 #[test]
 fn agent_prompt_blocks_out_of_worktree_path_when_plugin_root_set() {
-    // The carve-out is scoped to the plugin-root subtree only: a path
+    // The carve-out is scoped to the resolved bin/flow path only: a path
     // outside both the worktree AND the plugin root is still blocked
     // even when plugin_root is a valid absolute path.
     let prompt = "Read /etc/hosts and report.";
@@ -317,6 +320,23 @@ fn agent_prompt_blocks_out_of_worktree_path_when_plugin_root_set() {
     assert!(
         !allowed,
         "non-plugin-root out-of-worktree path must block even with plugin_root set"
+    );
+}
+
+#[test]
+fn agent_prompt_blocks_non_bin_flow_path_under_plugin_root() {
+    // The carve-out admits ONLY the resolved `<plugin_root>/bin/flow`
+    // path the resolver emits — not the whole plugin subtree. A
+    // non-`bin/flow` path UNDER the plugin root is still out-of-worktree
+    // (in a target project the plugin lives outside the project) and
+    // must stay blocked. A whole-subtree carve-out would have allowed
+    // it.
+    let prompt = "Read /Users/alice/.claude/plugins/flow/src/secret.rs and report.";
+    let (allowed, _) =
+        validate_agent_prompt(Some(prompt), Path::new(WORKTREE), true, Some(PLUGIN_ROOT));
+    assert!(
+        !allowed,
+        "a non-bin/flow path under the plugin root must be blocked"
     );
 }
 

--- a/tests/permissions.rs
+++ b/tests/permissions.rs
@@ -170,6 +170,13 @@ const PLACEHOLDER_SUBS: &[(&str, &str)] = &[
         "<test_command>",
         "bin/test .flow-states/test-branch-adversarial_test.py",
     ),
+    // Consumed by skills/flow-review/SKILL.md Step 1: the absolute
+    // plugin `bin/flow` path resolved via `bin/flow plugin-bin-flow`
+    // and substituted into the adversarial runner command
+    // (`<flow_cli> ci --test --file <temp_test_file>`). Substituting
+    // `bin/flow` keeps the resolved command matching the
+    // `Bash(*bin/flow *)` allow-list pattern.
+    ("<flow_cli>", "bin/flow"),
     // Consumed by skills/flow-prime/SKILL.md role-selection step's
     // `--role <role_value>` invocation. The role-selection step
     // resolves the placeholder to one of the concrete role names

--- a/tests/plugin_bin_flow.rs
+++ b/tests/plugin_bin_flow.rs
@@ -112,3 +112,55 @@ fn plugin_bin_flow_errors_when_root_not_absolute() {
         "stdout must be empty on the error path"
     );
 }
+
+#[test]
+fn plugin_bin_flow_trims_surrounding_whitespace_in_root() {
+    // A trailing-whitespace root (e.g. an env value with a stray
+    // newline) must resolve to the same clean path the trimmed
+    // agent_prompt_scan carve-out admits — not a space-bearing path the
+    // carve-out could never match.
+    let output = run_plugin_bin_flow(Some("  /abs/plugin/root  "));
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "/abs/plugin/root/bin/flow\n"
+    );
+}
+
+// --- run_impl hygiene (unit) ---
+//
+// These call `run_impl` directly so the NUL-strip + trim hygiene is
+// covered for inputs a subprocess env value cannot carry (an interior
+// NUL is rejected by `Command::env`). `run_impl` is pure over its
+// argument, so no ambient-env neutralization is needed.
+
+#[test]
+fn run_impl_strips_nul_bytes_matching_the_carveout() {
+    let (path, code) = flow_rs::plugin_bin_flow::run_impl(Some("/abs/plugin\0root"))
+        .expect("absolute root resolves");
+    assert_eq!(code, 0);
+    assert!(
+        !path.contains('\0'),
+        "run_impl must strip NUL bytes so its path matches the NUL-stripping carve-out; got {path:?}"
+    );
+    assert_eq!(path, "/abs/pluginroot/bin/flow");
+}
+
+#[test]
+fn run_impl_trims_whitespace_matching_the_carveout() {
+    let (path, _) = flow_rs::plugin_bin_flow::run_impl(Some(" /abs/plugin/root\n"))
+        .expect("absolute root resolves");
+    assert_eq!(path, "/abs/plugin/root/bin/flow");
+}
+
+#[test]
+fn run_impl_errors_when_whitespace_only_after_trim() {
+    let err = flow_rs::plugin_bin_flow::run_impl(Some("   \t  ")).unwrap_err();
+    assert_eq!(err.1, 1);
+    assert!(err.0.contains("unset or empty"), "got {}", err.0);
+}

--- a/tests/plugin_bin_flow.rs
+++ b/tests/plugin_bin_flow.rs
@@ -1,0 +1,114 @@
+//! Subprocess tests for `bin/flow plugin-bin-flow`. Mirrors
+//! `src/plugin_bin_flow.rs`. Each test spawns the compiled `flow-rs`
+//! binary with a controlled `CLAUDE_PLUGIN_ROOT` value and asserts the
+//! resolved-path / structured-error contract.
+//!
+//! The subcommand resolves the absolute plugin `bin/flow` path so the
+//! parent skill can substitute it into a sub-agent command instead of
+//! the unexpanded `${CLAUDE_PLUGIN_ROOT}/bin/flow` token. On a missing,
+//! empty, or non-absolute `CLAUDE_PLUGIN_ROOT` it must emit a non-zero
+//! structured error (never a path, never a panic) so every consumer
+//! halts rather than embedding a non-path string into an agent prompt.
+//!
+//! Subprocess hygiene per `.claude/rules/subprocess-test-hygiene.md`:
+//! every spawn neutralizes `GH_TOKEN`, `HOME`, and `FLOW_CI_RUNNING`,
+//! and sets `CLAUDE_PLUGIN_ROOT` explicitly so the child never inherits
+//! the runner's value.
+
+use std::process::{Command, Output};
+
+/// Run `flow-rs plugin-bin-flow` with the given `CLAUDE_PLUGIN_ROOT`
+/// value (`None` removes the variable from the child env). Returns the
+/// captured Output.
+fn run_plugin_bin_flow(plugin_root: Option<&str>) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_flow-rs"));
+    cmd.arg("plugin-bin-flow")
+        .env("GH_TOKEN", "invalid")
+        .env("HOME", "/tmp")
+        .env_remove("FLOW_CI_RUNNING");
+    match plugin_root {
+        Some(v) => {
+            cmd.env("CLAUDE_PLUGIN_ROOT", v);
+        }
+        None => {
+            cmd.env_remove("CLAUDE_PLUGIN_ROOT");
+        }
+    }
+    cmd.output().expect("spawn flow-rs plugin-bin-flow")
+}
+
+#[test]
+fn plugin_bin_flow_prints_absolute_path_when_root_is_absolute() {
+    let output = run_plugin_bin_flow(Some("/abs/plugin/root"));
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "/abs/plugin/root/bin/flow\n");
+}
+
+#[test]
+fn plugin_bin_flow_errors_when_root_unset() {
+    let output = run_plugin_bin_flow(None);
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "expected non-zero exit when CLAUDE_PLUGIN_ROOT is unset"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("panicked at"),
+        "must not panic when unset; stderr: {}",
+        stderr
+    );
+    assert!(
+        !stderr.is_empty(),
+        "expected structured stderr message when unset, got empty stderr"
+    );
+    // Never emit a path on the error path.
+    assert!(
+        String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+        "stdout must be empty on the error path"
+    );
+}
+
+#[test]
+fn plugin_bin_flow_errors_when_root_empty() {
+    let output = run_plugin_bin_flow(Some(""));
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "expected non-zero exit when CLAUDE_PLUGIN_ROOT is empty"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.is_empty(),
+        "expected structured stderr message when empty, got empty stderr"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+        "stdout must be empty on the error path"
+    );
+}
+
+#[test]
+fn plugin_bin_flow_errors_when_root_not_absolute() {
+    let output = run_plugin_bin_flow(Some("relative/plugin/root"));
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "expected non-zero exit when CLAUDE_PLUGIN_ROOT is not absolute"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.is_empty(),
+        "expected structured stderr message when non-absolute, got empty stderr"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+        "stdout must be empty on the error path"
+    );
+}

--- a/tests/skill_contracts.rs
+++ b/tests/skill_contracts.rs
@@ -8665,3 +8665,84 @@ fn performative_pause_scanner_normalizes_smart_quote_apostrophe() {
         violations[0]
     );
 }
+
+/// Agent instruction files (`agents/*.md`) must never embed the
+/// `${CLAUDE_PLUGIN_ROOT}` token — in prose OR inside a fenced code
+/// block. A command in an agent file is executed by the sub-agent in
+/// its own session, where the plugin-root env var is not expanded, so
+/// the literal token fails. The parent resolves the absolute plugin
+/// `bin/flow` path via `bin/flow plugin-bin-flow` and substitutes it;
+/// the agent runs the resolved `<flow_cli>` verbatim. Distinct from
+/// `no_prose_uses_plugin_root_expansion`, which scans prose OUTSIDE
+/// fences only — an agent-executed command lives INSIDE a fence and
+/// would slip past that scan.
+///
+/// Named regression: a future edit reintroduces
+/// `${CLAUDE_PLUGIN_ROOT}/bin/flow …` into an agent's runner fence.
+/// See `.claude/rules/agent-command-paths.md`.
+#[test]
+fn agents_carry_no_plugin_root_expansion() {
+    const FORBIDDEN: &str = "${CLAUDE_PLUGIN_ROOT}";
+    let agents_dir = common::agents_dir();
+    let entries =
+        fs::read_dir(&agents_dir).unwrap_or_else(|e| panic!("agents/ must be readable: {e}"));
+    let mut offenders: Vec<String> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("md") {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        if content.contains(FORBIDDEN) {
+            offenders.push(entry.file_name().to_string_lossy().to_string());
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "agents/*.md must not embed `{FORBIDDEN}` — sub-agents run their commands in a session \
+         where the plugin-root env var is not expanded; the parent resolves the absolute path \
+         via `bin/flow plugin-bin-flow`. See `.claude/rules/agent-command-paths.md`. \
+         Offending agents: {offenders:?}"
+    );
+}
+
+/// The flow-review adversarial `<test_command>` runner is embedded in
+/// the adversarial sub-agent's prompt and executed in the sub-agent's
+/// session, so it must carry the resolved `<flow_cli>` path, not the
+/// `${CLAUDE_PLUGIN_ROOT}` token (which the child does not expand). The
+/// assertion is bounded to the `<test_command>` block alone — the
+/// adversarial-setup section also holds a legitimate PARENT resolver
+/// fence (`${CLAUDE_PLUGIN_ROOT}/bin/flow plugin-bin-flow`, run by
+/// Claude Code, not the sub-agent), so a whole-section ban would be a
+/// false positive.
+///
+/// Named regression: a future edit reverts the runner block to
+/// `${CLAUDE_PLUGIN_ROOT}/bin/flow ci --test --file <temp_test_file>`.
+/// See `.claude/rules/agent-command-paths.md`.
+#[test]
+fn flow_review_adversarial_test_command_has_no_plugin_root_expansion() {
+    let skill = common::read_skill("flow-review");
+    let after = skill
+        .split_once("`<test_command>` = the bash invocation shown below")
+        .map(|(_, t)| t)
+        .expect("flow-review must define `<test_command>` in Step 1");
+    let block = after
+        .split_once("The adversarial agent always launches")
+        .map(|(s, _)| s)
+        .unwrap_or(after);
+    // Guard against a vacuous pass: the bounded slice must actually
+    // capture the `<test_command>` runner block.
+    assert!(
+        block.contains("ci --test --file"),
+        "the bounded slice must capture the `<test_command>` runner block; \
+         the bounding markers drifted"
+    );
+    assert!(
+        !block.contains("${CLAUDE_PLUGIN_ROOT}"),
+        "the adversarial `<test_command>` runner must use the resolved `<flow_cli>` path, not \
+         the `${{CLAUDE_PLUGIN_ROOT}}` token (the sub-agent does not expand it). \
+         See `.claude/rules/agent-command-paths.md`."
+    );
+}


### PR DESCRIPTION
## What

#1898.

Closes #1898

## Artifacts

| File | Path |
|------|------|
| Plan | `.flow-states/stop-flow-sub-agents/plan.md` |
| Log | `.flow-states/stop-flow-sub-agents/log` |
| State | `.flow-states/stop-flow-sub-agents/state.json` |
| Transcript | `/Users/ben/.claude/projects/-Users-ben-code-flow/94a67b7d-fad1-4e92-aa75-f9107281046a.jsonl` |

## Phase Timings

| Phase | Duration |
|-------|----------|
| Start | <1m |
| Code | 57m |
| Review | 31m |
| Complete | <1m |
| **Total** | **1h 29m** |

<!-- end:Phase Timings -->

## Token Cost

| Phase | Tokens | Cost |
|-------|--------|------|
| Start | 0 | $0.000 |
| Code | 0 | $0.000 |
| Review | 0 | $0.000 |
| Complete | 0 | $0.000 |
| **Total** | **0** | **$0.000** |

<!-- end:Token Cost -->

## Review Findings

- ✗ **Pre-mortem: hook reads CLAUDE_PLUGIN_ROOT from its own subprocess env with no fallback; if Claude Code does not export it to the hook process, the carve-out fails closed and hard-blocks every adversarial/ci-fixer sub-agent launch**
  - Dismissed — False positive: Claude Code's official Hooks reference guarantees CLAUDE_PROJECT_DIR, CLAUDE_PLUGIN_ROOT, and CLAUDE_PLUGIN_DATA are exported into every hook subprocess environment (verified via claude-code-guide against code.claude.com/docs/en/hooks). The premise 'hook may lack the var' does not hold, so the env read is reliable and the carve-out fires. utils.rs's exe-walk fallback exists for non-hook contexts (direct bin/flow dev/test invocation and the cargo-llvm-cov binary layout), not because hooks lack the var.
- ✗ **Pre-mortem: the SKILL HARD-GATE (halt if plugin-bin-flow exits non-zero) cannot detect the Finding-1 failure mode, giving false reassurance**
  - Dismissed — False positive: moot once Finding 1 is dismissed. CLAUDE_PLUGIN_ROOT is guaranteed in the hook env, so the hypothesized env-mismatch deadlock between the parent-fence resolver and the hook does not occur, and there is no undetected failure for the HARD-GATE to miss.
- ✗ **Documentation: docs/phases/phase-1-start.md, phase-3-review.md, phase-4-complete.md and docs/skills/flow-start.md, flow-complete.md do not mention the plugin-bin-flow resolution step added before the ci-fixer/adversarial launches**
  - Dismissed — False positive (value-vs-bureaucracy, tenant 6): these are high-level 'What It Does' summaries describing ci-fixer at the WHAT level ('ci-fixer commits a fix', 'falls back to the ci-fixer sub-agent'), not the agent-prompt command-construction mechanic. The plugin-bin-flow resolution is an internal launch detail with no command text in these docs to drift. docs/skills/flow-review.md WAS updated (Task 5) because it specifically described the bin/flow ci --test --file runner command; these docs do not.
- ✗ **Documentation: hook-cwd-resolution.md Carve-out section describes only the .flow-states/&lt;branch&gt;/ carve-out, not the new plugin-root carve-out in validate_agent_prompt**
  - Dismissed — False positive: hook-cwd-resolution.md is scoped to cwd-derived gating (its Carve-out paragraph explains the .flow-states carve-out as it relates to the payload-cwd-resolved worktree gate). The plugin-root carve-out is a different concern (plugin-root paths, not cwd) and is fully documented in the new .claude/rules/agent-command-paths.md plus the agent_prompt_scan.rs module doc comment (both updated in-PR). Adding it to hook-cwd-resolution.md would duplicate discoverable info.
- ✗ **Documentation: add cross-references between agent-command-paths.md and hook-cwd-resolution.md to connect the two sides of the mechanism**
  - Dismissed — False positive: directly contradicts .claude/rules/rule-authoring.md, which lists cross-references under 'Cut every time'. Each rule is a self-contained directive+trigger; the hook-side enforcement is discoverable via the agent_prompt_scan.rs module doc, not via inter-rule cross-references.
- ✓ **Adversarial: plugin_bin_flow::run_impl applied no NUL-strip/whitespace-trim hygiene while the agent_prompt_scan carve-out does, so a hygiene-affected CLAUDE_PLUGIN_ROOT produced a resolver path the carve-out could never admit (two failing probe tests)**
  - Fixed — Fixed: run_impl now applies the same replace('\\0','') + trim() hygiene as the carve-out, so the emitted path and the admitted prefix derive identically from one source. Guarded by plugin_bin_flow tests (whitespace subprocess + run_impl unit tests for NUL-strip, trim, whitespace-only-error).
- ✓ **Reviewer/Pre-mortem: the agent_prompt_scan plugin-root carve-out admitted any candidate under the whole plugin-root subtree, broader than the single &lt;plugin_root&gt;/bin/flow path the resolver emits — weakening the gate for non-bin/flow plugin paths (which are out-of-worktree in a target project)**
  - Fixed — Fixed: the carve-out now admits only the resolved &lt;plugin_root&gt;/bin/flow path (starts_with on pr_path.join(bin).join(flow)), matching the producer exactly. Module + function doc comments updated. Guarded by agent_prompt_blocks_non_bin_flow_path_under_plugin_root.
- ✓ **Reviewer: .claude/rules/agent-command-paths.md carried rationale/why prose that rule-authoring.md directs to cut**
  - Fixed — Fixed: trimmed the why-clauses (child-does-not-expand, expansion-works-there) to leave a tight directive+trigger plus the parent-fence carve-out.
- ✓ **Documentation: the NO_PLUGIN_ROOT test comment said 'Existing call sites pass None', a backward-facing reference per comment-quality.md**
  - Fixed — Fixed: rewrote present-tense ('A None plugin_root disables the plugin-root carve-out; cases using this constant exercise behavior where the carve-out is not in effect').

<!-- end:Review Findings -->

## State File

<details>
<summary>.flow-states/stop-flow-sub-agents.json</summary>

```json
{
  "schema_version": 1,
  "branch": "stop-flow-sub-agents",
  "relative_cwd": "",
  "repo": "benkruger/flow",
  "pr_number": 1899,
  "pr_url": "https://github.com/benkruger/flow/pull/1899",
  "started_at": "2026-06-14T16:08:07-07:00",
  "current_phase": "flow-complete",
  "files": {
    "plan": ".flow-states/stop-flow-sub-agents/plan.md",
    "log": ".flow-states/stop-flow-sub-agents/log",
    "state": ".flow-states/stop-flow-sub-agents/state.json"
  },
  "session_tty": "/dev/ttys015",
  "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
  "transcript_path": "/Users/ben/.claude/projects/-Users-ben-code-flow/94a67b7d-fad1-4e92-aa75-f9107281046a.jsonl",
  "notes": [],
  "prompt": "#1898",
  "phases": {
    "flow-start": {
      "name": "Start",
      "status": "complete",
      "started_at": "2026-06-14T16:08:07-07:00",
      "completed_at": "2026-06-14T16:08:47-07:00",
      "session_started_at": null,
      "cumulative_seconds": 40,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-14T16:08:07-07:00",
        "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 54,
        "seven_day_pct": 44,
        "session_input_tokens": 4423,
        "session_output_tokens": 37,
        "session_cache_creation_tokens": 72385,
        "session_cache_read_tokens": 0,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4423,
            "output": 37,
            "cache_create": 72385,
            "cache_read": 0
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 76808,
        "context_window_pct": 38.404
      },
      "window_at_complete": {
        "captured_at": "2026-06-14T16:08:47-07:00",
        "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 54,
        "seven_day_pct": 44,
        "session_input_tokens": 4423,
        "session_output_tokens": 37,
        "session_cache_creation_tokens": 72385,
        "session_cache_read_tokens": 0,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4423,
            "output": 37,
            "cache_create": 72385,
            "cache_read": 0
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 76808,
        "context_window_pct": 38.404
      }
    },
    "flow-code": {
      "name": "Code",
      "status": "complete",
      "started_at": "2026-06-14T16:08:56-07:00",
      "completed_at": "2026-06-14T17:06:18-07:00",
      "session_started_at": null,
      "cumulative_seconds": 3442,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-14T16:08:56-07:00",
        "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 54,
        "seven_day_pct": 44,
        "session_input_tokens": 4423,
        "session_output_tokens": 37,
        "session_cache_creation_tokens": 72385,
        "session_cache_read_tokens": 0,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4423,
            "output": 37,
            "cache_create": 72385,
            "cache_read": 0
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 76808,
        "context_window_pct": 38.404
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "code_task",
          "captured_at": "2026-06-14T16:13:56-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 55,
          "seven_day_pct": 44,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        },
        {
          "step": 2,
          "field": "code_task",
          "captured_at": "2026-06-14T16:13:56-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 55,
          "seven_day_pct": 44,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        },
        {
          "step": 3,
          "field": "code_task",
          "captured_at": "2026-06-14T16:30:11-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 57,
          "seven_day_pct": 45,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        },
        {
          "step": 4,
          "field": "code_task",
          "captured_at": "2026-06-14T16:30:11-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 57,
          "seven_day_pct": 45,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        },
        {
          "step": 5,
          "field": "code_task",
          "captured_at": "2026-06-14T16:37:10-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 60,
          "seven_day_pct": 45,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        },
        {
          "step": 6,
          "field": "code_task",
          "captured_at": "2026-06-14T16:45:21-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 60,
          "seven_day_pct": 45,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        },
        {
          "step": 7,
          "field": "code_task",
          "captured_at": "2026-06-14T16:52:55-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 61,
          "seven_day_pct": 45,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        },
        {
          "step": 8,
          "field": "code_task",
          "captured_at": "2026-06-14T16:58:41-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 61,
          "seven_day_pct": 46,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        },
        {
          "step": 9,
          "field": "code_task",
          "captured_at": "2026-06-14T17:03:26-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 61,
          "seven_day_pct": 46,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-06-14T17:06:18-07:00",
        "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 62,
        "seven_day_pct": 46,
        "session_input_tokens": 4423,
        "session_output_tokens": 37,
        "session_cache_creation_tokens": 72385,
        "session_cache_read_tokens": 0,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4423,
            "output": 37,
            "cache_create": 72385,
            "cache_read": 0
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 76808,
        "context_window_pct": 38.404
      }
    },
    "flow-review": {
      "name": "Review",
      "status": "complete",
      "started_at": "2026-06-14T17:06:35-07:00",
      "completed_at": "2026-06-14T17:37:38-07:00",
      "session_started_at": null,
      "cumulative_seconds": 1863,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-14T17:06:35-07:00",
        "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 62,
        "seven_day_pct": 46,
        "session_input_tokens": 4423,
        "session_output_tokens": 37,
        "session_cache_creation_tokens": 72385,
        "session_cache_read_tokens": 0,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4423,
            "output": 37,
            "cache_create": 72385,
            "cache_read": 0
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 76808,
        "context_window_pct": 38.404
      },
      "step_snapshots": [
        {
          "step": 1,
          "field": "review_step",
          "captured_at": "2026-06-14T17:08:27-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 62,
          "seven_day_pct": 46,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        },
        {
          "step": 2,
          "field": "review_step",
          "captured_at": "2026-06-14T17:20:11-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 64,
          "seven_day_pct": 46,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        },
        {
          "step": 3,
          "field": "review_step",
          "captured_at": "2026-06-14T17:26:12-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 65,
          "seven_day_pct": 46,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        },
        {
          "step": 4,
          "field": "review_step",
          "captured_at": "2026-06-14T17:37:10-07:00",
          "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
          "model": "claude-opus-4-8",
          "five_hour_pct": 67,
          "seven_day_pct": 47,
          "session_input_tokens": 4423,
          "session_output_tokens": 37,
          "session_cache_creation_tokens": 72385,
          "session_cache_read_tokens": 0,
          "by_model": {
            "claude-opus-4-8": {
              "input": 4423,
              "output": 37,
              "cache_create": 72385,
              "cache_read": 0
            }
          },
          "turn_count": 1,
          "tool_call_count": 0,
          "context_at_last_turn_tokens": 76808,
          "context_window_pct": 38.404
        }
      ],
      "agents_returned": [
        {
          "agent": "reviewer",
          "timestamp": "2026-06-14T17:11:27-07:00"
        },
        {
          "agent": "pre-mortem",
          "timestamp": "2026-06-14T17:11:31-07:00"
        },
        {
          "agent": "documentation",
          "timestamp": "2026-06-14T17:11:43-07:00"
        },
        {
          "agent": "adversarial",
          "timestamp": "2026-06-14T17:14:37-07:00"
        }
      ],
      "window_at_complete": {
        "captured_at": "2026-06-14T17:37:38-07:00",
        "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 67,
        "seven_day_pct": 47,
        "session_input_tokens": 4423,
        "session_output_tokens": 37,
        "session_cache_creation_tokens": 72385,
        "session_cache_read_tokens": 0,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4423,
            "output": 37,
            "cache_create": 72385,
            "cache_read": 0
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 76808,
        "context_window_pct": 38.404
      }
    },
    "flow-complete": {
      "name": "Complete",
      "status": "complete",
      "started_at": "2026-06-14T17:38:54-07:00",
      "completed_at": "2026-06-14T17:39:14-07:00",
      "session_started_at": null,
      "cumulative_seconds": 20,
      "visit_count": 1,
      "window_at_enter": {
        "captured_at": "2026-06-14T17:38:54-07:00",
        "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 67,
        "seven_day_pct": 47,
        "session_input_tokens": 4423,
        "session_output_tokens": 37,
        "session_cache_creation_tokens": 72385,
        "session_cache_read_tokens": 0,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4423,
            "output": 37,
            "cache_create": 72385,
            "cache_read": 0
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 76808,
        "context_window_pct": 38.404
      },
      "window_at_complete": {
        "captured_at": "2026-06-14T17:39:14-07:00",
        "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
        "model": "claude-opus-4-8",
        "five_hour_pct": 67,
        "seven_day_pct": 47,
        "session_input_tokens": 4423,
        "session_output_tokens": 37,
        "session_cache_creation_tokens": 72385,
        "session_cache_read_tokens": 0,
        "by_model": {
          "claude-opus-4-8": {
            "input": 4423,
            "output": 37,
            "cache_create": 72385,
            "cache_read": 0
          }
        },
        "turn_count": 1,
        "tool_call_count": 0,
        "context_at_last_turn_tokens": 76808,
        "context_window_pct": 38.404
      }
    }
  },
  "phase_transitions": [
    {
      "from": "flow-code",
      "to": "flow-code",
      "timestamp": "2026-06-14T16:08:56-07:00"
    },
    {
      "from": "flow-review",
      "to": "flow-review",
      "timestamp": "2026-06-14T17:06:35-07:00"
    },
    {
      "from": "flow-complete",
      "to": "flow-complete",
      "timestamp": "2026-06-14T17:38:54-07:00"
    }
  ],
  "skills": {
    "flow-start": {
      "continue": "auto"
    },
    "flow-code": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-review": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-learn": {
      "commit": "auto",
      "continue": "auto"
    },
    "flow-complete": {
      "continue": "auto"
    },
    "flow-abort": {
      "continue": "auto"
    }
  },
  "start_step": 4,
  "start_steps_total": 5,
  "window_at_start": {
    "captured_at": "2026-06-14T16:08:07-07:00",
    "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
    "model": "claude-opus-4-8",
    "five_hour_pct": 54,
    "seven_day_pct": 44,
    "session_input_tokens": 4423,
    "session_output_tokens": 37,
    "session_cache_creation_tokens": 72385,
    "session_cache_read_tokens": 0,
    "by_model": {
      "claude-opus-4-8": {
        "input": 4423,
        "output": 37,
        "cache_create": 72385,
        "cache_read": 0
      }
    },
    "turn_count": 1,
    "tool_call_count": 0,
    "context_at_last_turn_tokens": 76808,
    "context_window_pct": 38.404
  },
  "code_tasks_total": 9,
  "code_task_name": "Add plugin-bin-flow CLAUDE.md Key Files entry",
  "code_task": 9,
  "diff_stats": {
    "files_changed": 17,
    "insertions": 587,
    "deletions": 36,
    "captured_at": "2026-06-14T17:06:18-07:00"
  },
  "review_steps_total": 4,
  "review_step": 4,
  "findings": [
    {
      "finding": "Pre-mortem: hook reads CLAUDE_PLUGIN_ROOT from its own subprocess env with no fallback; if Claude Code does not export it to the hook process, the carve-out fails closed and hard-blocks every adversarial/ci-fixer sub-agent launch",
      "reason": "False positive: Claude Code's official Hooks reference guarantees CLAUDE_PROJECT_DIR, CLAUDE_PLUGIN_ROOT, and CLAUDE_PLUGIN_DATA are exported into every hook subprocess environment (verified via claude-code-guide against code.claude.com/docs/en/hooks). The premise 'hook may lack the var' does not hold, so the env read is reliable and the carve-out fires. utils.rs's exe-walk fallback exists for non-hook contexts (direct bin/flow dev/test invocation and the cargo-llvm-cov binary layout), not because hooks lack the var.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-14T17:25:30-07:00"
    },
    {
      "finding": "Pre-mortem: the SKILL HARD-GATE (halt if plugin-bin-flow exits non-zero) cannot detect the Finding-1 failure mode, giving false reassurance",
      "reason": "False positive: moot once Finding 1 is dismissed. CLAUDE_PLUGIN_ROOT is guaranteed in the hook env, so the hypothesized env-mismatch deadlock between the parent-fence resolver and the hook does not occur, and there is no undetected failure for the HARD-GATE to miss.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-14T17:25:37-07:00"
    },
    {
      "finding": "Documentation: docs/phases/phase-1-start.md, phase-3-review.md, phase-4-complete.md and docs/skills/flow-start.md, flow-complete.md do not mention the plugin-bin-flow resolution step added before the ci-fixer/adversarial launches",
      "reason": "False positive (value-vs-bureaucracy, tenant 6): these are high-level 'What It Does' summaries describing ci-fixer at the WHAT level ('ci-fixer commits a fix', 'falls back to the ci-fixer sub-agent'), not the agent-prompt command-construction mechanic. The plugin-bin-flow resolution is an internal launch detail with no command text in these docs to drift. docs/skills/flow-review.md WAS updated (Task 5) because it specifically described the bin/flow ci --test --file runner command; these docs do not.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-14T17:25:45-07:00"
    },
    {
      "finding": "Documentation: hook-cwd-resolution.md Carve-out section describes only the .flow-states/<branch>/ carve-out, not the new plugin-root carve-out in validate_agent_prompt",
      "reason": "False positive: hook-cwd-resolution.md is scoped to cwd-derived gating (its Carve-out paragraph explains the .flow-states carve-out as it relates to the payload-cwd-resolved worktree gate). The plugin-root carve-out is a different concern (plugin-root paths, not cwd) and is fully documented in the new .claude/rules/agent-command-paths.md plus the agent_prompt_scan.rs module doc comment (both updated in-PR). Adding it to hook-cwd-resolution.md would duplicate discoverable info.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-14T17:25:52-07:00"
    },
    {
      "finding": "Documentation: add cross-references between agent-command-paths.md and hook-cwd-resolution.md to connect the two sides of the mechanism",
      "reason": "False positive: directly contradicts .claude/rules/rule-authoring.md, which lists cross-references under 'Cut every time'. Each rule is a self-contained directive+trigger; the hook-side enforcement is discoverable via the agent_prompt_scan.rs module doc, not via inter-rule cross-references.",
      "outcome": "dismissed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-14T17:25:58-07:00"
    },
    {
      "finding": "Adversarial: plugin_bin_flow::run_impl applied no NUL-strip/whitespace-trim hygiene while the agent_prompt_scan carve-out does, so a hygiene-affected CLAUDE_PLUGIN_ROOT produced a resolver path the carve-out could never admit (two failing probe tests)",
      "reason": "Fixed: run_impl now applies the same replace('\\0','') + trim() hygiene as the carve-out, so the emitted path and the admitted prefix derive identically from one source. Guarded by plugin_bin_flow tests (whitespace subprocess + run_impl unit tests for NUL-strip, trim, whitespace-only-error).",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-14T17:30:47-07:00"
    },
    {
      "finding": "Reviewer/Pre-mortem: the agent_prompt_scan plugin-root carve-out admitted any candidate under the whole plugin-root subtree, broader than the single <plugin_root>/bin/flow path the resolver emits — weakening the gate for non-bin/flow plugin paths (which are out-of-worktree in a target project)",
      "reason": "Fixed: the carve-out now admits only the resolved <plugin_root>/bin/flow path (starts_with on pr_path.join(bin).join(flow)), matching the producer exactly. Module + function doc comments updated. Guarded by agent_prompt_blocks_non_bin_flow_path_under_plugin_root.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-14T17:30:55-07:00"
    },
    {
      "finding": "Reviewer: .claude/rules/agent-command-paths.md carried rationale/why prose that rule-authoring.md directs to cut",
      "reason": "Fixed: trimmed the why-clauses (child-does-not-expand, expansion-works-there) to leave a tight directive+trigger plus the parent-fence carve-out.",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-14T17:31:05-07:00"
    },
    {
      "finding": "Documentation: the NO_PLUGIN_ROOT test comment said 'Existing call sites pass None', a backward-facing reference per comment-quality.md",
      "reason": "Fixed: rewrote present-tense ('A None plugin_root disables the plugin-root carve-out; cases using this constant exercise behavior where the carve-out is not in effect').",
      "outcome": "fixed",
      "phase": "flow-review",
      "phase_name": "Review",
      "timestamp": "2026-06-14T17:31:11-07:00"
    }
  ],
  "complete_steps_total": 5,
  "complete_step": 5,
  "window_at_complete": {
    "captured_at": "2026-06-14T17:39:14-07:00",
    "session_id": "94a67b7d-fad1-4e92-aa75-f9107281046a",
    "model": "claude-opus-4-8",
    "five_hour_pct": 67,
    "seven_day_pct": 47,
    "session_input_tokens": 4423,
    "session_output_tokens": 37,
    "session_cache_creation_tokens": 72385,
    "session_cache_read_tokens": 0,
    "by_model": {
      "claude-opus-4-8": {
        "input": 4423,
        "output": 37,
        "cache_create": 72385,
        "cache_read": 0
      }
    },
    "turn_count": 1,
    "tool_call_count": 0,
    "context_at_last_turn_tokens": 76808,
    "context_window_pct": 38.404
  },
  "_auto_continue": "/flow:flow-complete"
}
```

</details>